### PR TITLE
Namespace ssh servers

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2754,16 +2754,30 @@ func (c *Client) DeleteToken(ctx context.Context, name string) error {
 	return trace.Wrap(err)
 }
 
-// GetNode returns a node by name and namespace.
+// GetNode returns an unscoped node by name and namespace.
+//
+// Deprecated: Use [Client.GetSSHServer] instead, which supports scoped nodes.
+// TODO(williamo): Remove in v20
 func (c *Client) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
-	resp, err := c.grpc.GetNode(ctx, &types.ResourceInNamespaceRequest{
-		Name:      name,
-		Namespace: namespace,
-	})
+	return c.GetSSHServer(ctx, presencepb.GetSSHServerRequest_builder{Name: name}.Build())
+}
+
+// GetSSHServer returns a scoped or unscoped ssh servers by name.
+func (c *Client) GetSSHServer(ctx context.Context, req *presencepb.GetSSHServerRequest) (types.Server, error) {
+	resp, err := c.PresenceServiceClient().GetSSHServer(ctx, req)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		if !trace.IsNotImplemented(trace.Wrap(err)) {
+			return nil, trace.Wrap(err)
+		}
+		if req.GetScope() != "" {
+			return nil, trace.BadParameter("requesting a scoped node from an outdated Teleport control plane that does not support it")
+		}
+		return c.grpc.GetNode(ctx, &types.ResourceInNamespaceRequest{
+			Name:      req.Name,
+			Namespace: defaults.Namespace,
+		})
 	}
-	return resp, nil
+	return resp.GetServer(), nil
 }
 
 // GetNodes returns a complete list of nodes that the user has access to in the given namespace.
@@ -2774,6 +2788,94 @@ func (c *Client) GetNodes(ctx context.Context, namespace string) ([]types.Server
 	})
 
 	return servers, trace.Wrap(err)
+}
+
+// ListSSHServers returns a page of registered ssh servers respecting scope filters.
+func (c *Client) ListSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) ([]types.Server, string, error) {
+	res, err := c.PresenceServiceClient().ListSSHServers(ctx, req)
+	if err != nil {
+		if !trace.IsNotImplemented(err) {
+			return nil, "", trace.Wrap(err)
+		}
+
+		// only allow fallback if the request is not expecting results to be scope filtered
+		if req.GetScopeFilter().GetScope() != "" {
+			return nil, "", trace.BadParameter("requesting list of scoped nodes from an outdated Teleport control plane that does not support it")
+		}
+
+		return c.listNodesFallback(ctx, int(req.GetPageSize()), req.GetPageToken())
+	}
+
+	servers := make([]types.Server, 0, len(res.GetServers()))
+	for _, server := range res.GetServers() {
+		servers = append(servers, server)
+	}
+	return servers, res.GetNextPageToken(), nil
+}
+
+func (c *Client) listNodesFallback(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	resp, err := c.ListResources(ctx, proto.ListResourcesRequest{
+		ResourceType: types.KindNode,
+		Namespace:    defaults.Namespace,
+		Limit:        int32(pageSize),
+		StartKey:     pageToken,
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	servers := make([]types.Server, 0, len(resp.Resources))
+	for _, resource := range resp.Resources {
+		server, ok := resource.(types.Server)
+		if !ok {
+			return nil, "", trace.BadParameter("expected types.Server, got %T", resource)
+		}
+		servers = append(servers, server)
+	}
+	return servers, resp.NextKey, nil
+}
+
+// RangeSSHServers returns a sequence of ssh servers filtered by the given
+// [*presencepb.ListSSHServersRequest].
+func (c *Client) RangeSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	if req == nil {
+		req = presencepb.ListSSHServersRequest_builder{}.Build()
+	}
+
+	pageFn := func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+		req.SetPageToken(pageToken)
+		req.SetPageSize(int32(pageSize))
+		return c.ListSSHServers(ctx, req)
+	}
+	return func(yield func(cluster types.Server, err error) bool) {
+		var fallback bool
+		for cluster, err := range clientutils.RangeResources(ctx, req.GetPageToken(), "", pageFn, types.Server.GetName) {
+			if trace.IsNotImplemented(err) {
+				// if control plane does not support ListNodes, we should try to fallback to the
+				// ListResources API
+				fallback = true
+				break
+			}
+			if !yield(cluster, err) {
+				return
+			}
+		}
+		if !fallback {
+			return
+		}
+		if req.GetScopeFilter().GetScope() != "" {
+			// only allow fallback if the request is not expecting results to be scope filtered
+			yield(nil, trace.BadParameter("requesting range of scoped kube cluster from an outdated Teleport control plane that does not support it"))
+			return
+		}
+		// fallback iterator
+		//nolint:staticcheck // TODO(eriktate): deprecated, to be removed in v20
+		for cluster, err := range clientutils.RangeResources(ctx, req.GetPageToken(), "", c.listNodesFallback, nil) {
+			if !yield(cluster, err) {
+				return
+			}
+		}
+	}
 }
 
 // UpsertNode is used by SSH servers to report their presence
@@ -2793,7 +2895,10 @@ func (c *Client) UpsertNode(ctx context.Context, node types.Server) (*types.Keep
 	return keepAlive, nil
 }
 
-// DeleteNode deletes a node by name and namespace.
+// DeleteNode deletes an unscoped node by name and namespace.
+//
+// Deprecated: Use [Client.DeleteNodeV2] instead, which supports scoped nodes.
+// TODO(williamo): Remove in v20
 func (c *Client) DeleteNode(ctx context.Context, namespace, name string) error {
 	if namespace == "" {
 		return trace.BadParameter("missing parameter namespace")
@@ -2801,11 +2906,29 @@ func (c *Client) DeleteNode(ctx context.Context, namespace, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing parameter name")
 	}
-	_, err := c.grpc.DeleteNode(ctx, &types.ResourceInNamespaceRequest{
-		Name:      name,
-		Namespace: namespace,
-	})
-	return trace.Wrap(err)
+	return trace.Wrap(c.DeleteSSHServer(ctx, presencepb.DeleteSSHServerRequest_builder{Name: name}.Build()))
+}
+
+// DeleteSSHServer deletes a scoped or unscoped ssh server by name.
+func (c *Client) DeleteSSHServer(ctx context.Context, req *presencepb.DeleteSSHServerRequest) error {
+	_, err := c.PresenceServiceClient().DeleteSSHServer(ctx, req)
+	if err != nil {
+		if !trace.IsNotImplemented(trace.Wrap(err)) {
+			return trace.Wrap(err)
+		}
+		if req.GetScope() != "" {
+			return trace.BadParameter("requesting deletion of a scoped node from an outdated Teleport control plane that does not support it")
+		}
+
+		if _, err := c.grpc.DeleteNode(ctx, &types.ResourceInNamespaceRequest{
+			Namespace: defaults.Namespace,
+			Name:      req.Name,
+		}); err != nil {
+			return trace.Wrap(err)
+		}
+
+	}
+	return nil
 }
 
 // DeleteAllNodes deletes all nodes in a given namespace.

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2754,16 +2754,30 @@ func (c *Client) DeleteToken(ctx context.Context, name string) error {
 	return trace.Wrap(err)
 }
 
-// GetNode returns a node by name and namespace.
+// GetNode returns an unscoped node by name and namespace.
+//
+// Deprecated: Use [Client.GetSSHServer] instead, which supports scoped nodes.
+// TODO(williamo): Remove in v20
 func (c *Client) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
-	resp, err := c.grpc.GetNode(ctx, &types.ResourceInNamespaceRequest{
-		Name:      name,
-		Namespace: namespace,
-	})
+	return c.GetSSHServer(ctx, presencepb.GetSSHServerRequest_builder{Name: name}.Build())
+}
+
+// GetSSHServer returns a scoped or unscoped ssh servers by name.
+func (c *Client) GetSSHServer(ctx context.Context, req *presencepb.GetSSHServerRequest) (types.Server, error) {
+	resp, err := c.PresenceServiceClient().GetSSHServer(ctx, req)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		if !trace.IsNotImplemented(trace.Wrap(err)) {
+			return nil, trace.Wrap(err)
+		}
+		if req.GetScope() != "" {
+			return nil, trace.BadParameter("requesting a scoped node from an outdated Teleport control plane that does not support it")
+		}
+		return c.grpc.GetNode(ctx, &types.ResourceInNamespaceRequest{
+			Name:      req.Name,
+			Namespace: defaults.Namespace,
+		})
 	}
-	return resp, nil
+	return resp.GetServer(), nil
 }
 
 // GetNodes returns a complete list of nodes that the user has access to in the given namespace.
@@ -2774,6 +2788,94 @@ func (c *Client) GetNodes(ctx context.Context, namespace string) ([]types.Server
 	})
 
 	return servers, trace.Wrap(err)
+}
+
+// ListSSHServers returns a page of registered ssh servers respecting scope filters.
+func (c *Client) ListSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) ([]types.Server, string, error) {
+	res, err := c.PresenceServiceClient().ListSSHServers(ctx, req)
+	if err != nil {
+		if !trace.IsNotImplemented(err) {
+			return nil, "", trace.Wrap(err)
+		}
+
+		// only allow fallback if the request is not expecting results to be scope filtered
+		if req.GetScopeFilter().GetScope() != "" {
+			return nil, "", trace.BadParameter("requesting list of scoped nodes from an outdated Teleport control plane that does not support it")
+		}
+
+		return c.listNodesFallback(ctx, int(req.GetPageSize()), req.GetPageToken())
+	}
+
+	servers := make([]types.Server, 0, len(res.GetServers()))
+	for _, server := range res.GetServers() {
+		servers = append(servers, server)
+	}
+	return servers, res.GetNextPageToken(), nil
+}
+
+func (c *Client) listNodesFallback(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	resp, err := c.ListResources(ctx, proto.ListResourcesRequest{
+		ResourceType: types.KindNode,
+		Namespace:    defaults.Namespace,
+		Limit:        int32(pageSize),
+		StartKey:     pageToken,
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	servers := make([]types.Server, 0, len(resp.Resources))
+	for _, resource := range resp.Resources {
+		server, ok := resource.(types.Server)
+		if !ok {
+			return nil, "", trace.BadParameter("expected types.Server, got %T", resource)
+		}
+		servers = append(servers, server)
+	}
+	return servers, resp.NextKey, nil
+}
+
+// RangeSSHServers returns a sequence of ssh servers filtered by the given
+// [*presencepb.ListSSHServersRequest].
+func (c *Client) RangeSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	if req == nil {
+		req = presencepb.ListSSHServersRequest_builder{}.Build()
+	}
+
+	pageFn := func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+		req.SetPageToken(pageToken)
+		req.SetPageSize(int32(pageSize))
+		return c.ListSSHServers(ctx, req)
+	}
+	return func(yield func(cluster types.Server, err error) bool) {
+		var fallback bool
+		for cluster, err := range clientutils.RangeResources(ctx, req.GetPageToken(), "", pageFn, types.Server.GetName) {
+			if trace.IsNotImplemented(err) {
+				// if control plane does not support ListNodes, we should try to fallback to the
+				// ListResources API
+				fallback = true
+				break
+			}
+			if !yield(cluster, err) {
+				return
+			}
+		}
+		if !fallback {
+			return
+		}
+		if req.GetScopeFilter().GetScope() != "" {
+			// only allow fallback if the request is not expecting results to be scope filtered
+			yield(nil, trace.BadParameter("requesting range of scoped kube cluster from an outdated Teleport control plane that does not support it"))
+			return
+		}
+		// fallback iterator
+		//nolint:staticcheck // TODO(eriktate): deprecated, to be removed in v20
+		for cluster, err := range clientutils.RangeResources(ctx, req.GetPageToken(), "", c.listNodesFallback, nil) {
+			if !yield(cluster, err) {
+				return
+			}
+		}
+	}
 }
 
 // UpsertNode is used by SSH servers to report their presence
@@ -2793,7 +2895,10 @@ func (c *Client) UpsertNode(ctx context.Context, node types.Server) (*types.Keep
 	return keepAlive, nil
 }
 
-// DeleteNode deletes a node by name and namespace.
+// DeleteNode deletes an unscoped node by name and namespace.
+//
+// Deprecated: Use [Client.DeleteSSHServer] instead, which supports scoped nodes.
+// TODO(williamo): Remove in v20
 func (c *Client) DeleteNode(ctx context.Context, namespace, name string) error {
 	if namespace == "" {
 		return trace.BadParameter("missing parameter namespace")
@@ -2801,11 +2906,29 @@ func (c *Client) DeleteNode(ctx context.Context, namespace, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing parameter name")
 	}
-	_, err := c.grpc.DeleteNode(ctx, &types.ResourceInNamespaceRequest{
-		Name:      name,
-		Namespace: namespace,
-	})
-	return trace.Wrap(err)
+	return trace.Wrap(c.DeleteSSHServer(ctx, presencepb.DeleteSSHServerRequest_builder{Name: name}.Build()))
+}
+
+// DeleteSSHServer deletes a scoped or unscoped ssh server by name.
+func (c *Client) DeleteSSHServer(ctx context.Context, req *presencepb.DeleteSSHServerRequest) error {
+	_, err := c.PresenceServiceClient().DeleteSSHServer(ctx, req)
+	if err != nil {
+		if !trace.IsNotImplemented(trace.Wrap(err)) {
+			return trace.Wrap(err)
+		}
+		if req.GetScope() != "" {
+			return trace.BadParameter("requesting deletion of a scoped node from an outdated Teleport control plane that does not support it")
+		}
+
+		if _, err := c.grpc.DeleteNode(ctx, &types.ResourceInNamespaceRequest{
+			Namespace: defaults.Namespace,
+			Name:      req.Name,
+		}); err != nil {
+			return trace.Wrap(err)
+		}
+
+	}
+	return nil
 }
 
 // DeleteAllNodes deletes all nodes in a given namespace.

--- a/api/gen/proto/go/teleport/presence/v1/service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_grpc.pb.go
@@ -54,6 +54,9 @@ const (
 	PresenceService_DeleteKubeCluster_FullMethodName   = "/teleport.presence.v1.PresenceService/DeleteKubeCluster"
 	PresenceService_DeleteKubeServer_FullMethodName    = "/teleport.presence.v1.PresenceService/DeleteKubeServer"
 	PresenceService_DeleteAppServer_FullMethodName     = "/teleport.presence.v1.PresenceService/DeleteAppServer"
+	PresenceService_GetSSHServer_FullMethodName        = "/teleport.presence.v1.PresenceService/GetSSHServer"
+	PresenceService_ListSSHServers_FullMethodName      = "/teleport.presence.v1.PresenceService/ListSSHServers"
+	PresenceService_DeleteSSHServer_FullMethodName     = "/teleport.presence.v1.PresenceService/DeleteSSHServer"
 )
 
 // PresenceServiceClient is the client API for PresenceService service.
@@ -92,7 +95,7 @@ type PresenceServiceClient interface {
 	DeleteProxyServer(ctx context.Context, in *DeleteProxyServerRequest, opts ...grpc.CallOption) (*DeleteProxyServerResponse, error)
 	// Fetches a kube cluster resource from the backend.
 	GetKubeCluster(ctx context.Context, in *GetKubeClusterRequest, opts ...grpc.CallOption) (*GetKubeClusterResponse, error)
-	// Lists kube cluster resources within the backend.
+	// Lists kube cluster resources from the backend.
 	ListKubeClusters(ctx context.Context, in *ListKubeClustersRequest, opts ...grpc.CallOption) (*ListKubeClustersResponse, error)
 	// Deletes a kube cluster resource from the backend.
 	DeleteKubeCluster(ctx context.Context, in *DeleteKubeClusterRequest, opts ...grpc.CallOption) (*DeleteKubeClusterResponse, error)
@@ -100,6 +103,12 @@ type PresenceServiceClient interface {
 	DeleteKubeServer(ctx context.Context, in *DeleteKubeServerRequest, opts ...grpc.CallOption) (*DeleteKubeServerResponse, error)
 	// Deletes a specific scoped or unscoped application server.
 	DeleteAppServer(ctx context.Context, in *DeleteAppServerRequest, opts ...grpc.CallOption) (*DeleteAppServerResponse, error)
+	// Gets a specific ssh server resource from the backend.
+	GetSSHServer(ctx context.Context, in *GetSSHServerRequest, opts ...grpc.CallOption) (*GetSSHServerResponse, error)
+	// Lists ssh servers resources from the backend.
+	ListSSHServers(ctx context.Context, in *ListSSHServersRequest, opts ...grpc.CallOption) (*ListSSHServersResponse, error)
+	// Deletes an ssh server resource from the backend.
+	DeleteSSHServer(ctx context.Context, in *DeleteSSHServerRequest, opts ...grpc.CallOption) (*DeleteSSHServerResponse, error)
 }
 
 type presenceServiceClient struct {
@@ -300,6 +309,36 @@ func (c *presenceServiceClient) DeleteAppServer(ctx context.Context, in *DeleteA
 	return out, nil
 }
 
+func (c *presenceServiceClient) GetSSHServer(ctx context.Context, in *GetSSHServerRequest, opts ...grpc.CallOption) (*GetSSHServerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSSHServerResponse)
+	err := c.cc.Invoke(ctx, PresenceService_GetSSHServer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *presenceServiceClient) ListSSHServers(ctx context.Context, in *ListSSHServersRequest, opts ...grpc.CallOption) (*ListSSHServersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSSHServersResponse)
+	err := c.cc.Invoke(ctx, PresenceService_ListSSHServers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *presenceServiceClient) DeleteSSHServer(ctx context.Context, in *DeleteSSHServerRequest, opts ...grpc.CallOption) (*DeleteSSHServerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteSSHServerResponse)
+	err := c.cc.Invoke(ctx, PresenceService_DeleteSSHServer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PresenceServiceServer is the server API for PresenceService service.
 // All implementations must embed UnimplementedPresenceServiceServer
 // for forward compatibility.
@@ -336,7 +375,7 @@ type PresenceServiceServer interface {
 	DeleteProxyServer(context.Context, *DeleteProxyServerRequest) (*DeleteProxyServerResponse, error)
 	// Fetches a kube cluster resource from the backend.
 	GetKubeCluster(context.Context, *GetKubeClusterRequest) (*GetKubeClusterResponse, error)
-	// Lists kube cluster resources within the backend.
+	// Lists kube cluster resources from the backend.
 	ListKubeClusters(context.Context, *ListKubeClustersRequest) (*ListKubeClustersResponse, error)
 	// Deletes a kube cluster resource from the backend.
 	DeleteKubeCluster(context.Context, *DeleteKubeClusterRequest) (*DeleteKubeClusterResponse, error)
@@ -344,6 +383,12 @@ type PresenceServiceServer interface {
 	DeleteKubeServer(context.Context, *DeleteKubeServerRequest) (*DeleteKubeServerResponse, error)
 	// Deletes a specific scoped or unscoped application server.
 	DeleteAppServer(context.Context, *DeleteAppServerRequest) (*DeleteAppServerResponse, error)
+	// Gets a specific ssh server resource from the backend.
+	GetSSHServer(context.Context, *GetSSHServerRequest) (*GetSSHServerResponse, error)
+	// Lists ssh servers resources from the backend.
+	ListSSHServers(context.Context, *ListSSHServersRequest) (*ListSSHServersResponse, error)
+	// Deletes an ssh server resource from the backend.
+	DeleteSSHServer(context.Context, *DeleteSSHServerRequest) (*DeleteSSHServerResponse, error)
 	mustEmbedUnimplementedPresenceServiceServer()
 }
 
@@ -410,6 +455,15 @@ func (UnimplementedPresenceServiceServer) DeleteKubeServer(context.Context, *Del
 }
 func (UnimplementedPresenceServiceServer) DeleteAppServer(context.Context, *DeleteAppServerRequest) (*DeleteAppServerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteAppServer not implemented")
+}
+func (UnimplementedPresenceServiceServer) GetSSHServer(context.Context, *GetSSHServerRequest) (*GetSSHServerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSSHServer not implemented")
+}
+func (UnimplementedPresenceServiceServer) ListSSHServers(context.Context, *ListSSHServersRequest) (*ListSSHServersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListSSHServers not implemented")
+}
+func (UnimplementedPresenceServiceServer) DeleteSSHServer(context.Context, *DeleteSSHServerRequest) (*DeleteSSHServerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteSSHServer not implemented")
 }
 func (UnimplementedPresenceServiceServer) mustEmbedUnimplementedPresenceServiceServer() {}
 func (UnimplementedPresenceServiceServer) testEmbeddedByValue()                         {}
@@ -774,6 +828,60 @@ func _PresenceService_DeleteAppServer_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PresenceService_GetSSHServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSSHServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PresenceServiceServer).GetSSHServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PresenceService_GetSSHServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PresenceServiceServer).GetSSHServer(ctx, req.(*GetSSHServerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PresenceService_ListSSHServers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSSHServersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PresenceServiceServer).ListSSHServers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PresenceService_ListSSHServers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PresenceServiceServer).ListSSHServers(ctx, req.(*ListSSHServersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PresenceService_DeleteSSHServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteSSHServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PresenceServiceServer).DeleteSSHServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PresenceService_DeleteSSHServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PresenceServiceServer).DeleteSSHServer(ctx, req.(*DeleteSSHServerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PresenceService_ServiceDesc is the grpc.ServiceDesc for PresenceService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -856,6 +964,18 @@ var PresenceService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteAppServer",
 			Handler:    _PresenceService_DeleteAppServer_Handler,
+		},
+		{
+			MethodName: "GetSSHServer",
+			Handler:    _PresenceService_GetSSHServer_Handler,
+		},
+		{
+			MethodName: "ListSSHServers",
+			Handler:    _PresenceService_ListSSHServers_Handler,
+		},
+		{
+			MethodName: "DeleteSSHServer",
+			Handler:    _PresenceService_DeleteSSHServer_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
@@ -2410,6 +2410,456 @@ func (b0 DeleteAppServerResponse_builder) Build() *DeleteAppServerResponse {
 	return m0
 }
 
+// The request for fetching for an SSH server.
+type GetSSHServerRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The name of the ssh server.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// The scope of the ssh server.
+	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSSHServerRequest) Reset() {
+	*x = GetSSHServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSSHServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSSHServerRequest) ProtoMessage() {}
+
+func (x *GetSSHServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetSSHServerRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *GetSSHServerRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *GetSSHServerRequest) SetName(v string) {
+	x.Name = v
+}
+
+func (x *GetSSHServerRequest) SetScope(v string) {
+	x.Scope = v
+}
+
+type GetSSHServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the ssh server.
+	Name string
+	// The scope of the ssh server.
+	Scope string
+}
+
+func (b0 GetSSHServerRequest_builder) Build() *GetSSHServerRequest {
+	m0 := &GetSSHServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Name = b.Name
+	x.Scope = b.Scope
+	return m0
+}
+
+// The response when fetching for an SSH server.
+type GetSSHServerResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Server        *types.ServerV2        `protobuf:"bytes,1,opt,name=server,proto3" json:"server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSSHServerResponse) Reset() {
+	*x = GetSSHServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSSHServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSSHServerResponse) ProtoMessage() {}
+
+func (x *GetSSHServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetSSHServerResponse) GetServer() *types.ServerV2 {
+	if x != nil {
+		return x.Server
+	}
+	return nil
+}
+
+func (x *GetSSHServerResponse) SetServer(v *types.ServerV2) {
+	x.Server = v
+}
+
+func (x *GetSSHServerResponse) HasServer() bool {
+	if x == nil {
+		return false
+	}
+	return x.Server != nil
+}
+
+func (x *GetSSHServerResponse) ClearServer() {
+	x.Server = nil
+}
+
+type GetSSHServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Server *types.ServerV2
+}
+
+func (b0 GetSSHServerResponse_builder) Build() *GetSSHServerResponse {
+	m0 := &GetSSHServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Server = b.Server
+	return m0
+}
+
+// The request for listing SSH servers.
+// TODO (williamo): We will eventually need to allow filtering by labels, predicate expressions, and keywords
+// if we are to replace ListResources for callers that only want SSH Servers.
+type ListSSHServersRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The maximum number of items to return.
+	// The server may impose a different page size at its discretion.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// The next_page_token value returned from a previous List request, if any.
+	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	// Filters ssh servers by scope.
+	ScopeFilter   *v1.Filter `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSSHServersRequest) Reset() {
+	*x = ListSSHServersRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSSHServersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSSHServersRequest) ProtoMessage() {}
+
+func (x *ListSSHServersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListSSHServersRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListSSHServersRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+func (x *ListSSHServersRequest) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.ScopeFilter
+	}
+	return nil
+}
+
+func (x *ListSSHServersRequest) SetPageSize(v int32) {
+	x.PageSize = v
+}
+
+func (x *ListSSHServersRequest) SetPageToken(v string) {
+	x.PageToken = v
+}
+
+func (x *ListSSHServersRequest) SetScopeFilter(v *v1.Filter) {
+	x.ScopeFilter = v
+}
+
+func (x *ListSSHServersRequest) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.ScopeFilter != nil
+}
+
+func (x *ListSSHServersRequest) ClearScopeFilter() {
+	x.ScopeFilter = nil
+}
+
+type ListSSHServersRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The maximum number of items to return.
+	// The server may impose a different page size at its discretion.
+	PageSize int32
+	// The next_page_token value returned from a previous List request, if any.
+	PageToken string
+	// Filters ssh servers by scope.
+	ScopeFilter *v1.Filter
+}
+
+func (b0 ListSSHServersRequest_builder) Build() *ListSSHServersRequest {
+	m0 := &ListSSHServersRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.PageSize = b.PageSize
+	x.PageToken = b.PageToken
+	x.ScopeFilter = b.ScopeFilter
+	return m0
+}
+
+// The response when listing SSH servers.
+type ListSSHServersResponse struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The page of ssh servers that matched the request.
+	Servers []*types.ServerV2 `protobuf:"bytes,1,rep,name=servers,proto3" json:"servers,omitempty"`
+	// Token to retrieve the next page of results, or empty if there are no
+	// more results in the list.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSSHServersResponse) Reset() {
+	*x = ListSSHServersResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSSHServersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSSHServersResponse) ProtoMessage() {}
+
+func (x *ListSSHServersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListSSHServersResponse) GetServers() []*types.ServerV2 {
+	if x != nil {
+		return x.Servers
+	}
+	return nil
+}
+
+func (x *ListSSHServersResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+func (x *ListSSHServersResponse) SetServers(v []*types.ServerV2) {
+	x.Servers = v
+}
+
+func (x *ListSSHServersResponse) SetNextPageToken(v string) {
+	x.NextPageToken = v
+}
+
+type ListSSHServersResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The page of ssh servers that matched the request.
+	Servers []*types.ServerV2
+	// Token to retrieve the next page of results, or empty if there are no
+	// more results in the list.
+	NextPageToken string
+}
+
+func (b0 ListSSHServersResponse_builder) Build() *ListSSHServersResponse {
+	m0 := &ListSSHServersResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Servers = b.Servers
+	x.NextPageToken = b.NextPageToken
+	return m0
+}
+
+// The request for deleting an SSH server.
+type DeleteSSHServerRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The name of the ssh server.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// The scoped of the ssh server
+	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSSHServerRequest) Reset() {
+	*x = DeleteSSHServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSSHServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSSHServerRequest) ProtoMessage() {}
+
+func (x *DeleteSSHServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteSSHServerRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DeleteSSHServerRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *DeleteSSHServerRequest) SetName(v string) {
+	x.Name = v
+}
+
+func (x *DeleteSSHServerRequest) SetScope(v string) {
+	x.Scope = v
+}
+
+type DeleteSSHServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the ssh server.
+	Name string
+	// The scoped of the ssh server
+	Scope string
+}
+
+func (b0 DeleteSSHServerRequest_builder) Build() *DeleteSSHServerRequest {
+	m0 := &DeleteSSHServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Name = b.Name
+	x.Scope = b.Scope
+	return m0
+}
+
+// The response when deleting an SSH server.
+type DeleteSSHServerResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSSHServerResponse) Reset() {
+	*x = DeleteSSHServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSSHServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSSHServerResponse) ProtoMessage() {}
+
+func (x *DeleteSSHServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type DeleteSSHServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 DeleteSSHServerResponse_builder) Build() *DeleteSSHServerResponse {
+	m0 := &DeleteSSHServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 var File_teleport_presence_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_presence_v1_service_proto_rawDesc = "" +
@@ -2504,7 +2954,24 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x19\n" +
-	"\x17DeleteAppServerResponse2\xc0\x10\n" +
+	"\x17DeleteAppServerResponse\"?\n" +
+	"\x13GetSSHServerRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"?\n" +
+	"\x14GetSSHServerResponse\x12'\n" +
+	"\x06server\x18\x01 \x01(\v2\x0f.types.ServerV2R\x06server\"\x92\x01\n" +
+	"\x15ListSSHServersRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\x12=\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"k\n" +
+	"\x16ListSSHServersResponse\x12)\n" +
+	"\aservers\x18\x01 \x03(\v2\x0f.types.ServerV2R\aservers\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"B\n" +
+	"\x16DeleteSSHServerRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x19\n" +
+	"\x17DeleteSSHServerResponse2\x84\x13\n" +
 	"\x0fPresenceService\x12Y\n" +
 	"\x10GetRemoteCluster\x12-.teleport.presence.v1.GetRemoteClusterRequest\x1a\x16.types.RemoteClusterV3\x12w\n" +
 	"\x12ListRemoteClusters\x12/.teleport.presence.v1.ListRemoteClustersRequest\x1a0.teleport.presence.v1.ListRemoteClustersResponse\x12_\n" +
@@ -2524,9 +2991,12 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x10ListKubeClusters\x12-.teleport.presence.v1.ListKubeClustersRequest\x1a..teleport.presence.v1.ListKubeClustersResponse\x12t\n" +
 	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12q\n" +
 	"\x10DeleteKubeServer\x12-.teleport.presence.v1.DeleteKubeServerRequest\x1a..teleport.presence.v1.DeleteKubeServerResponse\x12n\n" +
-	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
+	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponse\x12e\n" +
+	"\fGetSSHServer\x12).teleport.presence.v1.GetSSHServerRequest\x1a*.teleport.presence.v1.GetSSHServerResponse\x12k\n" +
+	"\x0eListSSHServers\x12+.teleport.presence.v1.ListSSHServersRequest\x1a,.teleport.presence.v1.ListSSHServersResponse\x12n\n" +
+	"\x0fDeleteSSHServer\x12,.teleport.presence.v1.DeleteSSHServerRequest\x1a-.teleport.presence.v1.DeleteSSHServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
 
-var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*GetRemoteClusterRequest)(nil),    // 0: teleport.presence.v1.GetRemoteClusterRequest
 	(*ListRemoteClustersRequest)(nil),  // 1: teleport.presence.v1.ListRemoteClustersRequest
@@ -2561,73 +3031,88 @@ var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*DeleteKubeServerResponse)(nil),   // 30: teleport.presence.v1.DeleteKubeServerResponse
 	(*DeleteAppServerRequest)(nil),     // 31: teleport.presence.v1.DeleteAppServerRequest
 	(*DeleteAppServerResponse)(nil),    // 32: teleport.presence.v1.DeleteAppServerResponse
-	(*types.RemoteClusterV3)(nil),      // 33: types.RemoteClusterV3
-	(*fieldmaskpb.FieldMask)(nil),      // 34: google.protobuf.FieldMask
-	(*types.ReverseTunnelV2)(nil),      // 35: types.ReverseTunnelV2
-	(*RelayServer)(nil),                // 36: teleport.presence.v1.RelayServer
-	(*types.ServerV2)(nil),             // 37: types.ServerV2
-	(*types.KubernetesClusterV3)(nil),  // 38: types.KubernetesClusterV3
-	(*v1.Filter)(nil),                  // 39: teleport.scopes.v1.Filter
-	(*emptypb.Empty)(nil),              // 40: google.protobuf.Empty
+	(*GetSSHServerRequest)(nil),        // 33: teleport.presence.v1.GetSSHServerRequest
+	(*GetSSHServerResponse)(nil),       // 34: teleport.presence.v1.GetSSHServerResponse
+	(*ListSSHServersRequest)(nil),      // 35: teleport.presence.v1.ListSSHServersRequest
+	(*ListSSHServersResponse)(nil),     // 36: teleport.presence.v1.ListSSHServersResponse
+	(*DeleteSSHServerRequest)(nil),     // 37: teleport.presence.v1.DeleteSSHServerRequest
+	(*DeleteSSHServerResponse)(nil),    // 38: teleport.presence.v1.DeleteSSHServerResponse
+	(*types.RemoteClusterV3)(nil),      // 39: types.RemoteClusterV3
+	(*fieldmaskpb.FieldMask)(nil),      // 40: google.protobuf.FieldMask
+	(*types.ReverseTunnelV2)(nil),      // 41: types.ReverseTunnelV2
+	(*RelayServer)(nil),                // 42: teleport.presence.v1.RelayServer
+	(*types.ServerV2)(nil),             // 43: types.ServerV2
+	(*types.KubernetesClusterV3)(nil),  // 44: types.KubernetesClusterV3
+	(*v1.Filter)(nil),                  // 45: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),              // 46: google.protobuf.Empty
 }
 var file_teleport_presence_v1_service_proto_depIdxs = []int32{
-	33, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
-	33, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
-	34, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
-	35, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
-	35, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
-	36, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
-	36, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
-	37, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
-	37, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
-	37, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
-	37, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
-	38, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
-	39, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
-	38, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
-	0,  // 14: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
-	1,  // 15: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
-	3,  // 16: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
-	4,  // 17: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
-	5,  // 18: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
-	7,  // 19: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
-	8,  // 20: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
-	9,  // 21: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
-	11, // 22: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
-	13, // 23: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
-	15, // 24: teleport.presence.v1.PresenceService.ListAuthServers:input_type -> teleport.presence.v1.ListAuthServersRequest
-	17, // 25: teleport.presence.v1.PresenceService.ListProxyServers:input_type -> teleport.presence.v1.ListProxyServersRequest
-	19, // 26: teleport.presence.v1.PresenceService.UpsertProxyServer:input_type -> teleport.presence.v1.UpsertProxyServerRequest
-	21, // 27: teleport.presence.v1.PresenceService.DeleteProxyServer:input_type -> teleport.presence.v1.DeleteProxyServerRequest
-	23, // 28: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
-	25, // 29: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
-	27, // 30: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
-	29, // 31: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
-	31, // 32: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
-	33, // 33: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
-	2,  // 34: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
-	33, // 35: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
-	40, // 36: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
-	6,  // 37: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
-	35, // 38: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
-	40, // 39: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
-	10, // 40: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
-	12, // 41: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
-	14, // 42: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
-	16, // 43: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
-	18, // 44: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
-	20, // 45: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
-	22, // 46: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
-	24, // 47: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
-	26, // 48: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
-	28, // 49: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
-	30, // 50: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
-	32, // 51: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
-	33, // [33:52] is the sub-list for method output_type
-	14, // [14:33] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	39, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
+	39, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
+	40, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
+	41, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
+	41, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
+	42, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
+	42, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
+	43, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
+	43, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
+	43, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
+	43, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
+	44, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
+	45, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	44, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
+	43, // 14: teleport.presence.v1.GetSSHServerResponse.server:type_name -> types.ServerV2
+	45, // 15: teleport.presence.v1.ListSSHServersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	43, // 16: teleport.presence.v1.ListSSHServersResponse.servers:type_name -> types.ServerV2
+	0,  // 17: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
+	1,  // 18: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
+	3,  // 19: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
+	4,  // 20: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
+	5,  // 21: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
+	7,  // 22: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
+	8,  // 23: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
+	9,  // 24: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
+	11, // 25: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
+	13, // 26: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
+	15, // 27: teleport.presence.v1.PresenceService.ListAuthServers:input_type -> teleport.presence.v1.ListAuthServersRequest
+	17, // 28: teleport.presence.v1.PresenceService.ListProxyServers:input_type -> teleport.presence.v1.ListProxyServersRequest
+	19, // 29: teleport.presence.v1.PresenceService.UpsertProxyServer:input_type -> teleport.presence.v1.UpsertProxyServerRequest
+	21, // 30: teleport.presence.v1.PresenceService.DeleteProxyServer:input_type -> teleport.presence.v1.DeleteProxyServerRequest
+	23, // 31: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
+	25, // 32: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
+	27, // 33: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
+	29, // 34: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
+	31, // 35: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
+	33, // 36: teleport.presence.v1.PresenceService.GetSSHServer:input_type -> teleport.presence.v1.GetSSHServerRequest
+	35, // 37: teleport.presence.v1.PresenceService.ListSSHServers:input_type -> teleport.presence.v1.ListSSHServersRequest
+	37, // 38: teleport.presence.v1.PresenceService.DeleteSSHServer:input_type -> teleport.presence.v1.DeleteSSHServerRequest
+	39, // 39: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
+	2,  // 40: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
+	39, // 41: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
+	46, // 42: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
+	6,  // 43: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
+	41, // 44: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
+	46, // 45: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
+	10, // 46: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
+	12, // 47: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
+	14, // 48: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
+	16, // 49: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
+	18, // 50: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
+	20, // 51: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
+	22, // 52: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
+	24, // 53: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
+	26, // 54: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
+	28, // 55: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
+	30, // 56: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
+	32, // 57: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
+	34, // 58: teleport.presence.v1.PresenceService.GetSSHServer:output_type -> teleport.presence.v1.GetSSHServerResponse
+	36, // 59: teleport.presence.v1.PresenceService.ListSSHServers:output_type -> teleport.presence.v1.ListSSHServersResponse
+	38, // 60: teleport.presence.v1.PresenceService.DeleteSSHServer:output_type -> teleport.presence.v1.DeleteSSHServerResponse
+	39, // [39:61] is the sub-list for method output_type
+	17, // [17:39] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_teleport_presence_v1_service_proto_init() }
@@ -2642,7 +3127,7 @@ func file_teleport_presence_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_presence_v1_service_proto_rawDesc), len(file_teleport_presence_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
@@ -2374,6 +2374,454 @@ func (b0 DeleteAppServerResponse_builder) Build() *DeleteAppServerResponse {
 	return m0
 }
 
+// The request for fetching for an SSH server.
+type GetSSHServerRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The name of the ssh server.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// The scope of the ssh server.
+	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSSHServerRequest) Reset() {
+	*x = GetSSHServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSSHServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSSHServerRequest) ProtoMessage() {}
+
+func (x *GetSSHServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetSSHServerRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *GetSSHServerRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *GetSSHServerRequest) SetName(v string) {
+	x.Name = v
+}
+
+func (x *GetSSHServerRequest) SetScope(v string) {
+	x.Scope = v
+}
+
+type GetSSHServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the ssh server.
+	Name string
+	// The scope of the ssh server.
+	Scope string
+}
+
+func (b0 GetSSHServerRequest_builder) Build() *GetSSHServerRequest {
+	m0 := &GetSSHServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Name = b.Name
+	x.Scope = b.Scope
+	return m0
+}
+
+// The response when fetching for an SSH server.
+type GetSSHServerResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Server        *types.ServerV2        `protobuf:"bytes,1,opt,name=server,proto3" json:"server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSSHServerResponse) Reset() {
+	*x = GetSSHServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSSHServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSSHServerResponse) ProtoMessage() {}
+
+func (x *GetSSHServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetSSHServerResponse) GetServer() *types.ServerV2 {
+	if x != nil {
+		return x.Server
+	}
+	return nil
+}
+
+func (x *GetSSHServerResponse) SetServer(v *types.ServerV2) {
+	x.Server = v
+}
+
+func (x *GetSSHServerResponse) HasServer() bool {
+	if x == nil {
+		return false
+	}
+	return x.Server != nil
+}
+
+func (x *GetSSHServerResponse) ClearServer() {
+	x.Server = nil
+}
+
+type GetSSHServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Server *types.ServerV2
+}
+
+func (b0 GetSSHServerResponse_builder) Build() *GetSSHServerResponse {
+	m0 := &GetSSHServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Server = b.Server
+	return m0
+}
+
+// The request for listing SSH servers.
+type ListSSHServersRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The maximum number of items to return.
+	// The server may impose a different page size at its discretion.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// The next_page_token value returned from a previous List request, if any.
+	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	// Filters ssh servers by scope.
+	ScopeFilter   *v1.Filter `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSSHServersRequest) Reset() {
+	*x = ListSSHServersRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSSHServersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSSHServersRequest) ProtoMessage() {}
+
+func (x *ListSSHServersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListSSHServersRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListSSHServersRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+func (x *ListSSHServersRequest) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.ScopeFilter
+	}
+	return nil
+}
+
+func (x *ListSSHServersRequest) SetPageSize(v int32) {
+	x.PageSize = v
+}
+
+func (x *ListSSHServersRequest) SetPageToken(v string) {
+	x.PageToken = v
+}
+
+func (x *ListSSHServersRequest) SetScopeFilter(v *v1.Filter) {
+	x.ScopeFilter = v
+}
+
+func (x *ListSSHServersRequest) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.ScopeFilter != nil
+}
+
+func (x *ListSSHServersRequest) ClearScopeFilter() {
+	x.ScopeFilter = nil
+}
+
+type ListSSHServersRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The maximum number of items to return.
+	// The server may impose a different page size at its discretion.
+	PageSize int32
+	// The next_page_token value returned from a previous List request, if any.
+	PageToken string
+	// Filters ssh servers by scope.
+	ScopeFilter *v1.Filter
+}
+
+func (b0 ListSSHServersRequest_builder) Build() *ListSSHServersRequest {
+	m0 := &ListSSHServersRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.PageSize = b.PageSize
+	x.PageToken = b.PageToken
+	x.ScopeFilter = b.ScopeFilter
+	return m0
+}
+
+// The response when listing SSH servers.
+type ListSSHServersResponse struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The page of ssh servers that matched the request.
+	Servers []*types.ServerV2 `protobuf:"bytes,1,rep,name=servers,proto3" json:"servers,omitempty"`
+	// Token to retrieve the next page of results, or empty if there are no
+	// more results in the list.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSSHServersResponse) Reset() {
+	*x = ListSSHServersResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSSHServersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSSHServersResponse) ProtoMessage() {}
+
+func (x *ListSSHServersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListSSHServersResponse) GetServers() []*types.ServerV2 {
+	if x != nil {
+		return x.Servers
+	}
+	return nil
+}
+
+func (x *ListSSHServersResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+func (x *ListSSHServersResponse) SetServers(v []*types.ServerV2) {
+	x.Servers = v
+}
+
+func (x *ListSSHServersResponse) SetNextPageToken(v string) {
+	x.NextPageToken = v
+}
+
+type ListSSHServersResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The page of ssh servers that matched the request.
+	Servers []*types.ServerV2
+	// Token to retrieve the next page of results, or empty if there are no
+	// more results in the list.
+	NextPageToken string
+}
+
+func (b0 ListSSHServersResponse_builder) Build() *ListSSHServersResponse {
+	m0 := &ListSSHServersResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Servers = b.Servers
+	x.NextPageToken = b.NextPageToken
+	return m0
+}
+
+// The request for deleting an SSH server.
+type DeleteSSHServerRequest struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The name of the ssh server.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// The scoped of the ssh server
+	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSSHServerRequest) Reset() {
+	*x = DeleteSSHServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSSHServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSSHServerRequest) ProtoMessage() {}
+
+func (x *DeleteSSHServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteSSHServerRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DeleteSSHServerRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *DeleteSSHServerRequest) SetName(v string) {
+	x.Name = v
+}
+
+func (x *DeleteSSHServerRequest) SetScope(v string) {
+	x.Scope = v
+}
+
+type DeleteSSHServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the ssh server.
+	Name string
+	// The scoped of the ssh server
+	Scope string
+}
+
+func (b0 DeleteSSHServerRequest_builder) Build() *DeleteSSHServerRequest {
+	m0 := &DeleteSSHServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Name = b.Name
+	x.Scope = b.Scope
+	return m0
+}
+
+// The response when deleting an SSH server.
+type DeleteSSHServerResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSSHServerResponse) Reset() {
+	*x = DeleteSSHServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSSHServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSSHServerResponse) ProtoMessage() {}
+
+func (x *DeleteSSHServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type DeleteSSHServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 DeleteSSHServerResponse_builder) Build() *DeleteSSHServerResponse {
+	m0 := &DeleteSSHServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 var File_teleport_presence_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_presence_v1_service_proto_rawDesc = "" +
@@ -2466,7 +2914,24 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x19\n" +
-	"\x17DeleteAppServerResponse2\xc0\x10\n" +
+	"\x17DeleteAppServerResponse\"?\n" +
+	"\x13GetSSHServerRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"?\n" +
+	"\x14GetSSHServerResponse\x12'\n" +
+	"\x06server\x18\x01 \x01(\v2\x0f.types.ServerV2R\x06server\"\x92\x01\n" +
+	"\x15ListSSHServersRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\x12=\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"k\n" +
+	"\x16ListSSHServersResponse\x12)\n" +
+	"\aservers\x18\x01 \x03(\v2\x0f.types.ServerV2R\aservers\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"B\n" +
+	"\x16DeleteSSHServerRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x19\n" +
+	"\x17DeleteSSHServerResponse2\x84\x13\n" +
 	"\x0fPresenceService\x12Y\n" +
 	"\x10GetRemoteCluster\x12-.teleport.presence.v1.GetRemoteClusterRequest\x1a\x16.types.RemoteClusterV3\x12w\n" +
 	"\x12ListRemoteClusters\x12/.teleport.presence.v1.ListRemoteClustersRequest\x1a0.teleport.presence.v1.ListRemoteClustersResponse\x12_\n" +
@@ -2486,9 +2951,12 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x10ListKubeClusters\x12-.teleport.presence.v1.ListKubeClustersRequest\x1a..teleport.presence.v1.ListKubeClustersResponse\x12t\n" +
 	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12q\n" +
 	"\x10DeleteKubeServer\x12-.teleport.presence.v1.DeleteKubeServerRequest\x1a..teleport.presence.v1.DeleteKubeServerResponse\x12n\n" +
-	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
+	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponse\x12e\n" +
+	"\fGetSSHServer\x12).teleport.presence.v1.GetSSHServerRequest\x1a*.teleport.presence.v1.GetSSHServerResponse\x12k\n" +
+	"\x0eListSSHServers\x12+.teleport.presence.v1.ListSSHServersRequest\x1a,.teleport.presence.v1.ListSSHServersResponse\x12n\n" +
+	"\x0fDeleteSSHServer\x12,.teleport.presence.v1.DeleteSSHServerRequest\x1a-.teleport.presence.v1.DeleteSSHServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
 
-var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*GetRemoteClusterRequest)(nil),    // 0: teleport.presence.v1.GetRemoteClusterRequest
 	(*ListRemoteClustersRequest)(nil),  // 1: teleport.presence.v1.ListRemoteClustersRequest
@@ -2523,73 +2991,88 @@ var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*DeleteKubeServerResponse)(nil),   // 30: teleport.presence.v1.DeleteKubeServerResponse
 	(*DeleteAppServerRequest)(nil),     // 31: teleport.presence.v1.DeleteAppServerRequest
 	(*DeleteAppServerResponse)(nil),    // 32: teleport.presence.v1.DeleteAppServerResponse
-	(*types.RemoteClusterV3)(nil),      // 33: types.RemoteClusterV3
-	(*fieldmaskpb.FieldMask)(nil),      // 34: google.protobuf.FieldMask
-	(*types.ReverseTunnelV2)(nil),      // 35: types.ReverseTunnelV2
-	(*RelayServer)(nil),                // 36: teleport.presence.v1.RelayServer
-	(*types.ServerV2)(nil),             // 37: types.ServerV2
-	(*types.KubernetesClusterV3)(nil),  // 38: types.KubernetesClusterV3
-	(*v1.Filter)(nil),                  // 39: teleport.scopes.v1.Filter
-	(*emptypb.Empty)(nil),              // 40: google.protobuf.Empty
+	(*GetSSHServerRequest)(nil),        // 33: teleport.presence.v1.GetSSHServerRequest
+	(*GetSSHServerResponse)(nil),       // 34: teleport.presence.v1.GetSSHServerResponse
+	(*ListSSHServersRequest)(nil),      // 35: teleport.presence.v1.ListSSHServersRequest
+	(*ListSSHServersResponse)(nil),     // 36: teleport.presence.v1.ListSSHServersResponse
+	(*DeleteSSHServerRequest)(nil),     // 37: teleport.presence.v1.DeleteSSHServerRequest
+	(*DeleteSSHServerResponse)(nil),    // 38: teleport.presence.v1.DeleteSSHServerResponse
+	(*types.RemoteClusterV3)(nil),      // 39: types.RemoteClusterV3
+	(*fieldmaskpb.FieldMask)(nil),      // 40: google.protobuf.FieldMask
+	(*types.ReverseTunnelV2)(nil),      // 41: types.ReverseTunnelV2
+	(*RelayServer)(nil),                // 42: teleport.presence.v1.RelayServer
+	(*types.ServerV2)(nil),             // 43: types.ServerV2
+	(*types.KubernetesClusterV3)(nil),  // 44: types.KubernetesClusterV3
+	(*v1.Filter)(nil),                  // 45: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),              // 46: google.protobuf.Empty
 }
 var file_teleport_presence_v1_service_proto_depIdxs = []int32{
-	33, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
-	33, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
-	34, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
-	35, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
-	35, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
-	36, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
-	36, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
-	37, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
-	37, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
-	37, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
-	37, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
-	38, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
-	39, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
-	38, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
-	0,  // 14: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
-	1,  // 15: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
-	3,  // 16: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
-	4,  // 17: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
-	5,  // 18: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
-	7,  // 19: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
-	8,  // 20: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
-	9,  // 21: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
-	11, // 22: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
-	13, // 23: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
-	15, // 24: teleport.presence.v1.PresenceService.ListAuthServers:input_type -> teleport.presence.v1.ListAuthServersRequest
-	17, // 25: teleport.presence.v1.PresenceService.ListProxyServers:input_type -> teleport.presence.v1.ListProxyServersRequest
-	19, // 26: teleport.presence.v1.PresenceService.UpsertProxyServer:input_type -> teleport.presence.v1.UpsertProxyServerRequest
-	21, // 27: teleport.presence.v1.PresenceService.DeleteProxyServer:input_type -> teleport.presence.v1.DeleteProxyServerRequest
-	23, // 28: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
-	25, // 29: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
-	27, // 30: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
-	29, // 31: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
-	31, // 32: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
-	33, // 33: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
-	2,  // 34: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
-	33, // 35: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
-	40, // 36: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
-	6,  // 37: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
-	35, // 38: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
-	40, // 39: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
-	10, // 40: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
-	12, // 41: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
-	14, // 42: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
-	16, // 43: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
-	18, // 44: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
-	20, // 45: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
-	22, // 46: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
-	24, // 47: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
-	26, // 48: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
-	28, // 49: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
-	30, // 50: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
-	32, // 51: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
-	33, // [33:52] is the sub-list for method output_type
-	14, // [14:33] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	39, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
+	39, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
+	40, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
+	41, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
+	41, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
+	42, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
+	42, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
+	43, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
+	43, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
+	43, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
+	43, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
+	44, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
+	45, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	44, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
+	43, // 14: teleport.presence.v1.GetSSHServerResponse.server:type_name -> types.ServerV2
+	45, // 15: teleport.presence.v1.ListSSHServersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	43, // 16: teleport.presence.v1.ListSSHServersResponse.servers:type_name -> types.ServerV2
+	0,  // 17: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
+	1,  // 18: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
+	3,  // 19: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
+	4,  // 20: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
+	5,  // 21: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
+	7,  // 22: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
+	8,  // 23: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
+	9,  // 24: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
+	11, // 25: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
+	13, // 26: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
+	15, // 27: teleport.presence.v1.PresenceService.ListAuthServers:input_type -> teleport.presence.v1.ListAuthServersRequest
+	17, // 28: teleport.presence.v1.PresenceService.ListProxyServers:input_type -> teleport.presence.v1.ListProxyServersRequest
+	19, // 29: teleport.presence.v1.PresenceService.UpsertProxyServer:input_type -> teleport.presence.v1.UpsertProxyServerRequest
+	21, // 30: teleport.presence.v1.PresenceService.DeleteProxyServer:input_type -> teleport.presence.v1.DeleteProxyServerRequest
+	23, // 31: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
+	25, // 32: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
+	27, // 33: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
+	29, // 34: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
+	31, // 35: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
+	33, // 36: teleport.presence.v1.PresenceService.GetSSHServer:input_type -> teleport.presence.v1.GetSSHServerRequest
+	35, // 37: teleport.presence.v1.PresenceService.ListSSHServers:input_type -> teleport.presence.v1.ListSSHServersRequest
+	37, // 38: teleport.presence.v1.PresenceService.DeleteSSHServer:input_type -> teleport.presence.v1.DeleteSSHServerRequest
+	39, // 39: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
+	2,  // 40: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
+	39, // 41: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
+	46, // 42: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
+	6,  // 43: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
+	41, // 44: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
+	46, // 45: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
+	10, // 46: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
+	12, // 47: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
+	14, // 48: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
+	16, // 49: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
+	18, // 50: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
+	20, // 51: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
+	22, // 52: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
+	24, // 53: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
+	26, // 54: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
+	28, // 55: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
+	30, // 56: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
+	32, // 57: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
+	34, // 58: teleport.presence.v1.PresenceService.GetSSHServer:output_type -> teleport.presence.v1.GetSSHServerResponse
+	36, // 59: teleport.presence.v1.PresenceService.ListSSHServers:output_type -> teleport.presence.v1.ListSSHServersResponse
+	38, // 60: teleport.presence.v1.PresenceService.DeleteSSHServer:output_type -> teleport.presence.v1.DeleteSSHServerResponse
+	39, // [39:61] is the sub-list for method output_type
+	17, // [17:39] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_teleport_presence_v1_service_proto_init() }
@@ -2604,7 +3087,7 @@ func file_teleport_presence_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_presence_v1_service_proto_rawDesc), len(file_teleport_presence_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
@@ -2325,6 +2325,445 @@ func (b0 DeleteAppServerResponse_builder) Build() *DeleteAppServerResponse {
 	return m0
 }
 
+// The request for fetching for an SSH server.
+type GetSSHServerRequest struct {
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name  string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Scope string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GetSSHServerRequest) Reset() {
+	*x = GetSSHServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSSHServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSSHServerRequest) ProtoMessage() {}
+
+func (x *GetSSHServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetSSHServerRequest) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *GetSSHServerRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
+func (x *GetSSHServerRequest) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *GetSSHServerRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
+}
+
+type GetSSHServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the ssh server.
+	Name string
+	// The scope of the ssh server.
+	Scope string
+}
+
+func (b0 GetSSHServerRequest_builder) Build() *GetSSHServerRequest {
+	m0 := &GetSSHServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Scope = b.Scope
+	return m0
+}
+
+// The response when fetching for an SSH server.
+type GetSSHServerResponse struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Server *types.ServerV2        `protobuf:"bytes,1,opt,name=server,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GetSSHServerResponse) Reset() {
+	*x = GetSSHServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSSHServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSSHServerResponse) ProtoMessage() {}
+
+func (x *GetSSHServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetSSHServerResponse) GetServer() *types.ServerV2 {
+	if x != nil {
+		return x.xxx_hidden_Server
+	}
+	return nil
+}
+
+func (x *GetSSHServerResponse) SetServer(v *types.ServerV2) {
+	x.xxx_hidden_Server = v
+}
+
+func (x *GetSSHServerResponse) HasServer() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Server != nil
+}
+
+func (x *GetSSHServerResponse) ClearServer() {
+	x.xxx_hidden_Server = nil
+}
+
+type GetSSHServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Server *types.ServerV2
+}
+
+func (b0 GetSSHServerResponse_builder) Build() *GetSSHServerResponse {
+	m0 := &GetSSHServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Server = b.Server
+	return m0
+}
+
+// The request for listing SSH servers.
+type ListSSHServersRequest struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PageSize    int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
+	xxx_hidden_PageToken   string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3"`
+	xxx_hidden_ScopeFilter *v1.Filter             `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *ListSSHServersRequest) Reset() {
+	*x = ListSSHServersRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSSHServersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSSHServersRequest) ProtoMessage() {}
+
+func (x *ListSSHServersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListSSHServersRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.xxx_hidden_PageSize
+	}
+	return 0
+}
+
+func (x *ListSSHServersRequest) GetPageToken() string {
+	if x != nil {
+		return x.xxx_hidden_PageToken
+	}
+	return ""
+}
+
+func (x *ListSSHServersRequest) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.xxx_hidden_ScopeFilter
+	}
+	return nil
+}
+
+func (x *ListSSHServersRequest) SetPageSize(v int32) {
+	x.xxx_hidden_PageSize = v
+}
+
+func (x *ListSSHServersRequest) SetPageToken(v string) {
+	x.xxx_hidden_PageToken = v
+}
+
+func (x *ListSSHServersRequest) SetScopeFilter(v *v1.Filter) {
+	x.xxx_hidden_ScopeFilter = v
+}
+
+func (x *ListSSHServersRequest) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ScopeFilter != nil
+}
+
+func (x *ListSSHServersRequest) ClearScopeFilter() {
+	x.xxx_hidden_ScopeFilter = nil
+}
+
+type ListSSHServersRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The maximum number of items to return.
+	// The server may impose a different page size at its discretion.
+	PageSize int32
+	// The next_page_token value returned from a previous List request, if any.
+	PageToken string
+	// Filters ssh servers by scope.
+	ScopeFilter *v1.Filter
+}
+
+func (b0 ListSSHServersRequest_builder) Build() *ListSSHServersRequest {
+	m0 := &ListSSHServersRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_PageSize = b.PageSize
+	x.xxx_hidden_PageToken = b.PageToken
+	x.xxx_hidden_ScopeFilter = b.ScopeFilter
+	return m0
+}
+
+// The response when listing SSH servers.
+type ListSSHServersResponse struct {
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Servers       *[]*types.ServerV2     `protobuf:"bytes,1,rep,name=servers,proto3"`
+	xxx_hidden_NextPageToken string                 `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *ListSSHServersResponse) Reset() {
+	*x = ListSSHServersResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSSHServersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSSHServersResponse) ProtoMessage() {}
+
+func (x *ListSSHServersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListSSHServersResponse) GetServers() []*types.ServerV2 {
+	if x != nil {
+		if x.xxx_hidden_Servers != nil {
+			return *x.xxx_hidden_Servers
+		}
+	}
+	return nil
+}
+
+func (x *ListSSHServersResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.xxx_hidden_NextPageToken
+	}
+	return ""
+}
+
+func (x *ListSSHServersResponse) SetServers(v []*types.ServerV2) {
+	x.xxx_hidden_Servers = &v
+}
+
+func (x *ListSSHServersResponse) SetNextPageToken(v string) {
+	x.xxx_hidden_NextPageToken = v
+}
+
+type ListSSHServersResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The page of ssh servers that matched the request.
+	Servers []*types.ServerV2
+	// Token to retrieve the next page of results, or empty if there are no
+	// more results in the list.
+	NextPageToken string
+}
+
+func (b0 ListSSHServersResponse_builder) Build() *ListSSHServersResponse {
+	m0 := &ListSSHServersResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Servers = &b.Servers
+	x.xxx_hidden_NextPageToken = b.NextPageToken
+	return m0
+}
+
+// The request for deleting an SSH server.
+type DeleteSSHServerRequest struct {
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name  string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Scope string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *DeleteSSHServerRequest) Reset() {
+	*x = DeleteSSHServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSSHServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSSHServerRequest) ProtoMessage() {}
+
+func (x *DeleteSSHServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteSSHServerRequest) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *DeleteSSHServerRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
+func (x *DeleteSSHServerRequest) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *DeleteSSHServerRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
+}
+
+type DeleteSSHServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the ssh server.
+	Name string
+	// The scoped of the ssh server
+	Scope string
+}
+
+func (b0 DeleteSSHServerRequest_builder) Build() *DeleteSSHServerRequest {
+	m0 := &DeleteSSHServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Scope = b.Scope
+	return m0
+}
+
+// The response when deleting an SSH server.
+type DeleteSSHServerResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSSHServerResponse) Reset() {
+	*x = DeleteSSHServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSSHServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSSHServerResponse) ProtoMessage() {}
+
+func (x *DeleteSSHServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type DeleteSSHServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 DeleteSSHServerResponse_builder) Build() *DeleteSSHServerResponse {
+	m0 := &DeleteSSHServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 var File_teleport_presence_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_presence_v1_service_proto_rawDesc = "" +
@@ -2417,7 +2856,24 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x19\n" +
-	"\x17DeleteAppServerResponse2\xc0\x10\n" +
+	"\x17DeleteAppServerResponse\"?\n" +
+	"\x13GetSSHServerRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"?\n" +
+	"\x14GetSSHServerResponse\x12'\n" +
+	"\x06server\x18\x01 \x01(\v2\x0f.types.ServerV2R\x06server\"\x92\x01\n" +
+	"\x15ListSSHServersRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\x12=\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"k\n" +
+	"\x16ListSSHServersResponse\x12)\n" +
+	"\aservers\x18\x01 \x03(\v2\x0f.types.ServerV2R\aservers\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"B\n" +
+	"\x16DeleteSSHServerRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x19\n" +
+	"\x17DeleteSSHServerResponse2\x84\x13\n" +
 	"\x0fPresenceService\x12Y\n" +
 	"\x10GetRemoteCluster\x12-.teleport.presence.v1.GetRemoteClusterRequest\x1a\x16.types.RemoteClusterV3\x12w\n" +
 	"\x12ListRemoteClusters\x12/.teleport.presence.v1.ListRemoteClustersRequest\x1a0.teleport.presence.v1.ListRemoteClustersResponse\x12_\n" +
@@ -2437,9 +2893,12 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x10ListKubeClusters\x12-.teleport.presence.v1.ListKubeClustersRequest\x1a..teleport.presence.v1.ListKubeClustersResponse\x12t\n" +
 	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12q\n" +
 	"\x10DeleteKubeServer\x12-.teleport.presence.v1.DeleteKubeServerRequest\x1a..teleport.presence.v1.DeleteKubeServerResponse\x12n\n" +
-	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
+	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponse\x12e\n" +
+	"\fGetSSHServer\x12).teleport.presence.v1.GetSSHServerRequest\x1a*.teleport.presence.v1.GetSSHServerResponse\x12k\n" +
+	"\x0eListSSHServers\x12+.teleport.presence.v1.ListSSHServersRequest\x1a,.teleport.presence.v1.ListSSHServersResponse\x12n\n" +
+	"\x0fDeleteSSHServer\x12,.teleport.presence.v1.DeleteSSHServerRequest\x1a-.teleport.presence.v1.DeleteSSHServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
 
-var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*GetRemoteClusterRequest)(nil),    // 0: teleport.presence.v1.GetRemoteClusterRequest
 	(*ListRemoteClustersRequest)(nil),  // 1: teleport.presence.v1.ListRemoteClustersRequest
@@ -2474,73 +2933,88 @@ var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*DeleteKubeServerResponse)(nil),   // 30: teleport.presence.v1.DeleteKubeServerResponse
 	(*DeleteAppServerRequest)(nil),     // 31: teleport.presence.v1.DeleteAppServerRequest
 	(*DeleteAppServerResponse)(nil),    // 32: teleport.presence.v1.DeleteAppServerResponse
-	(*types.RemoteClusterV3)(nil),      // 33: types.RemoteClusterV3
-	(*fieldmaskpb.FieldMask)(nil),      // 34: google.protobuf.FieldMask
-	(*types.ReverseTunnelV2)(nil),      // 35: types.ReverseTunnelV2
-	(*RelayServer)(nil),                // 36: teleport.presence.v1.RelayServer
-	(*types.ServerV2)(nil),             // 37: types.ServerV2
-	(*types.KubernetesClusterV3)(nil),  // 38: types.KubernetesClusterV3
-	(*v1.Filter)(nil),                  // 39: teleport.scopes.v1.Filter
-	(*emptypb.Empty)(nil),              // 40: google.protobuf.Empty
+	(*GetSSHServerRequest)(nil),        // 33: teleport.presence.v1.GetSSHServerRequest
+	(*GetSSHServerResponse)(nil),       // 34: teleport.presence.v1.GetSSHServerResponse
+	(*ListSSHServersRequest)(nil),      // 35: teleport.presence.v1.ListSSHServersRequest
+	(*ListSSHServersResponse)(nil),     // 36: teleport.presence.v1.ListSSHServersResponse
+	(*DeleteSSHServerRequest)(nil),     // 37: teleport.presence.v1.DeleteSSHServerRequest
+	(*DeleteSSHServerResponse)(nil),    // 38: teleport.presence.v1.DeleteSSHServerResponse
+	(*types.RemoteClusterV3)(nil),      // 39: types.RemoteClusterV3
+	(*fieldmaskpb.FieldMask)(nil),      // 40: google.protobuf.FieldMask
+	(*types.ReverseTunnelV2)(nil),      // 41: types.ReverseTunnelV2
+	(*RelayServer)(nil),                // 42: teleport.presence.v1.RelayServer
+	(*types.ServerV2)(nil),             // 43: types.ServerV2
+	(*types.KubernetesClusterV3)(nil),  // 44: types.KubernetesClusterV3
+	(*v1.Filter)(nil),                  // 45: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),              // 46: google.protobuf.Empty
 }
 var file_teleport_presence_v1_service_proto_depIdxs = []int32{
-	33, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
-	33, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
-	34, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
-	35, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
-	35, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
-	36, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
-	36, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
-	37, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
-	37, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
-	37, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
-	37, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
-	38, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
-	39, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
-	38, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
-	0,  // 14: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
-	1,  // 15: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
-	3,  // 16: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
-	4,  // 17: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
-	5,  // 18: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
-	7,  // 19: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
-	8,  // 20: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
-	9,  // 21: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
-	11, // 22: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
-	13, // 23: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
-	15, // 24: teleport.presence.v1.PresenceService.ListAuthServers:input_type -> teleport.presence.v1.ListAuthServersRequest
-	17, // 25: teleport.presence.v1.PresenceService.ListProxyServers:input_type -> teleport.presence.v1.ListProxyServersRequest
-	19, // 26: teleport.presence.v1.PresenceService.UpsertProxyServer:input_type -> teleport.presence.v1.UpsertProxyServerRequest
-	21, // 27: teleport.presence.v1.PresenceService.DeleteProxyServer:input_type -> teleport.presence.v1.DeleteProxyServerRequest
-	23, // 28: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
-	25, // 29: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
-	27, // 30: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
-	29, // 31: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
-	31, // 32: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
-	33, // 33: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
-	2,  // 34: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
-	33, // 35: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
-	40, // 36: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
-	6,  // 37: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
-	35, // 38: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
-	40, // 39: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
-	10, // 40: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
-	12, // 41: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
-	14, // 42: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
-	16, // 43: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
-	18, // 44: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
-	20, // 45: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
-	22, // 46: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
-	24, // 47: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
-	26, // 48: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
-	28, // 49: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
-	30, // 50: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
-	32, // 51: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
-	33, // [33:52] is the sub-list for method output_type
-	14, // [14:33] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	39, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
+	39, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
+	40, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
+	41, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
+	41, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
+	42, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
+	42, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
+	43, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
+	43, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
+	43, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
+	43, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
+	44, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
+	45, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	44, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
+	43, // 14: teleport.presence.v1.GetSSHServerResponse.server:type_name -> types.ServerV2
+	45, // 15: teleport.presence.v1.ListSSHServersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	43, // 16: teleport.presence.v1.ListSSHServersResponse.servers:type_name -> types.ServerV2
+	0,  // 17: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
+	1,  // 18: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
+	3,  // 19: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
+	4,  // 20: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
+	5,  // 21: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
+	7,  // 22: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
+	8,  // 23: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
+	9,  // 24: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
+	11, // 25: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
+	13, // 26: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
+	15, // 27: teleport.presence.v1.PresenceService.ListAuthServers:input_type -> teleport.presence.v1.ListAuthServersRequest
+	17, // 28: teleport.presence.v1.PresenceService.ListProxyServers:input_type -> teleport.presence.v1.ListProxyServersRequest
+	19, // 29: teleport.presence.v1.PresenceService.UpsertProxyServer:input_type -> teleport.presence.v1.UpsertProxyServerRequest
+	21, // 30: teleport.presence.v1.PresenceService.DeleteProxyServer:input_type -> teleport.presence.v1.DeleteProxyServerRequest
+	23, // 31: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
+	25, // 32: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
+	27, // 33: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
+	29, // 34: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
+	31, // 35: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
+	33, // 36: teleport.presence.v1.PresenceService.GetSSHServer:input_type -> teleport.presence.v1.GetSSHServerRequest
+	35, // 37: teleport.presence.v1.PresenceService.ListSSHServers:input_type -> teleport.presence.v1.ListSSHServersRequest
+	37, // 38: teleport.presence.v1.PresenceService.DeleteSSHServer:input_type -> teleport.presence.v1.DeleteSSHServerRequest
+	39, // 39: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
+	2,  // 40: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
+	39, // 41: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
+	46, // 42: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
+	6,  // 43: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
+	41, // 44: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
+	46, // 45: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
+	10, // 46: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
+	12, // 47: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
+	14, // 48: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
+	16, // 49: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
+	18, // 50: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
+	20, // 51: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
+	22, // 52: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
+	24, // 53: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
+	26, // 54: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
+	28, // 55: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
+	30, // 56: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
+	32, // 57: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
+	34, // 58: teleport.presence.v1.PresenceService.GetSSHServer:output_type -> teleport.presence.v1.GetSSHServerResponse
+	36, // 59: teleport.presence.v1.PresenceService.ListSSHServers:output_type -> teleport.presence.v1.ListSSHServersResponse
+	38, // 60: teleport.presence.v1.PresenceService.DeleteSSHServer:output_type -> teleport.presence.v1.DeleteSSHServerResponse
+	39, // [39:61] is the sub-list for method output_type
+	17, // [17:39] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_teleport_presence_v1_service_proto_init() }
@@ -2555,7 +3029,7 @@ func file_teleport_presence_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_presence_v1_service_proto_rawDesc), len(file_teleport_presence_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
@@ -2357,6 +2357,447 @@ func (b0 DeleteAppServerResponse_builder) Build() *DeleteAppServerResponse {
 	return m0
 }
 
+// The request for fetching for an SSH server.
+type GetSSHServerRequest struct {
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name  string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Scope string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GetSSHServerRequest) Reset() {
+	*x = GetSSHServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSSHServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSSHServerRequest) ProtoMessage() {}
+
+func (x *GetSSHServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetSSHServerRequest) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *GetSSHServerRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
+func (x *GetSSHServerRequest) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *GetSSHServerRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
+}
+
+type GetSSHServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the ssh server.
+	Name string
+	// The scope of the ssh server.
+	Scope string
+}
+
+func (b0 GetSSHServerRequest_builder) Build() *GetSSHServerRequest {
+	m0 := &GetSSHServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Scope = b.Scope
+	return m0
+}
+
+// The response when fetching for an SSH server.
+type GetSSHServerResponse struct {
+	state             protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Server *types.ServerV2        `protobuf:"bytes,1,opt,name=server,proto3"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GetSSHServerResponse) Reset() {
+	*x = GetSSHServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSSHServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSSHServerResponse) ProtoMessage() {}
+
+func (x *GetSSHServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *GetSSHServerResponse) GetServer() *types.ServerV2 {
+	if x != nil {
+		return x.xxx_hidden_Server
+	}
+	return nil
+}
+
+func (x *GetSSHServerResponse) SetServer(v *types.ServerV2) {
+	x.xxx_hidden_Server = v
+}
+
+func (x *GetSSHServerResponse) HasServer() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Server != nil
+}
+
+func (x *GetSSHServerResponse) ClearServer() {
+	x.xxx_hidden_Server = nil
+}
+
+type GetSSHServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Server *types.ServerV2
+}
+
+func (b0 GetSSHServerResponse_builder) Build() *GetSSHServerResponse {
+	m0 := &GetSSHServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Server = b.Server
+	return m0
+}
+
+// The request for listing SSH servers.
+// TODO (williamo): We will eventually need to allow filtering by labels, predicate expressions, and keywords
+// if we are to replace ListResources for callers that only want SSH Servers.
+type ListSSHServersRequest struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PageSize    int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
+	xxx_hidden_PageToken   string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3"`
+	xxx_hidden_ScopeFilter *v1.Filter             `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *ListSSHServersRequest) Reset() {
+	*x = ListSSHServersRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSSHServersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSSHServersRequest) ProtoMessage() {}
+
+func (x *ListSSHServersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListSSHServersRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.xxx_hidden_PageSize
+	}
+	return 0
+}
+
+func (x *ListSSHServersRequest) GetPageToken() string {
+	if x != nil {
+		return x.xxx_hidden_PageToken
+	}
+	return ""
+}
+
+func (x *ListSSHServersRequest) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.xxx_hidden_ScopeFilter
+	}
+	return nil
+}
+
+func (x *ListSSHServersRequest) SetPageSize(v int32) {
+	x.xxx_hidden_PageSize = v
+}
+
+func (x *ListSSHServersRequest) SetPageToken(v string) {
+	x.xxx_hidden_PageToken = v
+}
+
+func (x *ListSSHServersRequest) SetScopeFilter(v *v1.Filter) {
+	x.xxx_hidden_ScopeFilter = v
+}
+
+func (x *ListSSHServersRequest) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ScopeFilter != nil
+}
+
+func (x *ListSSHServersRequest) ClearScopeFilter() {
+	x.xxx_hidden_ScopeFilter = nil
+}
+
+type ListSSHServersRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The maximum number of items to return.
+	// The server may impose a different page size at its discretion.
+	PageSize int32
+	// The next_page_token value returned from a previous List request, if any.
+	PageToken string
+	// Filters ssh servers by scope.
+	ScopeFilter *v1.Filter
+}
+
+func (b0 ListSSHServersRequest_builder) Build() *ListSSHServersRequest {
+	m0 := &ListSSHServersRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_PageSize = b.PageSize
+	x.xxx_hidden_PageToken = b.PageToken
+	x.xxx_hidden_ScopeFilter = b.ScopeFilter
+	return m0
+}
+
+// The response when listing SSH servers.
+type ListSSHServersResponse struct {
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Servers       *[]*types.ServerV2     `protobuf:"bytes,1,rep,name=servers,proto3"`
+	xxx_hidden_NextPageToken string                 `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *ListSSHServersResponse) Reset() {
+	*x = ListSSHServersResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSSHServersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSSHServersResponse) ProtoMessage() {}
+
+func (x *ListSSHServersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListSSHServersResponse) GetServers() []*types.ServerV2 {
+	if x != nil {
+		if x.xxx_hidden_Servers != nil {
+			return *x.xxx_hidden_Servers
+		}
+	}
+	return nil
+}
+
+func (x *ListSSHServersResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.xxx_hidden_NextPageToken
+	}
+	return ""
+}
+
+func (x *ListSSHServersResponse) SetServers(v []*types.ServerV2) {
+	x.xxx_hidden_Servers = &v
+}
+
+func (x *ListSSHServersResponse) SetNextPageToken(v string) {
+	x.xxx_hidden_NextPageToken = v
+}
+
+type ListSSHServersResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The page of ssh servers that matched the request.
+	Servers []*types.ServerV2
+	// Token to retrieve the next page of results, or empty if there are no
+	// more results in the list.
+	NextPageToken string
+}
+
+func (b0 ListSSHServersResponse_builder) Build() *ListSSHServersResponse {
+	m0 := &ListSSHServersResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Servers = &b.Servers
+	x.xxx_hidden_NextPageToken = b.NextPageToken
+	return m0
+}
+
+// The request for deleting an SSH server.
+type DeleteSSHServerRequest struct {
+	state            protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name  string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Scope string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *DeleteSSHServerRequest) Reset() {
+	*x = DeleteSSHServerRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSSHServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSSHServerRequest) ProtoMessage() {}
+
+func (x *DeleteSSHServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *DeleteSSHServerRequest) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *DeleteSSHServerRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
+func (x *DeleteSSHServerRequest) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *DeleteSSHServerRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
+}
+
+type DeleteSSHServerRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The name of the ssh server.
+	Name string
+	// The scoped of the ssh server
+	Scope string
+}
+
+func (b0 DeleteSSHServerRequest_builder) Build() *DeleteSSHServerRequest {
+	m0 := &DeleteSSHServerRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_Scope = b.Scope
+	return m0
+}
+
+// The response when deleting an SSH server.
+type DeleteSSHServerResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSSHServerResponse) Reset() {
+	*x = DeleteSSHServerResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSSHServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSSHServerResponse) ProtoMessage() {}
+
+func (x *DeleteSSHServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type DeleteSSHServerResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 DeleteSSHServerResponse_builder) Build() *DeleteSSHServerResponse {
+	m0 := &DeleteSSHServerResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 var File_teleport_presence_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_presence_v1_service_proto_rawDesc = "" +
@@ -2451,7 +2892,24 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
 	"\x05scope\x18\x03 \x01(\tR\x05scope\"\x19\n" +
-	"\x17DeleteAppServerResponse2\xc0\x10\n" +
+	"\x17DeleteAppServerResponse\"?\n" +
+	"\x13GetSSHServerRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"?\n" +
+	"\x14GetSSHServerResponse\x12'\n" +
+	"\x06server\x18\x01 \x01(\v2\x0f.types.ServerV2R\x06server\"\x92\x01\n" +
+	"\x15ListSSHServersRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\x12=\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"k\n" +
+	"\x16ListSSHServersResponse\x12)\n" +
+	"\aservers\x18\x01 \x03(\v2\x0f.types.ServerV2R\aservers\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"B\n" +
+	"\x16DeleteSSHServerRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"\x19\n" +
+	"\x17DeleteSSHServerResponse2\x84\x13\n" +
 	"\x0fPresenceService\x12Y\n" +
 	"\x10GetRemoteCluster\x12-.teleport.presence.v1.GetRemoteClusterRequest\x1a\x16.types.RemoteClusterV3\x12w\n" +
 	"\x12ListRemoteClusters\x12/.teleport.presence.v1.ListRemoteClustersRequest\x1a0.teleport.presence.v1.ListRemoteClustersResponse\x12_\n" +
@@ -2471,9 +2929,12 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x10ListKubeClusters\x12-.teleport.presence.v1.ListKubeClustersRequest\x1a..teleport.presence.v1.ListKubeClustersResponse\x12t\n" +
 	"\x11DeleteKubeCluster\x12..teleport.presence.v1.DeleteKubeClusterRequest\x1a/.teleport.presence.v1.DeleteKubeClusterResponse\x12q\n" +
 	"\x10DeleteKubeServer\x12-.teleport.presence.v1.DeleteKubeServerRequest\x1a..teleport.presence.v1.DeleteKubeServerResponse\x12n\n" +
-	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
+	"\x0fDeleteAppServer\x12,.teleport.presence.v1.DeleteAppServerRequest\x1a-.teleport.presence.v1.DeleteAppServerResponse\x12e\n" +
+	"\fGetSSHServer\x12).teleport.presence.v1.GetSSHServerRequest\x1a*.teleport.presence.v1.GetSSHServerResponse\x12k\n" +
+	"\x0eListSSHServers\x12+.teleport.presence.v1.ListSSHServersRequest\x1a,.teleport.presence.v1.ListSSHServersResponse\x12n\n" +
+	"\x0fDeleteSSHServer\x12,.teleport.presence.v1.DeleteSSHServerRequest\x1a-.teleport.presence.v1.DeleteSSHServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
 
-var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*GetRemoteClusterRequest)(nil),    // 0: teleport.presence.v1.GetRemoteClusterRequest
 	(*ListRemoteClustersRequest)(nil),  // 1: teleport.presence.v1.ListRemoteClustersRequest
@@ -2508,73 +2969,88 @@ var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*DeleteKubeServerResponse)(nil),   // 30: teleport.presence.v1.DeleteKubeServerResponse
 	(*DeleteAppServerRequest)(nil),     // 31: teleport.presence.v1.DeleteAppServerRequest
 	(*DeleteAppServerResponse)(nil),    // 32: teleport.presence.v1.DeleteAppServerResponse
-	(*types.RemoteClusterV3)(nil),      // 33: types.RemoteClusterV3
-	(*fieldmaskpb.FieldMask)(nil),      // 34: google.protobuf.FieldMask
-	(*types.ReverseTunnelV2)(nil),      // 35: types.ReverseTunnelV2
-	(*RelayServer)(nil),                // 36: teleport.presence.v1.RelayServer
-	(*types.ServerV2)(nil),             // 37: types.ServerV2
-	(*types.KubernetesClusterV3)(nil),  // 38: types.KubernetesClusterV3
-	(*v1.Filter)(nil),                  // 39: teleport.scopes.v1.Filter
-	(*emptypb.Empty)(nil),              // 40: google.protobuf.Empty
+	(*GetSSHServerRequest)(nil),        // 33: teleport.presence.v1.GetSSHServerRequest
+	(*GetSSHServerResponse)(nil),       // 34: teleport.presence.v1.GetSSHServerResponse
+	(*ListSSHServersRequest)(nil),      // 35: teleport.presence.v1.ListSSHServersRequest
+	(*ListSSHServersResponse)(nil),     // 36: teleport.presence.v1.ListSSHServersResponse
+	(*DeleteSSHServerRequest)(nil),     // 37: teleport.presence.v1.DeleteSSHServerRequest
+	(*DeleteSSHServerResponse)(nil),    // 38: teleport.presence.v1.DeleteSSHServerResponse
+	(*types.RemoteClusterV3)(nil),      // 39: types.RemoteClusterV3
+	(*fieldmaskpb.FieldMask)(nil),      // 40: google.protobuf.FieldMask
+	(*types.ReverseTunnelV2)(nil),      // 41: types.ReverseTunnelV2
+	(*RelayServer)(nil),                // 42: teleport.presence.v1.RelayServer
+	(*types.ServerV2)(nil),             // 43: types.ServerV2
+	(*types.KubernetesClusterV3)(nil),  // 44: types.KubernetesClusterV3
+	(*v1.Filter)(nil),                  // 45: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),              // 46: google.protobuf.Empty
 }
 var file_teleport_presence_v1_service_proto_depIdxs = []int32{
-	33, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
-	33, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
-	34, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
-	35, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
-	35, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
-	36, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
-	36, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
-	37, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
-	37, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
-	37, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
-	37, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
-	38, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
-	39, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
-	38, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
-	0,  // 14: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
-	1,  // 15: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
-	3,  // 16: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
-	4,  // 17: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
-	5,  // 18: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
-	7,  // 19: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
-	8,  // 20: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
-	9,  // 21: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
-	11, // 22: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
-	13, // 23: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
-	15, // 24: teleport.presence.v1.PresenceService.ListAuthServers:input_type -> teleport.presence.v1.ListAuthServersRequest
-	17, // 25: teleport.presence.v1.PresenceService.ListProxyServers:input_type -> teleport.presence.v1.ListProxyServersRequest
-	19, // 26: teleport.presence.v1.PresenceService.UpsertProxyServer:input_type -> teleport.presence.v1.UpsertProxyServerRequest
-	21, // 27: teleport.presence.v1.PresenceService.DeleteProxyServer:input_type -> teleport.presence.v1.DeleteProxyServerRequest
-	23, // 28: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
-	25, // 29: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
-	27, // 30: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
-	29, // 31: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
-	31, // 32: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
-	33, // 33: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
-	2,  // 34: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
-	33, // 35: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
-	40, // 36: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
-	6,  // 37: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
-	35, // 38: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
-	40, // 39: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
-	10, // 40: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
-	12, // 41: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
-	14, // 42: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
-	16, // 43: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
-	18, // 44: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
-	20, // 45: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
-	22, // 46: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
-	24, // 47: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
-	26, // 48: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
-	28, // 49: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
-	30, // 50: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
-	32, // 51: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
-	33, // [33:52] is the sub-list for method output_type
-	14, // [14:33] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	39, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
+	39, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
+	40, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
+	41, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
+	41, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
+	42, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
+	42, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
+	43, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
+	43, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
+	43, // 9: teleport.presence.v1.UpsertProxyServerRequest.server:type_name -> types.ServerV2
+	43, // 10: teleport.presence.v1.UpsertProxyServerResponse.server:type_name -> types.ServerV2
+	44, // 11: teleport.presence.v1.GetKubeClusterResponse.cluster:type_name -> types.KubernetesClusterV3
+	45, // 12: teleport.presence.v1.ListKubeClustersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	44, // 13: teleport.presence.v1.ListKubeClustersResponse.clusters:type_name -> types.KubernetesClusterV3
+	43, // 14: teleport.presence.v1.GetSSHServerResponse.server:type_name -> types.ServerV2
+	45, // 15: teleport.presence.v1.ListSSHServersRequest.scope_filter:type_name -> teleport.scopes.v1.Filter
+	43, // 16: teleport.presence.v1.ListSSHServersResponse.servers:type_name -> types.ServerV2
+	0,  // 17: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
+	1,  // 18: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
+	3,  // 19: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
+	4,  // 20: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
+	5,  // 21: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
+	7,  // 22: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
+	8,  // 23: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
+	9,  // 24: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
+	11, // 25: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
+	13, // 26: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
+	15, // 27: teleport.presence.v1.PresenceService.ListAuthServers:input_type -> teleport.presence.v1.ListAuthServersRequest
+	17, // 28: teleport.presence.v1.PresenceService.ListProxyServers:input_type -> teleport.presence.v1.ListProxyServersRequest
+	19, // 29: teleport.presence.v1.PresenceService.UpsertProxyServer:input_type -> teleport.presence.v1.UpsertProxyServerRequest
+	21, // 30: teleport.presence.v1.PresenceService.DeleteProxyServer:input_type -> teleport.presence.v1.DeleteProxyServerRequest
+	23, // 31: teleport.presence.v1.PresenceService.GetKubeCluster:input_type -> teleport.presence.v1.GetKubeClusterRequest
+	25, // 32: teleport.presence.v1.PresenceService.ListKubeClusters:input_type -> teleport.presence.v1.ListKubeClustersRequest
+	27, // 33: teleport.presence.v1.PresenceService.DeleteKubeCluster:input_type -> teleport.presence.v1.DeleteKubeClusterRequest
+	29, // 34: teleport.presence.v1.PresenceService.DeleteKubeServer:input_type -> teleport.presence.v1.DeleteKubeServerRequest
+	31, // 35: teleport.presence.v1.PresenceService.DeleteAppServer:input_type -> teleport.presence.v1.DeleteAppServerRequest
+	33, // 36: teleport.presence.v1.PresenceService.GetSSHServer:input_type -> teleport.presence.v1.GetSSHServerRequest
+	35, // 37: teleport.presence.v1.PresenceService.ListSSHServers:input_type -> teleport.presence.v1.ListSSHServersRequest
+	37, // 38: teleport.presence.v1.PresenceService.DeleteSSHServer:input_type -> teleport.presence.v1.DeleteSSHServerRequest
+	39, // 39: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
+	2,  // 40: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
+	39, // 41: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
+	46, // 42: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
+	6,  // 43: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
+	41, // 44: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
+	46, // 45: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
+	10, // 46: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
+	12, // 47: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
+	14, // 48: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
+	16, // 49: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
+	18, // 50: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
+	20, // 51: teleport.presence.v1.PresenceService.UpsertProxyServer:output_type -> teleport.presence.v1.UpsertProxyServerResponse
+	22, // 52: teleport.presence.v1.PresenceService.DeleteProxyServer:output_type -> teleport.presence.v1.DeleteProxyServerResponse
+	24, // 53: teleport.presence.v1.PresenceService.GetKubeCluster:output_type -> teleport.presence.v1.GetKubeClusterResponse
+	26, // 54: teleport.presence.v1.PresenceService.ListKubeClusters:output_type -> teleport.presence.v1.ListKubeClustersResponse
+	28, // 55: teleport.presence.v1.PresenceService.DeleteKubeCluster:output_type -> teleport.presence.v1.DeleteKubeClusterResponse
+	30, // 56: teleport.presence.v1.PresenceService.DeleteKubeServer:output_type -> teleport.presence.v1.DeleteKubeServerResponse
+	32, // 57: teleport.presence.v1.PresenceService.DeleteAppServer:output_type -> teleport.presence.v1.DeleteAppServerResponse
+	34, // 58: teleport.presence.v1.PresenceService.GetSSHServer:output_type -> teleport.presence.v1.GetSSHServerResponse
+	36, // 59: teleport.presence.v1.PresenceService.ListSSHServers:output_type -> teleport.presence.v1.ListSSHServersResponse
+	38, // 60: teleport.presence.v1.PresenceService.DeleteSSHServer:output_type -> teleport.presence.v1.DeleteSSHServerResponse
+	39, // [39:61] is the sub-list for method output_type
+	17, // [17:39] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_teleport_presence_v1_service_proto_init() }
@@ -2589,7 +3065,7 @@ func file_teleport_presence_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_presence_v1_service_proto_rawDesc), len(file_teleport_presence_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   33,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/presence/v1/service.proto
+++ b/api/proto/teleport/presence/v1/service.proto
@@ -61,7 +61,7 @@ service PresenceService {
 
   // Fetches a kube cluster resource from the backend.
   rpc GetKubeCluster(GetKubeClusterRequest) returns (GetKubeClusterResponse);
-  // Lists kube cluster resources within the backend.
+  // Lists kube cluster resources from the backend.
   rpc ListKubeClusters(ListKubeClustersRequest) returns (ListKubeClustersResponse);
   // Deletes a kube cluster resource from the backend.
   rpc DeleteKubeCluster(DeleteKubeClusterRequest) returns (DeleteKubeClusterResponse);
@@ -71,6 +71,13 @@ service PresenceService {
 
   // Deletes a specific scoped or unscoped application server.
   rpc DeleteAppServer(DeleteAppServerRequest) returns (DeleteAppServerResponse);
+
+  // Gets a specific ssh server resource from the backend.
+  rpc GetSSHServer(GetSSHServerRequest) returns (GetSSHServerResponse);
+  // Lists ssh servers resources from the backend.
+  rpc ListSSHServers(ListSSHServersRequest) returns (ListSSHServersResponse);
+  // Deletes an ssh server resource from the backend.
+  rpc DeleteSSHServer(DeleteSSHServerRequest) returns (DeleteSSHServerResponse);
 }
 
 // Request for GetRemoteCluster
@@ -316,3 +323,47 @@ message DeleteAppServerRequest {
 
 // The response for deleting an application server.
 message DeleteAppServerResponse {}
+
+// The request for fetching for an SSH server.
+message GetSSHServerRequest {
+  // The name of the ssh server.
+  string name = 1;
+  // The scope of the ssh server.
+  string scope = 2;
+}
+
+// The response when fetching for an SSH server.
+message GetSSHServerResponse {
+  types.ServerV2 server = 1;
+}
+
+// The request for listing SSH servers.
+message ListSSHServersRequest {
+  // The maximum number of items to return.
+  // The server may impose a different page size at its discretion.
+  int32 page_size = 1;
+  // The next_page_token value returned from a previous List request, if any.
+  string page_token = 2;
+  // Filters ssh servers by scope.
+  teleport.scopes.v1.Filter scope_filter = 3;
+}
+
+// The response when listing SSH servers.
+message ListSSHServersResponse {
+  // The page of ssh servers that matched the request.
+  repeated types.ServerV2 servers = 1;
+  // Token to retrieve the next page of results, or empty if there are no
+  // more results in the list.
+  string next_page_token = 2;
+}
+
+// The request for deleting an SSH server.
+message DeleteSSHServerRequest {
+  // The name of the ssh server.
+  string name = 1;
+  // The scoped of the ssh server
+  string scope = 2;
+}
+
+// The response when deleting an SSH server.
+message DeleteSSHServerResponse {}

--- a/api/proto/teleport/presence/v1/service.proto
+++ b/api/proto/teleport/presence/v1/service.proto
@@ -61,7 +61,7 @@ service PresenceService {
 
   // Fetches a kube cluster resource from the backend.
   rpc GetKubeCluster(GetKubeClusterRequest) returns (GetKubeClusterResponse);
-  // Lists kube cluster resources within the backend.
+  // Lists kube cluster resources from the backend.
   rpc ListKubeClusters(ListKubeClustersRequest) returns (ListKubeClustersResponse);
   // Deletes a kube cluster resource from the backend.
   rpc DeleteKubeCluster(DeleteKubeClusterRequest) returns (DeleteKubeClusterResponse);
@@ -71,6 +71,13 @@ service PresenceService {
 
   // Deletes a specific scoped or unscoped application server.
   rpc DeleteAppServer(DeleteAppServerRequest) returns (DeleteAppServerResponse);
+
+  // Gets a specific ssh server resource from the backend.
+  rpc GetSSHServer(GetSSHServerRequest) returns (GetSSHServerResponse);
+  // Lists ssh servers resources from the backend.
+  rpc ListSSHServers(ListSSHServersRequest) returns (ListSSHServersResponse);
+  // Deletes an ssh server resource from the backend.
+  rpc DeleteSSHServer(DeleteSSHServerRequest) returns (DeleteSSHServerResponse);
 }
 
 // Request for GetRemoteCluster
@@ -323,3 +330,49 @@ message DeleteAppServerRequest {
 
 // The response for deleting an application server.
 message DeleteAppServerResponse {}
+
+// The request for fetching for an SSH server.
+message GetSSHServerRequest {
+  // The name of the ssh server.
+  string name = 1;
+  // The scope of the ssh server.
+  string scope = 2;
+}
+
+// The response when fetching for an SSH server.
+message GetSSHServerResponse {
+  types.ServerV2 server = 1;
+}
+
+// The request for listing SSH servers.
+// TODO (williamo): We will eventually need to allow filtering by labels, predicate expressions, and keywords
+// if we are to replace ListResources for callers that only want SSH Servers.
+message ListSSHServersRequest {
+  // The maximum number of items to return.
+  // The server may impose a different page size at its discretion.
+  int32 page_size = 1;
+  // The next_page_token value returned from a previous List request, if any.
+  string page_token = 2;
+  // Filters ssh servers by scope.
+  teleport.scopes.v1.Filter scope_filter = 3;
+}
+
+// The response when listing SSH servers.
+message ListSSHServersResponse {
+  // The page of ssh servers that matched the request.
+  repeated types.ServerV2 servers = 1;
+  // Token to retrieve the next page of results, or empty if there are no
+  // more results in the list.
+  string next_page_token = 2;
+}
+
+// The request for deleting an SSH server.
+message DeleteSSHServerRequest {
+  // The name of the ssh server.
+  string name = 1;
+  // The scoped of the ssh server
+  string scope = 2;
+}
+
+// The response when deleting an SSH server.
+message DeleteSSHServerResponse {}

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -37,6 +37,7 @@ import (
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/integration/helpers"
@@ -416,7 +417,10 @@ func TestEC2Labels(t *testing.T) {
 
 	// Check that EC2 labels were applied.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		node, err := authServer.GetNode(ctx, tconf.SSH.Namespace, nodes[0].GetName())
+		node, err := authServer.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+			Name:  nodes[0].GetName(),
+			Scope: nodes[0].GetScope(),
+		}.Build())
 		require.NoError(t, err)
 
 		_, nodeHasLabel := node.GetAllLabels()[tagName]

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/profile"
@@ -312,7 +313,7 @@ func testAuthLocalNodeControlStream(t *testing.T, suite *integrationTestSuite) {
 	var nodeID string
 	// verify node control stream registers, extracting the id.
 	require.Eventually(t, func() bool {
-		status, err := clt.GetInventoryStatus(context.Background(), proto.InventoryStatusRequest_builder{
+		status, err := clt.GetInventoryStatus(t.Context(), proto.InventoryStatusRequest_builder{
 			Connected: true,
 		}.Build())
 		require.NoError(t, err)
@@ -332,7 +333,7 @@ func testAuthLocalNodeControlStream(t *testing.T, suite *integrationTestSuite) {
 	var nodeAddr string
 	// verify node heartbeat was successful, extracting the addr.
 	require.Eventually(t, func() bool {
-		node, err := clt.GetNode(context.Background(), defaults.Namespace, nodeID)
+		node, err := clt.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{Name: nodeID}.Build())
 		if trace.IsNotFound(err) {
 			return false
 		}

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -40,7 +40,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
@@ -1245,7 +1245,7 @@ func testDeleteConnectMyComputerNode(t *testing.T, pack *dbhelpers.DatabasePack)
 
 	// waits for the node to be added
 	require.Eventually(t, func() bool {
-		_, err := authServer.GetNode(ctx, defaults.Namespace, nodeID)
+		_, err := authServer.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: nodeID}.Build())
 		return err == nil
 	}, time.Minute, time.Second, "waiting for node to join cluster")
 
@@ -1261,7 +1261,7 @@ func testDeleteConnectMyComputerNode(t *testing.T, pack *dbhelpers.DatabasePack)
 
 	// waits for the node to be deleted
 	require.Eventually(t, func() bool {
-		_, err := authServer.GetNode(ctx, defaults.Namespace, nodeID)
+		_, err := authServer.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: nodeID}.Build())
 		return trace.IsNotFound(err)
 	}, time.Minute, time.Second, "waiting for node to be deleted")
 }

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
@@ -25,7 +25,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
@@ -40,7 +40,7 @@ type openSSHEICEServerClient struct {
 
 // Get gets the Teleport OpenSSHEICE server of a given name.
 func (r openSSHEICEServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
-	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, key.Name)
+	server, err := r.teleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build())
 	if err != nil {
 		return server, trace.Wrap(err)
 	}
@@ -68,7 +68,7 @@ func (r openSSHEICEServerClient) Update(ctx context.Context, server types.Server
 
 // Delete deletes a Teleport OpenSSHEICE server.
 func (r openSSHEICEServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
-	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, key.Name))
+	return trace.Wrap(r.teleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build()))
 }
 
 // NewOpenSSHEICEServerV2Reconciler instantiates a new Kubernetes controller

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
@@ -72,11 +72,11 @@ func (g *opensshEICEServerV2TestingPrimitives) CreateTeleportResource(ctx contex
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Server, error) {
-	return g.setup.TeleportClient.GetNode(ctx, defaults.Namespace, name)
+	return g.setup.TeleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
-	return trace.Wrap(g.setup.TeleportClient.DeleteNode(ctx, defaults.Namespace, name))
+	return trace.Wrap(g.setup.TeleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build()))
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {

--- a/integrations/operator/controllers/resources/opensshserverv2_controller.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller.go
@@ -25,7 +25,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
@@ -40,7 +40,7 @@ type openSSHServerClient struct {
 
 // Get gets the Teleport OpenSSH server of a given name.
 func (r openSSHServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
-	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, key.Name)
+	server, err := r.teleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build())
 	if err != nil {
 		return server, trace.Wrap(err)
 	}
@@ -68,7 +68,7 @@ func (r openSSHServerClient) Update(ctx context.Context, server types.Server) er
 
 // Delete deletes a Teleport OpenSSH server.
 func (r openSSHServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
-	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, key.Name))
+	return trace.Wrap(r.teleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build()))
 }
 
 // NewOpenSSHServerV2Reconciler instantiates a new Kubernetes controller

--- a/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
@@ -64,11 +64,11 @@ func (g *opensshServerV2TestingPrimitives) CreateTeleportResource(ctx context.Co
 }
 
 func (g *opensshServerV2TestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Server, error) {
-	return g.setup.TeleportClient.GetNode(ctx, defaults.Namespace, name)
+	return g.setup.TeleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 }
 
 func (g *opensshServerV2TestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
-	return trace.Wrap(g.setup.TeleportClient.DeleteNode(ctx, defaults.Namespace, name))
+	return trace.Wrap(g.setup.TeleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build()))
 }
 
 func (g *opensshServerV2TestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {

--- a/integrations/terraform/testlib/server_test.go
+++ b/integrations/terraform/testlib/server_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -34,7 +34,7 @@ func (s *TerraformSuiteOSS) TestOpenSSHServer() {
 	s.T().Cleanup(cancel)
 
 	checkServerDestroyed := func(state *terraform.State) error {
-		_, err := s.client.GetNode(ctx, defaults.Namespace, "test")
+		_, err := s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "test"}.Build())
 		if trace.IsNotFound(err) {
 			return nil
 		}
@@ -86,7 +86,7 @@ func (s *TerraformSuiteOSS) TestOpenSSHServerNameless() {
 
 	checkServerDestroyed := func(state *terraform.State) error {
 		// The name is a UUID but we can lookup by hostname as well.
-		_, err := s.client.GetNode(ctx, defaults.Namespace, "test.local")
+		_, err := s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "test.local"}.Build())
 		if trace.IsNotFound(err) {
 			return nil
 		}
@@ -159,7 +159,7 @@ func (s *TerraformSuiteOSS) TestImportOpenSSHServer() {
 	require.NoError(s.T(), err)
 
 	require.Eventually(s.T(), func() bool {
-		_, err = s.client.GetNode(ctx, defaults.Namespace, server.GetName())
+		_, err = s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: server.GetName(), Scope: server.GetScope()}.Build())
 		if trace.IsNotFound(err) {
 			return false
 		}
@@ -193,7 +193,7 @@ func (s *TerraformSuiteOSS) TestOpenSSHEICEServer() {
 	s.T().Cleanup(cancel)
 
 	checkServerDestroyed := func(state *terraform.State) error {
-		_, err := s.client.GetNode(ctx, defaults.Namespace, "test")
+		_, err := s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "test"}.Build())
 		if trace.IsNotFound(err) {
 			return nil
 		}
@@ -288,7 +288,7 @@ func (s *TerraformSuiteOSS) TestImportOpenSSHEICEServer() {
 	require.NoError(s.T(), err)
 
 	require.Eventually(s.T(), func() bool {
-		_, err = s.client.GetNode(ctx, defaults.Namespace, server.GetName())
+		_, err = s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: server.GetName(), Scope: server.GetScope()}.Build())
 		if trace.IsNotFound(err) {
 			return false
 		}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1116,7 +1116,7 @@ func (a *ServerWithRoles) KeepAliveServer(ctx context.Context, handle types.Keep
 	scopedServer := a.ScopedServerWithRoles()
 	switch handle.GetType() {
 	case constants.KeepAliveNode:
-		if err := scopedServer.scopedContext.AgentOwnedResourceAction("", handle.Name, types.RoleNode); err != nil {
+		if err := scopedServer.scopedContext.AgentOwnedResourceAction(handle.Scope, handle.Name, types.RoleNode); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveApp:
@@ -1308,7 +1308,8 @@ func supportedScopedWatchKind(kind string) bool {
 		scopedaccess.KindScopedRole,
 		scopedaccess.KindScopedRoleAssignment,
 		types.KindKubernetesCluster,
-		types.KindWorkloadIdentity:
+		types.KindWorkloadIdentity,
+		types.KindNode:
 		return true
 	default:
 		return false
@@ -1515,20 +1516,28 @@ func (a *ServerWithRoles) DeleteAllNodes(ctx context.Context, namespace string) 
 	return a.authServer.DeleteAllNodes(ctx, namespace)
 }
 
-// DeleteNode deletes node in the namespace
+// DeleteNode deletes an unscoped node in the namespace.
+//
+// Deprecated: use PresenceService.DeleteSSHServer instead.
+// TODO(williamo): Remove in v20
 func (a *ServerWithRoles) DeleteNode(ctx context.Context, namespace, node string) error {
 	if err := a.actionNamespace(namespace, types.KindNode, types.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.DeleteNode(ctx, namespace, node)
+	return a.authServer.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: node}.Build())
 }
 
-// GetNode gets a node by name and namespace.
+// GetNode gets an unscoped node by name and namespace.
+//
+// Deprecated: use PresenceService.GetSSHServer instead.
+// TODO(williamo): Remove in v20
 func (a *ServerWithRoles) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
 	if err := a.actionNamespace(namespace, types.KindNode, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	node, err := a.authServer.GetNode(ctx, namespace, name)
+	node, err := a.authServer.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name: name,
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles_watch_authz_test.go
+++ b/lib/auth/auth_with_roles_watch_authz_test.go
@@ -264,7 +264,7 @@ func TestScopedWatchKindAuthz(t *testing.T) {
 			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
 			// kinds are namespaced.
 			name:      "non-namespaced kind EXACT denied by whitelist",
-			kind:      types.KindNode,
+			kind:      types.KindDatabase,
 			filter:    filter(scopesv1.Mode_MODE_EXACT, pinScope),
 			assertErr: requireAccessDenied,
 		},
@@ -272,7 +272,7 @@ func TestScopedWatchKindAuthz(t *testing.T) {
 			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
 			// kinds are namespaced.
 			name:      "non-namespaced kind ALL denied by whitelist for scoped caller",
-			kind:      types.KindNode,
+			kind:      types.KindDatabase,
 			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
 			assertErr: requireAccessDenied,
 		},
@@ -435,7 +435,7 @@ func TestUnscopedWatchKindAuthz(t *testing.T) {
 			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
 			// kinds are namespaced.
 			name:      "non-namespaced kind EXACT denied by whitelist",
-			kind:      types.KindNode,
+			kind:      types.KindDatabase,
 			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
 			assertErr: requireAccessDenied,
 		},

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -220,11 +220,11 @@ type ReadProxyAccessPoint interface {
 	// GetUser returns a services.User for this cluster.
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
 
-	// GetNode returns a node by name and namespace.
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 
-	// GetNodes returns a list of registered servers for this cluster.
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 
 	// GetProxies returns a list of proxy servers registered in the cluster
 	//
@@ -397,7 +397,8 @@ type ReadRelayAccessPoint interface {
 
 	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 
 	GetRelayServer(ctx context.Context, name string) (*presencev1.RelayServer, error)
 
@@ -448,11 +449,11 @@ type ReadRemoteProxyAccessPoint interface {
 	// GetRoles returns a list of roles
 	GetRoles(ctx context.Context) ([]types.Role, error)
 
-	// GetNode returns a node by name and namespace.
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 
-	// GetNodes returns a list of registered servers for this cluster.
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 
 	// GetProxies returns a list of proxy servers registered in the cluster
 	//
@@ -896,8 +897,8 @@ type ReadDiscoveryAccessPoint interface {
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(ctx context.Context) (types.ClusterName, error)
 
-	// GetNodes returns a list of registered servers for this cluster.
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 	// GetKubernetesServers returns all registered kubernetes servers.
 	GetKubernetesServers(ctx context.Context) ([]types.KubeServer, error)
 
@@ -1189,11 +1190,11 @@ type Cache interface {
 	// GetSessionRecordingConfig returns session recording configuration.
 	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
-	// GetNode returns a node by name and namespace.
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 
-	// GetNodes returns a list of registered servers for this cluster.
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 
 	// GetProxies returns a list of proxy servers registered in the cluster
 	//

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -221,11 +221,17 @@ type ReadProxyAccessPoint interface {
 	// GetUser returns a services.User for this cluster.
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
 
-	// GetNode returns a node by name and namespace.
+	// GetNode returns an unscoped node by name and namespace.
+	//
+	// Deprecated: Use GetSSHServer instead, which supports scoped nodes.
+	// TODO(williamo): Remove in v20
 	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
 
-	// GetNodes returns a list of registered servers for this cluster.
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
+
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 
 	// GetProxies returns a list of proxy servers registered in the cluster
 	//
@@ -398,7 +404,8 @@ type ReadRelayAccessPoint interface {
 
 	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 
 	GetRelayServer(ctx context.Context, name string) (*presencev1.RelayServer, error)
 
@@ -449,11 +456,17 @@ type ReadRemoteProxyAccessPoint interface {
 	// GetRoles returns a list of roles
 	GetRoles(ctx context.Context) ([]types.Role, error)
 
-	// GetNode returns a node by name and namespace.
+	// GetNode returns an unscoped node by name and namespace.
+	//
+	// Deprecated: Use GetSSHServer instead, which supports scoped nodes.
+	// TODO(williamo): Remove in v20
 	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
 
-	// GetNodes returns a list of registered servers for this cluster.
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
+
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 
 	// GetProxies returns a list of proxy servers registered in the cluster
 	//
@@ -897,8 +910,8 @@ type ReadDiscoveryAccessPoint interface {
 	// GetClusterName gets the name of the cluster from the backend.
 	GetClusterName(ctx context.Context) (types.ClusterName, error)
 
-	// GetNodes returns a list of registered servers for this cluster.
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 	// GetKubernetesServers returns all registered kubernetes servers.
 	GetKubernetesServers(ctx context.Context) ([]types.KubeServer, error)
 
@@ -1194,11 +1207,17 @@ type Cache interface {
 	// GetSessionRecordingConfig returns session recording configuration.
 	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
-	// GetNode returns a node by name and namespace.
+	// GetNode returns an unscoped node by name and namespace.
+	//
+	// Deprecated: Use [Cache.GetSSHServer] instead, which supports scoped nodes.
+	// TODO(williamo): Remove in v20
 	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
 
-	// GetNodes returns a list of registered servers for this cluster.
-	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
+
+	// NodesGetter defines methods for fetching node resources.
+	services.NodesGetter
 
 	// GetProxies returns a list of proxy servers registered in the cluster
 	//

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -3649,37 +3649,29 @@ func TestNodesCRUD(t *testing.T) {
 		t.Run("GetNode", func(t *testing.T) {
 			t.Parallel()
 			// Get Node
-			node, err := clt.GetNode(ctx, apidefaults.Namespace, "node1")
+			node, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "node1"}.Build())
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(node1, node,
 				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 			// GetNode should fail if node name isn't provided
-			_, err = clt.GetNode(ctx, apidefaults.Namespace, "")
-			require.True(t, trace.IsBadParameter(err), "trace.IsBadParameter failed: err=%v (%T)", err, trace.Unwrap(err))
-
-			// GetNode should fail if namespace isn't provided
-			_, err = clt.GetNode(ctx, "", "node1")
+			_, err = clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: ""}.Build())
 			require.True(t, trace.IsBadParameter(err), "trace.IsBadParameter failed: err=%v (%T)", err, trace.Unwrap(err))
 		})
 	})
 
 	t.Run("DeleteNode", func(t *testing.T) {
-		// Make sure can't delete with empty namespace or name.
-		err = clt.DeleteNode(ctx, apidefaults.Namespace, "")
-		require.Error(t, err)
-		require.ErrorAs(t, err, new(*trace.BadParameterError))
-
-		err = clt.DeleteNode(ctx, "", node1.GetName())
+		// Make sure can't delete with empty name.
+		err = clt.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: ""}.Build())
 		require.Error(t, err)
 		require.ErrorAs(t, err, new(*trace.BadParameterError))
 
 		// Delete node.
-		err = clt.DeleteNode(ctx, apidefaults.Namespace, node1.GetName())
+		err = clt.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: node1.GetName()}.Build())
 		require.NoError(t, err)
 
 		// Expect node not found
-		_, err := clt.GetNode(ctx, apidefaults.Namespace, "node1")
+		_, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "node1"}.Build())
 		require.ErrorAs(t, err, new(*trace.NotFoundError))
 	})
 
@@ -7698,7 +7690,7 @@ func TestScopedWatchEvents(t *testing.T) {
 		{
 			name:          "scoped host watching disallowed kind",
 			client:        scopedClient,
-			kind:          types.KindNode,
+			kind:          types.KindDatabase,
 			expectFailure: true,
 		},
 		{
@@ -7709,7 +7701,7 @@ func TestScopedWatchEvents(t *testing.T) {
 		{
 			name:          "scope pinned host watching disallowed kind",
 			client:        scopePinnedClient,
-			kind:          types.KindNode,
+			kind:          types.KindDatabase,
 			expectFailure: true,
 		},
 	}

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -65,6 +65,10 @@ type Backend interface {
 	DeleteKubeCluster(ctx context.Context, req *presencepb.DeleteKubeClusterRequest) error
 
 	DeleteKubeServer(ctx context.Context, req *presencepb.DeleteKubeServerRequest) error
+
+	GetSSHServer(ctx context.Context, req *presencepb.GetSSHServerRequest) (types.Server, error)
+	RangeSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) iter.Seq2[types.Server, error]
+	DeleteSSHServer(ctx context.Context, req *presencepb.DeleteSSHServerRequest) error
 }
 
 type Cache interface {
@@ -860,4 +864,130 @@ func (s *Service) DeleteKubeServer(
 		return nil, trace.Wrap(err)
 	}
 	return presencepb.DeleteKubeServerResponse_builder{}.Build(), nil
+}
+
+// GetSSHServer returns the specified node resource.
+func (s *Service) GetSSHServer(ctx context.Context, req *presencepb.GetSSHServerRequest) (*presencepb.GetSSHServerResponse, error) {
+	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, scopedaccess.Read); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	node, err := s.backend.GetSSHServer(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, scopedaccess.Read); err != nil {
+			return err
+		}
+		return checker.SSH().CanAccessSSHServer(node)
+	}); err != nil {
+		if trace.IsAccessDenied(err) {
+			return nil, trace.NotFound("not found")
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	nodeV2, ok := node.(*types.ServerV2)
+	if !ok {
+		return nil, trace.BadParameter("invalid node")
+	}
+	return presencepb.GetSSHServerResponse_builder{
+		Server: nodeV2,
+	}.Build(), nil
+}
+
+// getCursorForNode wraps [services.GetCursorForNode] with a signature
+// referencing [*types.ServerV2] directly. This helps go infer the proper
+// typing when using [generic.CollectPageAndCursor].
+func getCursorForNode(node *types.ServerV2) string {
+	return services.GetCursorForNode(node)
+}
+
+// ListSSHServers returns a page of registered nodes.
+func (s *Service) ListSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) (*presencepb.ListSSHServersResponse, error) {
+	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, scopedaccess.List); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// list method scope filters must use identity-based defaults per RFD 0229i
+	req.SetScopeFilter(authContext.CheckerContext.ResolveScopeFilter(req.GetScopeFilter()))
+
+	servers, nextToken, err := generic.CollectPageAndCursor(
+		stream.FilterMap(
+			s.backend.RangeSSHServers(ctx, req),
+			func(node types.Server) (*types.ServerV2, bool) {
+				// Filter out nodes the user doesn't have access to.
+				if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+					if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, scopedaccess.List); err != nil {
+						return err
+					}
+					return checker.SSH().CanAccessSSHServer(node)
+				}); err == nil {
+					nodeV2, ok := node.(*types.ServerV2)
+					return nodeV2, ok
+				}
+				return nil, false
+			},
+		),
+		int(req.GetPageSize()),
+		getCursorForNode,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return presencepb.ListSSHServersResponse_builder{
+		Servers:       servers,
+		NextPageToken: nextToken,
+	}.Build(), nil
+}
+
+// DeleteSSHServer removes the specified node resource.
+func (s *Service) DeleteSSHServer(ctx context.Context, req *presencepb.DeleteSSHServerRequest) (*presencepb.DeleteSSHServerResponse, error) {
+	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if req.GetName() == "" {
+		return nil, trace.BadParameter("name: must be specified")
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, scopedaccess.Delete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Make sure the user has access to the node before deleting it.
+	node, err := s.backend.GetSSHServer(ctx, presencepb.GetSSHServerRequest_builder{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}.Build())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindNode, scopedaccess.Delete)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.backend.DeleteSSHServer(ctx, req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return presencepb.DeleteSSHServerResponse_builder{}.Build(), nil
 }

--- a/lib/auth/presence/presencev1/service_kube_test.go
+++ b/lib/auth/presence/presencev1/service_kube_test.go
@@ -31,230 +31,116 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/services/local"
 )
 
 func TestPresenceServiceKubeClusters(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
 
-	readUser, _, err := authtest.CreateUserAndRole(
-		srv.Auth(),
-		"read-user",
-		[]string{},
-		[]types.Rule{
-			{
-				Resources: []string{types.KindKubernetesCluster},
-				Verbs:     []string{types.VerbRead},
-			},
-		},
-	)
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bk.Close()) })
+	kube, err := local.NewKubernetesService(bk)
 	require.NoError(t, err)
 
-	listUser, _, err := authtest.CreateUserAndRole(
-		srv.Auth(),
-		"list-user",
-		[]string{},
-		[]types.Rule{
-			{
-				Resources: []string{types.KindKubernetesCluster},
-				Verbs:     []string{types.VerbRead, types.VerbList},
-			},
-		},
-	)
-	require.NoError(t, err)
-
-	deleteUser, _, err := authtest.CreateUserAndRole(
-		srv.Auth(),
-		"delete-user",
-		[]string{},
-		[]types.Rule{
-			{
-				Resources: []string{types.KindKubernetesCluster},
-				Verbs:     []string{types.VerbDelete},
-			},
-		},
-	)
-	require.NoError(t, err)
+	roles := fakeScopedRoleReader{roles: map[string]*scopedaccessv1.ScopedRole{}}
+	scopedReadRole := roles.createScopedRole("read-role", types.VerbRead)
+	scopedListRole := roles.createScopedRole("list-role", types.VerbRead, types.VerbList)
+	scopedDeleteRole := roles.createScopedRole("delete-role", types.VerbDelete)
 
 	const (
-		parentScope     = "/aa"
-		scope           = "/aa/aa"
-		orthogonalScope = "/aa/bb"
-	)
-	createScopedRole := func(name string, verbs []string) *scopedaccessv1.ScopedRole {
-		scopedRole, err := srv.Auth().ScopedAccess().CreateScopedRole(t.Context(), scopedaccessv1.CreateScopedRoleRequest_builder{
-			Role: scopedaccessv1.ScopedRole_builder{
-				Kind:    scopedaccess.KindScopedRole,
-				Version: types.V1,
-				Metadata: headerv1.Metadata_builder{
-					Name: name,
-				}.Build(),
-				Scope: parentScope,
-				Spec: scopedaccessv1.ScopedRoleSpec_builder{
-					AssignableScopes: []string{scope, orthogonalScope},
-					// need kube block because of the CanAccessKubeCluster checks
-					Kube: scopedaccessv1.ScopedRoleKube_builder{
-						Labels: []*labelv1.Label{
-							labelv1.Label_builder{
-								Name:   types.Wildcard,
-								Values: []string{types.Wildcard},
-							}.Build(),
-						},
-						Resources: []*scopedaccessv1.KubeResource{
-							scopedaccessv1.KubeResource_builder{
-								Kind:      types.Wildcard,
-								Name:      types.Wildcard,
-								Namespace: types.Wildcard,
-								ApiGroup:  types.Wildcard,
-								Verbs:     []string{types.Wildcard},
-							}.Build(),
-						},
-					}.Build(),
-					Rules: []*scopedaccessv1.ScopedRule{
-						scopedaccessv1.ScopedRule_builder{
-							Resources: []string{types.KindKubernetesCluster},
-							Verbs:     verbs,
-						}.Build(),
-					},
-				}.Build(),
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
-		return scopedRole.GetRole()
-	}
-
-	scopedReadRole := createScopedRole("read-role", []string{types.VerbRead})
-	scopedListRole := createScopedRole("list-role", []string{types.VerbRead, types.VerbList})
-	scopedDeleteRole := createScopedRole("delete-role", []string{types.VerbDelete})
-
-	createAssignment := func(role *scopedaccessv1.ScopedRole, username, assignedScope string) *scopedaccessv1.ScopedRoleAssignment {
-		sra, err := srv.Auth().ScopedAccess().CreateScopedRoleAssignment(t.Context(), scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
-			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
-				Kind:    scopedaccess.KindScopedRoleAssignment,
-				SubKind: scopedaccess.SubKindDynamic,
-				Version: types.V1,
-				Metadata: headerv1.Metadata_builder{
-					Name: uuid.NewString(),
-				}.Build(),
-				Scope: assignedScope,
-				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					User: username,
-					Assignments: []*scopedaccessv1.Assignment{
-						scopedaccessv1.Assignment_builder{
-							Role:  scopes.QualifiedName{Scope: role.GetScope(), Name: role.GetMetadata().GetName()}.String(),
-							Scope: assignedScope,
-						}.Build(),
-					},
-				}.Build(),
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
-		return sra.GetAssignment()
-	}
-
-	waitForSRACache(
-		t,
-		srv,
-		createAssignment(scopedReadRole, readUser.GetName(), scope),
-		createAssignment(scopedListRole, listUser.GetName(), scope),
-		createAssignment(scopedDeleteRole, deleteUser.GetName(), scope),
+		readUser   = "read-user"
+		listUser   = "list-user"
+		deleteUser = "delete-user"
 	)
 
-	scopedCluster := newKubeCluster(t, srv.Auth(), scope, "kube-cluster", map[string]string{
+	scopedCluster := newKubeCluster(t, kube, testScope, "kube-cluster", map[string]string{
 		"env": "test",
 	})
-	orthogonalCluster := newKubeCluster(t, srv.Auth(), orthogonalScope, "kube-cluster", map[string]string{
+	orthogonalCluster := newKubeCluster(t, kube, testOrthogonalScope, "kube-cluster", map[string]string{
 		"env": "test",
 	})
-	// prodCluster := newKubeCluster(t, srv.Auth(), "/aa/aa", "prod-cluster", map[string]string{
-	// 	"env": "prod",
-	// })
-	unscopedCluster := newKubeCluster(t, srv.Auth(), "", "unscoped-cluster", map[string]string{
+	unscopedCluster := newKubeCluster(t, kube, "", "unscoped-cluster", map[string]string{
 		"env": "test",
 	})
-
-	newClient := func(t *testing.T, identity authtest.TestIdentity) *authclient.Client {
-		client, err := srv.NewClient(identity)
-		require.NoError(t, err)
-		t.Cleanup(func() { client.Close() })
-		return client
-	}
 
 	t.Run("GetKubeCluster", func(t *testing.T) {
 		for _, tt := range []struct {
 			name       string
-			client     *authclient.Client
+			authorizer authz.ScopedAuthorizer
 			cluster    types.KubeCluster
 			shouldFail bool
 		}{
 			{
-				name:    "unscoped read-user fetching unscoped kube cluster",
-				client:  newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster: unscopedCluster,
+				name:       "unscoped read-user fetching unscoped kube cluster",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
+				cluster:    unscopedCluster,
 			},
 			{
-				name:    "unscoped read-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster: scopedCluster,
+				name:       "unscoped read-user fetching scoped kube cluster",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
+				cluster:    scopedCluster,
 			},
 			{
-				name:    "unscoped delete-user fetching unscoped kube cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: unscopedCluster,
+				name:       "unscoped delete-user fetching unscoped kube cluster",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindKubernetesCluster, types.VerbDelete),
+				cluster:    unscopedCluster,
 				// default implicit role provides read access
 				shouldFail: false,
 			},
 			{
-				name:    "unscoped delete-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: scopedCluster,
+				name:       "unscoped delete-user fetching scoped kube cluster",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindKubernetesCluster, types.VerbDelete),
+				cluster:    scopedCluster,
 				// default implicit role provides read access
 				shouldFail: false,
 			},
 			{
-				name:    "scoped read-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster: scopedCluster,
+				name:       "scoped read-user fetching scoped kube cluster",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				cluster:    scopedCluster,
 			},
 			{
 				name:       "scoped read-user fetching orthogonal scoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped read-user fetching unscoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster:    orthogonalCluster,
-				shouldFail: true,
-			},
-			{
-				name:       "scoped delete-user fetching unscoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
-				name:    "scoped delete-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster: scopedCluster,
+				name:       "scoped delete-user fetching unscoped kube cluster",
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				cluster:    unscopedCluster,
+				shouldFail: true,
+			},
+			{
+				name:       "scoped delete-user fetching scoped kube cluster",
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				cluster:    scopedCluster,
 				// default implicit role provides read access
 				shouldFail: false,
 			},
 			{
 				name:       "scoped delete-user fetching orthogonal scoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
 				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				res, err := tt.client.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
+				srv := newPresenceService(t, backend{kube: kube}, tt.authorizer)
+				res, err := srv.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
 					Name:  tt.cluster.GetName(),
 					Scope: tt.cluster.GetScope(),
 				}.Build())
@@ -262,7 +148,7 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 					assert.Error(t, err)
 				} else {
 					assert.NoError(t, err)
-					assert.Empty(t, cmp.Diff(tt.cluster, res))
+					assert.Empty(t, cmp.Diff(tt.cluster, res.GetCluster()))
 				}
 			})
 		}
@@ -270,25 +156,24 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 
 	allClusters := []types.KubeCluster{unscopedCluster, scopedCluster, orthogonalCluster}
 	t.Run("ListKubeClusters", func(t *testing.T) {
-		t.Parallel()
 		for _, tt := range []struct {
 			name             string
-			client           *authclient.Client
+			authorizer       authz.ScopedAuthorizer
 			req              *presencev1pb.ListKubeClustersRequest
 			expectedClusters []types.KubeCluster
 			shouldFail       bool
 		}{
 			{
-				name:   "unscoped list-user listing all clusters without scope filter",
-				client: newClient(t, authtest.TestUser(listUser.GetName())),
+				name:       "unscoped list-user listing all clusters without scope filter",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindKubernetesCluster, types.VerbRead, types.VerbList),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 				}.Build(),
 				expectedClusters: []types.KubeCluster{unscopedCluster},
 			},
 			{
-				name:   "unscoped list-user listing all clusters filtering for all scopes",
-				client: newClient(t, authtest.TestUser(listUser.GetName())),
+				name:       "unscoped list-user listing all clusters filtering for all scopes",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindKubernetesCluster, types.VerbRead, types.VerbList),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
@@ -298,56 +183,57 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 				expectedClusters: allClusters,
 			},
 			{
-				name:   "unscoped list-user listing clusters with scope filter",
-				client: newClient(t, authtest.TestUser(listUser.GetName())),
+				name:       "unscoped list-user listing clusters with scope filter",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindKubernetesCluster, types.VerbRead, types.VerbList),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
-						Scope: scope,
+						Scope: testScope,
 						Mode:  scopesv1.Mode_MODE_EXACT,
 					}.Build(),
 				}.Build(),
 				expectedClusters: []types.KubeCluster{scopedCluster},
 			},
 			{
-				name:   "scoped list-user listing all clusters",
-				client: newClient(t, authtest.TestScopedUser(listUser.GetName(), scope)),
+				name:       "scoped list-user listing all clusters",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 				}.Build(),
 				expectedClusters: []types.KubeCluster{scopedCluster},
 			},
 			{
-				name:   "scoped list-user listing clusters with scope filter",
-				client: newClient(t, authtest.TestScopedUser(listUser.GetName(), scope)),
+				name:       "scoped list-user listing clusters with scope filter",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
-						Scope: scope,
+						Scope: testScope,
 						Mode:  scopesv1.Mode_MODE_EXACT,
 					}.Build(),
 				}.Build(),
 				expectedClusters: []types.KubeCluster{scopedCluster},
 			},
 			{
-				name:   "scoped list-user listing clusters with orthogonal scope filter",
-				client: newClient(t, authtest.TestScopedUser(listUser.GetName(), scope)),
+				name:       "scoped list-user listing clusters with orthogonal scope filter",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
-						Scope: orthogonalScope,
+						Scope: testOrthogonalScope,
 						Mode:  scopesv1.Mode_MODE_EXACT,
 					}.Build(),
 				}.Build(),
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				clusters, _, err := tt.client.ListKubeClusters(t.Context(), tt.req)
+				srv := newPresenceService(t, backend{kube: kube}, tt.authorizer)
+				res, err := srv.ListKubeClusters(t.Context(), tt.req)
 				if tt.shouldFail {
 					assert.Error(t, err)
 				} else {
 					assert.NoError(t, err)
-					assert.ElementsMatch(t, tt.expectedClusters, clusters)
+					assert.ElementsMatch(t, tt.expectedClusters, res.GetClusters())
 				}
 			})
 		}
@@ -357,76 +243,77 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 		t.Parallel()
 		for _, tt := range []struct {
 			name       string
-			client     *authclient.Client
+			authorizer authz.ScopedAuthorizer
 			cluster    types.KubeCluster
 			shouldFail bool
 		}{
 			{
 				name:       "unscoped read-user deleting unscoped cluster",
-				client:     newClient(t, authtest.TestUser(readUser.GetName())),
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
 				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "unscoped read-user deleting scoped cluster",
-				client:     newClient(t, authtest.TestUser(readUser.GetName())),
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
 				cluster:    scopedCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "unscoped read-user deleting orthogonal cluster",
-				client:     newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster:    scopedCluster,
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
+				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped read-user deleting unscoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped read-user deleting scoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    scopedCluster,
 				shouldFail: true,
 			},
 			{
-				name:       "scoped read-user deleting scoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
+				name:       "scoped read-user deleting orthogonal cluster",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped delete-user deleting unscoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
 				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped delete-user deleting orthogonal cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
 				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 			{
-				name:    "scoped delete-user deleting scoped cluster",
-				client:  newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster: scopedCluster,
+				name:       "scoped delete-user deleting scoped cluster",
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				cluster:    scopedCluster,
 			},
 			{
-				name:    "unscoped delete-user deleting unscoped cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: unscopedCluster,
+				name:       "unscoped delete-user deleting unscoped cluster",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindKubernetesCluster, types.VerbDelete),
+				cluster:    unscopedCluster,
 			},
 			{
-				name:    "unscoped delete-user deleting orthogonal cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: orthogonalCluster,
+				name:       "unscoped delete-user deleting orthogonal cluster",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindKubernetesCluster, types.VerbDelete),
+				cluster:    orthogonalCluster,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				err := tt.client.DeleteKubeCluster(t.Context(), presencev1pb.DeleteKubeClusterRequest_builder{
+				srv := newPresenceService(t, backend{kube: kube}, tt.authorizer)
+				_, err := srv.DeleteKubeCluster(t.Context(), presencev1pb.DeleteKubeClusterRequest_builder{
 					Name:  tt.cluster.GetName(),
 					Scope: tt.cluster.GetScope(),
 				}.Build())
@@ -440,7 +327,7 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 	})
 }
 
-func newKubeCluster(t *testing.T, srv *auth.Server, scope, name string, labels map[string]string) types.KubeCluster {
+func newKubeCluster(t *testing.T, srv *local.KubernetesService, scope, name string, labels map[string]string) types.KubeCluster {
 	t.Helper()
 
 	cluster, err := types.NewKubernetesClusterV3(types.Metadata{

--- a/lib/auth/presence/presencev1/service_node_test.go
+++ b/lib/auth/presence/presencev1/service_node_test.go
@@ -1,0 +1,337 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package presencev1_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	presencev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+func TestPresenceServiceNodes(t *testing.T) {
+	t.Parallel()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bk.Close()) })
+	presence := local.NewPresenceService(bk)
+
+	roles := fakeScopedRoleReader{roles: map[string]*accessv1.ScopedRole{}}
+	scopedReadRole := roles.createScopedRole("node-read-role", types.VerbRead)
+	scopedListRole := roles.createScopedRole("node-list-role", types.VerbRead, types.VerbList)
+	scopedDeleteRole := roles.createScopedRole("node-delete-role", types.VerbDelete)
+
+	const (
+		readUser   = "node-read-user"
+		listUser   = "node-list-user"
+		deleteUser = "node-delete-user"
+	)
+
+	unscopedNode := newNode(t, presence, scopes.QualifiedName{Name: "node", Scope: ""}, map[string]string{"env": "test"})
+	scopedNode := newNode(t, presence, scopes.QualifiedName{Name: "node", Scope: testScope}, map[string]string{"env": "test"})
+	orthogonalNode := newNode(t, presence, scopes.QualifiedName{Name: "node", Scope: testOrthogonalScope}, map[string]string{"env": "test"})
+
+	t.Run("GetNode", func(t *testing.T) {
+		for _, tt := range []struct {
+			name       string
+			authorizer authz.ScopedAuthorizer
+			node       types.Server
+			shouldFail bool
+		}{
+			{
+				name:       "unscoped read-user fetching unscoped node",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				node:       unscopedNode,
+			},
+			{
+				name:       "unscoped read-user fetching scoped node",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				node:       scopedNode,
+			},
+			{
+				name:       "unscoped read-user fetching orthogonal scoped node",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				node:       orthogonalNode,
+			},
+			{
+				name:       "scoped read-user fetching scoped node",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				node:       scopedNode,
+			},
+			{
+				name:       "scoped read-user fetching orthogonal scoped node",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				node:       orthogonalNode,
+				shouldFail: true,
+			},
+			{
+				name:       "scoped read-user fetching unscoped node",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				node:       unscopedNode,
+				shouldFail: true,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				srv := newPresenceService(t, backend{presence: presence}, tt.authorizer)
+				res, err := srv.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+					Name:  tt.node.GetName(),
+					Scope: tt.node.GetScope(),
+				}.Build())
+				if tt.shouldFail {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.Empty(t, cmp.Diff(tt.node, res.GetServer()))
+				}
+			})
+		}
+	})
+
+	allNodes := []types.Server{unscopedNode, scopedNode, orthogonalNode}
+	t.Run("ListNodes", func(t *testing.T) {
+		for _, tt := range []struct {
+			name          string
+			authorizer    authz.ScopedAuthorizer
+			req           *presencev1pb.ListSSHServersRequest
+			expectedNodes []types.Server
+			shouldFail    bool
+		}{
+			{
+				name:       "unscoped list-user listing all nodes without scope filter",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindNode, types.VerbRead, types.VerbList),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+				}.Build(),
+				expectedNodes: []types.Server{unscopedNode},
+			},
+			{
+				name:       "unscoped list-user listing all nodes filtering for all scopes",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindNode, types.VerbRead, types.VerbList),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Mode: scopesv1.Mode_MODE_ALL,
+					}.Build(),
+				}.Build(),
+				expectedNodes: allNodes,
+			},
+			{
+				name:       "unscoped list-user listing nodes with scope filter",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindNode, types.VerbRead, types.VerbList),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Scope: testScope,
+						Mode:  scopesv1.Mode_MODE_EXACT,
+					}.Build(),
+				}.Build(),
+				expectedNodes: []types.Server{scopedNode},
+			},
+			{
+				name:       "unscoped list-user listing nodes across a scope subtree",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindNode, types.VerbRead, types.VerbList),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Scope: testParentScope,
+						Mode:  scopesv1.Mode_MODE_DESCENDANTS,
+					}.Build(),
+				}.Build(),
+				expectedNodes: []types.Server{scopedNode, orthogonalNode},
+			},
+			{
+				name:       "scoped list-user listing all nodes",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+				}.Build(),
+				expectedNodes: []types.Server{scopedNode},
+			},
+			{
+				name:       "scoped list-user listing nodes with scope filter",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Scope: testScope,
+						Mode:  scopesv1.Mode_MODE_EXACT,
+					}.Build(),
+				}.Build(),
+				expectedNodes: []types.Server{scopedNode},
+			},
+			{
+				name:       "scoped list-user listing nodes with orthogonal scope filter",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Scope: testOrthogonalScope,
+						Mode:  scopesv1.Mode_MODE_EXACT,
+					}.Build(),
+				}.Build(),
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				srv := newPresenceService(t, backend{presence: presence}, tt.authorizer)
+				res, err := srv.ListSSHServers(t.Context(), tt.req)
+				if tt.shouldFail {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.ElementsMatch(t, tt.expectedNodes, res.GetServers())
+				}
+			})
+		}
+	})
+
+	t.Run("DeleteNode", func(t *testing.T) {
+		for _, tt := range []struct {
+			name      string
+			nodeScope string
+			// reqScope is the scope sent in the delete request. Defaults to
+			// nodeScope when empty, unless mismatchedScope is set.
+			mismatchedScope string
+			authorizer      authz.ScopedAuthorizer
+			shouldFail      bool
+		}{
+			{
+				name:       "unscoped read-user deleting unscoped node",
+				nodeScope:  "",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				shouldFail: true,
+			},
+			{
+				name:       "unscoped read-user deleting scoped node",
+				nodeScope:  testScope,
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				shouldFail: true,
+			},
+			{
+				name:       "scoped read-user deleting scoped node",
+				nodeScope:  testScope,
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				shouldFail: true,
+			},
+			{
+				name:       "scoped delete-user deleting unscoped node",
+				nodeScope:  "",
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				shouldFail: true,
+			},
+			{
+				name:       "scoped delete-user deleting orthogonal scoped node",
+				nodeScope:  testOrthogonalScope,
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				shouldFail: true,
+			},
+			{
+				name:       "scoped delete-user deleting scoped node",
+				nodeScope:  testScope,
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+			},
+			{
+				name:       "unscoped delete-user deleting unscoped node",
+				nodeScope:  "",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindNode, types.VerbDelete),
+			},
+			{
+				name:       "unscoped delete-user deleting scoped node",
+				nodeScope:  testScope,
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindNode, types.VerbDelete),
+			},
+			{
+				name:            "delete with mismatched scope",
+				nodeScope:       testScope,
+				mismatchedScope: testOrthogonalScope,
+				authorizer:      newFakeAuthorizer(t, deleteUser, types.KindNode, types.VerbDelete),
+				shouldFail:      true,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				name := uuid.NewString()
+				node := newNode(t, presence, scopes.QualifiedName{Name: name, Scope: tt.nodeScope}, map[string]string{"env": "test"})
+
+				reqScope := tt.nodeScope
+				if tt.mismatchedScope != "" {
+					reqScope = tt.mismatchedScope
+				}
+
+				srv := newPresenceService(t, backend{presence: presence}, tt.authorizer)
+				_, err := srv.DeleteSSHServer(t.Context(), presencev1pb.DeleteSSHServerRequest_builder{
+					Name:  name,
+					Scope: reqScope,
+				}.Build())
+				if tt.shouldFail {
+					assert.Error(t, err)
+					_, err := presence.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+						Name:  name,
+						Scope: tt.nodeScope,
+					}.Build())
+					assert.NoError(t, err)
+					return
+				}
+
+				assert.NoError(t, err)
+				_, err = presence.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+					Name:  node.GetName(),
+					Scope: tt.nodeScope,
+				}.Build())
+				assert.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+			})
+		}
+	})
+}
+
+func newNode(t *testing.T, presence *local.PresenceService, sqn scopes.QualifiedName, labels map[string]string) types.Server {
+	t.Helper()
+	server := &types.ServerV2{
+		Kind: types.KindNode,
+		Metadata: types.Metadata{
+			Name:   sqn.Name,
+			Labels: labels,
+		},
+		Scope: sqn.Scope,
+		Spec: types.ServerSpecV2{
+			Addr:     "127.0.0.1:22",
+			Hostname: sqn.Name,
+		},
+	}
+
+	_, err := presence.UpsertNode(t.Context(), server)
+	require.NoError(t, err)
+
+	res, err := presence.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+		Name:  sqn.Name,
+		Scope: sqn.Scope,
+	}.Build())
+	require.NoError(t, err)
+
+	return res
+}

--- a/lib/auth/presence/presencev1/service_test.go
+++ b/lib/auth/presence/presencev1/service_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"net"
 	"os"
 	"testing"
@@ -40,18 +41,27 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	presencev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/auth/presence/presencev1"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 )
 
 func newTestTLSServer(t testing.TB) *authtest.TLSServer {
@@ -1702,4 +1712,211 @@ func waitForSRACache(t *testing.T, srv *authtest.TLSServer, sras ...*scopedacces
 			require.NoError(t, err)
 		}
 	}, 10*time.Second, 100*time.Millisecond)
+}
+
+const (
+	testLocalCluster    = "test-cluster"
+	testParentScope     = "/aa"
+	testScope           = "/aa/aa"
+	testOrthogonalScope = "/aa/bb"
+)
+
+func newPresenceService(t *testing.T, backend presencev1.Backend, authorizer authz.ScopedAuthorizer) *presencev1.Service {
+	t.Helper()
+
+	svc, err := presencev1.NewService(presencev1.ServiceConfig{
+		Backend:          backend,
+		Authorizer:       stubAuthorizer{},
+		ScopedAuthorizer: authorizer,
+		AuthServer:       stubAuthServer{},
+		Cache:            stubCache{},
+		Emitter:          &eventstest.MockRecorderEmitter{},
+		Reporter:         usagereporter.DiscardUsageReporter{},
+		Clock:            clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+	return svc
+}
+
+type (
+	stubAuthorizer struct{ authz.Authorizer }
+	stubAuthServer struct{ presencev1.AuthServer }
+	stubCache      struct{ presencev1.Cache }
+)
+
+type backend struct {
+	presencev1.Backend
+	presence *local.PresenceService
+	kube     *local.KubernetesService
+}
+
+func (b backend) GetSSHServer(ctx context.Context, req *presencev1pb.GetSSHServerRequest) (types.Server, error) {
+	return b.presence.GetSSHServer(ctx, req)
+}
+
+func (b backend) RangeSSHServers(ctx context.Context, req *presencev1pb.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	return b.presence.RangeSSHServers(ctx, req)
+}
+
+func (b backend) DeleteSSHServer(ctx context.Context, req *presencev1pb.DeleteSSHServerRequest) error {
+	return b.presence.DeleteSSHServer(ctx, req)
+}
+
+func (b backend) GetKubeCluster(ctx context.Context, req *presencev1pb.GetKubeClusterRequest) (types.KubeCluster, error) {
+	return b.kube.GetKubeCluster(ctx, req)
+}
+
+func (b backend) RangeKubeClusters(ctx context.Context, req *presencev1pb.ListKubeClustersRequest) iter.Seq2[types.KubeCluster, error] {
+	return b.kube.RangeKubeClusters(ctx, req)
+}
+
+func (b backend) DeleteKubeCluster(ctx context.Context, req *presencev1pb.DeleteKubeClusterRequest) error {
+	return b.kube.DeleteKubeCluster(ctx, req)
+}
+
+func newFakeAuthorizer(t *testing.T, username, kind string, verbs ...string) fakeScopedAuthorizer {
+	t.Helper()
+
+	role, err := types.NewRole(username+"-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins: []string{"root"},
+			NodeLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			KubernetesLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			Rules: []types.Rule{types.NewRule(kind, verbs)},
+		},
+	})
+	require.NoError(t, err)
+
+	user, err := types.NewUser(username)
+	require.NoError(t, err)
+	user.SetRoles([]string{role.GetName()})
+
+	return fakeScopedAuthorizer{
+		ctx: authz.ScopedContextFromUnscopedContext(&authz.Context{
+			User: user,
+			Checker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+				Username: username,
+				Roles:    []string{role.GetName()},
+			}, testLocalCluster, services.NewRoleSet(role)),
+			AdminActionAuthState: authz.AdminActionAuthNotRequired,
+		}),
+	}
+}
+
+type fakeScopedAuthorizer struct {
+	ctx *authz.ScopedContext
+}
+
+func (f fakeScopedAuthorizer) AuthorizeScoped(context.Context) (*authz.ScopedContext, error) {
+	return f.ctx, nil
+}
+
+func newFakeScopedAuthorizer(t *testing.T, username, pinScope string, reader fakeScopedRoleReader, roles ...*scopedaccessv1.ScopedRole) fakeScopedAuthorizer {
+	t.Helper()
+
+	assigned := make([]string, 0, len(roles))
+	for _, role := range roles {
+		assigned = append(assigned, scopes.QualifiedName{
+			Scope: role.GetScope(),
+			Name:  role.GetMetadata().GetName(),
+		}.String())
+	}
+
+	user, err := types.NewUser(username)
+	require.NoError(t, err)
+
+	checkerContext, err := services.NewScopedAccessCheckerContext(t.Context(), &services.AccessInfo{
+		Username: username,
+		ScopePin: scopesv1.Pin_builder{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
+			Scope: pinScope,
+			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+				pinScope: {pinScope: assigned},
+			}),
+		}.Build(),
+	}, testLocalCluster, reader)
+	require.NoError(t, err)
+
+	return fakeScopedAuthorizer{
+		ctx: &authz.ScopedContext{
+			User:           user,
+			CheckerContext: checkerContext,
+		},
+	}
+}
+
+type fakeScopedRoleReader struct {
+	roles map[string]*scopedaccessv1.ScopedRole
+}
+
+func (r fakeScopedRoleReader) createScopedRole(name string, verbs ...string) *scopedaccessv1.ScopedRole {
+	role := scopedaccessv1.ScopedRole_builder{
+		Kind:    scopedaccess.KindScopedRole,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: name,
+		}.Build(),
+		Scope: testParentScope,
+		Spec: scopedaccessv1.ScopedRoleSpec_builder{
+			AssignableScopes: []string{testScope, testOrthogonalScope},
+			Rules: []*scopedaccessv1.ScopedRule{
+				scopedaccessv1.ScopedRule_builder{
+					Resources: []string{
+						types.KindNode,
+						types.KindKubernetesCluster,
+					},
+					Verbs: verbs,
+				}.Build(),
+			},
+			Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+				Logins: []string{"root"},
+				Labels: []*labelv1.Label{
+					labelv1.Label_builder{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					}.Build(),
+				},
+			}.Build(),
+			Kube: scopedaccessv1.ScopedRoleKube_builder{
+				Labels: []*labelv1.Label{
+					labelv1.Label_builder{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					}.Build(),
+				},
+				Resources: []*scopedaccessv1.KubeResource{
+					scopedaccessv1.KubeResource_builder{
+						Kind:      types.Wildcard,
+						Name:      types.Wildcard,
+						Namespace: types.Wildcard,
+						ApiGroup:  types.Wildcard,
+						Verbs:     []string{types.Wildcard},
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build()
+
+	r.roles[scopes.QualifiedName{Scope: role.GetScope(), Name: name}.String()] = role
+	return role
+}
+
+func (r fakeScopedRoleReader) GetScopedRole(_ context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	role, ok := r.roles[scopes.QualifiedName{Scope: req.GetScope(), Name: req.GetName()}.String()]
+	if !ok {
+		return nil, trace.NotFound("scoped role %q not found", req.GetName())
+	}
+	return scopedaccessv1.GetScopedRoleResponse_builder{Role: role}.Build(), nil
+}
+
+func (r fakeScopedRoleReader) ListScopedRoles(context.Context, *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	roles := make([]*scopedaccessv1.ScopedRole, 0, len(r.roles))
+	for _, role := range r.roles {
+		roles = append(roles, role)
+	}
+	return scopedaccessv1.ListScopedRolesResponse_builder{Roles: roles}.Build(), nil
 }

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1801,7 +1801,7 @@ func TestServersCRUD(t *testing.T) {
 	_, err = clt.UpsertNode(ctx, srv)
 	require.NoError(t, err)
 
-	node, err := clt.GetNode(ctx, srv.Metadata.Namespace, srv.GetName())
+	node, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: srv.GetName()}.Build())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(node, srv, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
@@ -1810,7 +1810,7 @@ func TestServersCRUD(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out, []types.Server{srv}, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = clt.DeleteNode(ctx, srv.Metadata.Namespace, srv.GetName())
+	err = clt.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: srv.GetName()}.Build())
 	require.NoError(t, err)
 
 	out, err = clt.GetNodes(ctx, srv.Metadata.Namespace)

--- a/lib/cache/node.go
+++ b/lib/cache/node.go
@@ -18,11 +18,15 @@ package cache
 
 import (
 	"context"
+	"iter"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -41,7 +45,7 @@ func newNodeCollection(p services.Presence, w types.WatchKind) (*collection[type
 			types.KindNode,
 			types.Server.DeepCopy,
 			map[nodeIndex]func(types.Server) string{
-				nodeNameIndex: types.Server.GetName,
+				nodeNameIndex: services.GetCursorForNode,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
 			return p.GetNodes(ctx, defaults.Namespace)
@@ -71,7 +75,7 @@ func (c *Cache) GetNode(ctx context.Context, namespace, name string) (types.Serv
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		node, err := c.Config.Presence.GetNode(ctx, namespace, name)
+		node, err := c.Config.Presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 		return node, trace.Wrap(err)
 	}
 
@@ -81,6 +85,27 @@ func (c *Cache) GetNode(ctx context.Context, namespace, name string) (types.Serv
 	}
 
 	return n.DeepCopy(), nil
+}
+
+// GetSSHServer returns the specified scoped or unscoped node.
+func (c *Cache) GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetSSHServer")
+	defer span.End()
+
+	getter := genericGetter[types.Server, nodeIndex]{
+		cache:      c,
+		collection: c.collections.nodes,
+		index:      nodeNameIndex,
+		upstreamGet: func(ctx context.Context, _ string) (types.Server, error) {
+			return c.Config.Presence.GetSSHServer(ctx, req)
+		},
+	}
+
+	out, err := getter.get(ctx, scopes.MakeResourceCursor(req.GetScope(), req.GetName()))
+	if out == nil {
+		return nil, trace.Wrap(err)
+	}
+	return out.DeepCopy(), trace.Wrap(err)
 }
 
 type getNodesCacheKey struct {
@@ -113,6 +138,61 @@ func (c *Cache) GetNodes(ctx context.Context, namespace string) ([]types.Server,
 
 	return out, nil
 
+}
+
+// ListSSHServers returns a page of registered nodes.
+func (c *Cache) ListSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) ([]types.Server, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListNodes")
+	defer span.End()
+
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	lister := genericLister[types.Server, nodeIndex]{
+		cache:      c,
+		collection: c.collections.nodes,
+		index:      nodeNameIndex,
+		upstreamList: func(ctx context.Context, _ int, _ string) ([]types.Server, string, error) {
+			return c.Config.Presence.ListSSHServers(ctx, req)
+		},
+		nextToken: services.GetCursorForNode,
+		filter: func(server types.Server) bool {
+			return scopes.MatchScope(scopeFilter, server.GetScope())
+		},
+	}
+	return lister.list(ctx, int(req.GetPageSize()), req.GetPageToken())
+}
+
+// RangeSSHServers returns a sequence of nodes filtered by the given
+// [*presencev1.ListSSHServersRequest].
+func (c *Cache) RangeSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	ctx, span := c.Tracer.Start(ctx, "cache/RangeSSHServers")
+	defer span.End()
+
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return stream.Fail[types.Server](trace.Wrap(err))
+	}
+
+	lister := genericLister[types.Server, nodeIndex]{
+		cache:      c,
+		collection: c.collections.nodes,
+		index:      nodeNameIndex,
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+			return c.Config.Presence.ListSSHServers(ctx, presencev1.ListSSHServersRequest_builder{
+				PageSize:    int32(pageSize),
+				PageToken:   pageToken,
+				ScopeFilter: scopeFilter,
+			}.Build())
+		},
+		filter: func(server types.Server) bool {
+			return scopes.MatchScope(scopeFilter, server.GetScope())
+		},
+		nextToken: services.GetCursorForNode,
+	}
+
+	return lister.Range(ctx, req.GetPageToken(), "")
 }
 
 // getNodesWithTTLCache implements TTL-based caching for the GetNodes endpoint.  All nodes that will be returned from the caching layer

--- a/lib/cache/node.go
+++ b/lib/cache/node.go
@@ -18,11 +18,15 @@ package cache
 
 import (
 	"context"
+	"iter"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -41,7 +45,7 @@ func newNodeCollection(p services.Presence, w types.WatchKind) (*collection[type
 			types.KindNode,
 			types.Server.DeepCopy,
 			map[nodeIndex]func(types.Server) string{
-				nodeNameIndex: types.Server.GetName,
+				nodeNameIndex: services.GetCursorForNode,
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.Server, error) {
 			return p.GetNodes(ctx, defaults.Namespace)
@@ -71,7 +75,7 @@ func (c *Cache) GetNode(ctx context.Context, namespace, name string) (types.Serv
 	defer rg.Release()
 
 	if !rg.ReadCache() {
-		node, err := c.Config.Presence.GetNode(ctx, namespace, name)
+		node, err := c.Config.Presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 		return node, trace.Wrap(err)
 	}
 
@@ -81,6 +85,27 @@ func (c *Cache) GetNode(ctx context.Context, namespace, name string) (types.Serv
 	}
 
 	return n.DeepCopy(), nil
+}
+
+// GetSSHServer returns the specified scoped or unscoped node.
+func (c *Cache) GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetSSHServer")
+	defer span.End()
+
+	getter := genericGetter[types.Server, nodeIndex]{
+		cache:      c,
+		collection: c.collections.nodes,
+		index:      nodeNameIndex,
+		upstreamGet: func(ctx context.Context, _ string) (types.Server, error) {
+			return c.Config.Presence.GetSSHServer(ctx, req)
+		},
+	}
+
+	out, err := getter.get(ctx, scopes.MakeResourceCursor(req.GetScope(), req.GetName()))
+	if out == nil {
+		return nil, trace.Wrap(err)
+	}
+	return out.DeepCopy(), trace.Wrap(err)
 }
 
 type getNodesCacheKey struct {
@@ -113,6 +138,61 @@ func (c *Cache) GetNodes(ctx context.Context, namespace string) ([]types.Server,
 
 	return out, nil
 
+}
+
+// ListSSHServers returns a page of registered nodes.
+func (c *Cache) ListSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) ([]types.Server, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListNodes")
+	defer span.End()
+
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	lister := genericLister[types.Server, nodeIndex]{
+		cache:      c,
+		collection: c.collections.nodes,
+		index:      nodeNameIndex,
+		upstreamList: func(ctx context.Context, _ int, _ string) ([]types.Server, string, error) {
+			return c.Config.Presence.ListSSHServers(ctx, req)
+		},
+		nextToken: services.GetCursorForNode,
+		filter: func(server types.Server) bool {
+			return scopes.MatchScope(scopeFilter, server.GetScope())
+		},
+	}
+	return lister.list(ctx, int(req.GetPageSize()), req.GetPageToken())
+}
+
+// RangeSSHServers returns a sequence of nodes filtered by the given
+// [*presencev1.ListSSHServersRequest].
+func (c *Cache) RangeSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	ctx, span := c.Tracer.Start(ctx, "cache/RangeNodes")
+	defer span.End()
+
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return stream.Fail[types.Server](trace.Wrap(err))
+	}
+
+	lister := genericLister[types.Server, nodeIndex]{
+		cache:      c,
+		collection: c.collections.nodes,
+		index:      nodeNameIndex,
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+			return c.Config.Presence.ListSSHServers(ctx, presencev1.ListSSHServersRequest_builder{
+				PageSize:    int32(pageSize),
+				PageToken:   pageToken,
+				ScopeFilter: scopeFilter,
+			}.Build())
+		},
+		filter: func(server types.Server) bool {
+			return scopes.MatchScope(scopeFilter, server.GetScope())
+		},
+		nextToken: services.GetCursorForNode,
+	}
+
+	return lister.Range(ctx, req.GetPageToken(), "")
 }
 
 // getNodesWithTTLCache implements TTL-based caching for the GetNodes endpoint.  All nodes that will be returned from the caching layer

--- a/lib/cache/node_test.go
+++ b/lib/cache/node_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"iter"
 	"testing"
 	"time"
 
@@ -27,8 +28,37 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 )
+
+const (
+	nodeProdScope    = "/aws/prod"
+	nodeStagingScope = "/aws/staging"
+)
+
+func newNodeResource(name string) (types.Server, error) {
+	return NewServer(types.KindNode, name, "127.0.0.1:2022", apidefaults.Namespace), nil
+}
+
+// listNodesAdapter adapts a ListNodes method to the page function shape the
+// resource test harness expects.
+func listNodesAdapter(fn func(context.Context, *presencev1.ListSSHServersRequest) ([]types.Server, string, error)) func(context.Context, int, string) ([]types.Server, string, error) {
+	return func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+		return fn(ctx, presencev1.ListSSHServersRequest_builder{
+			PageSize:  int32(pageSize),
+			PageToken: pageToken,
+		}.Build())
+	}
+}
+
+// rangeNodesAdapter adapts a RangeNodes method to the range function shape the
+// resource test harness expects.
+func rangeNodesAdapter(fn func(context.Context, *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error]) func(context.Context, string, string) iter.Seq2[types.Server, error] {
+	return func(ctx context.Context, start, _ string) iter.Seq2[types.Server, error] {
+		return fn(ctx, presencev1.ListSSHServersRequest_builder{PageToken: start}.Build())
+	}
+}
 
 // TestNodes tests nodes cache
 func TestNodes(t *testing.T) {
@@ -41,10 +71,8 @@ func TestNodes(t *testing.T) {
 		t.Cleanup(p.Close)
 
 		testResources(t, p, testFuncs[types.Server]{
-			newResource: func(name string) (types.Server, error) {
-				return NewServer(types.KindNode, name, "127.0.0.1:2022", apidefaults.Namespace), nil
-			},
-			create: withKeepalive(p.presenceS.UpsertNode),
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
 			list: getAllAdapter(func(ctx context.Context) ([]types.Server, error) {
 				return p.presenceS.GetNodes(ctx, apidefaults.Namespace)
 			}),
@@ -66,10 +94,8 @@ func TestNodes(t *testing.T) {
 		t.Cleanup(p.Close)
 
 		testResources(t, p, testFuncs[types.Server]{
-			newResource: func(name string) (types.Server, error) {
-				return NewServer(types.KindNode, name, "127.0.0.1:2022", apidefaults.Namespace), nil
-			},
-			create: withKeepalive(p.presenceS.UpsertNode),
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
 			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
 				req := proto.ListResourcesRequest{
 					ResourceType: types.KindNode,
@@ -112,6 +138,76 @@ func TestNodes(t *testing.T) {
 				return out, resp.NextKey, nil
 			},
 			update: withKeepalive(p.presenceS.UpsertNode),
+			deleteAll: func(ctx context.Context) error {
+				return p.presenceS.DeleteAllNodes(ctx, apidefaults.Namespace)
+			},
+		})
+	})
+
+	// GetSSHServer replaces GetNode as the single-node getter.
+	t.Run("GetSSHServer", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestPack(t, ForProxy)
+		t.Cleanup(p.Close)
+
+		testResources(t, p, testFuncs[types.Server]{
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
+			list: getAllAdapter(func(ctx context.Context) ([]types.Server, error) {
+				return p.presenceS.GetNodes(ctx, apidefaults.Namespace)
+			}),
+			cacheGet: func(ctx context.Context, name string) (types.Server, error) {
+				return p.cache.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
+			},
+			cacheList: getAllAdapter(func(ctx context.Context) ([]types.Server, error) {
+				return p.cache.GetNodes(ctx, apidefaults.Namespace)
+			}),
+			update: withKeepalive(p.presenceS.UpsertNode),
+			deleteAll: func(ctx context.Context) error {
+				return p.presenceS.DeleteAllNodes(ctx, apidefaults.Namespace)
+			},
+		}, withSkipPaginationTest())
+	})
+
+	t.Run("ListNodes", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestPack(t, ForProxy)
+		t.Cleanup(p.Close)
+
+		testResources(t, p, testFuncs[types.Server]{
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
+			list:        listNodesAdapter(p.presenceS.ListSSHServers),
+			cacheGet: func(ctx context.Context, name string) (types.Server, error) {
+				return p.cache.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
+			},
+			cacheList: listNodesAdapter(p.cache.ListSSHServers),
+			update:    withKeepalive(p.presenceS.UpsertNode),
+			deleteAll: func(ctx context.Context) error {
+				return p.presenceS.DeleteAllNodes(ctx, apidefaults.Namespace)
+			},
+		})
+	})
+
+	t.Run("RangeNodes", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestPack(t, ForProxy, ignoreRangeEndKey())
+		t.Cleanup(p.Close)
+
+		testResources(t, p, testFuncs[types.Server]{
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
+			list:        listNodesAdapter(p.presenceS.ListSSHServers),
+			Range:       rangeNodesAdapter(p.presenceS.RangeSSHServers),
+			cacheGet: func(ctx context.Context, name string) (types.Server, error) {
+				return p.cache.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
+			},
+			cacheList:  listNodesAdapter(p.cache.ListSSHServers),
+			cacheRange: rangeNodesAdapter(p.cache.RangeSSHServers),
+			update:     withKeepalive(p.presenceS.UpsertNode),
 			deleteAll: func(ctx context.Context) error {
 				return p.presenceS.DeleteAllNodes(ctx, apidefaults.Namespace)
 			},

--- a/lib/cache/node_test.go
+++ b/lib/cache/node_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"iter"
 	"testing"
 	"time"
 
@@ -27,8 +28,32 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 )
+
+func newNodeResource(name string) (types.Server, error) {
+	return NewServer(types.KindNode, name, "127.0.0.1:2022", apidefaults.Namespace), nil
+}
+
+// listNodesAdapter adapts a ListNodes method to the page function shape the
+// resource test harness expects.
+func listNodesAdapter(fn func(context.Context, *presencev1.ListSSHServersRequest) ([]types.Server, string, error)) func(context.Context, int, string) ([]types.Server, string, error) {
+	return func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+		return fn(ctx, presencev1.ListSSHServersRequest_builder{
+			PageSize:  int32(pageSize),
+			PageToken: pageToken,
+		}.Build())
+	}
+}
+
+// rangeNodesAdapter adapts a RangeSSHServers method to the range function shape the
+// resource test harness expects.
+func rangeNodesAdapter(fn func(context.Context, *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error]) func(context.Context, string, string) iter.Seq2[types.Server, error] {
+	return func(ctx context.Context, start, _ string) iter.Seq2[types.Server, error] {
+		return fn(ctx, presencev1.ListSSHServersRequest_builder{PageToken: start}.Build())
+	}
+}
 
 // TestNodes tests nodes cache
 func TestNodes(t *testing.T) {
@@ -41,10 +66,8 @@ func TestNodes(t *testing.T) {
 		t.Cleanup(p.Close)
 
 		testResources(t, p, testFuncs[types.Server]{
-			newResource: func(name string) (types.Server, error) {
-				return NewServer(types.KindNode, name, "127.0.0.1:2022", apidefaults.Namespace), nil
-			},
-			create: withKeepalive(p.presenceS.UpsertNode),
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
 			list: getAllAdapter(func(ctx context.Context) ([]types.Server, error) {
 				return p.presenceS.GetNodes(ctx, apidefaults.Namespace)
 			}),
@@ -66,10 +89,8 @@ func TestNodes(t *testing.T) {
 		t.Cleanup(p.Close)
 
 		testResources(t, p, testFuncs[types.Server]{
-			newResource: func(name string) (types.Server, error) {
-				return NewServer(types.KindNode, name, "127.0.0.1:2022", apidefaults.Namespace), nil
-			},
-			create: withKeepalive(p.presenceS.UpsertNode),
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
 			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
 				req := proto.ListResourcesRequest{
 					ResourceType: types.KindNode,
@@ -112,6 +133,76 @@ func TestNodes(t *testing.T) {
 				return out, resp.NextKey, nil
 			},
 			update: withKeepalive(p.presenceS.UpsertNode),
+			deleteAll: func(ctx context.Context) error {
+				return p.presenceS.DeleteAllNodes(ctx, apidefaults.Namespace)
+			},
+		})
+	})
+
+	// GetSSHServer replaces GetNode as the single-node getter.
+	t.Run("GetSSHServer", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestPack(t, ForProxy)
+		t.Cleanup(p.Close)
+
+		testResources(t, p, testFuncs[types.Server]{
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
+			list: getAllAdapter(func(ctx context.Context) ([]types.Server, error) {
+				return p.presenceS.GetNodes(ctx, apidefaults.Namespace)
+			}),
+			cacheGet: func(ctx context.Context, name string) (types.Server, error) {
+				return p.cache.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
+			},
+			cacheList: getAllAdapter(func(ctx context.Context) ([]types.Server, error) {
+				return p.cache.GetNodes(ctx, apidefaults.Namespace)
+			}),
+			update: withKeepalive(p.presenceS.UpsertNode),
+			deleteAll: func(ctx context.Context) error {
+				return p.presenceS.DeleteAllNodes(ctx, apidefaults.Namespace)
+			},
+		}, withSkipPaginationTest())
+	})
+
+	t.Run("ListNodes", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestPack(t, ForProxy)
+		t.Cleanup(p.Close)
+
+		testResources(t, p, testFuncs[types.Server]{
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
+			list:        listNodesAdapter(p.presenceS.ListSSHServers),
+			cacheGet: func(ctx context.Context, name string) (types.Server, error) {
+				return p.cache.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
+			},
+			cacheList: listNodesAdapter(p.cache.ListSSHServers),
+			update:    withKeepalive(p.presenceS.UpsertNode),
+			deleteAll: func(ctx context.Context) error {
+				return p.presenceS.DeleteAllNodes(ctx, apidefaults.Namespace)
+			},
+		})
+	})
+
+	t.Run("RangeSSHServers", func(t *testing.T) {
+		t.Parallel()
+
+		p := newTestPack(t, ForProxy, ignoreRangeEndKey())
+		t.Cleanup(p.Close)
+
+		testResources(t, p, testFuncs[types.Server]{
+			newResource: newNodeResource,
+			create:      withKeepalive(p.presenceS.UpsertNode),
+			list:        listNodesAdapter(p.presenceS.ListSSHServers),
+			Range:       rangeNodesAdapter(p.presenceS.RangeSSHServers),
+			cacheGet: func(ctx context.Context, name string) (types.Server, error) {
+				return p.cache.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
+			},
+			cacheList:  listNodesAdapter(p.cache.ListSSHServers),
+			cacheRange: rangeNodesAdapter(p.cache.RangeSSHServers),
+			update:     withKeepalive(p.presenceS.UpsertNode),
 			deleteAll: func(ctx context.Context) error {
 				return p.presenceS.DeleteAllNodes(ctx, apidefaults.Namespace)
 			},

--- a/lib/decision/service.go
+++ b/lib/decision/service.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/lib/services"
@@ -38,8 +38,8 @@ import (
 
 // NodeGetter is a service that gets a node.
 type NodeGetter interface {
-	// GetNode returns a node by name and namespace.
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 }
 
 // ClusterNetworkingConfigGetter is a service that gets the cluster networking configuration.
@@ -164,7 +164,9 @@ func (s *Service) EvaluateSSHAccess(ctx context.Context, req *decisionpb.Evaluat
 		return nil, trace.Errorf("session joining is not yet supported by the decision service")
 	}
 
-	target, err := s.cfg.AccessPoint.GetNode(ctx, apidefaults.Namespace, req.GetNode().GetName())
+	target, err := s.cfg.AccessPoint.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name: req.GetNode().GetName(),
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/join/ec2join/ec2.go
+++ b/lib/join/ec2join/ec2.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	config "github.com/gravitational/teleport/lib/cloud/aws/config"
@@ -172,8 +173,8 @@ func checkPendingTime(iid *imds.InstanceIdentityDocument, provisionToken provisi
 	return nil
 }
 
-func nodeExists(ctx context.Context, presence services.Presence, hostID string) (bool, error) {
-	_, err := presence.GetNode(ctx, defaults.Namespace, hostID)
+func nodeExists(ctx context.Context, presence services.Presence, hostID, scope string) (bool, error) {
+	_, err := presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: hostID, Scope: scope}.Build())
 	switch {
 	case trace.IsNotFound(err):
 		return false, nil
@@ -270,10 +271,10 @@ func desktopServiceExists(ctx context.Context, presence services.Presence, hostI
 	return false, nil
 }
 
-func resourceExists(ctx context.Context, presence services.Presence, role types.SystemRole, hostID string) (bool, error) {
+func resourceExists(ctx context.Context, presence services.Presence, role types.SystemRole, hostID, scope string) (bool, error) {
 	switch role {
 	case types.RoleNode:
-		return nodeExists(ctx, presence, hostID)
+		return nodeExists(ctx, presence, hostID, scope)
 	case types.RoleProxy:
 		return proxyExists(ctx, presence, hostID)
 	case types.RoleKube:
@@ -324,7 +325,7 @@ func tryToDetectIdentityReuse(ctx context.Context, params *CheckEC2RequestParams
 				// don't have any presence check.
 				continue
 			}
-			alreadyExists, err := resourceExists(ctx, params.Presence, role, hostID)
+			alreadyExists, err := resourceExists(ctx, params.Presence, role, hostID, params.ProvisionToken.GetAssignedScope())
 			if err != nil {
 				return trace.Wrap(err, "checking if %s with ID %s already exists", params.Role, hostID)
 			}
@@ -334,7 +335,7 @@ func tryToDetectIdentityReuse(ctx context.Context, params *CheckEC2RequestParams
 		}
 		return nil
 	}
-	alreadyExists, err := resourceExists(ctx, params.Presence, params.Role, hostID)
+	alreadyExists, err := resourceExists(ctx, params.Presence, params.Role, hostID, params.ProvisionToken.GetAssignedScope())
 	if err != nil {
 		return trace.Wrap(err, "checking if %s with ID %s already exists", params.Role, hostID)
 	}

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -473,6 +473,21 @@ func TestJoinEC2(t *testing.T) {
 			_, err = testServer.Auth().UpsertNode(t.Context(), node)
 			require.NoError(t, err)
 
+			// Introduction of ssh server namespacing means that
+			// 2 identical names ins different scopes is valid.
+			// We should only collide when the duplicate's scope also matches.
+			scopedNode := &types.ServerV2{
+				Kind:    types.KindNode,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name:      instance2.account + "-" + instance2.instanceID,
+					Namespace: defaults.Namespace,
+				},
+				Scope: "/test/one",
+			}
+			_, err = testServer.Auth().UpsertNode(t.Context(), scopedNode)
+			require.NoError(t, err)
+
 			nopClient, err := testServer.NewClient(authtest.TestNop())
 			require.NoError(t, err)
 
@@ -634,7 +649,7 @@ func TestHostUniqueCheck(t *testing.T) {
 				require.NoError(t, err)
 			},
 			deleter: func(t *testing.T, hostID string) {
-				require.NoError(t, a.DeleteNode(t.Context(), defaults.Namespace, hostID))
+				require.NoError(t, a.DeleteSSHServer(t.Context(), presencev1.DeleteSSHServerRequest_builder{Name: hostID}.Build()))
 			},
 		},
 		{

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -25,6 +25,7 @@ import (
 	"math/rand/v2"
 	"net"
 	"os"
+	"slices"
 	"sync"
 
 	"github.com/gravitational/trace"
@@ -510,7 +511,7 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 	}
 
 	var maxScore int
-	scores := make(map[string]int)
+	scores := make(map[scopes.QualifiedName]int)
 	matches, err := cluster.GetNodes(ctx, func(server readonly.Server) bool {
 		if scopePin != nil {
 			// TODO(fspmarshall/scopes): implement scope-aware node storage. filtering agents based on scope is sub-optimal. scoping
@@ -532,7 +533,10 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 			return false
 		}
 
-		scores[server.GetName()] = score
+		// Keyed by scope-qualified name: node names are only unique within a
+		// scope, so same-named nodes in different scopes would otherwise share
+		// a single score entry and overwrite each other.
+		scores[scopes.QualifiedName{Scope: server.GetScope(), Name: server.GetName()}] = score
 		maxScore = max(maxScore, score)
 		return true
 	})
@@ -544,15 +548,32 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 		// if a dial request for an id-like target creates multiple matches,
 		// give precedence to the exact match if one exists. If not, handle
 		// multiple matchers per-usual below.
+		//
+		// With the introduction of scope namespacing, it is now technically possible
+		// to create ssh servers with matching id-like names in multiple scopes.
+		// TODO (williamo/scopes): Replace this with SQN based routing
+		var nameMatches []types.Server
 		for _, m := range matches {
 			if m.GetName() == host {
-				matches = []types.Server{m}
-				break
+				nameMatches = append(nameMatches, m)
+			}
+		}
+
+		if len(nameMatches) > 0 {
+			// Narrow to the name matches rather than to a single one. A lone
+			// name match still collapses to it as before, but colliding names
+			// across scopes are left ambiguous for the handling below.
+			// If there is an unscoped server, take it over scoped servers
+			// that collide with its name.
+			matches = nameMatches
+
+			if slices.ContainsFunc(matches, func(m types.Server) bool { return m.GetScope() == "" }) {
+				matches = slices.DeleteFunc(matches, func(m types.Server) bool { return m.GetScope() != "" })
 			}
 		}
 	}
 
-	// NOTE: there is an open question here about wether or not we should be doing scope-aware
+	// NOTE: there is an open question here about whether or not we should be doing scope-aware
 	// disambiguation when multiple matches are found. In some cases, this seems like the obviously
 	// right thing to do.  For example, when there is a match in `/foo` and a match in `/foo/bar`,
 	// it would seem obvious that the match in `/foo` should be preferred per scope hierarchy rules.
@@ -569,7 +590,7 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 		// mix of match qualities, filter out the lower quality matches to reduce ambiguity.
 		filtered := matches[:0]
 		for _, m := range matches {
-			if scores[m.GetName()] < maxScore {
+			if scores[scopes.QualifiedName{Scope: m.GetScope(), Name: m.GetName()}] < maxScore {
 				continue
 			}
 

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -120,6 +120,11 @@ func TestScopePinning(t *testing.T) {
 
 	ctx := t.Context()
 
+	// node names are only unique within a scope, so an id-like target can match
+	// more than one node.
+	unscopedCollisionID := uuid.NewString()
+	scopedCollisionID := uuid.NewString()
+
 	// set up servers across varioous scopes with various hostname collision
 	// scenarios (parent/child, same-scope, orthogonal scopes, etc).
 	servers := createServers([]server{
@@ -127,6 +132,34 @@ func TestScopePinning(t *testing.T) {
 			scope:    "",
 			name:     uuid.NewString(),
 			hostname: "unscoped.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			// An unscoped node whose id collides with a scoped one.
+			// Dial reaches unscoped
+			scope:    "",
+			name:     unscopedCollisionID,
+			hostname: "id-collision-unscoped.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			scope:    "/staging",
+			name:     unscopedCollisionID,
+			hostname: "id-collision-scoped.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			// Two scoped nodes colliding on id with nothing unscoped to
+			// disambiguate, so the dial must stay ambiguous.
+			scope:    "/staging",
+			name:     scopedCollisionID,
+			hostname: "id-collision-staging.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			scope:    "/prod",
+			name:     scopedCollisionID,
+			hostname: "id-collision-prod.example.com",
 			addr:     "1.2.3.4:0",
 		},
 		{
@@ -228,6 +261,22 @@ func TestScopePinning(t *testing.T) {
 			pin:       nil,
 			ambiguous: true,
 		},
+		{
+			name: "unscoped node wins an id collision with a scoped node",
+			host: unscopedCollisionID,
+			pin:  nil,
+		},
+		{
+			name: "only scoped node reachable by colliding id as a scoped user",
+			host: unscopedCollisionID,
+			pin:  scopesv1.Pin_builder{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging"}.Build(),
+		},
+		{
+			name:      "colliding ids across scopes are ambiguous",
+			host:      scopedCollisionID,
+			pin:       nil,
+			ambiguous: true,
+		},
 	}
 
 	// use strict routing to ensure only one match is possible per test case.
@@ -296,6 +345,18 @@ func TestRouteScoring(t *testing.T) {
 			name:     "not-a-uuid",
 			hostname: "test.example.com",
 			addr:     "3.4.5.6:22",
+		},
+		{
+			scope:    "/test",
+			name:     "shared-scoring-name",
+			hostname: "direct.example.com",
+			addr:     "1.2.3.4:2222",
+		},
+		{
+			scope:    "/test2",
+			name:     "shared-scoring-name",
+			hostname: "indirect.example.com",
+			addr:     "1.2.3.4:3333",
 		},
 	})
 
@@ -373,6 +434,13 @@ func TestRouteScoring(t *testing.T) {
 			desc:   "non-uuid name",
 			host:   "not-a-uuid",
 			expect: "test.example.com",
+		},
+		{
+			// The direct hostname match must win over its same-named twin in
+			// another scope, which only matches indirectly.
+			desc:   "same name across scopes with differing match quality",
+			host:   "direct.example.com",
+			expect: "direct.example.com",
 		},
 	}
 

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -147,6 +147,9 @@ func isAllowedScopedRule(kind string, verb string) bool {
 	case types.KindAppServer:
 		// app servers can be read/written, and embed an app resource that carries no credential material.
 		return isReadWriteNoSecrets(verb)
+	case types.KindNode:
+		// ssh servers can be read/written, and do not currently contain a concept of a secret.
+		return isReadWriteNoSecrets(verb)
 	case types.KindAccessList:
 		// access lists can be read/written, and do not contain a concept of a secret.
 		// permissions for access list members are conferred by permissions for

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -356,18 +356,6 @@ func GetCursorForAppServer(server types.AppServer) string {
 	return scopes.MakeResourceCursorWithHost(server.GetScope(), server.GetHostID(), server.GetName())
 }
 
-// GetCursorForResource returns the pagination cursor for a
-// resource used in ListResources.
-func GetCursorForResource(r types.ResourceWithLabels) string {
-	switch res := r.(type) {
-	case types.AppServer:
-		return GetCursorForAppServer(res)
-	case types.KubeServer:
-		return GetCursorForKubeServer(res)
-	}
-	return backend.GetPaginationKey(r)
-}
-
 // ValidatePublicAddr requires a lowercase DNS-1123 hostname. An
 // empty addr is treated as unset.
 func ValidatePublicAddr(appName, addr string) error {

--- a/lib/services/cursor.go
+++ b/lib/services/cursor.go
@@ -1,0 +1,36 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+// GetCursorForResource returns the pagination cursor for a
+// resource used in ListResources.
+func GetCursorForResource(r types.ResourceWithLabels) string {
+	switch res := r.(type) {
+	case types.AppServer:
+		return GetCursorForAppServer(res)
+	case types.KubeServer:
+		return GetCursorForKubeServer(res)
+	case types.Server:
+		return GetCursorForNode(res)
+	}
+	return backend.GetPaginationKey(r)
+}

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -1330,7 +1330,7 @@ func (p *nodeParser) parse(event backend.Event) (types.Resource, error) {
 			}
 			return &types.ServerV2{
 				Kind:    types.KindNode,
-				Version: types.V3,
+				Version: types.V2,
 				Metadata: types.Metadata{
 					Name: components[1],
 				},

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -1305,7 +1305,9 @@ func (p *userParser) parse(event backend.Event) (types.Resource, error) {
 
 func newNodeParser() *nodeParser {
 	return &nodeParser{
-		baseParser: newBaseParser(backend.NewKey(nodesPrefix, apidefaults.Namespace)),
+		baseParser: newBaseParser(
+			backend.NewKey(nodesPrefix, apidefaults.Namespace),
+			backend.NewKey(scopedPrefix, nodesPrefix)),
 	}
 }
 
@@ -1316,6 +1318,25 @@ type nodeParser struct {
 func (p *nodeParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		scopedNodeParserKey := backend.NewKey(scopedPrefix, nodesPrefix)
+		if event.Item.Key.HasPrefix(scopedNodeParserKey) {
+			components := event.Item.Key.TrimPrefix(scopedNodeParserKey).Components()
+			if len(components) != 2 {
+				return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+			}
+			scope, err := scopes.DecodeFromKey(components[0])
+			if err != nil {
+				return nil, trace.Wrap(err, "failed decoding scope from node server key %q", event.Item.Key.String())
+			}
+			return &types.ServerV2{
+				Kind:    types.KindNode,
+				Version: types.V3,
+				Metadata: types.Metadata{
+					Name: components[1],
+				},
+				Scope: scope,
+			}, nil
+		}
 		name := event.Item.Key.TrimPrefix(backend.NewKey(nodesPrefix, apidefaults.Namespace)).String()
 		if name == "" {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -1305,7 +1305,9 @@ func (p *userParser) parse(event backend.Event) (types.Resource, error) {
 
 func newNodeParser() *nodeParser {
 	return &nodeParser{
-		baseParser: newBaseParser(backend.NewKey(nodesPrefix, apidefaults.Namespace)),
+		baseParser: newBaseParser(
+			backend.NewKey(nodesPrefix, apidefaults.Namespace),
+			backend.NewKey(scopedPrefix, nodesPrefix)),
 	}
 }
 
@@ -1316,6 +1318,25 @@ type nodeParser struct {
 func (p *nodeParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
+		scopedNodeParserKey := backend.NewKey(scopedPrefix, nodesPrefix)
+		if event.Item.Key.HasPrefix(scopedNodeParserKey) {
+			components := event.Item.Key.TrimPrefix(scopedNodeParserKey).Components()
+			if len(components) != 2 {
+				return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())
+			}
+			scope, err := scopes.DecodeFromKey(components[0])
+			if err != nil {
+				return nil, trace.Wrap(err, "failed decoding scope from node server key %q", event.Item.Key.String())
+			}
+			return &types.ServerV2{
+				Kind:    types.KindNode,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: components[1],
+				},
+				Scope: scope,
+			}, nil
+		}
 		name := event.Item.Key.TrimPrefix(backend.NewKey(nodesPrefix, apidefaults.Namespace)).String()
 		if name == "" {
 			return nil, trace.NotFound("failed parsing %v", event.Item.Key.String())

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1818,6 +1818,10 @@ func (s *PresenceService) listSSHServers(ctx context.Context, req proto.ListReso
 }
 
 func getFakePaginationKey(ki backend.KeyedItem) string {
+	if server, ok := ki.(types.Server); ok && server.GetKind() == types.KindNode {
+		return services.GetCursorForNode(server)
+	}
+
 	// TODO(eriktate/scopes): this will need to be reassessed when we implement scoped namespacing
 	if kubeCluster, ok := ki.(types.KubeCluster); ok {
 		if scope := kubeCluster.GetScope(); scope != "" {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -59,6 +59,7 @@ type PresenceService struct {
 	relayServers *generic.ServiceWrapper[*presencev1.RelayServer]
 	appServers   *generic.ScopeAwareService[types.AppServer]
 	kubeServers  *generic.ScopeAwareService[types.KubeServer]
+	sshServers   *generic.ScopeAwareService[types.Server]
 }
 
 type appServerServiceParams struct {
@@ -154,6 +155,22 @@ func NewPresenceService(b backend.Backend) *PresenceService {
 	if err != nil {
 		panic("impossible: failed to construct kube_server service wrapper")
 	}
+
+	sshServers, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[types.Server]{
+		Backend:               b,
+		ResourceKind:          types.KindNode,
+		UnscopedBackendPrefix: nodesUnscopedPrefix(),
+		ScopedBackendPrefix:   nodesScopedPrefix(),
+		MarshalFunc:           services.MarshalServer,
+		UnmarshalFunc: func(b []byte, mo ...services.MarshalOption) (types.Server, error) {
+			server, err := services.UnmarshalServer(b, types.KindNode, mo...)
+			return server, trace.Wrap(err)
+		},
+	})
+	if err != nil {
+		panic("impossible: failed to construct node service wrapper")
+	}
+
 	return &PresenceService{
 		logger:  slog.With(teleport.ComponentKey, "Presence"),
 		jitter:  retryutils.FullJitter,
@@ -162,6 +179,7 @@ func NewPresenceService(b backend.Backend) *PresenceService {
 		relayServers: relayServers,
 		appServers:   appServers,
 		kubeServers:  kubeServers,
+		sshServers:   sshServers,
 	}
 }
 
@@ -301,83 +319,89 @@ func (s *PresenceService) upsertServer(ctx context.Context, prefix string, serve
 	return server, nil
 }
 
-// DeleteAllNodes deletes all nodes in a namespace
+// DeleteAllNodes deletes all scoped and unscoped nodes.
 func (s *PresenceService) DeleteAllNodes(ctx context.Context, namespace string) error {
-	startKey := backend.ExactKey(nodesPrefix, namespace)
-	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
+	return trace.Wrap(s.sshServers.DeleteAllResources(ctx))
 }
 
-// DeleteNode deletes node
+// DeleteNode deletes node in a namespace
+// Deprecated: use DeleteNodeV2 instead, which supports scoped nodes.
+// TODO(williamo): Remove in v20
 func (s *PresenceService) DeleteNode(ctx context.Context, namespace string, name string) error {
-	key := backend.NewKey(nodesPrefix, namespace, name)
-	return s.Delete(ctx, key)
+	return s.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build())
+}
+
+// DeleteNode removes a specific scoped or unscoped node.
+func (s *PresenceService) DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error {
+	if req.GetName() == "" {
+		return trace.BadParameter("no name specified for ssh server deletion")
+	}
+	return trace.Wrap(s.sshServers.DeleteResource(ctx, scopes.QualifiedName{
+		Name:  req.GetName(),
+		Scope: req.GetScope(),
+	}))
 }
 
 // AppendDeleteNodeActions adds conditional actions to an atomic write to
-// delete a node resource.
+// delete an unscoped node resource.
+//
+// Deprecated: use AppendDeleteScopedNodeActions instead. Kept temporarily so
+// gravitational/teleport.e compiles across the rename; remove once e has
+// migrated.
 func (s *PresenceService) AppendDeleteNodeActions(
 	actions []backend.ConditionalAction,
 	namespace string,
 	name string,
 	condition backend.Condition,
 ) ([]backend.ConditionalAction, error) {
+	return s.AppendDeleteScopedNodeActions(actions, scopes.QualifiedName{Name: name}, condition)
+}
+
+// AppendDeleteScopedNodeActions adds conditional actions to an atomic write to
+// delete a scoped or unscoped node resource.
+func (s *PresenceService) AppendDeleteScopedNodeActions(
+	actions []backend.ConditionalAction,
+	scopedName scopes.QualifiedName,
+	condition backend.Condition,
+) ([]backend.ConditionalAction, error) {
+	if scopedName.Name == "" {
+		return nil, trace.BadParameter("no name specified for node deletion")
+	}
+
+	svc, err := s.sshServers.WithScopePrefix(scopedName.Scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return append(actions, backend.ConditionalAction{
-		Key:       backend.NewKey(nodesPrefix, namespace, name),
+		Key:       svc.MakeKey(backend.NewKey(scopedName.Name)),
 		Condition: condition,
 		Action:    backend.Delete(),
 	}), nil
 }
 
-// GetNode returns a node by name and namespace.
+// GetNode returns an unscoped node by name.
+//
+// Deprecated: use GetSSHServer instead, which supports scoped nodes.
+// TODO(williamo): Remove in v20
 func (s *PresenceService) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
-	if namespace == "" {
-		return nil, trace.BadParameter("missing parameter namespace")
-	}
-	if name == "" {
-		return nil, trace.BadParameter("missing parameter name")
-	}
-	item, err := s.Get(ctx, backend.NewKey(nodesPrefix, namespace, name))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return services.UnmarshalServer(
-		item.Value,
-		types.KindNode,
-		services.WithExpires(item.Expires),
-		services.WithRevision(item.Revision),
-	)
+	return s.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 }
 
-// GetNodes returns a list of registered servers
+// GetSSHServer returns a scoped or unscoped node by name.
+func (s *PresenceService) GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error) {
+	if req.GetName() == "" {
+		return nil, trace.BadParameter("missing parameter name")
+	}
+	return s.sshServers.GetResource(ctx, scopes.QualifiedName{
+		Name:  req.GetName(),
+		Scope: req.GetScope(),
+	})
+}
+
+// GetNodes returns all registered scoped and unscoped nodes.
 func (s *PresenceService) GetNodes(ctx context.Context, namespace string) ([]types.Server, error) {
-	if namespace == "" {
-		return nil, trace.BadParameter("missing namespace value")
-	}
-
-	// Get all items in the bucket.
-	startKey := backend.ExactKey(nodesPrefix, namespace)
-	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	// Marshal values into a []services.Server slice.
-	servers := make([]types.Server, len(result.Items))
-	for i, item := range result.Items {
-		server, err := services.UnmarshalServer(
-			item.Value,
-			types.KindNode,
-			[]services.MarshalOption{
-				services.WithExpires(item.Expires),
-				services.WithRevision(item.Revision),
-			}...,
-		)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		servers[i] = server
-	}
-
-	return servers, nil
+	return stream.Collect(s.sshServers.Resources(ctx, "", ""))
 }
 
 // UpsertNode registers node presence, permanently if TTL is 0 or for the
@@ -390,22 +414,18 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 		return nil, trace.Wrap(err)
 	}
 
-	item, err := itemFromNode(server)
+	upserted, err := s.sshServers.UpsertResource(ctx, server)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	_, err = s.Put(ctx, *item)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if server.Expiry().IsZero() {
+	if upserted.Expiry().IsZero() {
 		return &types.KeepAlive{}, nil
 	}
 	return &types.KeepAlive{
-		Type:  types.KeepAlive_NODE,
-		Name:  server.GetName(),
-		Scope: server.GetScope(),
+		Type:    types.KeepAlive_NODE,
+		Name:    server.GetName(),
+		Expires: upserted.Expiry(),
+		Scope:   server.GetScope(),
 	}, nil
 }
 
@@ -423,7 +443,7 @@ func (s *PresenceService) AppendPutNodeActions(
 		return nil, trace.Wrap(err)
 	}
 
-	item, err := itemFromNode(server)
+	item, err := s.sshServers.MakeBackendItem(server)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -431,21 +451,8 @@ func (s *PresenceService) AppendPutNodeActions(
 	return append(actions, backend.ConditionalAction{
 		Key:       item.Key,
 		Condition: condition,
-		Action:    backend.Put(*item),
+		Action:    backend.Put(item),
 	}), nil
-}
-
-func itemFromNode(server types.Server) (*backend.Item, error) {
-	value, err := services.MarshalServer(server)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &backend.Item{
-		Key:      backend.NewKey(nodesPrefix, server.GetNamespace(), server.GetName()),
-		Value:    value,
-		Expires:  server.Expiry(),
-		Revision: server.GetRevision(),
-	}, nil
 }
 
 // UpdateNode conditionally updates the provided server.
@@ -457,18 +464,40 @@ func (s *PresenceService) UpdateNode(ctx context.Context, server types.Server) (
 		return nil, trace.Wrap(err)
 	}
 
-	item, err := itemFromNode(server)
+	updated, err := s.sshServers.ConditionalUpdateResource(ctx, server)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	return updated, nil
+}
 
-	lease, err := s.ConditionalUpdate(ctx, *item)
-	if err != nil {
-		return nil, trace.Wrap(err)
+// ListSSHServers returns a page of nodes respecting scope filters, covering both the
+// unscoped and the scoped backend entries.
+func (s *PresenceService) ListSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) ([]types.Server, string, error) {
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	filterFn := func(server types.Server) bool {
+		return scopes.MatchScope(scopeFilter, server.GetScope())
 	}
 
-	server.SetRevision(lease.Revision)
-	return server, nil
+	return s.sshServers.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), filterFn)
+}
+
+// RangeSSHServers returns a sequence of nodes filtered by the given
+// [*presencev1.ListSSHServersRequest], covering both the unscoped and the scoped
+// backend entries.
+func (s *PresenceService) RangeSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return stream.Fail[types.Server](trace.Wrap(err))
+	}
+	filterFn := func(server types.Server) (types.Server, bool) {
+		return server, scopes.MatchScope(scopeFilter, server.GetScope())
+	}
+
+	return stream.FilterMap(s.sshServers.Resources(ctx, req.GetPageToken(), ""), filterFn)
 }
 
 // rangeAuthServers returns auth servers within the range [start, end]
@@ -1357,7 +1386,11 @@ func (s *PresenceService) KeepAliveServer(ctx context.Context, h types.KeepAlive
 	var key backend.Key
 	switch h.GetType() {
 	case constants.KeepAliveNode:
-		key = backend.NewKey(nodesPrefix, h.Namespace, h.Name)
+		if encodedScope == "" {
+			key = nodesUnscopedPrefix().AppendKey(backend.NewKey(h.Name))
+		} else {
+			key = nodesScopedPrefix().AppendKey(backend.NewKey(encodedScope, h.Name))
+		}
 	case constants.KeepAliveApp:
 		if h.HostID != "" {
 			key = backend.NewKey(appServersPrefix, h.Namespace, h.HostID, h.Name)
@@ -1589,8 +1622,7 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 	case types.KindAppServer:
 		return s.listAppServers(ctx, req)
 	case types.KindNode:
-		keyPrefix = []string{nodesPrefix, req.Namespace}
-		unmarshalItemFunc = backendItemToServer(types.KindNode)
+		return s.listSSHServers(ctx, req)
 	case types.KindWindowsDesktopService:
 		keyPrefix = []string{windowsDesktopServicesPrefix}
 		unmarshalItemFunc = backendItemToWindowsDesktopService
@@ -1740,6 +1772,47 @@ func (s *PresenceService) listKubeServers(ctx context.Context, req proto.ListRes
 
 	return &types.ListResourcesResponse{
 		Resources: types.KubeServers(servers).AsResources(),
+		NextKey:   nextKey,
+	}, nil
+}
+
+// listSSHServers returns a page of nodes retrieving both the unscoped and the
+// scoped backend entries.
+func (s *PresenceService) listSSHServers(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+	filter := services.MatchResourceFilter{
+		ResourceKind:   req.ResourceType,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+	}
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		filter.PredicateExpression = expression
+	}
+
+	var matchErr error
+	servers, nextKey, err := s.sshServers.ListResourcesWithFilter(ctx, int(req.Limit), req.StartKey, func(server types.Server) bool {
+		if matchErr != nil {
+			return false
+		}
+		match, err := services.MatchResourceByFilters(server, filter, nil /* ignore dup matches */)
+		if err != nil {
+			matchErr = err
+			return false
+		}
+		return match
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if matchErr != nil {
+		return nil, trace.Wrap(matchErr)
+	}
+
+	return &types.ListResourcesResponse{
+		Resources: types.Servers(servers).AsResources(),
 		NextKey:   nextKey,
 	}, nil
 }
@@ -2144,11 +2217,26 @@ func (relayServerParser) prefixes() []backend.Key {
 }
 
 func kubeServersUnscopedPrefix() backend.Key {
-	return backend.NewKey("kubeServers")
+	return backend.NewKey(kubeServersPrefix)
 }
 
 func kubeServersScopedPrefix() backend.Key {
-	return backend.NewKey("scoped", "kubeServers")
+	return backend.NewKey(scopedPrefix, kubeServersPrefix)
+}
+
+// nodesUnscopedPrefix returns the backend prefix for unscoped nodes:
+//   - /nodes/default/<name>
+//
+// The legacy default namespace is part of the unscoped backend prefix, as we
+// do not support anything other than default.
+func nodesUnscopedPrefix() backend.Key {
+	return backend.NewKey(nodesPrefix, apidefaults.Namespace)
+}
+
+// nodesScopedPrefix returns the backend prefix for scoped nodes:
+//   - /scoped/nodes/<encoded-scope>/<name>
+func nodesScopedPrefix() backend.Key {
+	return backend.NewKey(scopedPrefix, nodesPrefix)
 }
 
 const (
@@ -2172,4 +2260,5 @@ const (
 	serverInfoPrefix             = "serverInfos"
 	cloudLabelsPrefix            = "cloudLabels"
 	relayServersPrefix           = "relay_servers"
+	kubeServersPrefix            = "kubeServers"
 )

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -354,12 +354,12 @@ func (s *PresenceService) AppendDeleteNodeActions(
 	name string,
 	condition backend.Condition,
 ) ([]backend.ConditionalAction, error) {
-	return s.AppendDeleteScopedNodeActions(actions, scopes.QualifiedName{Name: name}, condition)
+	return s.AppendDeleteSSHServerActions(actions, scopes.QualifiedName{Name: name}, condition)
 }
 
-// AppendDeleteScopedNodeActions adds conditional actions to an atomic write to
+// AppendDeleteSSHServerActions adds conditional actions to an atomic write to
 // delete a scoped or unscoped node resource.
-func (s *PresenceService) AppendDeleteScopedNodeActions(
+func (s *PresenceService) AppendDeleteSSHServerActions(
 	actions []backend.ConditionalAction,
 	scopedName scopes.QualifiedName,
 	condition backend.Condition,

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -58,6 +58,7 @@ type PresenceService struct {
 	relayServers *generic.ServiceWrapper[*presencev1.RelayServer]
 	appServers   *generic.ScopeAwareService[types.AppServer]
 	kubeServers  *generic.ScopeAwareService[types.KubeServer]
+	sshServers   *generic.ScopeAwareService[types.Server]
 }
 
 type appServerServiceParams struct {
@@ -153,6 +154,22 @@ func NewPresenceService(b backend.Backend) *PresenceService {
 	if err != nil {
 		panic("impossible: failed to construct kube_server service wrapper")
 	}
+
+	sshServers, err := generic.NewScopeAwareService(&generic.ScopeAwareServiceConfig[types.Server]{
+		Backend:               b,
+		ResourceKind:          types.KindNode,
+		UnscopedBackendPrefix: nodesUnscopedPrefix(),
+		ScopedBackendPrefix:   nodesScopedPrefix(),
+		MarshalFunc:           services.MarshalServer,
+		UnmarshalFunc: func(b []byte, mo ...services.MarshalOption) (types.Server, error) {
+			server, err := services.UnmarshalServer(b, types.KindNode, mo...)
+			return server, trace.Wrap(err)
+		},
+	})
+	if err != nil {
+		panic("impossible: failed to construct node service wrapper")
+	}
+
 	return &PresenceService{
 		logger:  slog.With(teleport.ComponentKey, "Presence"),
 		jitter:  retryutils.FullJitter,
@@ -161,6 +178,7 @@ func NewPresenceService(b backend.Backend) *PresenceService {
 		relayServers: relayServers,
 		appServers:   appServers,
 		kubeServers:  kubeServers,
+		sshServers:   sshServers,
 	}
 }
 
@@ -300,83 +318,82 @@ func (s *PresenceService) upsertServer(ctx context.Context, prefix string, serve
 	return server, nil
 }
 
-// DeleteAllNodes deletes all nodes in a namespace
+// DeleteAllNodes deletes all scoped and unscoped nodes.
 func (s *PresenceService) DeleteAllNodes(ctx context.Context, namespace string) error {
-	startKey := backend.ExactKey(nodesPrefix, namespace)
-	return s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
+	return trace.Wrap(s.sshServers.DeleteAllResources(ctx))
 }
 
-// DeleteNode deletes node
-func (s *PresenceService) DeleteNode(ctx context.Context, namespace string, name string) error {
-	key := backend.NewKey(nodesPrefix, namespace, name)
-	return s.Delete(ctx, key)
+// DeleteNode removes a specific scoped or unscoped node.
+func (s *PresenceService) DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error {
+	if req.GetName() == "" {
+		return trace.BadParameter("no name specified for ssh server deletion")
+	}
+	return trace.Wrap(s.sshServers.DeleteResource(ctx, scopes.QualifiedName{
+		Name:  req.GetName(),
+		Scope: req.GetScope(),
+	}))
 }
 
 // AppendDeleteNodeActions adds conditional actions to an atomic write to
-// delete a node resource.
+// delete an unscoped node resource.
+//
+// Deprecated: use AppendDeleteScopedNodeActions instead. Kept temporarily so
+// gravitational/teleport.e compiles across the rename; remove once e has
+// migrated.
 func (s *PresenceService) AppendDeleteNodeActions(
 	actions []backend.ConditionalAction,
 	namespace string,
 	name string,
 	condition backend.Condition,
 ) ([]backend.ConditionalAction, error) {
+	return s.AppendDeleteSSHServerActions(actions, scopes.QualifiedName{Name: name}, condition)
+}
+
+// AppendDeleteSSHServerActions adds conditional actions to an atomic write to
+// delete a scoped or unscoped node resource.
+func (s *PresenceService) AppendDeleteSSHServerActions(
+	actions []backend.ConditionalAction,
+	scopedName scopes.QualifiedName,
+	condition backend.Condition,
+) ([]backend.ConditionalAction, error) {
+	if scopedName.Name == "" {
+		return nil, trace.BadParameter("no name specified for node deletion")
+	}
+
+	svc, err := s.sshServers.WithScopePrefix(scopedName.Scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return append(actions, backend.ConditionalAction{
-		Key:       backend.NewKey(nodesPrefix, namespace, name),
+		Key:       svc.MakeKey(backend.NewKey(scopedName.Name)),
 		Condition: condition,
 		Action:    backend.Delete(),
 	}), nil
 }
 
-// GetNode returns a node by name and namespace.
+// GetNode returns an unscoped node by name.
+//
+// Deprecated: use GetSSHServer instead, which supports scoped nodes.
+// TODO(williamo): Remove when e no longer needs this.
 func (s *PresenceService) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
-	if namespace == "" {
-		return nil, trace.BadParameter("missing parameter namespace")
-	}
-	if name == "" {
-		return nil, trace.BadParameter("missing parameter name")
-	}
-	item, err := s.Get(ctx, backend.NewKey(nodesPrefix, namespace, name))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return services.UnmarshalServer(
-		item.Value,
-		types.KindNode,
-		services.WithExpires(item.Expires),
-		services.WithRevision(item.Revision),
-	)
+	return s.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 }
 
-// GetNodes returns a list of registered servers
+// GetSSHServer returns a scoped or unscoped node by name.
+func (s *PresenceService) GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error) {
+	if req.GetName() == "" {
+		return nil, trace.BadParameter("missing parameter name")
+	}
+	return s.sshServers.GetResource(ctx, scopes.QualifiedName{
+		Name:  req.GetName(),
+		Scope: req.GetScope(),
+	})
+}
+
+// GetNodes returns all registered scoped and unscoped nodes.
 func (s *PresenceService) GetNodes(ctx context.Context, namespace string) ([]types.Server, error) {
-	if namespace == "" {
-		return nil, trace.BadParameter("missing namespace value")
-	}
-
-	// Get all items in the bucket.
-	startKey := backend.ExactKey(nodesPrefix, namespace)
-	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	// Marshal values into a []services.Server slice.
-	servers := make([]types.Server, len(result.Items))
-	for i, item := range result.Items {
-		server, err := services.UnmarshalServer(
-			item.Value,
-			types.KindNode,
-			[]services.MarshalOption{
-				services.WithExpires(item.Expires),
-				services.WithRevision(item.Revision),
-			}...,
-		)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		servers[i] = server
-	}
-
-	return servers, nil
+	return stream.Collect(s.sshServers.Resources(ctx, "", ""))
 }
 
 // UpsertNode registers node presence, permanently if TTL is 0 or for the
@@ -389,22 +406,18 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 		return nil, trace.Wrap(err)
 	}
 
-	item, err := itemFromNode(server)
+	upserted, err := s.sshServers.UpsertResource(ctx, server)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	_, err = s.Put(ctx, *item)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if server.Expiry().IsZero() {
+	if upserted.Expiry().IsZero() {
 		return &types.KeepAlive{}, nil
 	}
 	return &types.KeepAlive{
-		Type:  types.KeepAlive_NODE,
-		Name:  server.GetName(),
-		Scope: server.GetScope(),
+		Type:    types.KeepAlive_NODE,
+		Name:    server.GetName(),
+		Expires: upserted.Expiry(),
+		Scope:   server.GetScope(),
 	}, nil
 }
 
@@ -422,7 +435,7 @@ func (s *PresenceService) AppendPutNodeActions(
 		return nil, trace.Wrap(err)
 	}
 
-	item, err := itemFromNode(server)
+	item, err := s.sshServers.MakeBackendItem(server)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -430,21 +443,8 @@ func (s *PresenceService) AppendPutNodeActions(
 	return append(actions, backend.ConditionalAction{
 		Key:       item.Key,
 		Condition: condition,
-		Action:    backend.Put(*item),
+		Action:    backend.Put(item),
 	}), nil
-}
-
-func itemFromNode(server types.Server) (*backend.Item, error) {
-	value, err := services.MarshalServer(server)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &backend.Item{
-		Key:      backend.NewKey(nodesPrefix, server.GetNamespace(), server.GetName()),
-		Value:    value,
-		Expires:  server.Expiry(),
-		Revision: server.GetRevision(),
-	}, nil
 }
 
 // UpdateNode conditionally updates the provided server.
@@ -456,18 +456,40 @@ func (s *PresenceService) UpdateNode(ctx context.Context, server types.Server) (
 		return nil, trace.Wrap(err)
 	}
 
-	item, err := itemFromNode(server)
+	updated, err := s.sshServers.ConditionalUpdateResource(ctx, server)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	return updated, nil
+}
 
-	lease, err := s.ConditionalUpdate(ctx, *item)
-	if err != nil {
-		return nil, trace.Wrap(err)
+// ListSSHServers returns a page of nodes respecting scope filters, covering both the
+// unscoped and the scoped backend entries.
+func (s *PresenceService) ListSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) ([]types.Server, string, error) {
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	filterFn := func(server types.Server) bool {
+		return scopes.MatchScope(scopeFilter, server.GetScope())
 	}
 
-	server.SetRevision(lease.Revision)
-	return server, nil
+	return s.sshServers.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), filterFn)
+}
+
+// RangeSSHServers returns a sequence of nodes filtered by the given
+// [*presencev1.ListSSHServersRequest], covering both the unscoped and the scoped
+// backend entries.
+func (s *PresenceService) RangeSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	scopeFilter := req.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return stream.Fail[types.Server](trace.Wrap(err))
+	}
+	filterFn := func(server types.Server) (types.Server, bool) {
+		return server, scopes.MatchScope(scopeFilter, server.GetScope())
+	}
+
+	return stream.FilterMap(s.sshServers.Resources(ctx, req.GetPageToken(), ""), filterFn)
 }
 
 // rangeAuthServers returns auth servers within the range [start, end]
@@ -1363,7 +1385,11 @@ func (s *PresenceService) KeepAliveServer(ctx context.Context, h types.KeepAlive
 	var key backend.Key
 	switch h.GetType() {
 	case constants.KeepAliveNode:
-		key = backend.NewKey(nodesPrefix, h.Namespace, h.Name)
+		if encodedScope == "" {
+			key = nodesUnscopedPrefix().AppendKey(backend.NewKey(h.Name))
+		} else {
+			key = nodesScopedPrefix().AppendKey(backend.NewKey(encodedScope, h.Name))
+		}
 	case constants.KeepAliveApp:
 		if h.HostID != "" {
 			key = backend.NewKey(appServersPrefix, h.Namespace, h.HostID, h.Name)
@@ -1595,8 +1621,7 @@ func (s *PresenceService) listResources(ctx context.Context, req proto.ListResou
 	case types.KindAppServer:
 		return s.listAppServers(ctx, req)
 	case types.KindNode:
-		keyPrefix = []string{nodesPrefix, req.Namespace}
-		unmarshalItemFunc = backendItemToServer(types.KindNode)
+		return s.listSSHServers(ctx, req)
 	case types.KindWindowsDesktopService:
 		keyPrefix = []string{windowsDesktopServicesPrefix}
 		unmarshalItemFunc = backendItemToWindowsDesktopService
@@ -1750,6 +1775,47 @@ func (s *PresenceService) listKubeServers(ctx context.Context, req proto.ListRes
 	}, nil
 }
 
+// listSSHServers returns a page of nodes retrieving both the unscoped and the
+// scoped backend entries.
+func (s *PresenceService) listSSHServers(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
+	filter := services.MatchResourceFilter{
+		ResourceKind:   req.ResourceType,
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+	}
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		filter.PredicateExpression = expression
+	}
+
+	var matchErr error
+	servers, nextKey, err := s.sshServers.ListResourcesWithFilter(ctx, int(req.Limit), req.StartKey, func(server types.Server) bool {
+		if matchErr != nil {
+			return false
+		}
+		match, err := services.MatchResourceByFilters(server, filter, nil /* ignore dup matches */)
+		if err != nil {
+			matchErr = err
+			return false
+		}
+		return match
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if matchErr != nil {
+		return nil, trace.Wrap(matchErr)
+	}
+
+	return &types.ListResourcesResponse{
+		Resources: types.Servers(servers).AsResources(),
+		NextKey:   nextKey,
+	}, nil
+}
+
 func getFakePaginationKey(ki backend.KeyedItem) string {
 	switch item := ki.(type) {
 	case types.KubeCluster:
@@ -1758,6 +1824,10 @@ func getFakePaginationKey(ki backend.KeyedItem) string {
 		return services.GetCursorForKubeServer(item)
 	case types.AppServer:
 		return services.GetCursorForAppServer(item)
+	case types.Server:
+		if item.GetKind() == types.KindNode {
+			return services.GetCursorForNode(item)
+		}
 	}
 
 	return backend.GetPaginationKey(ki)
@@ -2142,11 +2212,26 @@ func (relayServerParser) prefixes() []backend.Key {
 }
 
 func kubeServersUnscopedPrefix() backend.Key {
-	return backend.NewKey("kubeServers")
+	return backend.NewKey(kubeServersPrefix)
 }
 
 func kubeServersScopedPrefix() backend.Key {
-	return backend.NewKey("scoped", "kubeServers")
+	return backend.NewKey(scopedPrefix, kubeServersPrefix)
+}
+
+// nodesUnscopedPrefix returns the backend prefix for unscoped nodes:
+//   - /nodes/default/<name>
+//
+// The legacy default namespace is part of the unscoped backend prefix, as we
+// do not support anything other than default.
+func nodesUnscopedPrefix() backend.Key {
+	return backend.NewKey(nodesPrefix, apidefaults.Namespace)
+}
+
+// nodesScopedPrefix returns the backend prefix for scoped nodes:
+//   - /scoped/nodes/<encoded-scope>/<name>
+func nodesScopedPrefix() backend.Key {
+	return backend.NewKey(scopedPrefix, nodesPrefix)
 }
 
 const (
@@ -2170,4 +2255,5 @@ const (
 	serverInfoPrefix             = "serverInfos"
 	cloudLabelsPrefix            = "cloudLabels"
 	relayServersPrefix           = "relay_servers"
+	kubeServersPrefix            = "kubeServers"
 )

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -43,6 +43,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
@@ -671,11 +672,11 @@ func TestNodeCRUD(t *testing.T) {
 	})
 
 	t.Run("UpdateNode", func(t *testing.T) {
-		node1, err = presence.GetNode(ctx, apidefaults.Namespace, node1.GetName())
+		node1, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: node1.GetName()}.Build())
 		require.NoError(t, err)
 		node1.SetAddr("1.2.3.4:8080")
 
-		node2, err = presence.GetNode(ctx, apidefaults.Namespace, node2.GetName())
+		node2, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: node2.GetName()}.Build())
 		require.NoError(t, err)
 
 		node1, err = presence.UpdateNode(ctx, node1)
@@ -705,36 +706,28 @@ func TestNodeCRUD(t *testing.T) {
 			require.Len(t, nodes, 2)
 			require.Empty(t, cmp.Diff([]types.Server{node1, node2}, nodes,
 				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-
-			// GetNodes should fail if namespace isn't provided
-			_, err = presence.GetNodes(ctx, "")
-			require.True(t, trace.IsBadParameter(err))
 		})
 		t.Run("GetNode", func(t *testing.T) {
 			t.Parallel()
 			// Get Node
-			node, err := presence.GetNode(ctx, apidefaults.Namespace, "node1")
+			node, err := presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "node1"}.Build())
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(node1, node,
 				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 			// GetNode should fail if node name isn't provided
-			_, err = presence.GetNode(ctx, apidefaults.Namespace, "")
-			require.True(t, trace.IsBadParameter(err))
-
-			// GetNode should fail if namespace isn't provided
-			_, err = presence.GetNode(ctx, "", "node1")
+			_, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{}.Build())
 			require.True(t, trace.IsBadParameter(err))
 		})
 	})
 
 	t.Run("DeleteNode", func(t *testing.T) {
 		// Delete node.
-		err = presence.DeleteNode(ctx, apidefaults.Namespace, node1.GetName())
+		err = presence.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: node1.GetName()}.Build())
 		require.NoError(t, err)
 
 		// Expect node not found
-		_, err := presence.GetNode(ctx, apidefaults.Namespace, "node1")
+		_, err := presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "node1"}.Build())
 		require.ErrorAs(t, err, new(*trace.NotFoundError))
 	})
 
@@ -1203,11 +1196,13 @@ func TestListResources_Helpers(t *testing.T) {
 	presence := NewPresenceService(bend)
 
 	tests := []struct {
-		name  string
-		fetch func(proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
+		name       string
+		scopeAware bool
+		fetch      func(proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
 	}{
 		{
-			name: "listResources",
+			name:       "listResources",
+			scopeAware: true,
 			fetch: func(req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
 				return presence.listResources(ctx, req)
 			},
@@ -1289,8 +1284,21 @@ func TestListResources_Helpers(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				resp, err := tc.fetch(req)
-				require.NoError(t, err)
-				require.Empty(t, resp.NextKey)
+				if !tc.scopeAware {
+					require.Empty(t, resp.NextKey)
+				} else {
+					require.Equal(t, scopes.ResourceCursorScopedStart(), resp.NextKey)
+
+					next, err := tc.fetch(proto.ListResourcesRequest{
+						ResourceType: types.KindNode,
+						Namespace:    apidefaults.Namespace,
+						StartKey:     resp.NextKey,
+						Limit:        10,
+					})
+					require.NoError(t, err)
+					require.Empty(t, next.Resources)
+					require.Empty(t, next.NextKey)
+				}
 
 				fetchedNodes, err := types.ResourcesWithLabels(resp.Resources).AsServers()
 				require.NoError(t, err)
@@ -1345,7 +1353,22 @@ func TestListResources_Helpers(t *testing.T) {
 				fetchedNodes, err = types.ResourcesWithLabels(resp.Resources).AsServers()
 				require.NoError(t, err)
 				require.Equal(t, nodes[15:20], fetchedNodes)
-				require.Empty(t, resp.NextKey)
+
+				if !tc.scopeAware {
+					require.Empty(t, resp.NextKey)
+				} else {
+					require.Equal(t, scopes.ResourceCursorScopedStart(), resp.NextKey)
+
+					next, err := tc.fetch(proto.ListResourcesRequest{
+						ResourceType: types.KindNode,
+						Namespace:    apidefaults.Namespace,
+						StartKey:     resp.NextKey,
+						Limit:        10,
+					})
+					require.NoError(t, err)
+					require.Empty(t, next.Resources)
+					require.Empty(t, next.NextKey)
+				}
 			})
 		}
 	})
@@ -2365,5 +2388,184 @@ func TestScopedLease(t *testing.T) {
 		lease, err = presence.UpsertApplicationServer(ctx, scopedServer)
 		require.NoError(t, err)
 		require.Equal(t, scope, lease.Scope)
+	})
+}
+
+func mustCreateNode(t *testing.T, name, scope string) *types.ServerV2 {
+	t.Helper()
+
+	node, err := types.NewServerWithLabels(name, types.KindNode, types.ServerSpecV2{}, nil)
+	require.NoError(t, err)
+
+	server, ok := node.(*types.ServerV2)
+	require.True(t, ok, "expected types.ServerV2")
+	server.Scope = scope
+	server.SetExpiry(time.Now().Add(24 * time.Hour))
+	return server
+}
+
+func nodeCursors(nodes []types.Server) []string {
+	out := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		out = append(out, services.GetCursorForNode(node))
+	}
+	slices.Sort(out)
+	return out
+}
+
+func TestNodesCRUD(t *testing.T) {
+	t.Parallel()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bk.Close() })
+
+	presence := NewPresenceService(backend.NewSanitizer(bk))
+
+	const (
+		prodScope    = "/prod/test"
+		stagingScope = "/staging/test"
+	)
+
+	unscopedTest := mustCreateNode(t, "test", "")
+	prodTest := mustCreateNode(t, "test", prodScope)
+	stagingTest := mustCreateNode(t, "test", stagingScope)
+	prodTest2 := mustCreateNode(t, "test2", prodScope)
+
+	allNodes := []types.Server{unscopedTest, prodTest, stagingTest, prodTest2}
+	nodes, err := presence.GetNodes(t.Context(), apidefaults.Namespace)
+	require.NoError(t, err)
+	require.Empty(t, nodes)
+
+	for _, node := range allNodes {
+		lease, err := presence.UpsertNode(t.Context(), node)
+		require.NoError(t, err)
+		require.Equal(t, node.GetScope(), lease.Scope)
+	}
+
+	t.Run("get same named nodes across scopes", func(t *testing.T) {
+		for _, tt := range []struct {
+			name  string
+			scope string
+		}{
+			{name: "unscoped", scope: ""},
+			{name: "prod", scope: prodScope},
+			{name: "staging", scope: stagingScope},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				node, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{
+					Name:  "test",
+					Scope: tt.scope,
+				}.Build())
+				require.NoError(t, err)
+				require.Equal(t, tt.scope, node.GetScope())
+				// require.Equal(t, tt.addr, node.GetAddr())
+			})
+		}
+
+		// A name that exists in only one scope is not reachable from another.
+		_, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{
+			Name:  "test2",
+			Scope: stagingScope,
+		}.Build())
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+		_, err = presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{Name: "db"}.Build())
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+	})
+
+	t.Run("GetNodes", func(t *testing.T) {
+		nodes, err := presence.GetNodes(t.Context(), apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Equal(t, nodeCursors(allNodes), nodeCursors(nodes))
+	})
+
+	t.Run("list nodes with filters", func(t *testing.T) {
+		for _, tt := range []struct {
+			name   string
+			filter *scopesv1.Filter
+			expect []types.Server
+		}{
+			{
+				name:   "unspecified matches every scope",
+				filter: nil,
+				expect: allNodes,
+			},
+			{
+				name:   "all",
+				filter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+				expect: allNodes,
+			},
+			{
+				name:   "unscoped only",
+				filter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+				expect: []types.Server{unscopedTest},
+			},
+			{
+				name:   "exact",
+				filter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: prodScope}.Build(),
+				expect: []types.Server{prodTest, prodTest2},
+			},
+			{
+				name:   "descendants",
+				filter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/prod"}.Build(),
+				expect: []types.Server{prodTest, prodTest2},
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				req := presencev1.ListSSHServersRequest_builder{ScopeFilter: tt.filter}.Build()
+
+				listed, next, err := presence.ListSSHServers(t.Context(), req)
+				require.NoError(t, err)
+				require.Empty(t, next)
+				require.Equal(t, nodeCursors(tt.expect), nodeCursors(listed))
+
+				ranged, err := iterstream.Collect(presence.RangeSSHServers(t.Context(), req))
+				require.NoError(t, err)
+				require.Equal(t, nodeCursors(tt.expect), nodeCursors(ranged))
+			})
+		}
+	})
+
+	t.Run("delete scoped", func(t *testing.T) {
+		require.NoError(t, presence.DeleteSSHServer(t.Context(), presencev1.DeleteSSHServerRequest_builder{
+			Name:  "test",
+			Scope: prodScope,
+		}.Build()))
+
+		_, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{
+			Name:  "test",
+			Scope: prodScope,
+		}.Build())
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+		nodes, err := presence.GetNodes(t.Context(), apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Equal(t, nodeCursors([]types.Server{unscopedTest, stagingTest, prodTest2}), nodeCursors(nodes))
+	})
+
+	t.Run("delete unscoped", func(t *testing.T) {
+		require.NoError(t, presence.DeleteSSHServer(t.Context(), presencev1.DeleteSSHServerRequest_builder{
+			Name: "test",
+		}.Build()))
+
+		_, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{Name: "web"}.Build())
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+		staging, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{
+			Name:  "test",
+			Scope: stagingScope,
+		}.Build())
+		require.NoError(t, err)
+		require.Equal(t, stagingScope, staging.GetScope())
+	})
+
+	t.Run("DeleteAllNodes", func(t *testing.T) {
+		require.NoError(t, presence.DeleteAllNodes(t.Context(), apidefaults.Namespace))
+
+		nodes, err := presence.GetNodes(t.Context(), apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Empty(t, nodes)
 	})
 }

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -43,6 +43,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
@@ -671,11 +672,17 @@ func TestNodeCRUD(t *testing.T) {
 	})
 
 	t.Run("UpdateNode", func(t *testing.T) {
-		node1, err = presence.GetNode(ctx, apidefaults.Namespace, node1.GetName())
+		node1, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+			Name:  node1.GetName(),
+			Scope: node1.GetScope(),
+		}.Build())
 		require.NoError(t, err)
 		node1.SetAddr("1.2.3.4:8080")
 
-		node2, err = presence.GetNode(ctx, apidefaults.Namespace, node2.GetName())
+		node2, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+			Name:  node2.GetName(),
+			Scope: node2.GetScope(),
+		}.Build())
 		require.NoError(t, err)
 
 		node1, err = presence.UpdateNode(ctx, node1)
@@ -705,36 +712,28 @@ func TestNodeCRUD(t *testing.T) {
 			require.Len(t, nodes, 2)
 			require.Empty(t, cmp.Diff([]types.Server{node1, node2}, nodes,
 				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
-
-			// GetNodes should fail if namespace isn't provided
-			_, err = presence.GetNodes(ctx, "")
-			require.True(t, trace.IsBadParameter(err))
 		})
 		t.Run("GetNode", func(t *testing.T) {
 			t.Parallel()
 			// Get Node
-			node, err := presence.GetNode(ctx, apidefaults.Namespace, "node1")
+			node, err := presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "node1"}.Build())
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(node1, node,
 				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 			// GetNode should fail if node name isn't provided
-			_, err = presence.GetNode(ctx, apidefaults.Namespace, "")
-			require.True(t, trace.IsBadParameter(err))
-
-			// GetNode should fail if namespace isn't provided
-			_, err = presence.GetNode(ctx, "", "node1")
+			_, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{}.Build())
 			require.True(t, trace.IsBadParameter(err))
 		})
 	})
 
 	t.Run("DeleteNode", func(t *testing.T) {
 		// Delete node.
-		err = presence.DeleteNode(ctx, apidefaults.Namespace, node1.GetName())
+		err = presence.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: node1.GetName()}.Build())
 		require.NoError(t, err)
 
 		// Expect node not found
-		_, err := presence.GetNode(ctx, apidefaults.Namespace, "node1")
+		_, err := presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "node1"}.Build())
 		require.ErrorAs(t, err, new(*trace.NotFoundError))
 	})
 
@@ -1203,11 +1202,13 @@ func TestListResources_Helpers(t *testing.T) {
 	presence := NewPresenceService(bend)
 
 	tests := []struct {
-		name  string
-		fetch func(proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
+		name       string
+		scopeAware bool
+		fetch      func(proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
 	}{
 		{
-			name: "listResources",
+			name:       "listResources",
+			scopeAware: true,
 			fetch: func(req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
 				return presence.listResources(ctx, req)
 			},
@@ -1290,7 +1291,21 @@ func TestListResources_Helpers(t *testing.T) {
 				t.Parallel()
 				resp, err := tc.fetch(req)
 				require.NoError(t, err)
-				require.Empty(t, resp.NextKey)
+				if !tc.scopeAware {
+					require.Empty(t, resp.NextKey)
+				} else {
+					require.Equal(t, scopes.ResourceCursorScopedStart(), resp.NextKey)
+
+					next, err := tc.fetch(proto.ListResourcesRequest{
+						ResourceType: types.KindNode,
+						Namespace:    apidefaults.Namespace,
+						StartKey:     resp.NextKey,
+						Limit:        10,
+					})
+					require.NoError(t, err)
+					require.Empty(t, next.Resources)
+					require.Empty(t, next.NextKey)
+				}
 
 				fetchedNodes, err := types.ResourcesWithLabels(resp.Resources).AsServers()
 				require.NoError(t, err)
@@ -1345,7 +1360,22 @@ func TestListResources_Helpers(t *testing.T) {
 				fetchedNodes, err = types.ResourcesWithLabels(resp.Resources).AsServers()
 				require.NoError(t, err)
 				require.Equal(t, nodes[15:20], fetchedNodes)
-				require.Empty(t, resp.NextKey)
+
+				if !tc.scopeAware {
+					require.Empty(t, resp.NextKey)
+				} else {
+					require.Equal(t, scopes.ResourceCursorScopedStart(), resp.NextKey)
+
+					next, err := tc.fetch(proto.ListResourcesRequest{
+						ResourceType: types.KindNode,
+						Namespace:    apidefaults.Namespace,
+						StartKey:     resp.NextKey,
+						Limit:        10,
+					})
+					require.NoError(t, err)
+					require.Empty(t, next.Resources)
+					require.Empty(t, next.NextKey)
+				}
 			})
 		}
 	})
@@ -1613,6 +1643,23 @@ func TestFakePaginateScopedCursors(t *testing.T) {
 	scopedAppServer, err := types.NewAppServerV3FromApp(scopedApp, "host", "host-id")
 	require.NoError(t, err)
 
+	unscopedNode := &types.ServerV2{
+		Kind:    types.KindNode,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: "node",
+		},
+	}
+
+	scopedNode := &types.ServerV2{
+		Kind:    types.KindNode,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: "node",
+		},
+		Scope: scope,
+	}
+
 	for _, tt := range []struct {
 		name          string
 		params        FakePaginateParams
@@ -1665,6 +1712,24 @@ func TestFakePaginateScopedCursors(t *testing.T) {
 			resources:     []types.ResourceWithLabels{scopedAppServer, unscopedAppServer},
 			expectNextKey: "host-id/a",
 		},
+		{
+			name: "next key is scoped node",
+			params: FakePaginateParams{
+				ResourceType: types.KindNode,
+				Limit:        1,
+			},
+			resources:     []types.ResourceWithLabels{unscopedNode, scopedNode},
+			expectNextKey: "~scoped/" + encodedScope + "/node",
+		},
+		{
+			name: "next key is unscoped node",
+			params: FakePaginateParams{
+				ResourceType: types.KindNode,
+				Limit:        1,
+			},
+			resources:     []types.ResourceWithLabels{scopedNode, unscopedNode},
+			expectNextKey: "node",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := FakePaginate(tt.resources, tt.params)
@@ -1677,7 +1742,6 @@ func TestFakePaginateScopedCursors(t *testing.T) {
 			require.Equal(t, tt.expectNextKey, res.NextKey)
 		})
 	}
-
 }
 
 func TestPresenceService_CancelSemaphoreLease(t *testing.T) {
@@ -2480,5 +2544,184 @@ func TestScopedLease(t *testing.T) {
 		lease, err = presence.UpsertApplicationServer(ctx, scopedServer)
 		require.NoError(t, err)
 		require.Equal(t, scope, lease.Scope)
+	})
+}
+
+func mustCreateNode(t *testing.T, name, scope string) *types.ServerV2 {
+	t.Helper()
+
+	node, err := types.NewServerWithLabels(name, types.KindNode, types.ServerSpecV2{}, nil)
+	require.NoError(t, err)
+
+	server, ok := node.(*types.ServerV2)
+	require.True(t, ok, "expected types.ServerV2")
+	server.Scope = scope
+	server.SetExpiry(time.Now().Add(24 * time.Hour))
+	return server
+}
+
+func nodeCursors(nodes []types.Server) []string {
+	out := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		out = append(out, services.GetCursorForNode(node))
+	}
+	slices.Sort(out)
+	return out
+}
+
+func TestNodesCRUD(t *testing.T) {
+	t.Parallel()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = bk.Close() })
+
+	presence := NewPresenceService(backend.NewSanitizer(bk))
+
+	const (
+		prodScope    = "/prod/test"
+		stagingScope = "/staging/test"
+	)
+
+	unscopedTest := mustCreateNode(t, "test", "")
+	prodTest := mustCreateNode(t, "test", prodScope)
+	stagingTest := mustCreateNode(t, "test", stagingScope)
+	prodTest2 := mustCreateNode(t, "test2", prodScope)
+
+	allNodes := []types.Server{unscopedTest, prodTest, stagingTest, prodTest2}
+	nodes, err := presence.GetNodes(t.Context(), apidefaults.Namespace)
+	require.NoError(t, err)
+	require.Empty(t, nodes)
+
+	for _, node := range allNodes {
+		lease, err := presence.UpsertNode(t.Context(), node)
+		require.NoError(t, err)
+		require.Equal(t, node.GetScope(), lease.Scope)
+	}
+
+	t.Run("get same named nodes across scopes", func(t *testing.T) {
+		for _, tt := range []struct {
+			name  string
+			scope string
+		}{
+			{name: "unscoped", scope: ""},
+			{name: "prod", scope: prodScope},
+			{name: "staging", scope: stagingScope},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				node, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{
+					Name:  "test",
+					Scope: tt.scope,
+				}.Build())
+				require.NoError(t, err)
+				require.Equal(t, tt.scope, node.GetScope())
+				// require.Equal(t, tt.addr, node.GetAddr())
+			})
+		}
+
+		// A name that exists in only one scope is not reachable from another.
+		_, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{
+			Name:  "test2",
+			Scope: stagingScope,
+		}.Build())
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+		_, err = presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{Name: "db"}.Build())
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+	})
+
+	t.Run("GetNodes", func(t *testing.T) {
+		nodes, err := presence.GetNodes(t.Context(), apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Equal(t, nodeCursors(allNodes), nodeCursors(nodes))
+	})
+
+	t.Run("list nodes with filters", func(t *testing.T) {
+		for _, tt := range []struct {
+			name   string
+			filter *scopesv1.Filter
+			expect []types.Server
+		}{
+			{
+				name:   "unspecified matches every scope",
+				filter: nil,
+				expect: allNodes,
+			},
+			{
+				name:   "all",
+				filter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+				expect: allNodes,
+			},
+			{
+				name:   "unscoped only",
+				filter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+				expect: []types.Server{unscopedTest},
+			},
+			{
+				name:   "exact",
+				filter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: prodScope}.Build(),
+				expect: []types.Server{prodTest, prodTest2},
+			},
+			{
+				name:   "descendants",
+				filter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/prod"}.Build(),
+				expect: []types.Server{prodTest, prodTest2},
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				req := presencev1.ListSSHServersRequest_builder{ScopeFilter: tt.filter}.Build()
+
+				listed, next, err := presence.ListSSHServers(t.Context(), req)
+				require.NoError(t, err)
+				require.Empty(t, next)
+				require.Equal(t, nodeCursors(tt.expect), nodeCursors(listed))
+
+				ranged, err := iterstream.Collect(presence.RangeSSHServers(t.Context(), req))
+				require.NoError(t, err)
+				require.Equal(t, nodeCursors(tt.expect), nodeCursors(ranged))
+			})
+		}
+	})
+
+	t.Run("delete scoped", func(t *testing.T) {
+		require.NoError(t, presence.DeleteSSHServer(t.Context(), presencev1.DeleteSSHServerRequest_builder{
+			Name:  "test",
+			Scope: prodScope,
+		}.Build()))
+
+		_, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{
+			Name:  "test",
+			Scope: prodScope,
+		}.Build())
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+		nodes, err := presence.GetNodes(t.Context(), apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Equal(t, nodeCursors([]types.Server{unscopedTest, stagingTest, prodTest2}), nodeCursors(nodes))
+	})
+
+	t.Run("delete unscoped", func(t *testing.T) {
+		require.NoError(t, presence.DeleteSSHServer(t.Context(), presencev1.DeleteSSHServerRequest_builder{
+			Name: "test",
+		}.Build()))
+
+		_, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{Name: "web"}.Build())
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
+
+		staging, err := presence.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{
+			Name:  "test",
+			Scope: stagingScope,
+		}.Build())
+		require.NoError(t, err)
+		require.Equal(t, stagingScope, staging.GetScope())
+	})
+
+	t.Run("DeleteAllNodes", func(t *testing.T) {
+		require.NoError(t, presence.DeleteAllNodes(t.Context(), apidefaults.Namespace))
+
+		nodes, err := presence.GetNodes(t.Context(), apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Empty(t, nodes)
 	})
 }

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -1588,6 +1588,63 @@ func TestFakePaginateWithScopes(t *testing.T) {
 	}
 }
 
+// TestFakePaginateNodesWithScopes verifies that fake pagination over nodes that
+// share a name across scopes visits each node exactly once. Node names are only
+// unique within a scope, so the pagination key must incorporate the scope.
+func TestFakePaginateNodesWithScopes(t *testing.T) {
+	t.Parallel()
+
+	makeScope := func(i int) string {
+		a := byte('a')
+		z := byte('z')
+		mod := int(z - a)
+		return fmt.Sprintf("/%c%c", a+byte(i/mod), a+byte(i%mod))
+	}
+	newNode := func(i int) *types.ServerV2 {
+		return &types.ServerV2{
+			Kind:    types.KindNode,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name: "node",
+				// we use the revision to easily tell the resources apart
+				Revision: strconv.Itoa(i),
+			},
+			Scope: makeScope(i),
+		}
+	}
+
+	nodeCount := 100
+	// all nodes have the same name, so the only way to correctly paginate them
+	// is by scope
+	resources := make([]types.ResourceWithLabels, nodeCount)
+	for i := range nodeCount {
+		resources[i] = newNode(i)
+	}
+
+	for _, pageSize := range []int{1, 2, 3, 5, 8, 13, 21} {
+		startKey := ""
+		count := 0
+		for range nodeCount/pageSize + 1 {
+			res, err := FakePaginate(resources, FakePaginateParams{
+				ResourceType: types.KindNode,
+				Limit:        int32(pageSize),
+				Kinds:        []string{types.KindNode},
+				StartKey:     startKey,
+			})
+			require.NoError(t, err)
+			for _, r := range res.Resources {
+				assert.Equal(t, strconv.Itoa(count), r.GetRevision())
+				count++
+			}
+			startKey = res.NextKey
+			if startKey == "" {
+				break
+			}
+		}
+		require.Equal(t, nodeCount, count, "page size %d", pageSize)
+	}
+}
+
 func TestPresenceService_CancelSemaphoreLease(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -372,7 +372,10 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	_, err = s.PresenceS.UpsertNode(ctx, srv)
 	require.NoError(t, err)
 
-	node, err := s.PresenceS.GetNode(ctx, srv.Metadata.Namespace, srv.GetName())
+	node, err := s.PresenceS.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name:  srv.GetName(),
+		Scope: srv.GetScope(),
+	}.Build())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(node, srv, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
@@ -381,7 +384,10 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out, []types.Server{srv}, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = s.PresenceS.DeleteNode(ctx, srv.Metadata.Namespace, srv.GetName())
+	err = s.PresenceS.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Name:  srv.GetName(),
+		Scope: srv.GetScope(),
+	}.Build())
 	require.NoError(t, err)
 
 	out, err = s.PresenceS.GetNodes(ctx, srv.Metadata.Namespace)

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -372,7 +372,7 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	_, err = s.PresenceS.UpsertNode(ctx, srv)
 	require.NoError(t, err)
 
-	node, err := s.PresenceS.GetNode(ctx, srv.Metadata.Namespace, srv.GetName())
+	node, err := s.PresenceS.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: srv.GetName()}.Build())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(node, srv, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
@@ -381,7 +381,7 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out, []types.Server{srv}, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = s.PresenceS.DeleteNode(ctx, srv.Metadata.Namespace, srv.GetName())
+	err = s.PresenceS.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: srv.GetName()}.Build())
 	require.NoError(t, err)
 
 	out, err = s.PresenceS.GetNodes(ctx, srv.Metadata.Namespace)

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -203,6 +203,8 @@ func MatchResourceByFilters(resource types.ResourceWithLabels, filter MatchResou
 		scope = res.GetScope()
 	case types.AppServer:
 		scope = res.GetScope()
+	case types.Server:
+		scope = res.GetScope()
 	}
 	// We assume when filtering for services like KubeService, AppServer, and DatabaseServer
 	// the user is wanting to filter the contained resource ie. KubeClusters, Application, and Database.

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -201,6 +201,8 @@ func MatchResourceByFilters(resource types.ResourceWithLabels, filter MatchResou
 		scope = res.GetScope()
 	case types.KubeServer:
 		scope = res.GetScope()
+	case types.Server:
+		scope = res.GetScope()
 	}
 	// We assume when filtering for services like KubeService, AppServer, and DatabaseServer
 	// the user is wanting to filter the contained resource ie. KubeClusters, Application, and Database.

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -46,6 +46,14 @@ type ProxyGetter interface {
 type NodesGetter interface {
 	// GetNodes returns a list of registered servers.
 	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+
+	// ListSSHServers returns a page of registered nodes with the ability to apply
+	// scope filters.
+	ListSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) ([]types.Server, string, error)
+
+	// RangeSSHServers returns a sequence of nodes filtered by the given
+	// scope filter.
+	RangeSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error]
 }
 
 // DatabaseServersGetter is a service that gets database servers.
@@ -75,17 +83,17 @@ type Presence interface {
 	// Semaphores is responsible for semaphore handling
 	types.Semaphores
 
-	// GetNode returns a node by name and namespace.
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 
 	// NodesGetter gets nodes
 	NodesGetter
 
-	// DeleteAllNodes deletes all nodes in a namespace.
+	// DeleteAllNodes deletes all scoped and unscoped nodes.
 	DeleteAllNodes(ctx context.Context, namespace string) error
 
-	// DeleteNode deletes node in a namespace
-	DeleteNode(ctx context.Context, namespace, name string) error
+	// DeleteNode removes a specific scoped or unscoped node.
+	DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error
 
 	// UpsertNode registers node presence, permanently if TTL is 0 or for the
 	// specified duration with second resolution if it's >= 1 second.

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -46,6 +46,14 @@ type ProxyGetter interface {
 type NodesGetter interface {
 	// GetNodes returns a list of registered servers.
 	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
+
+	// ListSSHServers returns a page of registered nodes with the ability to apply
+	// scope filters.
+	ListSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) ([]types.Server, string, error)
+
+	// RangeSSHServers returns a sequence of nodes filtered by the given
+	// scope filter.
+	RangeSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error]
 }
 
 // DatabaseServersGetter is a service that gets database servers.
@@ -75,17 +83,28 @@ type Presence interface {
 	// Semaphores is responsible for semaphore handling
 	types.Semaphores
 
-	// GetNode returns a node by name and namespace.
+	// GetNode returns an unscoped node by name and namespace.
+	//
+	// Deprecated: Use [Presence.GetSSHServer] instead, which supports scoped
+	// nodes.
+	// TODO(williamo): Remove in v20
 	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 
 	// NodesGetter gets nodes
 	NodesGetter
 
-	// DeleteAllNodes deletes all nodes in a namespace.
+	// DeleteAllNodes deletes all scoped and unscoped nodes.
 	DeleteAllNodes(ctx context.Context, namespace string) error
 
-	// DeleteNode deletes node in a namespace
+	// Deprecated: Use [Presence.DeleteSSHServer] instead, which supports scoped nodes.
+	// TODO(williamo): Remove in v20
 	DeleteNode(ctx context.Context, namespace, name string) error
+
+	// DeleteNode removes a specific scoped or unscoped node.
+	DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error
 
 	// UpsertNode registers node presence, permanently if TTL is 0 or for the
 	// specified duration with second resolution if it's >= 1 second.

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -547,6 +548,13 @@ func MarshalServers(s []types.Server) ([]byte, error) {
 	}
 
 	return bytes, nil
+}
+
+// GetCursorForNode returns the resource cursor identifying a node in the
+// logical resource stream: "<name>" for unscoped nodes and
+// "~scoped/<encoded-scope>/<name>" for scoped nodes.
+func GetCursorForNode(server types.Server) string {
+	return scopes.MakeResourceCursor(server.GetScope(), server.GetName())
 }
 
 // NodeHasMissedKeepAlives checks if node has missed its keep alive

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -1217,7 +1217,7 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 	kubeServers = kubeServers[1:]
 
 	// delete everything else
-	err = clt.DeleteNode(ctx, "default", node.GetName())
+	err = clt.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: node.GetName(), Scope: node.GetScope()}.Build())
 	require.NoError(t, err)
 	err = clt.DeleteSAMLIdPServiceProvider(ctx, samlapp.GetName())
 	require.NoError(t, err)

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/defaults"
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -1630,13 +1631,20 @@ func NewNodeWatcher(ctx context.Context, cfg NodeWatcherConfig) (*GenericWatcher
 		ResourceKind:          types.KindNode,
 		ScopeFilter:           cfg.ScopeFilter,
 		ResourceGetter: func(ctx context.Context) ([]types.Server, error) {
-			// TODO(fspmarshall/scopes): this list does not yet honor scope filters, so it
-			// currently returns nodes in every scope and happens to match a MODE_ALL watch.
-			// Once the list API supports scope filters (and defaults unscoped callers to
-			// unscoped-only, like the watch API), this call must honor cfg.ScopeFilter.
-			return cfg.NodesGetter.GetNodes(ctx, apidefaults.Namespace)
+			return iterstream.Collect(cfg.NodesGetter.RangeSSHServers(ctx, presencev1.ListSSHServersRequest_builder{
+				ScopeFilter: cfg.ScopeFilter.ToProto(),
+			}.Build()))
 		},
-		ResourceKey:            types.Server.GetName,
+		ResourceKey: GetCursorForNode,
+		DeleteKey: func(res types.Resource) string {
+			// Delete events for scoped nodes carry a partially populated
+			// server so that the scope can be recovered from the key, while
+			// unscoped nodes only emit a resource header.
+			if node, ok := res.(types.Server); ok {
+				return GetCursorForNode(node)
+			}
+			return scopes.MakeResourceCursor("", res.GetName())
+		},
 		DisableUpdateBroadcast: true,
 		CloneFunc:              types.Server.DeepCopy,
 		ReadOnlyFunc: func(resource types.Server) readonly.Server {

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -1190,7 +1190,10 @@ func TestNodeWatcher(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, filtered, 3)
 
-	require.NoError(t, presence.DeleteNode(ctx, apidefaults.Namespace, nodes[0].GetName()))
+	require.NoError(t, presence.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Name:  nodes[0].GetName(),
+		Scope: nodes[0].GetScope(),
+	}.Build()))
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		filtered, err := w.CurrentResources(ctx)

--- a/lib/srv/discovery/discovery_eks_test.go
+++ b/lib/srv/discovery/discovery_eks_test.go
@@ -442,6 +442,14 @@ func (m *mockAuthServer) GetNodes(ctx context.Context, namespace string) ([]type
 	return nil, nil
 }
 
+func (m *mockAuthServer) ListSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) ([]types.Server, string, error) {
+	return nil, "", nil
+}
+
+func (m *mockAuthServer) RangeSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	return stream.Empty[types.Server]()
+}
+
 func (m *mockAuthServer) EnrollEKSClusters(ctx context.Context, req *integrationpb.EnrollEKSClustersRequest, opts ...grpc.CallOption) (*integrationpb.EnrollEKSClustersResponse, error) {
 	return m.enrollEKSClusters(ctx, req, opts...)
 }

--- a/lib/teleterm/services/connectmycomputer/connectmycomputer.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer.go
@@ -34,7 +34,7 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/connectmycomputer"
@@ -264,8 +264,8 @@ type AccessAndIdentity interface {
 	// See services.Identity.UpdateUser.
 	UpdateUser(context.Context, types.User) (types.User, error)
 
-	// See services.Presence.GetNode.
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+	// See services.Presence.GetSSHServer.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 }
 
 // CertManager enables the usage of only select methods from [client.ProxyClient] so that there
@@ -432,7 +432,9 @@ func (n *NodeJoinWait) waitForNode(ctx context.Context, accessAndIdentity Access
 	//
 	// This means that we might return immediately if the node is still in the cache, even if
 	// technically the agent has not joined the cluster yet. We're fine with this edge case.
-	server, err := accessAndIdentity.GetNode(ctx, apidefaults.Namespace, nodeName)
+	server, err := accessAndIdentity.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name: nodeName,
+	}.Build())
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
@@ -547,7 +549,7 @@ func (n *NodeDelete) Run(ctx context.Context, presence Presence, cluster *cluste
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = presence.DeleteNode(ctx, apidefaults.Namespace, hostUUID)
+	err = presence.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: hostUUID}.Build())
 	if trace.IsNotFound(err) {
 		return nil
 	}
@@ -580,7 +582,7 @@ func (n *NodeDeleteConfig) checkAndSetDefaults() error {
 // During a normal operation, auth.ClientI is passed as this interface.
 type Presence interface {
 	// See services.Presence.GetNode.
-	DeleteNode(ctx context.Context, namespace, name string) error
+	DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error
 }
 
 type NodeName struct {

--- a/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -372,7 +373,7 @@ func (m *mockAccessAndIdentity) UpdateUser(ctx context.Context, user types.User)
 	return user, nil
 }
 
-func (m *mockAccessAndIdentity) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
+func (m *mockAccessAndIdentity) GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error) {
 	if m.nodeErr != nil {
 		return nil, m.nodeErr
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -97,6 +97,7 @@ import (
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	transportpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -7672,7 +7673,7 @@ func TestDiagnoseSSHConnection(t *testing.T) {
 
 	// Wait for node to show up
 	require.Eventually(t, func() bool {
-		_, err := env.server.Auth().GetNode(ctx, apidefaults.Namespace, nodeName)
+		_, err := env.server.Auth().GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: nodeName}.Build())
 		if trace.IsNotFound(err) {
 			return false
 		}

--- a/lib/web/servers_test.go
+++ b/lib/web/servers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/ui"
@@ -154,7 +155,7 @@ func TestCreateNode(t *testing.T) {
 			}
 
 			// Ensure node exists
-			node, err := env.proxies[0].client.GetNode(ctx, "default", tt.req.Name)
+			node, err := env.proxies[0].client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: tt.req.Name}.Build())
 			require.NoError(t, err)
 
 			require.Equal(t, tt.req.Name, node.GetName())

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
@@ -894,7 +895,6 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 	_, err = clt.UpsertNode(ctx, classicNode)
 	require.NoError(t, err)
 
-	// scopedNode has scope "/" so SQN lookups with "/::scoped-node" succeed.
 	scopedNode, err := types.NewServer("scoped-node", types.KindNode, types.ServerSpecV2{
 		Hostname: "scoped-host",
 		Addr:     "127.0.0.1:23",
@@ -968,7 +968,7 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 
 		timeout := time.After(30 * time.Second)
 		for {
-			node, err := clt.GetNode(ctx, apidefaults.Namespace, "unscoped-node")
+			node, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "unscoped-node"}.Build())
 			if err == nil && node.GetHostname() == "unscoped-host-edited" {
 				break
 			}
@@ -995,7 +995,10 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 
 		timeout := time.After(30 * time.Second)
 		for {
-			node, err := clt.GetNode(ctx, apidefaults.Namespace, "scoped-node")
+			node, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+				Scope: "/staging",
+				Name:  "scoped-node",
+			}.Build())
 			if err == nil && node.GetHostname() == "scoped-host-edited" {
 				break
 			}
@@ -1009,12 +1012,21 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 	})
 
 	t.Run("scope-qualified delete", func(t *testing.T) {
-		_, err := runResourceCommand(t, clt, []string{"rm", "node", "/staging::scoped-node"})
+		scopedNodeReq := presencev1.GetSSHServerRequest_builder{
+			Scope: "/staging",
+			Name:  "scoped-node",
+		}.Build()
+
+		// make sure the node exists
+		_, err := clt.GetSSHServer(ctx, scopedNodeReq)
+		require.NoError(t, err, "scoped-node should exist before deletion")
+
+		_, err = runResourceCommand(t, clt, []string{"rm", "node", "/staging::scoped-node"})
 		require.NoError(t, err)
 
 		timeout := time.After(30 * time.Second)
 		for {
-			_, err = clt.GetNode(ctx, apidefaults.Namespace, "scoped-node")
+			_, err = clt.GetSSHServer(ctx, scopedNodeReq)
 			if trace.IsNotFound(err) {
 				break
 			}
@@ -1033,7 +1045,7 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 
 		timeout := time.After(30 * time.Second)
 		for {
-			_, err = clt.GetNode(ctx, apidefaults.Namespace, "unscoped-node")
+			_, err = clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "unscoped-node"}.Build())
 			if trace.IsNotFound(err) {
 				break
 			}

--- a/tool/tctl/common/resources/server.go
+++ b/tool/tctl/common/resources/server.go
@@ -20,20 +20,19 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/gravitational/trace"
 
-	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
-	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/tool/common"
 )
 
@@ -120,12 +119,12 @@ func getScopedNode(ctx context.Context, client *authclient.Client, subKind strin
 		// harm in falling back to the unscoped handler here.
 		return getServer(ctx, client, services.Ref{Kind: types.KindNode}, opts)
 	}
-	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
+	node, err := client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-	if node.GetScope() != sqn.Scope {
-		return nil, scopeMismatchNotFound(types.KindNode, *sqn, node.GetScope())
 	}
 	return &ServerCollection{servers: []types.Server{node}}, nil
 }
@@ -134,14 +133,10 @@ func deleteScopedNode(ctx context.Context, client *authclient.Client, subKind st
 	if subKind != "" {
 		return rejectSubKind(types.KindNode, subKind)
 	}
-	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if node.GetScope() != sqn.Scope {
-		return scopeMismatchNotFound(types.KindNode, sqn, node.GetScope())
-	}
-	if err := client.DeleteNode(ctx, defaults.Namespace, sqn.Name); err != nil {
+	if err := client.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf("node %v has been deleted\n", sqn.String())
@@ -155,7 +150,11 @@ func createServer(ctx context.Context, client *authclient.Client, raw services.U
 	}
 
 	name := server.GetName()
-	_, err = client.GetNode(ctx, server.GetNamespace(), name)
+	scope := server.GetScope()
+	_, err = client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Scope: scope,
+		Name:  name,
+	}.Build())
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
@@ -172,64 +171,67 @@ func createServer(ctx context.Context, client *authclient.Client, raw services.U
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("node %q has been %s\n", name, upsertVerb(exists, opts.Force))
+	fmt.Printf("node %q has been %s\n", scopes.QualifiedName{Name: name, Scope: scope}.String(), upsertVerb(exists, opts.Force))
 	return nil
 }
 
 func deleteServer(ctx context.Context, client *authclient.Client, ref services.Ref) error {
-	if err := client.DeleteNode(ctx, defaults.Namespace, ref.Name); err != nil {
+	sqn, err := scopes.ParseQualifiedName(ref.Name)
+	if err != nil {
+		sqn = scopes.QualifiedName{Name: ref.Name}
+	}
+	if err := client.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("node %v has been deleted\n", ref.Name)
+	fmt.Printf("node %v has been deleted\n", sqn.String())
 	return nil
 }
 
 func getServer(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	var search []string
+	var sqn scopes.QualifiedName
 	if ref.Name != "" {
-		search = []string{ref.Name}
-	}
-
-	req := proto.ListUnifiedResourcesRequest{
-		Kinds:          []string{types.KindNode},
-		SearchKeywords: search,
-		SortBy:         types.SortBy{Field: types.ResourceKind},
-	}
-
-	var collection ServerCollection
-	for {
-		page, next, err := apiclient.GetUnifiedResourcePage(ctx, client, &req)
+		var err error
+		sqn, err = scopes.ParseQualifiedName(ref.Name)
 		if err != nil {
+			sqn = scopes.QualifiedName{Name: ref.Name}
+		}
+
+		node, err := client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+			Scope: sqn.Scope,
+			Name:  sqn.Name,
+		}.Build())
+		switch {
+		case err == nil:
+			return NewServerCollection([]types.Server{node}), nil
+		case !trace.IsNotFound(err):
 			return nil, trace.Wrap(err)
 		}
-
-		for _, r := range page {
-			srv, ok := r.ResourceWithLabels.(types.Server)
-			if !ok {
-				slog.WarnContext(ctx, "expected types.Server but received unexpected type", "resource_type", logutils.TypeAttr(r))
-				continue
-			}
-
-			if ref.Name == "" {
-				collection.servers = append(collection.servers, srv)
-				continue
-			}
-
-			if srv.GetName() == ref.Name || srv.GetHostname() == ref.Name {
-				collection.servers = []types.Server{srv}
-				return &collection, nil
-			}
-		}
-
-		req.StartKey = next
-		if req.StartKey == "" {
-			break
-		}
 	}
 
-	if len(collection.servers) == 0 && ref.Name != "" {
-		return nil, trace.NotFound("node with ID %q not found", ref.Name)
+	nodes, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+		return client.ListSSHServers(ctx, presencev1.ListSSHServersRequest_builder{
+			PageSize:    int32(pageSize),
+			PageToken:   pageToken,
+			ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+		}.Build())
+	}))
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	return &collection, nil
+	if ref.Name == "" {
+		return NewServerCollection(nodes), nil
+	}
+
+	// Nodes may be referenced by ID or by hostname, so hostname is supplied as
+	// an alternate name.
+	nodes = FilterBySQNOrDiscoveredName(nodes, sqn, types.Server.GetHostname)
+	if len(nodes) == 0 {
+		return nil, trace.NotFound("node with ID %q not found", sqn.String())
+	}
+
+	return NewServerCollection(nodes), nil
 }


### PR DESCRIPTION
This PR:

- Adds the necessary backend to namespace ssh servers in the presence service
- Adds scope aware rpcs:

```
// Gets a specific ssh server resource from the backend.
rpc GetNode(GetNodeRequest) returns (GetNodeResponse);
// Lists ssh servers resources from the backend.
rpc ListNodes(ListNodesRequest) returns (ListNodesResponse);
// Deletes an ssh server resource from the backend.
rpc DeleteNode(DeleteNodeRequest) returns (DeleteNodeResponse);
  ```
 

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Add Scope namespacing support for SSH Servers


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Able to join scoped ssh nodes
- [x] Able to join unscoped ssh nodes
- [x] Able to join/create openSSH nodes
- [x] Able to ssh into scoped/unscoped/openssh nodes
