### PR TITLE
Update Node Watcher & Update to use new NodeV2 functions

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2897,7 +2897,7 @@ func (c *Client) UpsertNode(ctx context.Context, node types.Server) (*types.Keep
 
 // DeleteNode deletes an unscoped node by name and namespace.
 //
-// Deprecated: Use [Client.DeleteNodeV2] instead, which supports scoped nodes.
+// Deprecated: Use [Client.DeleteSSHServer] instead, which supports scoped nodes.
 // TODO(williamo): Remove in v20
 func (c *Client) DeleteNode(ctx context.Context, namespace, name string) error {
 	if namespace == "" {

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -37,6 +37,7 @@ import (
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/integration/helpers"
@@ -416,7 +417,7 @@ func TestEC2Labels(t *testing.T) {
 
 	// Check that EC2 labels were applied.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		node, err := authServer.GetNode(ctx, tconf.SSH.Namespace, nodes[0].GetName())
+		node, err := authServer.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: nodes[0].GetName()}.Build())
 		require.NoError(t, err)
 
 		_, nodeHasLabel := node.GetAllLabels()[tagName]

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -37,6 +37,7 @@ import (
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/integration/helpers"
@@ -416,7 +417,10 @@ func TestEC2Labels(t *testing.T) {
 
 	// Check that EC2 labels were applied.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		node, err := authServer.GetNode(ctx, tconf.SSH.Namespace, nodes[0].GetName())
+		node, err := authServer.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+			Name:  nodes[0].GetName(),
+			Scope: nodes[0].GetScope(),
+		}.Build())
 		require.NoError(t, err)
 
 		_, nodeHasLabel := node.GetAllLabels()[tagName]

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/profile"
@@ -332,7 +333,7 @@ func testAuthLocalNodeControlStream(t *testing.T, suite *integrationTestSuite) {
 	var nodeAddr string
 	// verify node heartbeat was successful, extracting the addr.
 	require.Eventually(t, func() bool {
-		node, err := clt.GetNode(context.Background(), defaults.Namespace, nodeID)
+		node, err := clt.GetSSHServer(context.Background(), presencev1.GetSSHServerRequest_builder{Name: nodeID}.Build())
 		if trace.IsNotFound(err) {
 			return false
 		}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -67,6 +67,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/profile"
@@ -312,7 +313,7 @@ func testAuthLocalNodeControlStream(t *testing.T, suite *integrationTestSuite) {
 	var nodeID string
 	// verify node control stream registers, extracting the id.
 	require.Eventually(t, func() bool {
-		status, err := clt.GetInventoryStatus(context.Background(), proto.InventoryStatusRequest_builder{
+		status, err := clt.GetInventoryStatus(t.Context(), proto.InventoryStatusRequest_builder{
 			Connected: true,
 		}.Build())
 		require.NoError(t, err)
@@ -332,7 +333,7 @@ func testAuthLocalNodeControlStream(t *testing.T, suite *integrationTestSuite) {
 	var nodeAddr string
 	// verify node heartbeat was successful, extracting the addr.
 	require.Eventually(t, func() bool {
-		node, err := clt.GetNode(context.Background(), defaults.Namespace, nodeID)
+		node, err := clt.GetSSHServer(t.Context(), presencev1.GetSSHServerRequest_builder{Name: nodeID}.Build())
 		if trace.IsNotFound(err) {
 			return false
 		}

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -40,7 +40,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
@@ -1245,7 +1245,7 @@ func testDeleteConnectMyComputerNode(t *testing.T, pack *dbhelpers.DatabasePack)
 
 	// waits for the node to be added
 	require.Eventually(t, func() bool {
-		_, err := authServer.GetNode(ctx, defaults.Namespace, nodeID)
+		_, err := authServer.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: nodeID}.Build())
 		return err == nil
 	}, time.Minute, time.Second, "waiting for node to join cluster")
 
@@ -1261,7 +1261,7 @@ func testDeleteConnectMyComputerNode(t *testing.T, pack *dbhelpers.DatabasePack)
 
 	// waits for the node to be deleted
 	require.Eventually(t, func() bool {
-		_, err := authServer.GetNode(ctx, defaults.Namespace, nodeID)
+		_, err := authServer.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: nodeID}.Build())
 		return trace.IsNotFound(err)
 	}, time.Minute, time.Second, "waiting for node to be deleted")
 }

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
@@ -40,6 +40,7 @@ type openSSHEICEServerClient struct {
 
 // Get gets the Teleport OpenSSHEICE server of a given name.
 func (r openSSHEICEServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
+	//nolint:staticcheck // TODO(williamo): remove when we update IAC
 	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, key.Name)
 	if err != nil {
 		return server, trace.Wrap(err)
@@ -68,6 +69,7 @@ func (r openSSHEICEServerClient) Update(ctx context.Context, server types.Server
 
 // Delete deletes a Teleport OpenSSHEICE server.
 func (r openSSHEICEServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	//nolint:staticcheck // TODO(williamo): remove when we update IAC
 	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, key.Name))
 }
 

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
@@ -25,7 +25,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
@@ -40,7 +40,7 @@ type openSSHEICEServerClient struct {
 
 // Get gets the Teleport OpenSSHEICE server of a given name.
 func (r openSSHEICEServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
-	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, key.Name)
+	server, err := r.teleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build())
 	if err != nil {
 		return server, trace.Wrap(err)
 	}
@@ -68,7 +68,7 @@ func (r openSSHEICEServerClient) Update(ctx context.Context, server types.Server
 
 // Delete deletes a Teleport OpenSSHEICE server.
 func (r openSSHEICEServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
-	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, key.Name))
+	return trace.Wrap(r.teleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build()))
 }
 
 // NewOpenSSHEICEServerV2Reconciler instantiates a new Kubernetes controller

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
@@ -72,10 +72,12 @@ func (g *opensshEICEServerV2TestingPrimitives) CreateTeleportResource(ctx contex
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Server, error) {
+	//nolint:staticcheck // TODO(williamo): remove when we update IAC
 	return g.setup.TeleportClient.GetNode(ctx, defaults.Namespace, name)
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
+	//nolint:staticcheck // TODO(williamo): remove when we update IAC
 	return trace.Wrap(g.setup.TeleportClient.DeleteNode(ctx, defaults.Namespace, name))
 }
 

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
@@ -72,11 +72,11 @@ func (g *opensshEICEServerV2TestingPrimitives) CreateTeleportResource(ctx contex
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Server, error) {
-	return g.setup.TeleportClient.GetNode(ctx, defaults.Namespace, name)
+	return g.setup.TeleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
-	return trace.Wrap(g.setup.TeleportClient.DeleteNode(ctx, defaults.Namespace, name))
+	return trace.Wrap(g.setup.TeleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build()))
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {

--- a/integrations/operator/controllers/resources/opensshserverv2_controller.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller.go
@@ -40,6 +40,7 @@ type openSSHServerClient struct {
 
 // Get gets the Teleport OpenSSH server of a given name.
 func (r openSSHServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
+	//nolint:staticcheck // TODO(williamo): remove when we update IAC
 	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, key.Name)
 	if err != nil {
 		return server, trace.Wrap(err)
@@ -68,6 +69,7 @@ func (r openSSHServerClient) Update(ctx context.Context, server types.Server) er
 
 // Delete deletes a Teleport OpenSSH server.
 func (r openSSHServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
+	//nolint:staticcheck // TODO(williamo): remove when we update IAC
 	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, key.Name))
 }
 

--- a/integrations/operator/controllers/resources/opensshserverv2_controller.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller.go
@@ -25,7 +25,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
@@ -40,7 +40,7 @@ type openSSHServerClient struct {
 
 // Get gets the Teleport OpenSSH server of a given name.
 func (r openSSHServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
-	server, err := r.teleportClient.GetNode(ctx, defaults.Namespace, key.Name)
+	server, err := r.teleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build())
 	if err != nil {
 		return server, trace.Wrap(err)
 	}
@@ -68,7 +68,7 @@ func (r openSSHServerClient) Update(ctx context.Context, server types.Server) er
 
 // Delete deletes a Teleport OpenSSH server.
 func (r openSSHServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
-	return trace.Wrap(r.teleportClient.DeleteNode(ctx, defaults.Namespace, key.Name))
+	return trace.Wrap(r.teleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build()))
 }
 
 // NewOpenSSHServerV2Reconciler instantiates a new Kubernetes controller

--- a/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
@@ -64,10 +64,12 @@ func (g *opensshServerV2TestingPrimitives) CreateTeleportResource(ctx context.Co
 }
 
 func (g *opensshServerV2TestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Server, error) {
+	//nolint:staticcheck // TODO(williamo): remove when we update IAC
 	return g.setup.TeleportClient.GetNode(ctx, defaults.Namespace, name)
 }
 
 func (g *opensshServerV2TestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
+	//nolint:staticcheck // TODO(williamo): remove when we update IAC
 	return trace.Wrap(g.setup.TeleportClient.DeleteNode(ctx, defaults.Namespace, name))
 }
 

--- a/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
@@ -64,11 +64,11 @@ func (g *opensshServerV2TestingPrimitives) CreateTeleportResource(ctx context.Co
 }
 
 func (g *opensshServerV2TestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Server, error) {
-	return g.setup.TeleportClient.GetNode(ctx, defaults.Namespace, name)
+	return g.setup.TeleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 }
 
 func (g *opensshServerV2TestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
-	return trace.Wrap(g.setup.TeleportClient.DeleteNode(ctx, defaults.Namespace, name))
+	return trace.Wrap(g.setup.TeleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build()))
 }
 
 func (g *opensshServerV2TestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {

--- a/integrations/terraform/testlib/server_test.go
+++ b/integrations/terraform/testlib/server_test.go
@@ -87,6 +87,7 @@ func (s *TerraformSuiteOSS) TestOpenSSHServerNameless() {
 
 	checkServerDestroyed := func(state *terraform.State) error {
 		// The name is a UUID but we can lookup by hostname as well.
+		//nolint:staticcheck // TODO(williamo): remove when we update IAC
 		_, err := s.client.GetNode(ctx, defaults.Namespace, "test.local")
 		if trace.IsNotFound(err) {
 			return nil

--- a/integrations/terraform/testlib/server_test.go
+++ b/integrations/terraform/testlib/server_test.go
@@ -34,6 +34,7 @@ func (s *TerraformSuiteOSS) TestOpenSSHServer() {
 	s.T().Cleanup(cancel)
 
 	checkServerDestroyed := func(state *terraform.State) error {
+		//nolint:staticcheck // TODO(williamo): remove when we update IAC
 		_, err := s.client.GetNode(ctx, defaults.Namespace, "test")
 		if trace.IsNotFound(err) {
 			return nil
@@ -159,6 +160,7 @@ func (s *TerraformSuiteOSS) TestImportOpenSSHServer() {
 	require.NoError(s.T(), err)
 
 	require.Eventually(s.T(), func() bool {
+		//nolint:staticcheck // TODO(williamo): remove when we update IAC
 		_, err = s.client.GetNode(ctx, defaults.Namespace, server.GetName())
 		if trace.IsNotFound(err) {
 			return false
@@ -193,6 +195,7 @@ func (s *TerraformSuiteOSS) TestOpenSSHEICEServer() {
 	s.T().Cleanup(cancel)
 
 	checkServerDestroyed := func(state *terraform.State) error {
+		//nolint:staticcheck // TODO(williamo): remove when we update IAC
 		_, err := s.client.GetNode(ctx, defaults.Namespace, "test")
 		if trace.IsNotFound(err) {
 			return nil
@@ -288,6 +291,7 @@ func (s *TerraformSuiteOSS) TestImportOpenSSHEICEServer() {
 	require.NoError(s.T(), err)
 
 	require.Eventually(s.T(), func() bool {
+		//nolint:staticcheck // TODO(williamo): remove when we update IAC
 		_, err = s.client.GetNode(ctx, defaults.Namespace, server.GetName())
 		if trace.IsNotFound(err) {
 			return false

--- a/integrations/terraform/testlib/server_test.go
+++ b/integrations/terraform/testlib/server_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -34,7 +34,7 @@ func (s *TerraformSuiteOSS) TestOpenSSHServer() {
 	s.T().Cleanup(cancel)
 
 	checkServerDestroyed := func(state *terraform.State) error {
-		_, err := s.client.GetNode(ctx, defaults.Namespace, "test")
+		_, err := s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "test"}.Build())
 		if trace.IsNotFound(err) {
 			return nil
 		}
@@ -86,7 +86,7 @@ func (s *TerraformSuiteOSS) TestOpenSSHServerNameless() {
 
 	checkServerDestroyed := func(state *terraform.State) error {
 		// The name is a UUID but we can lookup by hostname as well.
-		_, err := s.client.GetNode(ctx, defaults.Namespace, "test.local")
+		_, err := s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "test.local"}.Build())
 		if trace.IsNotFound(err) {
 			return nil
 		}
@@ -159,7 +159,7 @@ func (s *TerraformSuiteOSS) TestImportOpenSSHServer() {
 	require.NoError(s.T(), err)
 
 	require.Eventually(s.T(), func() bool {
-		_, err = s.client.GetNode(ctx, defaults.Namespace, server.GetName())
+		_, err = s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: server.GetName(), Scope: server.GetScope()}.Build())
 		if trace.IsNotFound(err) {
 			return false
 		}
@@ -193,7 +193,7 @@ func (s *TerraformSuiteOSS) TestOpenSSHEICEServer() {
 	s.T().Cleanup(cancel)
 
 	checkServerDestroyed := func(state *terraform.State) error {
-		_, err := s.client.GetNode(ctx, defaults.Namespace, "test")
+		_, err := s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "test"}.Build())
 		if trace.IsNotFound(err) {
 			return nil
 		}
@@ -288,7 +288,7 @@ func (s *TerraformSuiteOSS) TestImportOpenSSHEICEServer() {
 	require.NoError(s.T(), err)
 
 	require.Eventually(s.T(), func() bool {
-		_, err = s.client.GetNode(ctx, defaults.Namespace, server.GetName())
+		_, err = s.client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: server.GetName(), Scope: server.GetScope()}.Build())
 		if trace.IsNotFound(err) {
 			return false
 		}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1115,7 +1115,7 @@ func (a *ServerWithRoles) KeepAliveServer(ctx context.Context, handle types.Keep
 	scopedServer := a.ScopedServerWithRoles()
 	switch handle.GetType() {
 	case constants.KeepAliveNode:
-		if err := scopedServer.scopedContext.AgentOwnedResourceAction("", handle.Name, types.RoleNode); err != nil {
+		if err := scopedServer.scopedContext.AgentOwnedResourceAction(handle.Scope, handle.Name, types.RoleNode); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.KeepAliveApp:
@@ -1281,7 +1281,8 @@ func supportedScopedWatchKind(kind string) bool {
 		types.KindAccessListReview,
 		scopedaccess.KindScopedRole,
 		scopedaccess.KindScopedRoleAssignment,
-		types.KindKubernetesCluster:
+		types.KindKubernetesCluster,
+		types.KindNode:
 		return true
 	default:
 		return false
@@ -1476,20 +1477,28 @@ func (a *ServerWithRoles) DeleteAllNodes(ctx context.Context, namespace string) 
 	return a.authServer.DeleteAllNodes(ctx, namespace)
 }
 
-// DeleteNode deletes node in the namespace
+// DeleteNode deletes an unscoped node in the namespace.
+//
+// Deprecated: use PresenceService.DeleteSSHServer instead.
+// TODO(williamo): Remove in v20
 func (a *ServerWithRoles) DeleteNode(ctx context.Context, namespace, node string) error {
 	if err := a.actionNamespace(namespace, types.KindNode, types.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.DeleteNode(ctx, namespace, node)
+	return a.authServer.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: node}.Build())
 }
 
-// GetNode gets a node by name and namespace.
+// GetNode gets an unscoped node by name and namespace.
+//
+// Deprecated: use PresenceService.GetSSHServer instead.
+// TODO(williamo): Remove in v20
 func (a *ServerWithRoles) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
 	if err := a.actionNamespace(namespace, types.KindNode, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	node, err := a.authServer.GetNode(ctx, namespace, name)
+	node, err := a.authServer.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name: name,
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles_watch_authz_test.go
+++ b/lib/auth/auth_with_roles_watch_authz_test.go
@@ -200,7 +200,7 @@ func TestScopedWatchKindAuthz(t *testing.T) {
 			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
 			// kinds are namespaced.
 			name:      "non-namespaced kind EXACT denied by whitelist",
-			kind:      types.KindNode,
+			kind:      types.KindDatabase,
 			filter:    filter(scopesv1.Mode_MODE_EXACT, pinScope),
 			assertErr: requireAccessDenied,
 		},
@@ -208,7 +208,7 @@ func TestScopedWatchKindAuthz(t *testing.T) {
 			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
 			// kinds are namespaced.
 			name:      "non-namespaced kind ALL denied by whitelist for scoped caller",
-			kind:      types.KindNode,
+			kind:      types.KindDatabase,
 			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
 			assertErr: requireAccessDenied,
 		},
@@ -371,7 +371,7 @@ func TestUnscopedWatchKindAuthz(t *testing.T) {
 			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
 			// kinds are namespaced.
 			name:      "non-namespaced kind EXACT denied by whitelist",
-			kind:      types.KindNode,
+			kind:      types.KindDatabase,
 			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
 			assertErr: requireAccessDenied,
 		},

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -221,12 +221,6 @@ type ReadProxyAccessPoint interface {
 	// GetUser returns a services.User for this cluster.
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
 
-	// GetNode returns an unscoped node by name and namespace.
-	//
-	// Deprecated: Use GetSSHServer instead, which supports scoped nodes.
-	// TODO(williamo): Remove in v20
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
-
 	// GetSSHServer returns a scoped or unscoped node by name.
 	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 
@@ -455,12 +449,6 @@ type ReadRemoteProxyAccessPoint interface {
 
 	// GetRoles returns a list of roles
 	GetRoles(ctx context.Context) ([]types.Role, error)
-
-	// GetNode returns an unscoped node by name and namespace.
-	//
-	// Deprecated: Use GetSSHServer instead, which supports scoped nodes.
-	// TODO(williamo): Remove in v20
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
 
 	// GetSSHServer returns a scoped or unscoped node by name.
 	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
@@ -1206,12 +1194,6 @@ type Cache interface {
 
 	// GetSessionRecordingConfig returns session recording configuration.
 	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
-
-	// GetNode returns an unscoped node by name and namespace.
-	//
-	// Deprecated: Use [Cache.GetSSHServer] instead, which supports scoped nodes.
-	// TODO(williamo): Remove in v20
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
 
 	// GetSSHServer returns a scoped or unscoped node by name.
 	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -3648,37 +3648,29 @@ func TestNodesCRUD(t *testing.T) {
 		t.Run("GetNode", func(t *testing.T) {
 			t.Parallel()
 			// Get Node
-			node, err := clt.GetNode(ctx, apidefaults.Namespace, "node1")
+			node, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "node1"}.Build())
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(node1, node,
 				cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
 			// GetNode should fail if node name isn't provided
-			_, err = clt.GetNode(ctx, apidefaults.Namespace, "")
-			require.True(t, trace.IsBadParameter(err), "trace.IsBadParameter failed: err=%v (%T)", err, trace.Unwrap(err))
-
-			// GetNode should fail if namespace isn't provided
-			_, err = clt.GetNode(ctx, "", "node1")
+			_, err = clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: ""}.Build())
 			require.True(t, trace.IsBadParameter(err), "trace.IsBadParameter failed: err=%v (%T)", err, trace.Unwrap(err))
 		})
 	})
 
 	t.Run("DeleteNode", func(t *testing.T) {
-		// Make sure can't delete with empty namespace or name.
-		err = clt.DeleteNode(ctx, apidefaults.Namespace, "")
-		require.Error(t, err)
-		require.ErrorAs(t, err, new(*trace.BadParameterError))
-
-		err = clt.DeleteNode(ctx, "", node1.GetName())
+		// Make sure can't delete with empty name.
+		err = clt.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: ""}.Build())
 		require.Error(t, err)
 		require.ErrorAs(t, err, new(*trace.BadParameterError))
 
 		// Delete node.
-		err = clt.DeleteNode(ctx, apidefaults.Namespace, node1.GetName())
+		err = clt.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: node1.GetName()}.Build())
 		require.NoError(t, err)
 
 		// Expect node not found
-		_, err := clt.GetNode(ctx, apidefaults.Namespace, "node1")
+		_, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "node1"}.Build())
 		require.ErrorAs(t, err, new(*trace.NotFoundError))
 	})
 
@@ -7374,7 +7366,7 @@ func TestScopedWatchEvents(t *testing.T) {
 		{
 			name:          "scoped host watching disallowed kind",
 			client:        scopedClient,
-			kind:          types.KindNode,
+			kind:          types.KindDatabase,
 			expectFailure: true,
 		},
 		{
@@ -7385,7 +7377,7 @@ func TestScopedWatchEvents(t *testing.T) {
 		{
 			name:          "scope pinned host watching disallowed kind",
 			client:        scopePinnedClient,
-			kind:          types.KindNode,
+			kind:          types.KindDatabase,
 			expectFailure: true,
 		},
 	}

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -64,6 +64,10 @@ type Backend interface {
 	DeleteKubeCluster(ctx context.Context, req *presencepb.DeleteKubeClusterRequest) error
 
 	DeleteKubeServer(ctx context.Context, req *presencepb.DeleteKubeServerRequest) error
+
+	GetSSHServer(ctx context.Context, req *presencepb.GetSSHServerRequest) (types.Server, error)
+	RangeSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) iter.Seq2[types.Server, error]
+	DeleteSSHServer(ctx context.Context, req *presencepb.DeleteSSHServerRequest) error
 }
 
 type Cache interface {
@@ -849,4 +853,133 @@ func (s *Service) DeleteKubeServer(
 		return nil, trace.Wrap(err)
 	}
 	return presencepb.DeleteKubeServerResponse_builder{}.Build(), nil
+}
+
+// GetNode returns the specified node resource.
+func (s *Service) GetNode(ctx context.Context, req *presencepb.GetSSHServerRequest) (*presencepb.GetSSHServerResponse, error) {
+	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	node, err := s.backend.GetSSHServer(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbRead); err != nil {
+			return err
+		}
+		return checker.SSH().CanAccessSSHServer(node)
+	}); err != nil {
+		if trace.IsAccessDenied(err) {
+			return nil, trace.NotFound("not found")
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	nodeV2, ok := node.(*types.ServerV2)
+	if !ok {
+		return nil, trace.BadParameter("invalid node")
+	}
+	return presencepb.GetSSHServerResponse_builder{
+		Server: nodeV2,
+	}.Build(), nil
+}
+
+// getCursorForNode wraps [services.GetCursorForNode] with a signature
+// referencing [*types.ServerV2] directly. This helps go infer the proper
+// typing when using [generic.CollectPageAndCursor].
+func getCursorForNode(node *types.ServerV2) string {
+	return services.GetCursorForNode(node)
+}
+
+// ListNodes returns a page of registered nodes.
+func (s *Service) ListNodes(ctx context.Context, req *presencepb.ListSSHServersRequest) (*presencepb.ListSSHServersResponse, error) {
+	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// list method scope filters must use identity-based defaults per RFD 0229i
+	req.SetScopeFilter(authContext.CheckerContext.ResolveScopeFilter(req.GetScopeFilter()))
+
+	servers, nextToken, err := generic.CollectPageAndCursor(
+		stream.FilterMap(
+			s.backend.RangeSSHServers(ctx, req),
+			func(node types.Server) (*types.ServerV2, bool) {
+				// Filter out nodes the user doesn't have access to.
+				if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+					if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbRead, types.VerbList); err != nil {
+						return err
+					}
+					return checker.SSH().CanAccessSSHServer(node)
+				}); err == nil {
+					nodeV2, ok := node.(*types.ServerV2)
+					return nodeV2, ok
+				}
+				return nil, false
+			},
+		),
+		int(req.GetPageSize()),
+		getCursorForNode,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return presencepb.ListSSHServersResponse_builder{
+		Servers:       servers,
+		NextPageToken: nextToken,
+	}.Build(), nil
+}
+
+// DeleteSSHServer removes the specified node resource.
+func (s *Service) DeleteNode(ctx context.Context, req *presencepb.DeleteSSHServerRequest) (*presencepb.DeleteSSHServerResponse, error) {
+	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if req.GetName() == "" {
+		return nil, trace.BadParameter("name: must be specified")
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Make sure the user has access to the node before deleting it.
+	node, err := s.backend.GetSSHServer(ctx, presencepb.GetSSHServerRequest_builder{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}.Build())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbDelete); err != nil {
+			return err
+		}
+		return checker.SSH().CanAccessSSHServer(node)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.backend.DeleteSSHServer(ctx, req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return presencepb.DeleteSSHServerResponse_builder{}.Build(), nil
 }

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -921,7 +921,7 @@ func (s *Service) ListNodes(ctx context.Context, req *presencepb.ListSSHServersR
 			func(node types.Server) (*types.ServerV2, bool) {
 				// Filter out nodes the user doesn't have access to.
 				if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
-					if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbRead, types.VerbList); err != nil {
+					if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbList); err != nil {
 						return err
 					}
 					return checker.SSH().CanAccessSSHServer(node)

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -855,8 +855,8 @@ func (s *Service) DeleteKubeServer(
 	return presencepb.DeleteKubeServerResponse_builder{}.Build(), nil
 }
 
-// GetNode returns the specified node resource.
-func (s *Service) GetNode(ctx context.Context, req *presencepb.GetSSHServerRequest) (*presencepb.GetSSHServerResponse, error) {
+// GetSSHServer returns the specified node resource.
+func (s *Service) GetSSHServer(ctx context.Context, req *presencepb.GetSSHServerRequest) (*presencepb.GetSSHServerResponse, error) {
 	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -900,8 +900,8 @@ func getCursorForNode(node *types.ServerV2) string {
 	return services.GetCursorForNode(node)
 }
 
-// ListNodes returns a page of registered nodes.
-func (s *Service) ListNodes(ctx context.Context, req *presencepb.ListSSHServersRequest) (*presencepb.ListSSHServersResponse, error) {
+// ListSSHServers returns a page of registered nodes.
+func (s *Service) ListSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) (*presencepb.ListSSHServersResponse, error) {
 	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -946,7 +946,7 @@ func (s *Service) ListNodes(ctx context.Context, req *presencepb.ListSSHServersR
 }
 
 // DeleteSSHServer removes the specified node resource.
-func (s *Service) DeleteNode(ctx context.Context, req *presencepb.DeleteSSHServerRequest) (*presencepb.DeleteSSHServerResponse, error) {
+func (s *Service) DeleteSSHServer(ctx context.Context, req *presencepb.DeleteSSHServerRequest) (*presencepb.DeleteSSHServerResponse, error) {
 	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -970,10 +970,7 @@ func (s *Service) DeleteSSHServer(ctx context.Context, req *presencepb.DeleteSSH
 		return nil, trace.Wrap(err)
 	}
 	if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
-		if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbDelete); err != nil {
-			return err
-		}
-		return checker.SSH().CanAccessSSHServer(node)
+		return checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbDelete)
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -64,6 +64,10 @@ type Backend interface {
 	DeleteKubeCluster(ctx context.Context, req *presencepb.DeleteKubeClusterRequest) error
 
 	DeleteKubeServer(ctx context.Context, req *presencepb.DeleteKubeServerRequest) error
+
+	GetSSHServer(ctx context.Context, req *presencepb.GetSSHServerRequest) (types.Server, error)
+	RangeSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) iter.Seq2[types.Server, error]
+	DeleteSSHServer(ctx context.Context, req *presencepb.DeleteSSHServerRequest) error
 }
 
 type Cache interface {
@@ -849,4 +853,130 @@ func (s *Service) DeleteKubeServer(
 		return nil, trace.Wrap(err)
 	}
 	return presencepb.DeleteKubeServerResponse_builder{}.Build(), nil
+}
+
+// GetSSHServer returns the specified node resource.
+func (s *Service) GetSSHServer(ctx context.Context, req *presencepb.GetSSHServerRequest) (*presencepb.GetSSHServerResponse, error) {
+	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	node, err := s.backend.GetSSHServer(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbRead); err != nil {
+			return err
+		}
+		return checker.SSH().CanAccessSSHServer(node)
+	}); err != nil {
+		if trace.IsAccessDenied(err) {
+			return nil, trace.NotFound("not found")
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	nodeV2, ok := node.(*types.ServerV2)
+	if !ok {
+		return nil, trace.BadParameter("invalid node")
+	}
+	return presencepb.GetSSHServerResponse_builder{
+		Server: nodeV2,
+	}.Build(), nil
+}
+
+// getCursorForNode wraps [services.GetCursorForNode] with a signature
+// referencing [*types.ServerV2] directly. This helps go infer the proper
+// typing when using [generic.CollectPageAndCursor].
+func getCursorForNode(node *types.ServerV2) string {
+	return services.GetCursorForNode(node)
+}
+
+// ListSSHServers returns a page of registered nodes.
+func (s *Service) ListSSHServers(ctx context.Context, req *presencepb.ListSSHServersRequest) (*presencepb.ListSSHServersResponse, error) {
+	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// list method scope filters must use identity-based defaults per RFD 0229i
+	req.SetScopeFilter(authContext.CheckerContext.ResolveScopeFilter(req.GetScopeFilter()))
+
+	servers, nextToken, err := generic.CollectPageAndCursor(
+		stream.FilterMap(
+			s.backend.RangeSSHServers(ctx, req),
+			func(node types.Server) (*types.ServerV2, bool) {
+				// Filter out nodes the user doesn't have access to.
+				if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+					if err := checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbList); err != nil {
+						return err
+					}
+					return checker.SSH().CanAccessSSHServer(node)
+				}); err == nil {
+					nodeV2, ok := node.(*types.ServerV2)
+					return nodeV2, ok
+				}
+				return nil, false
+			},
+		),
+		int(req.GetPageSize()),
+		getCursorForNode,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return presencepb.ListSSHServersResponse_builder{
+		Servers:       servers,
+		NextPageToken: nextToken,
+	}.Build(), nil
+}
+
+// DeleteSSHServer removes the specified node resource.
+func (s *Service) DeleteSSHServer(ctx context.Context, req *presencepb.DeleteSSHServerRequest) (*presencepb.DeleteSSHServerResponse, error) {
+	authContext, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if req.GetName() == "" {
+		return nil, trace.BadParameter("name: must be specified")
+	}
+
+	ruleCtx := authContext.RuleContext()
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbDelete); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Make sure the user has access to the node before deleting it.
+	node, err := s.backend.GetSSHServer(ctx, presencepb.GetSSHServerRequest_builder{
+		Scope: req.GetScope(),
+		Name:  req.GetName(),
+	}.Build())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := authContext.CheckerContext.Decision(ctx, node.GetScope(), func(checker *services.ScopedAccessChecker) error {
+		return checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbDelete)
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := s.backend.DeleteSSHServer(ctx, req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return presencepb.DeleteSSHServerResponse_builder{}.Build(), nil
 }

--- a/lib/auth/presence/presencev1/service_kube_test.go
+++ b/lib/auth/presence/presencev1/service_kube_test.go
@@ -20,240 +20,119 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
-	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	presencev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
-	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/auth/authtest"
-	"github.com/gravitational/teleport/lib/scopes"
-	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services/local"
 )
 
 func TestPresenceServiceKubeClusters(t *testing.T) {
 	t.Parallel()
-	srv := newTestTLSServer(t)
 
-	readUser, _, err := authtest.CreateUserAndRole(
-		srv.Auth(),
-		"read-user",
-		[]string{},
-		[]types.Rule{
-			{
-				Resources: []string{types.KindKubernetesCluster},
-				Verbs:     []string{types.VerbRead},
-			},
-		},
-	)
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bk.Close()) })
+	kube, err := local.NewKubernetesService(bk)
 	require.NoError(t, err)
 
-	listUser, _, err := authtest.CreateUserAndRole(
-		srv.Auth(),
-		"list-user",
-		[]string{},
-		[]types.Rule{
-			{
-				Resources: []string{types.KindKubernetesCluster},
-				Verbs:     []string{types.VerbRead, types.VerbList},
-			},
-		},
-	)
-	require.NoError(t, err)
-
-	deleteUser, _, err := authtest.CreateUserAndRole(
-		srv.Auth(),
-		"delete-user",
-		[]string{},
-		[]types.Rule{
-			{
-				Resources: []string{types.KindKubernetesCluster},
-				Verbs:     []string{types.VerbDelete},
-			},
-		},
-	)
-	require.NoError(t, err)
+	roles := fakeScopedRoleReader{roles: map[string]*accessv1.ScopedRole{}}
+	scopedReadRole := roles.createScopedRole("read-role", types.VerbRead)
+	scopedListRole := roles.createScopedRole("list-role", types.VerbRead, types.VerbList)
+	scopedDeleteRole := roles.createScopedRole("delete-role", types.VerbDelete)
 
 	const (
-		parentScope     = "/aa"
-		scope           = "/aa/aa"
-		orthogonalScope = "/aa/bb"
-	)
-	createScopedRole := func(name string, verbs []string) *scopedaccessv1.ScopedRole {
-		scopedRole, err := srv.Auth().ScopedAccess().CreateScopedRole(t.Context(), scopedaccessv1.CreateScopedRoleRequest_builder{
-			Role: scopedaccessv1.ScopedRole_builder{
-				Kind:    scopedaccess.KindScopedRole,
-				Version: types.V1,
-				Metadata: headerv1.Metadata_builder{
-					Name: name,
-				}.Build(),
-				Scope: parentScope,
-				Spec: scopedaccessv1.ScopedRoleSpec_builder{
-					AssignableScopes: []string{scope, orthogonalScope},
-					// need kube block because of the CanAccessKubeCluster checks
-					Kube: scopedaccessv1.ScopedRoleKube_builder{
-						Labels: []*labelv1.Label{
-							labelv1.Label_builder{
-								Name:   types.Wildcard,
-								Values: []string{types.Wildcard},
-							}.Build(),
-						},
-						Resources: []*scopedaccessv1.KubeResource{
-							scopedaccessv1.KubeResource_builder{
-								Kind:      types.Wildcard,
-								Name:      types.Wildcard,
-								Namespace: types.Wildcard,
-								ApiGroup:  types.Wildcard,
-								Verbs:     []string{types.Wildcard},
-							}.Build(),
-						},
-					}.Build(),
-					Rules: []*scopedaccessv1.ScopedRule{
-						scopedaccessv1.ScopedRule_builder{
-							Resources: []string{types.KindKubernetesCluster},
-							Verbs:     verbs,
-						}.Build(),
-					},
-				}.Build(),
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
-		return scopedRole.GetRole()
-	}
-
-	scopedReadRole := createScopedRole("read-role", []string{types.VerbRead})
-	scopedListRole := createScopedRole("list-role", []string{types.VerbRead, types.VerbList})
-	scopedDeleteRole := createScopedRole("delete-role", []string{types.VerbDelete})
-
-	createAssignment := func(role *scopedaccessv1.ScopedRole, username, assignedScope string) *scopedaccessv1.ScopedRoleAssignment {
-		sra, err := srv.Auth().ScopedAccess().CreateScopedRoleAssignment(t.Context(), scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
-			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
-				Kind:    scopedaccess.KindScopedRoleAssignment,
-				SubKind: scopedaccess.SubKindDynamic,
-				Version: types.V1,
-				Metadata: headerv1.Metadata_builder{
-					Name: uuid.NewString(),
-				}.Build(),
-				Scope: assignedScope,
-				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					User: username,
-					Assignments: []*scopedaccessv1.Assignment{
-						scopedaccessv1.Assignment_builder{
-							Role:  scopes.QualifiedName{Scope: role.GetScope(), Name: role.GetMetadata().GetName()}.String(),
-							Scope: assignedScope,
-						}.Build(),
-					},
-				}.Build(),
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
-		return sra.GetAssignment()
-	}
-
-	waitForSRACache(
-		t,
-		srv,
-		createAssignment(scopedReadRole, readUser.GetName(), scope),
-		createAssignment(scopedListRole, listUser.GetName(), scope),
-		createAssignment(scopedDeleteRole, deleteUser.GetName(), scope),
+		readUser   = "read-user"
+		listUser   = "list-user"
+		deleteUser = "delete-user"
 	)
 
-	scopedCluster := newKubeCluster(t, srv.Auth(), scope, "kube-cluster", map[string]string{
+	scopedCluster := newKubeCluster(t, kube, testScope, "kube-cluster", map[string]string{
 		"env": "test",
 	})
-	orthogonalCluster := newKubeCluster(t, srv.Auth(), orthogonalScope, "kube-cluster", map[string]string{
+	orthogonalCluster := newKubeCluster(t, kube, testOrthogonalScope, "kube-cluster", map[string]string{
 		"env": "test",
 	})
-	// prodCluster := newKubeCluster(t, srv.Auth(), "/aa/aa", "prod-cluster", map[string]string{
-	// 	"env": "prod",
-	// })
-	unscopedCluster := newKubeCluster(t, srv.Auth(), "", "unscoped-cluster", map[string]string{
+	unscopedCluster := newKubeCluster(t, kube, "", "unscoped-cluster", map[string]string{
 		"env": "test",
 	})
-
-	newClient := func(t *testing.T, identity authtest.TestIdentity) *authclient.Client {
-		client, err := srv.NewClient(identity)
-		require.NoError(t, err)
-		t.Cleanup(func() { client.Close() })
-		return client
-	}
 
 	t.Run("GetKubeCluster", func(t *testing.T) {
 		for _, tt := range []struct {
 			name       string
-			client     *authclient.Client
+			authorizer authz.ScopedAuthorizer
 			cluster    types.KubeCluster
 			shouldFail bool
 		}{
 			{
-				name:    "unscoped read-user fetching unscoped kube cluster",
-				client:  newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster: unscopedCluster,
+				name:       "unscoped read-user fetching unscoped kube cluster",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
+				cluster:    unscopedCluster,
 			},
 			{
-				name:    "unscoped read-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster: scopedCluster,
+				name:       "unscoped read-user fetching scoped kube cluster",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
+				cluster:    scopedCluster,
 			},
 			{
-				name:    "unscoped delete-user fetching unscoped kube cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: unscopedCluster,
+				name:       "unscoped delete-user fetching unscoped kube cluster",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindKubernetesCluster, types.VerbDelete),
+				cluster:    unscopedCluster,
 				// default implicit role provides read access
 				shouldFail: false,
 			},
 			{
-				name:    "unscoped delete-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: scopedCluster,
+				name:       "unscoped delete-user fetching scoped kube cluster",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindKubernetesCluster, types.VerbDelete),
+				cluster:    scopedCluster,
 				// default implicit role provides read access
 				shouldFail: false,
 			},
 			{
-				name:    "scoped read-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster: scopedCluster,
+				name:       "scoped read-user fetching scoped kube cluster",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				cluster:    scopedCluster,
 			},
 			{
 				name:       "scoped read-user fetching orthogonal scoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped read-user fetching unscoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster:    orthogonalCluster,
-				shouldFail: true,
-			},
-			{
-				name:       "scoped delete-user fetching unscoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
-				name:    "scoped delete-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster: scopedCluster,
+				name:       "scoped delete-user fetching unscoped kube cluster",
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				cluster:    unscopedCluster,
+				shouldFail: true,
+			},
+			{
+				name:       "scoped delete-user fetching scoped kube cluster",
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				cluster:    scopedCluster,
 				// default implicit role provides read access
 				shouldFail: false,
 			},
 			{
 				name:       "scoped delete-user fetching orthogonal scoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
 				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				res, err := tt.client.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
+				srv := newPresenceService(t, backend{kube: kube}, tt.authorizer)
+				res, err := srv.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
 					Name:  tt.cluster.GetName(),
 					Scope: tt.cluster.GetScope(),
 				}.Build())
@@ -261,7 +140,7 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 					assert.Error(t, err)
 				} else {
 					assert.NoError(t, err)
-					assert.Empty(t, cmp.Diff(tt.cluster, res))
+					assert.Empty(t, cmp.Diff(tt.cluster, res.GetCluster()))
 				}
 			})
 		}
@@ -269,25 +148,24 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 
 	allClusters := []types.KubeCluster{unscopedCluster, scopedCluster, orthogonalCluster}
 	t.Run("ListKubeClusters", func(t *testing.T) {
-		t.Parallel()
 		for _, tt := range []struct {
 			name             string
-			client           *authclient.Client
+			authorizer       authz.ScopedAuthorizer
 			req              *presencev1pb.ListKubeClustersRequest
 			expectedClusters []types.KubeCluster
 			shouldFail       bool
 		}{
 			{
-				name:   "unscoped list-user listing all clusters without scope filter",
-				client: newClient(t, authtest.TestUser(listUser.GetName())),
+				name:       "unscoped list-user listing all clusters without scope filter",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindKubernetesCluster, types.VerbRead, types.VerbList),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 				}.Build(),
 				expectedClusters: []types.KubeCluster{unscopedCluster},
 			},
 			{
-				name:   "unscoped list-user listing all clusters filtering for all scopes",
-				client: newClient(t, authtest.TestUser(listUser.GetName())),
+				name:       "unscoped list-user listing all clusters filtering for all scopes",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindKubernetesCluster, types.VerbRead, types.VerbList),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
@@ -297,56 +175,57 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 				expectedClusters: allClusters,
 			},
 			{
-				name:   "unscoped list-user listing clusters with scope filter",
-				client: newClient(t, authtest.TestUser(listUser.GetName())),
+				name:       "unscoped list-user listing clusters with scope filter",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindKubernetesCluster, types.VerbRead, types.VerbList),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
-						Scope: scope,
+						Scope: testScope,
 						Mode:  scopesv1.Mode_MODE_EXACT,
 					}.Build(),
 				}.Build(),
 				expectedClusters: []types.KubeCluster{scopedCluster},
 			},
 			{
-				name:   "scoped list-user listing all clusters",
-				client: newClient(t, authtest.TestScopedUser(listUser.GetName(), scope)),
+				name:       "scoped list-user listing all clusters",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 				}.Build(),
 				expectedClusters: []types.KubeCluster{scopedCluster},
 			},
 			{
-				name:   "scoped list-user listing clusters with scope filter",
-				client: newClient(t, authtest.TestScopedUser(listUser.GetName(), scope)),
+				name:       "scoped list-user listing clusters with scope filter",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
-						Scope: scope,
+						Scope: testScope,
 						Mode:  scopesv1.Mode_MODE_EXACT,
 					}.Build(),
 				}.Build(),
 				expectedClusters: []types.KubeCluster{scopedCluster},
 			},
 			{
-				name:   "scoped list-user listing clusters with orthogonal scope filter",
-				client: newClient(t, authtest.TestScopedUser(listUser.GetName(), scope)),
+				name:       "scoped list-user listing clusters with orthogonal scope filter",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
 				req: presencev1pb.ListKubeClustersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
-						Scope: orthogonalScope,
+						Scope: testOrthogonalScope,
 						Mode:  scopesv1.Mode_MODE_EXACT,
 					}.Build(),
 				}.Build(),
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				clusters, _, err := tt.client.ListKubeClusters(t.Context(), tt.req)
+				srv := newPresenceService(t, backend{kube: kube}, tt.authorizer)
+				res, err := srv.ListKubeClusters(t.Context(), tt.req)
 				if tt.shouldFail {
 					assert.Error(t, err)
 				} else {
 					assert.NoError(t, err)
-					assert.ElementsMatch(t, tt.expectedClusters, clusters)
+					assert.ElementsMatch(t, tt.expectedClusters, res.GetClusters())
 				}
 			})
 		}
@@ -356,76 +235,77 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 		t.Parallel()
 		for _, tt := range []struct {
 			name       string
-			client     *authclient.Client
+			authorizer authz.ScopedAuthorizer
 			cluster    types.KubeCluster
 			shouldFail bool
 		}{
 			{
 				name:       "unscoped read-user deleting unscoped cluster",
-				client:     newClient(t, authtest.TestUser(readUser.GetName())),
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
 				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "unscoped read-user deleting scoped cluster",
-				client:     newClient(t, authtest.TestUser(readUser.GetName())),
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
 				cluster:    scopedCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "unscoped read-user deleting orthogonal cluster",
-				client:     newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster:    scopedCluster,
+				authorizer: newFakeAuthorizer(t, readUser, types.KindKubernetesCluster, types.VerbRead),
+				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped read-user deleting unscoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped read-user deleting scoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    scopedCluster,
 				shouldFail: true,
 			},
 			{
-				name:       "scoped read-user deleting scoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
+				name:       "scoped read-user deleting orthogonal cluster",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
 				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped delete-user deleting unscoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
 				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
 				name:       "scoped delete-user deleting orthogonal cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
 				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 			{
-				name:    "scoped delete-user deleting scoped cluster",
-				client:  newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster: scopedCluster,
+				name:       "scoped delete-user deleting scoped cluster",
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				cluster:    scopedCluster,
 			},
 			{
-				name:    "unscoped delete-user deleting unscoped cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: unscopedCluster,
+				name:       "unscoped delete-user deleting unscoped cluster",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindKubernetesCluster, types.VerbDelete),
+				cluster:    unscopedCluster,
 			},
 			{
-				name:    "unscoped delete-user deleting orthogonal cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: orthogonalCluster,
+				name:       "unscoped delete-user deleting orthogonal cluster",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindKubernetesCluster, types.VerbDelete),
+				cluster:    orthogonalCluster,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				err := tt.client.DeleteKubeCluster(t.Context(), presencev1pb.DeleteKubeClusterRequest_builder{
+				srv := newPresenceService(t, backend{kube: kube}, tt.authorizer)
+				_, err := srv.DeleteKubeCluster(t.Context(), presencev1pb.DeleteKubeClusterRequest_builder{
 					Name:  tt.cluster.GetName(),
 					Scope: tt.cluster.GetScope(),
 				}.Build())
@@ -439,7 +319,7 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 	})
 }
 
-func newKubeCluster(t *testing.T, srv *auth.Server, scope, name string, labels map[string]string) types.KubeCluster {
+func newKubeCluster(t *testing.T, srv *local.KubernetesService, scope, name string, labels map[string]string) types.KubeCluster {
 	t.Helper()
 
 	cluster, err := types.NewKubernetesClusterV3(types.Metadata{

--- a/lib/auth/presence/presencev1/service_node_test.go
+++ b/lib/auth/presence/presencev1/service_node_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -37,17 +38,17 @@ import (
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
-func TestPresenceServiceKubeClusters(t *testing.T) {
+func TestPresenceServiceNodes(t *testing.T) {
 	t.Parallel()
 	srv := newTestTLSServer(t)
 
 	readUser, _, err := authtest.CreateUserAndRole(
 		srv.Auth(),
-		"read-user",
+		"node-read-user",
 		[]string{},
 		[]types.Rule{
 			{
-				Resources: []string{types.KindKubernetesCluster},
+				Resources: []string{types.KindNode},
 				Verbs:     []string{types.VerbRead},
 			},
 		},
@@ -56,11 +57,11 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 
 	listUser, _, err := authtest.CreateUserAndRole(
 		srv.Auth(),
-		"list-user",
+		"node-list-user",
 		[]string{},
 		[]types.Rule{
 			{
-				Resources: []string{types.KindKubernetesCluster},
+				Resources: []string{types.KindNode},
 				Verbs:     []string{types.VerbRead, types.VerbList},
 			},
 		},
@@ -69,11 +70,11 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 
 	deleteUser, _, err := authtest.CreateUserAndRole(
 		srv.Auth(),
-		"delete-user",
+		"node-delete-user",
 		[]string{},
 		[]types.Rule{
 			{
-				Resources: []string{types.KindKubernetesCluster},
+				Resources: []string{types.KindNode},
 				Verbs:     []string{types.VerbDelete},
 			},
 		},
@@ -96,27 +97,19 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 				Scope: parentScope,
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
 					AssignableScopes: []string{scope, orthogonalScope},
-					// need kube block because of the CanAccessKubeCluster checks
-					Kube: scopedaccessv1.ScopedRoleKube_builder{
+					// need ssh block because of the CanAccessSSHServer checks
+					Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+						Logins: []string{"root"},
 						Labels: []*labelv1.Label{
 							labelv1.Label_builder{
 								Name:   types.Wildcard,
 								Values: []string{types.Wildcard},
 							}.Build(),
 						},
-						Resources: []*scopedaccessv1.KubeResource{
-							scopedaccessv1.KubeResource_builder{
-								Kind:      types.Wildcard,
-								Name:      types.Wildcard,
-								Namespace: types.Wildcard,
-								ApiGroup:  types.Wildcard,
-								Verbs:     []string{types.Wildcard},
-							}.Build(),
-						},
 					}.Build(),
 					Rules: []*scopedaccessv1.ScopedRule{
 						scopedaccessv1.ScopedRule_builder{
-							Resources: []string{types.KindKubernetesCluster},
+							Resources: []string{types.KindNode},
 							Verbs:     verbs,
 						}.Build(),
 					},
@@ -127,9 +120,9 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 		return scopedRole.GetRole()
 	}
 
-	scopedReadRole := createScopedRole("read-role", []string{types.VerbRead})
-	scopedListRole := createScopedRole("list-role", []string{types.VerbRead, types.VerbList})
-	scopedDeleteRole := createScopedRole("delete-role", []string{types.VerbDelete})
+	scopedReadRole := createScopedRole("node-read-role", []string{types.VerbRead})
+	scopedListRole := createScopedRole("node-list-role", []string{types.VerbRead, types.VerbList})
+	scopedDeleteRole := createScopedRole("node-delete-role", []string{types.VerbDelete})
 
 	createAssignment := func(role *scopedaccessv1.ScopedRole, username, assignedScope string) *scopedaccessv1.ScopedRoleAssignment {
 		sra, err := srv.Auth().ScopedAccess().CreateScopedRoleAssignment(t.Context(), scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
@@ -164,15 +157,9 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 		createAssignment(scopedDeleteRole, deleteUser.GetName(), scope),
 	)
 
-	scopedCluster := newKubeCluster(t, srv.Auth(), scope, "kube-cluster", map[string]string{
-		"env": "test",
-	})
-	orthogonalCluster := newKubeCluster(t, srv.Auth(), orthogonalScope, "kube-cluster", map[string]string{
-		"env": "test",
-	})
-	unscopedCluster := newKubeCluster(t, srv.Auth(), "", "unscoped-cluster", map[string]string{
-		"env": "test",
-	})
+	unscopedNode := newNode(t, srv.Auth(), "", "node", map[string]string{"env": "test"})
+	scopedNode := newNode(t, srv.Auth(), scope, "node", map[string]string{"env": "test"})
+	orthogonalNode := newNode(t, srv.Auth(), orthogonalScope, "node", map[string]string{"env": "test"})
 
 	newClient := func(t *testing.T, identity authtest.TestIdentity) *authclient.Client {
 		client, err := srv.NewClient(identity)
@@ -181,154 +168,137 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 		return client
 	}
 
-	t.Run("GetKubeCluster", func(t *testing.T) {
+	t.Run("GetNode", func(t *testing.T) {
 		for _, tt := range []struct {
 			name       string
 			client     *authclient.Client
-			cluster    types.KubeCluster
+			node       types.Server
 			shouldFail bool
 		}{
 			{
-				name:    "unscoped read-user fetching unscoped kube cluster",
-				client:  newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster: unscopedCluster,
+				name:   "unscoped read-user fetching unscoped node",
+				client: newClient(t, authtest.TestUser(readUser.GetName())),
+				node:   unscopedNode,
 			},
 			{
-				name:    "unscoped read-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster: scopedCluster,
+				name:   "unscoped read-user fetching scoped node",
+				client: newClient(t, authtest.TestUser(readUser.GetName())),
+				node:   scopedNode,
 			},
 			{
-				name:    "unscoped delete-user fetching unscoped kube cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: unscopedCluster,
-				// default implicit role provides read access
-				shouldFail: false,
+				name:   "unscoped read-user fetching orthogonal scoped node",
+				client: newClient(t, authtest.TestUser(readUser.GetName())),
+				node:   orthogonalNode,
 			},
 			{
-				name:    "unscoped delete-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: scopedCluster,
-				// default implicit role provides read access
-				shouldFail: false,
+				name:   "scoped read-user fetching scoped node",
+				client: newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
+				node:   scopedNode,
 			},
 			{
-				name:    "scoped read-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster: scopedCluster,
-			},
-			{
-				name:       "scoped read-user fetching orthogonal scoped kube cluster",
+				name:       "scoped read-user fetching orthogonal scoped node",
 				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster:    orthogonalCluster,
+				node:       orthogonalNode,
 				shouldFail: true,
 			},
 			{
-				name:       "scoped read-user fetching unscoped kube cluster",
+				name:       "scoped read-user fetching unscoped node",
 				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster:    orthogonalCluster,
-				shouldFail: true,
-			},
-			{
-				name:       "scoped delete-user fetching unscoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster:    unscopedCluster,
-				shouldFail: true,
-			},
-			{
-				name:    "scoped delete-user fetching scoped kube cluster",
-				client:  newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster: scopedCluster,
-				// default implicit role provides read access
-				shouldFail: false,
-			},
-			{
-				name:       "scoped delete-user fetching orthogonal scoped kube cluster",
-				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster:    orthogonalCluster,
+				node:       unscopedNode,
 				shouldFail: true,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				res, err := tt.client.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
-					Name:  tt.cluster.GetName(),
-					Scope: tt.cluster.GetScope(),
+				res, err := tt.client.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+					Name:  tt.node.GetName(),
+					Scope: tt.node.GetScope(),
 				}.Build())
 				if tt.shouldFail {
 					assert.Error(t, err)
 				} else {
 					assert.NoError(t, err)
-					assert.Empty(t, cmp.Diff(tt.cluster, res))
+					assert.Empty(t, cmp.Diff(tt.node, res))
 				}
 			})
 		}
 	})
 
-	allClusters := []types.KubeCluster{unscopedCluster, scopedCluster, orthogonalCluster}
-	t.Run("ListKubeClusters", func(t *testing.T) {
-		t.Parallel()
+	allNodes := []types.Server{unscopedNode, scopedNode, orthogonalNode}
+	t.Run("ListNodes", func(t *testing.T) {
 		for _, tt := range []struct {
-			name             string
-			client           *authclient.Client
-			req              *presencev1pb.ListKubeClustersRequest
-			expectedClusters []types.KubeCluster
-			shouldFail       bool
+			name          string
+			client        *authclient.Client
+			req           *presencev1pb.ListSSHServersRequest
+			expectedNodes []types.Server
+			shouldFail    bool
 		}{
 			{
-				name:   "unscoped list-user listing all clusters without scope filter",
+				name:   "unscoped list-user listing all nodes without scope filter",
 				client: newClient(t, authtest.TestUser(listUser.GetName())),
-				req: presencev1pb.ListKubeClustersRequest_builder{
+				req: presencev1pb.ListSSHServersRequest_builder{
 					PageSize: 10,
 				}.Build(),
-				expectedClusters: []types.KubeCluster{unscopedCluster},
+				expectedNodes: []types.Server{unscopedNode},
 			},
 			{
-				name:   "unscoped list-user listing all clusters filtering for all scopes",
+				name:   "unscoped list-user listing all nodes filtering for all scopes",
 				client: newClient(t, authtest.TestUser(listUser.GetName())),
-				req: presencev1pb.ListKubeClustersRequest_builder{
+				req: presencev1pb.ListSSHServersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
 						Mode: scopesv1.Mode_MODE_ALL,
 					}.Build(),
 				}.Build(),
-				expectedClusters: allClusters,
+				expectedNodes: allNodes,
 			},
 			{
-				name:   "unscoped list-user listing clusters with scope filter",
+				name:   "unscoped list-user listing nodes with scope filter",
 				client: newClient(t, authtest.TestUser(listUser.GetName())),
-				req: presencev1pb.ListKubeClustersRequest_builder{
+				req: presencev1pb.ListSSHServersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
 						Scope: scope,
 						Mode:  scopesv1.Mode_MODE_EXACT,
 					}.Build(),
 				}.Build(),
-				expectedClusters: []types.KubeCluster{scopedCluster},
+				expectedNodes: []types.Server{scopedNode},
 			},
 			{
-				name:   "scoped list-user listing all clusters",
+				name:   "unscoped list-user listing nodes across a scope subtree",
+				client: newClient(t, authtest.TestUser(listUser.GetName())),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Scope: parentScope,
+						Mode:  scopesv1.Mode_MODE_DESCENDANTS,
+					}.Build(),
+				}.Build(),
+				expectedNodes: []types.Server{scopedNode, orthogonalNode},
+			},
+			{
+				name:   "scoped list-user listing all nodes",
 				client: newClient(t, authtest.TestScopedUser(listUser.GetName(), scope)),
-				req: presencev1pb.ListKubeClustersRequest_builder{
+				req: presencev1pb.ListSSHServersRequest_builder{
 					PageSize: 10,
 				}.Build(),
-				expectedClusters: []types.KubeCluster{scopedCluster},
+				expectedNodes: []types.Server{scopedNode},
 			},
 			{
-				name:   "scoped list-user listing clusters with scope filter",
+				name:   "scoped list-user listing nodes with scope filter",
 				client: newClient(t, authtest.TestScopedUser(listUser.GetName(), scope)),
-				req: presencev1pb.ListKubeClustersRequest_builder{
+				req: presencev1pb.ListSSHServersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
 						Scope: scope,
 						Mode:  scopesv1.Mode_MODE_EXACT,
 					}.Build(),
 				}.Build(),
-				expectedClusters: []types.KubeCluster{scopedCluster},
+				expectedNodes: []types.Server{scopedNode},
 			},
 			{
-				name:   "scoped list-user listing clusters with orthogonal scope filter",
+				name:   "scoped list-user listing nodes with orthogonal scope filter",
 				client: newClient(t, authtest.TestScopedUser(listUser.GetName(), scope)),
-				req: presencev1pb.ListKubeClustersRequest_builder{
+				req: presencev1pb.ListSSHServersRequest_builder{
 					PageSize: 10,
 					ScopeFilter: scopesv1.Filter_builder{
 						Scope: orthogonalScope,
@@ -338,117 +308,137 @@ func TestPresenceServiceKubeClusters(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				clusters, _, err := tt.client.ListKubeClusters(t.Context(), tt.req)
+				nodes, _, err := tt.client.ListSSHServers(t.Context(), tt.req)
 				if tt.shouldFail {
 					assert.Error(t, err)
 				} else {
 					assert.NoError(t, err)
-					assert.ElementsMatch(t, tt.expectedClusters, clusters)
+					assert.ElementsMatch(t, tt.expectedNodes, nodes)
 				}
 			})
 		}
 	})
 
-	t.Run("DeleteKubeCluster", func(t *testing.T) {
-		t.Parallel()
+	// Runs last and without t.Parallel: it creates and removes nodes in the
+	// same scopes the read subtests assert over.
+	t.Run("DeleteNode", func(t *testing.T) {
 		for _, tt := range []struct {
-			name       string
-			client     *authclient.Client
-			cluster    types.KubeCluster
-			shouldFail bool
+			name string
+			// nodeScope is the scope the target node is created in.
+			nodeScope string
+			// reqScope is the scope sent in the delete request. Defaults to
+			// nodeScope when empty, unless mismatchedScope is set.
+			mismatchedScope string
+			client          *authclient.Client
+			shouldFail      bool
 		}{
 			{
-				name:       "unscoped read-user deleting unscoped cluster",
+				name:       "unscoped read-user deleting unscoped node",
+				nodeScope:  "",
 				client:     newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
-				name:       "unscoped read-user deleting scoped cluster",
+				name:       "unscoped read-user deleting scoped node",
+				nodeScope:  scope,
 				client:     newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster:    scopedCluster,
 				shouldFail: true,
 			},
 			{
-				name:       "unscoped read-user deleting orthogonal cluster",
-				client:     newClient(t, authtest.TestUser(readUser.GetName())),
-				cluster:    scopedCluster,
-				shouldFail: true,
-			},
-			{
-				name:       "scoped read-user deleting unscoped cluster",
+				name:       "scoped read-user deleting scoped node",
+				nodeScope:  scope,
 				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
-				name:       "scoped read-user deleting scoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster:    scopedCluster,
-				shouldFail: true,
-			},
-			{
-				name:       "scoped read-user deleting scoped cluster",
-				client:     newClient(t, authtest.TestScopedUser(readUser.GetName(), scope)),
-				cluster:    orthogonalCluster,
-				shouldFail: true,
-			},
-			{
-				name:       "scoped delete-user deleting unscoped cluster",
+				name:       "scoped delete-user deleting unscoped node",
+				nodeScope:  "",
 				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster:    unscopedCluster,
 				shouldFail: true,
 			},
 			{
-				name:       "scoped delete-user deleting orthogonal cluster",
+				name:       "scoped delete-user deleting orthogonal scoped node",
+				nodeScope:  orthogonalScope,
 				client:     newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster:    orthogonalCluster,
 				shouldFail: true,
 			},
 			{
-				name:    "scoped delete-user deleting scoped cluster",
-				client:  newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
-				cluster: scopedCluster,
+				name:      "scoped delete-user deleting scoped node",
+				nodeScope: scope,
+				client:    newClient(t, authtest.TestScopedUser(deleteUser.GetName(), scope)),
 			},
 			{
-				name:    "unscoped delete-user deleting unscoped cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: unscopedCluster,
+				name:      "unscoped delete-user deleting unscoped node",
+				nodeScope: "",
+				client:    newClient(t, authtest.TestUser(deleteUser.GetName())),
 			},
 			{
-				name:    "unscoped delete-user deleting orthogonal cluster",
-				client:  newClient(t, authtest.TestUser(deleteUser.GetName())),
-				cluster: orthogonalCluster,
+				name:      "unscoped delete-user deleting scoped node",
+				nodeScope: scope,
+				client:    newClient(t, authtest.TestUser(deleteUser.GetName())),
+			},
+			{
+				// The node exists, but not in the requested scope, so the
+				// delete must not fall through to the node of the same name in
+				// another scope.
+				name:            "delete with mismatched scope",
+				nodeScope:       scope,
+				mismatchedScope: orthogonalScope,
+				client:          newClient(t, authtest.TestUser(deleteUser.GetName())),
+				shouldFail:      true,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				err := tt.client.DeleteKubeCluster(t.Context(), presencev1pb.DeleteKubeClusterRequest_builder{
-					Name:  tt.cluster.GetName(),
-					Scope: tt.cluster.GetScope(),
+				name := uuid.NewString()
+				node := newNode(t, srv.Auth(), tt.nodeScope, name, map[string]string{"env": "test"})
+
+				reqScope := tt.nodeScope
+				if tt.mismatchedScope != "" {
+					reqScope = tt.mismatchedScope
+				}
+
+				err := tt.client.DeleteSSHServer(t.Context(), presencev1pb.DeleteSSHServerRequest_builder{
+					Name:  name,
+					Scope: reqScope,
 				}.Build())
 				if tt.shouldFail {
 					assert.Error(t, err)
-				} else {
+					_, err := srv.Auth().GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+						Name:  name,
+						Scope: tt.nodeScope,
+					}.Build())
 					assert.NoError(t, err)
+					return
 				}
+
+				assert.NoError(t, err)
+				_, err = srv.Auth().GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+					Name:  node.GetName(),
+					Scope: tt.nodeScope,
+				}.Build())
+				assert.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
 			})
 		}
 	})
 }
 
-func newKubeCluster(t *testing.T, srv *auth.Server, scope, name string, labels map[string]string) types.KubeCluster {
+func newNode(t *testing.T, srv *auth.Server, scope, name string, labels map[string]string) types.Server {
 	t.Helper()
 
-	cluster, err := types.NewKubernetesClusterV3(types.Metadata{
-		Name:   name,
-		Labels: labels,
-	}, types.KubernetesClusterSpecV3{})
+	node, err := types.NewServerWithLabels(name, types.KindNode, types.ServerSpecV2{
+		Addr:     "127.0.0.1:22",
+		Hostname: name,
+	}, labels)
 	require.NoError(t, err)
-	cluster.Scope = scope
 
-	err = srv.CreateKubernetesCluster(t.Context(), cluster)
+	server, ok := node.(*types.ServerV2)
+	require.True(t, ok, "expected types.ServerV2")
+	server.Scope = scope
+
+	_, err = srv.UpsertNode(t.Context(), server)
 	require.NoError(t, err)
-	res, err := srv.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
+
+	res, err := srv.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
 		Name:  name,
 		Scope: scope,
 	}.Build())

--- a/lib/auth/presence/presencev1/service_node_test.go
+++ b/lib/auth/presence/presencev1/service_node_test.go
@@ -1,0 +1,337 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package presencev1_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	presencev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	accessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+func TestPresenceServiceNodes(t *testing.T) {
+	t.Parallel()
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bk.Close()) })
+	presence := local.NewPresenceService(bk)
+
+	roles := fakeScopedRoleReader{roles: map[string]*accessv1.ScopedRole{}}
+	scopedReadRole := roles.createScopedRole("node-read-role", types.VerbRead)
+	scopedListRole := roles.createScopedRole("node-list-role", types.VerbRead, types.VerbList)
+	scopedDeleteRole := roles.createScopedRole("node-delete-role", types.VerbDelete)
+
+	const (
+		readUser   = "node-read-user"
+		listUser   = "node-list-user"
+		deleteUser = "node-delete-user"
+	)
+
+	unscopedNode := newNode(t, presence, scopes.QualifiedName{Name: "node", Scope: ""}, map[string]string{"env": "test"})
+	scopedNode := newNode(t, presence, scopes.QualifiedName{Name: "node", Scope: testScope}, map[string]string{"env": "test"})
+	orthogonalNode := newNode(t, presence, scopes.QualifiedName{Name: "node", Scope: testOrthogonalScope}, map[string]string{"env": "test"})
+
+	t.Run("GetNode", func(t *testing.T) {
+		for _, tt := range []struct {
+			name       string
+			authorizer authz.ScopedAuthorizer
+			node       types.Server
+			shouldFail bool
+		}{
+			{
+				name:       "unscoped read-user fetching unscoped node",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				node:       unscopedNode,
+			},
+			{
+				name:       "unscoped read-user fetching scoped node",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				node:       scopedNode,
+			},
+			{
+				name:       "unscoped read-user fetching orthogonal scoped node",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				node:       orthogonalNode,
+			},
+			{
+				name:       "scoped read-user fetching scoped node",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				node:       scopedNode,
+			},
+			{
+				name:       "scoped read-user fetching orthogonal scoped node",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				node:       orthogonalNode,
+				shouldFail: true,
+			},
+			{
+				name:       "scoped read-user fetching unscoped node",
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				node:       unscopedNode,
+				shouldFail: true,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				srv := newPresenceService(t, backend{presence: presence}, tt.authorizer)
+				res, err := srv.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+					Name:  tt.node.GetName(),
+					Scope: tt.node.GetScope(),
+				}.Build())
+				if tt.shouldFail {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.Empty(t, cmp.Diff(tt.node, res.GetServer()))
+				}
+			})
+		}
+	})
+
+	allNodes := []types.Server{unscopedNode, scopedNode, orthogonalNode}
+	t.Run("ListNodes", func(t *testing.T) {
+		for _, tt := range []struct {
+			name          string
+			authorizer    authz.ScopedAuthorizer
+			req           *presencev1pb.ListSSHServersRequest
+			expectedNodes []types.Server
+			shouldFail    bool
+		}{
+			{
+				name:       "unscoped list-user listing all nodes without scope filter",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindNode, types.VerbRead, types.VerbList),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+				}.Build(),
+				expectedNodes: []types.Server{unscopedNode},
+			},
+			{
+				name:       "unscoped list-user listing all nodes filtering for all scopes",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindNode, types.VerbRead, types.VerbList),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Mode: scopesv1.Mode_MODE_ALL,
+					}.Build(),
+				}.Build(),
+				expectedNodes: allNodes,
+			},
+			{
+				name:       "unscoped list-user listing nodes with scope filter",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindNode, types.VerbRead, types.VerbList),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Scope: testScope,
+						Mode:  scopesv1.Mode_MODE_EXACT,
+					}.Build(),
+				}.Build(),
+				expectedNodes: []types.Server{scopedNode},
+			},
+			{
+				name:       "unscoped list-user listing nodes across a scope subtree",
+				authorizer: newFakeAuthorizer(t, listUser, types.KindNode, types.VerbRead, types.VerbList),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Scope: testParentScope,
+						Mode:  scopesv1.Mode_MODE_DESCENDANTS,
+					}.Build(),
+				}.Build(),
+				expectedNodes: []types.Server{scopedNode, orthogonalNode},
+			},
+			{
+				name:       "scoped list-user listing all nodes",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+				}.Build(),
+				expectedNodes: []types.Server{scopedNode},
+			},
+			{
+				name:       "scoped list-user listing nodes with scope filter",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Scope: testScope,
+						Mode:  scopesv1.Mode_MODE_EXACT,
+					}.Build(),
+				}.Build(),
+				expectedNodes: []types.Server{scopedNode},
+			},
+			{
+				name:       "scoped list-user listing nodes with orthogonal scope filter",
+				authorizer: newFakeScopedAuthorizer(t, listUser, testScope, roles, scopedListRole),
+				req: presencev1pb.ListSSHServersRequest_builder{
+					PageSize: 10,
+					ScopeFilter: scopesv1.Filter_builder{
+						Scope: testOrthogonalScope,
+						Mode:  scopesv1.Mode_MODE_EXACT,
+					}.Build(),
+				}.Build(),
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				srv := newPresenceService(t, backend{presence: presence}, tt.authorizer)
+				res, err := srv.ListSSHServers(t.Context(), tt.req)
+				if tt.shouldFail {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.ElementsMatch(t, tt.expectedNodes, res.GetServers())
+				}
+			})
+		}
+	})
+
+	t.Run("DeleteNode", func(t *testing.T) {
+		for _, tt := range []struct {
+			name      string
+			nodeScope string
+			// reqScope is the scope sent in the delete request. Defaults to
+			// nodeScope when empty, unless mismatchedScope is set.
+			mismatchedScope string
+			authorizer      authz.ScopedAuthorizer
+			shouldFail      bool
+		}{
+			{
+				name:       "unscoped read-user deleting unscoped node",
+				nodeScope:  "",
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				shouldFail: true,
+			},
+			{
+				name:       "unscoped read-user deleting scoped node",
+				nodeScope:  testScope,
+				authorizer: newFakeAuthorizer(t, readUser, types.KindNode, types.VerbRead),
+				shouldFail: true,
+			},
+			{
+				name:       "scoped read-user deleting scoped node",
+				nodeScope:  testScope,
+				authorizer: newFakeScopedAuthorizer(t, readUser, testScope, roles, scopedReadRole),
+				shouldFail: true,
+			},
+			{
+				name:       "scoped delete-user deleting unscoped node",
+				nodeScope:  "",
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				shouldFail: true,
+			},
+			{
+				name:       "scoped delete-user deleting orthogonal scoped node",
+				nodeScope:  testOrthogonalScope,
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+				shouldFail: true,
+			},
+			{
+				name:       "scoped delete-user deleting scoped node",
+				nodeScope:  testScope,
+				authorizer: newFakeScopedAuthorizer(t, deleteUser, testScope, roles, scopedDeleteRole),
+			},
+			{
+				name:       "unscoped delete-user deleting unscoped node",
+				nodeScope:  "",
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindNode, types.VerbDelete),
+			},
+			{
+				name:       "unscoped delete-user deleting scoped node",
+				nodeScope:  testScope,
+				authorizer: newFakeAuthorizer(t, deleteUser, types.KindNode, types.VerbDelete),
+			},
+			{
+				name:            "delete with mismatched scope",
+				nodeScope:       testScope,
+				mismatchedScope: testOrthogonalScope,
+				authorizer:      newFakeAuthorizer(t, deleteUser, types.KindNode, types.VerbDelete),
+				shouldFail:      true,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				name := uuid.NewString()
+				node := newNode(t, presence, scopes.QualifiedName{Name: name, Scope: tt.nodeScope}, map[string]string{"env": "test"})
+
+				reqScope := tt.nodeScope
+				if tt.mismatchedScope != "" {
+					reqScope = tt.mismatchedScope
+				}
+
+				srv := newPresenceService(t, backend{presence: presence}, tt.authorizer)
+				_, err := srv.DeleteSSHServer(t.Context(), presencev1pb.DeleteSSHServerRequest_builder{
+					Name:  name,
+					Scope: reqScope,
+				}.Build())
+				if tt.shouldFail {
+					assert.Error(t, err)
+					_, err := presence.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+						Name:  name,
+						Scope: tt.nodeScope,
+					}.Build())
+					assert.NoError(t, err)
+					return
+				}
+
+				assert.NoError(t, err)
+				_, err = presence.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+					Name:  node.GetName(),
+					Scope: tt.nodeScope,
+				}.Build())
+				assert.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+			})
+		}
+	})
+}
+
+func newNode(t *testing.T, presence *local.PresenceService, sqn scopes.QualifiedName, labels map[string]string) types.Server {
+	t.Helper()
+	server := &types.ServerV2{
+		Kind: types.KindNode,
+		Metadata: types.Metadata{
+			Name:   sqn.Name,
+			Labels: labels,
+		},
+		Scope: sqn.Scope,
+		Spec: types.ServerSpecV2{
+			Addr:     "127.0.0.1:22",
+			Hostname: sqn.Name,
+		},
+	}
+
+	_, err := presence.UpsertNode(t.Context(), server)
+	require.NoError(t, err)
+
+	res, err := presence.GetSSHServer(t.Context(), presencev1pb.GetSSHServerRequest_builder{
+		Name:  sqn.Name,
+		Scope: sqn.Scope,
+	}.Build())
+	require.NoError(t, err)
+
+	return res
+}

--- a/lib/auth/presence/presencev1/service_test.go
+++ b/lib/auth/presence/presencev1/service_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"net"
 	"os"
 	"testing"
@@ -40,18 +41,27 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	presencev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/auth/presence/presencev1"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 )
 
 func newTestTLSServer(t testing.TB) *authtest.TLSServer {
@@ -1702,4 +1712,211 @@ func waitForSRACache(t *testing.T, srv *authtest.TLSServer, sras ...*scopedacces
 			require.NoError(t, err)
 		}
 	}, 10*time.Second, 100*time.Millisecond)
+}
+
+const (
+	testLocalCluster    = "test-cluster"
+	testParentScope     = "/aa"
+	testScope           = "/aa/aa"
+	testOrthogonalScope = "/aa/bb"
+)
+
+func newPresenceService(t *testing.T, backend presencev1.Backend, authorizer authz.ScopedAuthorizer) *presencev1.Service {
+	t.Helper()
+
+	svc, err := presencev1.NewService(presencev1.ServiceConfig{
+		Backend:          backend,
+		Authorizer:       stubAuthorizer{},
+		ScopedAuthorizer: authorizer,
+		AuthServer:       stubAuthServer{},
+		Cache:            stubCache{},
+		Emitter:          &eventstest.MockRecorderEmitter{},
+		Reporter:         usagereporter.DiscardUsageReporter{},
+		Clock:            clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+	return svc
+}
+
+type (
+	stubAuthorizer struct{ authz.Authorizer }
+	stubAuthServer struct{ presencev1.AuthServer }
+	stubCache      struct{ presencev1.Cache }
+)
+
+type backend struct {
+	presencev1.Backend
+	presence *local.PresenceService
+	kube     *local.KubernetesService
+}
+
+func (b backend) GetSSHServer(ctx context.Context, req *presencev1pb.GetSSHServerRequest) (types.Server, error) {
+	return b.presence.GetSSHServer(ctx, req)
+}
+
+func (b backend) RangeSSHServers(ctx context.Context, req *presencev1pb.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	return b.presence.RangeSSHServers(ctx, req)
+}
+
+func (b backend) DeleteSSHServer(ctx context.Context, req *presencev1pb.DeleteSSHServerRequest) error {
+	return b.presence.DeleteSSHServer(ctx, req)
+}
+
+func (b backend) GetKubeCluster(ctx context.Context, req *presencev1pb.GetKubeClusterRequest) (types.KubeCluster, error) {
+	return b.kube.GetKubeCluster(ctx, req)
+}
+
+func (b backend) RangeKubeClusters(ctx context.Context, req *presencev1pb.ListKubeClustersRequest) iter.Seq2[types.KubeCluster, error] {
+	return b.kube.RangeKubeClusters(ctx, req)
+}
+
+func (b backend) DeleteKubeCluster(ctx context.Context, req *presencev1pb.DeleteKubeClusterRequest) error {
+	return b.kube.DeleteKubeCluster(ctx, req)
+}
+
+func newFakeAuthorizer(t *testing.T, username, kind string, verbs ...string) fakeScopedAuthorizer {
+	t.Helper()
+
+	role, err := types.NewRole(username+"-role", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins: []string{"root"},
+			NodeLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			KubernetesLabels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			Rules: []types.Rule{types.NewRule(kind, verbs)},
+		},
+	})
+	require.NoError(t, err)
+
+	user, err := types.NewUser(username)
+	require.NoError(t, err)
+	user.SetRoles([]string{role.GetName()})
+
+	return fakeScopedAuthorizer{
+		ctx: authz.ScopedContextFromUnscopedContext(&authz.Context{
+			User: user,
+			Checker: services.NewAccessCheckerWithRoleSet(&services.AccessInfo{
+				Username: username,
+				Roles:    []string{role.GetName()},
+			}, testLocalCluster, services.NewRoleSet(role)),
+			AdminActionAuthState: authz.AdminActionAuthNotRequired,
+		}),
+	}
+}
+
+type fakeScopedAuthorizer struct {
+	ctx *authz.ScopedContext
+}
+
+func (f fakeScopedAuthorizer) AuthorizeScoped(context.Context) (*authz.ScopedContext, error) {
+	return f.ctx, nil
+}
+
+func newFakeScopedAuthorizer(t *testing.T, username, pinScope string, reader fakeScopedRoleReader, roles ...*scopedaccessv1.ScopedRole) fakeScopedAuthorizer {
+	t.Helper()
+
+	assigned := make([]string, 0, len(roles))
+	for _, role := range roles {
+		assigned = append(assigned, scopes.QualifiedName{
+			Scope: role.GetScope(),
+			Name:  role.GetMetadata().GetName(),
+		}.String())
+	}
+
+	user, err := types.NewUser(username)
+	require.NoError(t, err)
+
+	checkerContext, err := services.NewScopedAccessCheckerContext(t.Context(), &services.AccessInfo{
+		Username: username,
+		ScopePin: scopesv1.Pin_builder{
+			Kind:  scopesv1.PinKind_PIN_KIND_USER,
+			Scope: pinScope,
+			AssignmentTree: pinning.AssignmentTreeFromMap(map[string]map[string][]string{
+				pinScope: {pinScope: assigned},
+			}),
+		}.Build(),
+	}, testLocalCluster, reader)
+	require.NoError(t, err)
+
+	return fakeScopedAuthorizer{
+		ctx: &authz.ScopedContext{
+			User:           user,
+			CheckerContext: checkerContext,
+		},
+	}
+}
+
+type fakeScopedRoleReader struct {
+	roles map[string]*scopedaccessv1.ScopedRole
+}
+
+func (r fakeScopedRoleReader) createScopedRole(name string, verbs ...string) *scopedaccessv1.ScopedRole {
+	role := scopedaccessv1.ScopedRole_builder{
+		Kind:    scopedaccess.KindScopedRole,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: name,
+		}.Build(),
+		Scope: testParentScope,
+		Spec: scopedaccessv1.ScopedRoleSpec_builder{
+			AssignableScopes: []string{testScope, testOrthogonalScope},
+			Rules: []*scopedaccessv1.ScopedRule{
+				scopedaccessv1.ScopedRule_builder{
+					Resources: []string{
+						types.KindNode,
+						types.KindKubernetesCluster,
+					},
+					Verbs: verbs,
+				}.Build(),
+			},
+			Ssh: scopedaccessv1.ScopedRoleSSH_builder{
+				Logins: []string{"root"},
+				Labels: []*labelv1.Label{
+					labelv1.Label_builder{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					}.Build(),
+				},
+			}.Build(),
+			Kube: scopedaccessv1.ScopedRoleKube_builder{
+				Labels: []*labelv1.Label{
+					labelv1.Label_builder{
+						Name:   types.Wildcard,
+						Values: []string{types.Wildcard},
+					}.Build(),
+				},
+				Resources: []*scopedaccessv1.KubeResource{
+					scopedaccessv1.KubeResource_builder{
+						Kind:      types.Wildcard,
+						Name:      types.Wildcard,
+						Namespace: types.Wildcard,
+						ApiGroup:  types.Wildcard,
+						Verbs:     []string{types.Wildcard},
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build()
+
+	r.roles[scopes.QualifiedName{Scope: role.GetScope(), Name: name}.String()] = role
+	return role
+}
+
+func (r fakeScopedRoleReader) GetScopedRole(_ context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	role, ok := r.roles[scopes.QualifiedName{Scope: req.GetScope(), Name: req.GetName()}.String()]
+	if !ok {
+		return nil, trace.NotFound("scoped role %q not found", req.GetName())
+	}
+	return scopedaccessv1.GetScopedRoleResponse_builder{Role: role}.Build(), nil
+}
+
+func (r fakeScopedRoleReader) ListScopedRoles(context.Context, *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	roles := make([]*scopedaccessv1.ScopedRole, 0, len(r.roles))
+	for _, role := range r.roles {
+		roles = append(roles, role)
+	}
+	return scopedaccessv1.ListScopedRolesResponse_builder{Roles: roles}.Build(), nil
 }

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1801,7 +1801,7 @@ func TestServersCRUD(t *testing.T) {
 	_, err = clt.UpsertNode(ctx, srv)
 	require.NoError(t, err)
 
-	node, err := clt.GetNode(ctx, srv.Metadata.Namespace, srv.GetName())
+	node, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: srv.GetName()}.Build())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(node, srv, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
@@ -1810,7 +1810,7 @@ func TestServersCRUD(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out, []types.Server{srv}, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = clt.DeleteNode(ctx, srv.Metadata.Namespace, srv.GetName())
+	err = clt.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: srv.GetName()}.Build())
 	require.NoError(t, err)
 
 	out, err = clt.GetNodes(ctx, srv.Metadata.Namespace)

--- a/lib/cache/node.go
+++ b/lib/cache/node.go
@@ -167,7 +167,7 @@ func (c *Cache) ListSSHServers(ctx context.Context, req *presencev1.ListSSHServe
 // RangeSSHServers returns a sequence of nodes filtered by the given
 // [*presencev1.ListSSHServersRequest].
 func (c *Cache) RangeSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error] {
-	ctx, span := c.Tracer.Start(ctx, "cache/RangeNodes")
+	ctx, span := c.Tracer.Start(ctx, "cache/RangeSSHServers")
 	defer span.End()
 
 	scopeFilter := req.GetScopeFilter()

--- a/lib/cache/node_test.go
+++ b/lib/cache/node_test.go
@@ -32,11 +32,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-const (
-	nodeProdScope    = "/aws/prod"
-	nodeStagingScope = "/aws/staging"
-)
-
 func newNodeResource(name string) (types.Server, error) {
 	return NewServer(types.KindNode, name, "127.0.0.1:2022", apidefaults.Namespace), nil
 }
@@ -52,7 +47,7 @@ func listNodesAdapter(fn func(context.Context, *presencev1.ListSSHServersRequest
 	}
 }
 
-// rangeNodesAdapter adapts a RangeNodes method to the range function shape the
+// rangeNodesAdapter adapts a RangeSSHServers method to the range function shape the
 // resource test harness expects.
 func rangeNodesAdapter(fn func(context.Context, *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error]) func(context.Context, string, string) iter.Seq2[types.Server, error] {
 	return func(ctx context.Context, start, _ string) iter.Seq2[types.Server, error] {
@@ -191,7 +186,7 @@ func TestNodes(t *testing.T) {
 		})
 	})
 
-	t.Run("RangeNodes", func(t *testing.T) {
+	t.Run("RangeSSHServers", func(t *testing.T) {
 		t.Parallel()
 
 		p := newTestPack(t, ForProxy, ignoreRangeEndKey())

--- a/lib/decision/service.go
+++ b/lib/decision/service.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/lib/services"
@@ -38,8 +38,8 @@ import (
 
 // NodeGetter is a service that gets a node.
 type NodeGetter interface {
-	// GetNode returns a node by name and namespace.
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+	// GetSSHServer returns a scoped or unscoped node by name.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 }
 
 // ClusterNetworkingConfigGetter is a service that gets the cluster networking configuration.
@@ -164,7 +164,9 @@ func (s *Service) EvaluateSSHAccess(ctx context.Context, req *decisionpb.Evaluat
 		return nil, trace.Errorf("session joining is not yet supported by the decision service")
 	}
 
-	target, err := s.cfg.AccessPoint.GetNode(ctx, apidefaults.Namespace, req.GetNode().GetName())
+	target, err := s.cfg.AccessPoint.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name: req.GetNode().GetName(),
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/join/ec2join/ec2.go
+++ b/lib/join/ec2join/ec2.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	config "github.com/gravitational/teleport/lib/cloud/aws/config"
@@ -172,8 +173,8 @@ func checkPendingTime(iid *imds.InstanceIdentityDocument, provisionToken provisi
 	return nil
 }
 
-func nodeExists(ctx context.Context, presence services.Presence, hostID string) (bool, error) {
-	_, err := presence.GetNode(ctx, defaults.Namespace, hostID)
+func nodeExists(ctx context.Context, presence services.Presence, hostID, scope string) (bool, error) {
+	_, err := presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: hostID, Scope: scope}.Build())
 	switch {
 	case trace.IsNotFound(err):
 		return false, nil
@@ -182,6 +183,7 @@ func nodeExists(ctx context.Context, presence services.Presence, hostID string) 
 	default:
 		return true, nil
 	}
+	return false, nil
 }
 
 func proxyExists(ctx context.Context, presence services.Presence, hostID string) (bool, error) {

--- a/lib/join/ec2join/ec2.go
+++ b/lib/join/ec2join/ec2.go
@@ -183,7 +183,6 @@ func nodeExists(ctx context.Context, presence services.Presence, hostID, scope s
 	default:
 		return true, nil
 	}
-	return false, nil
 }
 
 func proxyExists(ctx context.Context, presence services.Presence, hostID string) (bool, error) {
@@ -272,10 +271,10 @@ func desktopServiceExists(ctx context.Context, presence services.Presence, hostI
 	return false, nil
 }
 
-func resourceExists(ctx context.Context, presence services.Presence, role types.SystemRole, hostID string) (bool, error) {
+func resourceExists(ctx context.Context, presence services.Presence, role types.SystemRole, hostID, scope string) (bool, error) {
 	switch role {
 	case types.RoleNode:
-		return nodeExists(ctx, presence, hostID)
+		return nodeExists(ctx, presence, hostID, scope)
 	case types.RoleProxy:
 		return proxyExists(ctx, presence, hostID)
 	case types.RoleKube:
@@ -326,7 +325,7 @@ func tryToDetectIdentityReuse(ctx context.Context, params *CheckEC2RequestParams
 				// don't have any presence check.
 				continue
 			}
-			alreadyExists, err := resourceExists(ctx, params.Presence, role, hostID)
+			alreadyExists, err := resourceExists(ctx, params.Presence, role, hostID, params.ProvisionToken.GetAssignedScope())
 			if err != nil {
 				return trace.Wrap(err, "checking if %s with ID %s already exists", params.Role, hostID)
 			}
@@ -336,7 +335,7 @@ func tryToDetectIdentityReuse(ctx context.Context, params *CheckEC2RequestParams
 		}
 		return nil
 	}
-	alreadyExists, err := resourceExists(ctx, params.Presence, params.Role, hostID)
+	alreadyExists, err := resourceExists(ctx, params.Presence, params.Role, hostID, params.ProvisionToken.GetAssignedScope())
 	if err != nil {
 		return trace.Wrap(err, "checking if %s with ID %s already exists", params.Role, hostID)
 	}

--- a/lib/join/ec2join/ec2.go
+++ b/lib/join/ec2join/ec2.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	config "github.com/gravitational/teleport/lib/cloud/aws/config"
@@ -172,8 +173,8 @@ func checkPendingTime(iid *imds.InstanceIdentityDocument, provisionToken provisi
 	return nil
 }
 
-func nodeExists(ctx context.Context, presence services.Presence, hostID string) (bool, error) {
-	_, err := presence.GetNode(ctx, defaults.Namespace, hostID)
+func nodeExists(ctx context.Context, presence services.Presence, hostID, scope string) (bool, error) {
+	_, err := presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: hostID, Scope: scope}.Build())
 	switch {
 	case trace.IsNotFound(err):
 		return false, nil
@@ -270,10 +271,10 @@ func desktopServiceExists(ctx context.Context, presence services.Presence, hostI
 	return false, nil
 }
 
-func resourceExists(ctx context.Context, presence services.Presence, role types.SystemRole, hostID string) (bool, error) {
+func resourceExists(ctx context.Context, presence services.Presence, role types.SystemRole, hostID, scope string) (bool, error) {
 	switch role {
 	case types.RoleNode:
-		return nodeExists(ctx, presence, hostID)
+		return nodeExists(ctx, presence, hostID, scope)
 	case types.RoleProxy:
 		return proxyExists(ctx, presence, hostID)
 	case types.RoleKube:
@@ -324,7 +325,7 @@ func tryToDetectIdentityReuse(ctx context.Context, params *CheckEC2RequestParams
 				// don't have any presence check.
 				continue
 			}
-			alreadyExists, err := resourceExists(ctx, params.Presence, role, hostID)
+			alreadyExists, err := resourceExists(ctx, params.Presence, role, hostID, params.ProvisionToken.GetAssignedScope())
 			if err != nil {
 				return trace.Wrap(err, "checking if %s with ID %s already exists", params.Role, hostID)
 			}
@@ -334,7 +335,7 @@ func tryToDetectIdentityReuse(ctx context.Context, params *CheckEC2RequestParams
 		}
 		return nil
 	}
-	alreadyExists, err := resourceExists(ctx, params.Presence, params.Role, hostID)
+	alreadyExists, err := resourceExists(ctx, params.Presence, params.Role, hostID, params.ProvisionToken.GetAssignedScope())
 	if err != nil {
 		return trace.Wrap(err, "checking if %s with ID %s already exists", params.Role, hostID)
 	}

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -634,7 +634,7 @@ func TestHostUniqueCheck(t *testing.T) {
 				require.NoError(t, err)
 			},
 			deleter: func(t *testing.T, hostID string) {
-				require.NoError(t, a.DeleteNode(t.Context(), defaults.Namespace, hostID))
+				require.NoError(t, a.DeleteSSHServer(t.Context(), presencev1.DeleteSSHServerRequest_builder{Name: hostID}.Build()))
 			},
 		},
 		{

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -473,6 +473,21 @@ func TestJoinEC2(t *testing.T) {
 			_, err = testServer.Auth().UpsertNode(t.Context(), node)
 			require.NoError(t, err)
 
+			// Introduction of ssh server namespacing means that
+			// 2 identical names ins different scopes is valid.
+			// We should only collide when the duplicate's scope also matches.
+			scopedNode := &types.ServerV2{
+				Kind:    types.KindNode,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name:      instance2.account + "-" + instance2.instanceID,
+					Namespace: defaults.Namespace,
+				},
+				Scope: "/test/one",
+			}
+			_, err = testServer.Auth().UpsertNode(t.Context(), scopedNode)
+			require.NoError(t, err)
+
 			nopClient, err := testServer.NewClient(authtest.TestNop())
 			require.NoError(t, err)
 

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -473,6 +473,21 @@ func TestJoinEC2(t *testing.T) {
 			_, err = testServer.Auth().UpsertNode(t.Context(), node)
 			require.NoError(t, err)
 
+			// Introduction of ssh server namespacing means that
+			// 2 identical names ins different scopes is valid.
+			// We should only collide when the duplicate's scope also matches.
+			scopedNode := &types.ServerV2{
+				Kind:    types.KindNode,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name:      instance2.account + "-" + instance2.instanceID,
+					Namespace: defaults.Namespace,
+				},
+				Scope: "/test/one",
+			}
+			_, err = testServer.Auth().UpsertNode(t.Context(), scopedNode)
+			require.NoError(t, err)
+
 			nopClient, err := testServer.NewClient(authtest.TestNop())
 			require.NoError(t, err)
 
@@ -634,7 +649,7 @@ func TestHostUniqueCheck(t *testing.T) {
 				require.NoError(t, err)
 			},
 			deleter: func(t *testing.T, hostID string) {
-				require.NoError(t, a.DeleteNode(t.Context(), defaults.Namespace, hostID))
+				require.NoError(t, a.DeleteSSHServer(t.Context(), presencev1.DeleteSSHServerRequest_builder{Name: hostID}.Build()))
 			},
 		},
 		{

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -25,6 +25,7 @@ import (
 	"math/rand/v2"
 	"net"
 	"os"
+	"slices"
 	"sync"
 
 	"github.com/gravitational/trace"
@@ -544,15 +545,32 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 		// if a dial request for an id-like target creates multiple matches,
 		// give precedence to the exact match if one exists. If not, handle
 		// multiple matchers per-usual below.
+		//
+		// With the introduction of scope namespacing, it is now technically possible
+		// to create ssh servers with matching id-like names in multiple scopes.
+		// TODO (williamo/scopes): Replace this with SQN based routing
+		var nameMatches []types.Server
 		for _, m := range matches {
 			if m.GetName() == host {
-				matches = []types.Server{m}
-				break
+				nameMatches = append(nameMatches, m)
+			}
+		}
+
+		if len(nameMatches) > 0 {
+			// Narrow to the name matches rather than to a single one. A lone
+			// name match still collapses to it as before, but colliding names
+			// across scopes are left ambiguous for the handling below.
+			// If there is an unscoped server, take it over scoped servers
+			// that collide with its name.
+			matches = nameMatches
+
+			if slices.ContainsFunc(matches, func(m types.Server) bool { return m.GetScope() == "" }) {
+				matches = slices.DeleteFunc(matches, func(m types.Server) bool { return m.GetScope() != "" })
 			}
 		}
 	}
 
-	// NOTE: there is an open question here about wether or not we should be doing scope-aware
+	// NOTE: there is an open question here about whether or not we should be doing scope-aware
 	// disambiguation when multiple matches are found. In some cases, this seems like the obviously
 	// right thing to do.  For example, when there is a match in `/foo` and a match in `/foo/bar`,
 	// it would seem obvious that the match in `/foo` should be preferred per scope hierarchy rules.

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -533,7 +533,10 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 			return false
 		}
 
-		scores[server.GetName()] = score
+		// Keyed by scope-qualified name: node names are only unique within a
+		// scope, so same-named nodes in different scopes would otherwise share
+		// a single score entry and overwrite each other.
+		scores[scopes.QualifiedName{Scope: server.GetScope(), Name: server.GetName()}.String()] = score
 		maxScore = max(maxScore, score)
 		return true
 	})
@@ -587,7 +590,7 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 		// mix of match qualities, filter out the lower quality matches to reduce ambiguity.
 		filtered := matches[:0]
 		for _, m := range matches {
-			if scores[m.GetName()] < maxScore {
+			if scores[scopes.QualifiedName{Scope: m.GetScope(), Name: m.GetName()}.String()] < maxScore {
 				continue
 			}
 

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -25,6 +25,7 @@ import (
 	"math/rand/v2"
 	"net"
 	"os"
+	"slices"
 	"sync"
 
 	"github.com/gravitational/trace"
@@ -510,7 +511,7 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 	}
 
 	var maxScore int
-	scores := make(map[string]int)
+	scores := make(map[scopes.QualifiedName]int)
 	matches, err := cluster.GetNodes(ctx, func(server readonly.Server) bool {
 		if scopePin != nil {
 			// TODO(fspmarshall/scopes): implement scope-aware node storage. filtering agents based on scope is sub-optimal. scoping
@@ -532,7 +533,10 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 			return false
 		}
 
-		scores[server.GetName()] = score
+		// Keyed by scope-qualified name: node names are only unique within a
+		// scope, so same-named nodes in different scopes would otherwise share
+		// a single score entry and overwrite each other.
+		scores[scopes.QualifiedName{Scope: server.GetScope(), Name: server.GetName()}] = score
 		maxScore = max(maxScore, score)
 		return true
 	})
@@ -544,15 +548,32 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 		// if a dial request for an id-like target creates multiple matches,
 		// give precedence to the exact match if one exists. If not, handle
 		// multiple matchers per-usual below.
+		//
+		// With the introduction of scope namespacing, it is now technically possible
+		// to create ssh servers with matching id-like names in multiple scopes.
+		// TODO (williamo/scopes): Replace this with SQN based routing
+		var nameMatches []types.Server
 		for _, m := range matches {
 			if m.GetName() == host {
-				matches = []types.Server{m}
-				break
+				nameMatches = append(nameMatches, m)
+			}
+		}
+
+		if len(nameMatches) > 0 {
+			// Narrow to the name matches rather than to a single one. A lone
+			// name match still collapses to it as before, but colliding names
+			// across scopes are left ambiguous for the handling below.
+			// If there is an unscoped server, take it over scoped servers
+			// that collide with its name.
+			matches = nameMatches
+
+			if slices.ContainsFunc(matches, func(m types.Server) bool { return m.GetScope() == "" }) {
+				matches = slices.DeleteFunc(matches, func(m types.Server) bool { return m.GetScope() != "" })
 			}
 		}
 	}
 
-	// NOTE: there is an open question here about wether or not we should be doing scope-aware
+	// NOTE: there is an open question here about whether or not we should be doing scope-aware
 	// disambiguation when multiple matches are found. In some cases, this seems like the obviously
 	// right thing to do.  For example, when there is a match in `/foo` and a match in `/foo/bar`,
 	// it would seem obvious that the match in `/foo` should be preferred per scope hierarchy rules.
@@ -569,7 +590,7 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 		// mix of match qualities, filter out the lower quality matches to reduce ambiguity.
 		filtered := matches[:0]
 		for _, m := range matches {
-			if scores[m.GetName()] < maxScore {
+			if scores[scopes.QualifiedName{Scope: m.GetScope(), Name: m.GetName()}] < maxScore {
 				continue
 			}
 

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -346,6 +346,22 @@ func TestRouteScoring(t *testing.T) {
 			hostname: "test.example.com",
 			addr:     "3.4.5.6:22",
 		},
+		{
+			// Shares a name with the node below but in a different scope, and
+			// matches "direct.example.com" by hostname (a direct match) while
+			// its twin only matches via resolved ip (an indirect match). The
+			// score map must key on scope+name or the two overwrite each other.
+			scope:    "/alpha",
+			name:     "shared-scoring-name",
+			hostname: "direct.example.com",
+			addr:     "1.2.3.4:2222",
+		},
+		{
+			scope:    "/beta",
+			name:     "shared-scoring-name",
+			hostname: "indirect.example.com",
+			addr:     "1.2.3.4:3333",
+		},
 	})
 
 	// scoring behavior is independent of routing strategy so we just
@@ -422,6 +438,13 @@ func TestRouteScoring(t *testing.T) {
 			desc:   "non-uuid name",
 			host:   "not-a-uuid",
 			expect: "test.example.com",
+		},
+		{
+			// The direct hostname match must win over its same-named twin in
+			// another scope, which only matches indirectly.
+			desc:   "same name across scopes with differing match quality",
+			host:   "direct.example.com",
+			expect: "direct.example.com",
 		},
 	}
 

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -120,6 +120,11 @@ func TestScopePinning(t *testing.T) {
 
 	ctx := t.Context()
 
+	// node names are only unique within a scope, so an id-like target can match
+	// more than one node.
+	unscopedCollisionID := uuid.NewString()
+	scopedCollisionID := uuid.NewString()
+
 	// set up servers across varioous scopes with various hostname collision
 	// scenarios (parent/child, same-scope, orthogonal scopes, etc).
 	servers := createServers([]server{
@@ -127,6 +132,34 @@ func TestScopePinning(t *testing.T) {
 			scope:    "",
 			name:     uuid.NewString(),
 			hostname: "unscoped.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			// An unscoped node whose id collides with a scoped one.
+			// Dial reaches unscoped
+			scope:    "",
+			name:     unscopedCollisionID,
+			hostname: "id-collision-unscoped.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			scope:    "/staging",
+			name:     unscopedCollisionID,
+			hostname: "id-collision-scoped.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			// Two scoped nodes colliding on id with nothing unscoped to
+			// disambiguate, so the dial must stay ambiguous.
+			scope:    "/staging",
+			name:     scopedCollisionID,
+			hostname: "id-collision-staging.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			scope:    "/prod",
+			name:     scopedCollisionID,
+			hostname: "id-collision-prod.example.com",
 			addr:     "1.2.3.4:0",
 		},
 		{
@@ -225,6 +258,22 @@ func TestScopePinning(t *testing.T) {
 		{
 			name:      "parent/child conflict when unpinned",
 			host:      "parent-child.example.com",
+			pin:       nil,
+			ambiguous: true,
+		},
+		{
+			name: "unscoped node wins an id collision with a scoped node",
+			host: unscopedCollisionID,
+			pin:  nil,
+		},
+		{
+			name: "only scoped node reachable by colliding id when pinned",
+			host: unscopedCollisionID,
+			pin:  scopesv1.Pin_builder{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging"}.Build(),
+		},
+		{
+			name:      "colliding ids across scopes are ambiguous",
+			host:      scopedCollisionID,
 			pin:       nil,
 			ambiguous: true,
 		},

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -120,6 +120,11 @@ func TestScopePinning(t *testing.T) {
 
 	ctx := t.Context()
 
+	// node names are only unique within a scope, so an id-like target can match
+	// more than one node.
+	unscopedCollisionID := uuid.NewString()
+	scopedCollisionID := uuid.NewString()
+
 	// set up servers across varioous scopes with various hostname collision
 	// scenarios (parent/child, same-scope, orthogonal scopes, etc).
 	servers := createServers([]server{
@@ -127,6 +132,34 @@ func TestScopePinning(t *testing.T) {
 			scope:    "",
 			name:     uuid.NewString(),
 			hostname: "unscoped.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			// An unscoped node whose id collides with a scoped one.
+			// Dial reaches unscoped
+			scope:    "",
+			name:     unscopedCollisionID,
+			hostname: "id-collision-unscoped.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			scope:    "/staging",
+			name:     unscopedCollisionID,
+			hostname: "id-collision-scoped.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			// Two scoped nodes colliding on id with nothing unscoped to
+			// disambiguate, so the dial must stay ambiguous.
+			scope:    "/staging",
+			name:     scopedCollisionID,
+			hostname: "id-collision-staging.example.com",
+			addr:     "1.2.3.4:0",
+		},
+		{
+			scope:    "/prod",
+			name:     scopedCollisionID,
+			hostname: "id-collision-prod.example.com",
 			addr:     "1.2.3.4:0",
 		},
 		{
@@ -228,6 +261,22 @@ func TestScopePinning(t *testing.T) {
 			pin:       nil,
 			ambiguous: true,
 		},
+		{
+			name: "unscoped node wins an id collision with a scoped node",
+			host: unscopedCollisionID,
+			pin:  nil,
+		},
+		{
+			name: "only scoped node reachable by colliding id as a scoped user",
+			host: unscopedCollisionID,
+			pin:  scopesv1.Pin_builder{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/staging"}.Build(),
+		},
+		{
+			name:      "colliding ids across scopes are ambiguous",
+			host:      scopedCollisionID,
+			pin:       nil,
+			ambiguous: true,
+		},
 	}
 
 	// use strict routing to ensure only one match is possible per test case.
@@ -296,6 +345,18 @@ func TestRouteScoring(t *testing.T) {
 			name:     "not-a-uuid",
 			hostname: "test.example.com",
 			addr:     "3.4.5.6:22",
+		},
+		{
+			scope:    "/test",
+			name:     "shared-scoring-name",
+			hostname: "direct.example.com",
+			addr:     "1.2.3.4:2222",
+		},
+		{
+			scope:    "/test2",
+			name:     "shared-scoring-name",
+			hostname: "indirect.example.com",
+			addr:     "1.2.3.4:3333",
 		},
 	})
 
@@ -373,6 +434,13 @@ func TestRouteScoring(t *testing.T) {
 			desc:   "non-uuid name",
 			host:   "not-a-uuid",
 			expect: "test.example.com",
+		},
+		{
+			// The direct hostname match must win over its same-named twin in
+			// another scope, which only matches indirectly.
+			desc:   "same name across scopes with differing match quality",
+			host:   "direct.example.com",
+			expect: "direct.example.com",
 		},
 	}
 

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -43,6 +43,8 @@ func isAllowedScopedRule(kind string, verb string) bool {
 		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
 	case types.KindAppServer:
 		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
+	case types.KindNode:
+		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
 	case types.KindAccessList:
 		// access lists can be read/written, and do not contain a concept of a secret.
 		// permissions for access list members are conferred by permissions for

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -356,18 +356,6 @@ func GetCursorForAppServer(server types.AppServer) string {
 	return scopes.MakeResourceCursorWithHost(server.GetScope(), server.GetHostID(), server.GetName())
 }
 
-// GetCursorForResource returns the pagination cursor for a
-// resource used in ListResources.
-func GetCursorForResource(r types.ResourceWithLabels) string {
-	switch res := r.(type) {
-	case types.AppServer:
-		return GetCursorForAppServer(res)
-	case types.KubeServer:
-		return GetCursorForKubeServer(res)
-	}
-	return backend.GetPaginationKey(r)
-}
-
 // ValidatePublicAddr requires a lowercase DNS-1123 hostname. An
 // empty addr is treated as unset.
 func ValidatePublicAddr(appName, addr string) error {

--- a/lib/services/cursor.go
+++ b/lib/services/cursor.go
@@ -1,0 +1,36 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+// GetCursorForResource returns the pagination cursor for a
+// resource used in ListResources.
+func GetCursorForResource(r types.ResourceWithLabels) string {
+	switch res := r.(type) {
+	case types.AppServer:
+		return GetCursorForAppServer(res)
+	case types.KubeServer:
+		return GetCursorForKubeServer(res)
+	case types.Server:
+		return GetCursorForNode(res)
+	}
+	return backend.GetPaginationKey(r)
+}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -324,13 +324,6 @@ func (s *PresenceService) DeleteAllNodes(ctx context.Context, namespace string) 
 	return trace.Wrap(s.sshServers.DeleteAllResources(ctx))
 }
 
-// DeleteNode deletes node in a namespace
-// Deprecated: use DeleteSSHServer instead, which supports scoped nodes.
-// TODO(williamo): Remove in v20
-func (s *PresenceService) DeleteNode(ctx context.Context, namespace string, name string) error {
-	return s.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build())
-}
-
 // DeleteNode removes a specific scoped or unscoped node.
 func (s *PresenceService) DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error {
 	if req.GetName() == "" {
@@ -383,7 +376,7 @@ func (s *PresenceService) AppendDeleteSSHServerActions(
 // GetNode returns an unscoped node by name.
 //
 // Deprecated: use GetSSHServer instead, which supports scoped nodes.
-// TODO(williamo): Remove in v20
+// TODO(williamo): Remove when e no longer needs this.
 func (s *PresenceService) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
 	return s.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 }

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -325,7 +325,7 @@ func (s *PresenceService) DeleteAllNodes(ctx context.Context, namespace string) 
 }
 
 // DeleteNode deletes node in a namespace
-// Deprecated: use DeleteNodeV2 instead, which supports scoped nodes.
+// Deprecated: use DeleteSSHServer instead, which supports scoped nodes.
 // TODO(williamo): Remove in v20
 func (s *PresenceService) DeleteNode(ctx context.Context, namespace string, name string) error {
 	return s.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build())

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -324,13 +324,6 @@ func (s *PresenceService) DeleteAllNodes(ctx context.Context, namespace string) 
 	return trace.Wrap(s.sshServers.DeleteAllResources(ctx))
 }
 
-// DeleteNode deletes node in a namespace
-// Deprecated: use DeleteNodeV2 instead, which supports scoped nodes.
-// TODO(williamo): Remove in v20
-func (s *PresenceService) DeleteNode(ctx context.Context, namespace string, name string) error {
-	return s.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build())
-}
-
 // DeleteNode removes a specific scoped or unscoped node.
 func (s *PresenceService) DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error {
 	if req.GetName() == "" {
@@ -383,7 +376,7 @@ func (s *PresenceService) AppendDeleteSSHServerActions(
 // GetNode returns an unscoped node by name.
 //
 // Deprecated: use GetSSHServer instead, which supports scoped nodes.
-// TODO(williamo): Remove in v20
+// TODO(williamo): Remove when e no longer needs this.
 func (s *PresenceService) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
 	return s.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
 }

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -1284,6 +1284,7 @@ func TestListResources_Helpers(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				resp, err := tc.fetch(req)
+				require.NoError(t, err)
 				if !tc.scopeAware {
 					require.Empty(t, resp.NextKey)
 				} else {

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -672,11 +672,17 @@ func TestNodeCRUD(t *testing.T) {
 	})
 
 	t.Run("UpdateNode", func(t *testing.T) {
-		node1, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: node1.GetName()}.Build())
+		node1, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+			Name:  node1.GetName(),
+			Scope: node1.GetScope(),
+		}.Build())
 		require.NoError(t, err)
 		node1.SetAddr("1.2.3.4:8080")
 
-		node2, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: node2.GetName()}.Build())
+		node2, err = presence.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+			Name:  node2.GetName(),
+			Scope: node2.GetScope(),
+		}.Build())
 		require.NoError(t, err)
 
 		node1, err = presence.UpdateNode(ctx, node1)
@@ -1284,6 +1290,7 @@ func TestListResources_Helpers(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				resp, err := tc.fetch(req)
+				require.NoError(t, err)
 				if !tc.scopeAware {
 					require.Empty(t, resp.NextKey)
 				} else {

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -372,7 +372,10 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	_, err = s.PresenceS.UpsertNode(ctx, srv)
 	require.NoError(t, err)
 
-	node, err := s.PresenceS.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: srv.GetName()}.Build())
+	node, err := s.PresenceS.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name:  srv.GetName(),
+		Scope: srv.GetScope(),
+	}.Build())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(node, srv, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
@@ -381,7 +384,10 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Empty(t, cmp.Diff(out, []types.Server{srv}, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 
-	err = s.PresenceS.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: srv.GetName()}.Build())
+	err = s.PresenceS.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Name:  srv.GetName(),
+		Scope: srv.GetScope(),
+	}.Build())
 	require.NoError(t, err)
 
 	out, err = s.PresenceS.GetNodes(ctx, srv.Metadata.Namespace)

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -83,13 +83,6 @@ type Presence interface {
 	// Semaphores is responsible for semaphore handling
 	types.Semaphores
 
-	// GetNode returns an unscoped node by name and namespace.
-	//
-	// Deprecated: Use [Presence.GetSSHServer] instead, which supports scoped
-	// nodes.
-	// TODO(williamo): Remove in v20
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
-
 	// GetSSHServer returns a scoped or unscoped node by name.
 	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 
@@ -98,10 +91,6 @@ type Presence interface {
 
 	// DeleteAllNodes deletes all scoped and unscoped nodes.
 	DeleteAllNodes(ctx context.Context, namespace string) error
-
-	// Deprecated: Use [Presence.DeleteSSHServer] instead, which supports scoped nodes.
-	// TODO(williamo): Remove in v20
-	DeleteNode(ctx context.Context, namespace, name string) error
 
 	// DeleteNode removes a specific scoped or unscoped node.
 	DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -1217,7 +1217,7 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 	kubeServers = kubeServers[1:]
 
 	// delete everything else
-	err = clt.DeleteNode(ctx, "default", node.GetName())
+	err = clt.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: node.GetName()}.Build())
 	require.NoError(t, err)
 	err = clt.DeleteSAMLIdPServiceProvider(ctx, samlapp.GetName())
 	require.NoError(t, err)

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -1217,7 +1217,7 @@ func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {
 	kubeServers = kubeServers[1:]
 
 	// delete everything else
-	err = clt.DeleteNode(ctx, "default", node.GetName())
+	err = clt.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: node.GetName(), Scope: node.GetScope()}.Build())
 	require.NoError(t, err)
 	err = clt.DeleteSAMLIdPServiceProvider(ctx, samlapp.GetName())
 	require.NoError(t, err)

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -39,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/defaults"
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/utils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -1622,13 +1624,20 @@ func NewNodeWatcher(ctx context.Context, cfg NodeWatcherConfig) (*GenericWatcher
 		ResourceKind:          types.KindNode,
 		ScopeFilter:           cfg.ScopeFilter,
 		ResourceGetter: func(ctx context.Context) ([]types.Server, error) {
-			// TODO(fspmarshall/scopes): this list does not yet honor scope filters, so it
-			// currently returns nodes in every scope and happens to match a MODE_ALL watch.
-			// Once the list API supports scope filters (and defaults unscoped callers to
-			// unscoped-only, like the watch API), this call must honor cfg.ScopeFilter.
-			return cfg.NodesGetter.GetNodes(ctx, apidefaults.Namespace)
+			return iterstream.Collect(cfg.NodesGetter.RangeSSHServers(ctx, presencev1.ListSSHServersRequest_builder{
+				ScopeFilter: cfg.ScopeFilter.ToProto(),
+			}.Build()))
 		},
-		ResourceKey:            types.Server.GetName,
+		ResourceKey: GetCursorForNode,
+		DeleteKey: func(res types.Resource) string {
+			// Delete events for scoped nodes carry a partially populated
+			// server so that the scope can be recovered from the key, while
+			// unscoped nodes only emit a resource header.
+			if node, ok := res.(types.Server); ok {
+				return GetCursorForNode(node)
+			}
+			return scopes.MakeResourceCursor("", res.GetName())
+		},
 		DisableUpdateBroadcast: true,
 		CloneFunc:              types.Server.DeepCopy,
 		ReadOnlyFunc: func(resource types.Server) readonly.Server {

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -1191,7 +1191,7 @@ func TestNodeWatcher(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, filtered, 3)
 
-	require.NoError(t, presence.DeleteNode(ctx, apidefaults.Namespace, nodes[0].GetName()))
+	require.NoError(t, presence.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: nodes[0].GetName()}.Build()))
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		filtered, err := w.CurrentResources(ctx)

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -1191,7 +1191,10 @@ func TestNodeWatcher(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, filtered, 3)
 
-	require.NoError(t, presence.DeleteNode(ctx, apidefaults.Namespace, nodes[0].GetName()))
+	require.NoError(t, presence.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Name:  nodes[0].GetName(),
+		Scope: nodes[0].GetScope(),
+	}.Build()))
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		filtered, err := w.CurrentResources(ctx)

--- a/lib/srv/discovery/discovery_eks_test.go
+++ b/lib/srv/discovery/discovery_eks_test.go
@@ -442,6 +442,14 @@ func (m *mockAuthServer) GetNodes(ctx context.Context, namespace string) ([]type
 	return nil, nil
 }
 
+func (m *mockAuthServer) ListSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) ([]types.Server, string, error) {
+	return nil, "", nil
+}
+
+func (m *mockAuthServer) RangeSSHServers(ctx context.Context, req *presencev1.ListSSHServersRequest) iter.Seq2[types.Server, error] {
+	return stream.Empty[types.Server]()
+}
+
 func (m *mockAuthServer) EnrollEKSClusters(ctx context.Context, req *integrationpb.EnrollEKSClustersRequest, opts ...grpc.CallOption) (*integrationpb.EnrollEKSClustersResponse, error) {
 	return m.enrollEKSClusters(ctx, req, opts...)
 }

--- a/lib/teleterm/services/connectmycomputer/connectmycomputer.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer.go
@@ -34,7 +34,6 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
@@ -265,8 +264,8 @@ type AccessAndIdentity interface {
 	// See services.Identity.UpdateUser.
 	UpdateUser(context.Context, types.User) (types.User, error)
 
-	// See services.Presence.GetNode.
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+	// See services.Presence.GetSSHServer.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 }
 
 // CertManager enables the usage of only select methods from [client.ProxyClient] so that there
@@ -433,7 +432,9 @@ func (n *NodeJoinWait) waitForNode(ctx context.Context, accessAndIdentity Access
 	//
 	// This means that we might return immediately if the node is still in the cache, even if
 	// technically the agent has not joined the cluster yet. We're fine with this edge case.
-	server, err := accessAndIdentity.GetNode(ctx, apidefaults.Namespace, nodeName)
+	server, err := accessAndIdentity.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name: nodeName,
+	}.Build())
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)

--- a/lib/teleterm/services/connectmycomputer/connectmycomputer.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/connectmycomputer"
@@ -547,7 +548,7 @@ func (n *NodeDelete) Run(ctx context.Context, presence Presence, cluster *cluste
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = presence.DeleteNode(ctx, apidefaults.Namespace, hostUUID)
+	err = presence.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: hostUUID}.Build())
 	if trace.IsNotFound(err) {
 		return nil
 	}
@@ -580,7 +581,7 @@ func (n *NodeDeleteConfig) checkAndSetDefaults() error {
 // During a normal operation, auth.ClientI is passed as this interface.
 type Presence interface {
 	// See services.Presence.GetNode.
-	DeleteNode(ctx context.Context, namespace, name string) error
+	DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error
 }
 
 type NodeName struct {

--- a/lib/teleterm/services/connectmycomputer/connectmycomputer.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer.go
@@ -34,7 +34,7 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/connectmycomputer"
@@ -264,8 +264,8 @@ type AccessAndIdentity interface {
 	// See services.Identity.UpdateUser.
 	UpdateUser(context.Context, types.User) (types.User, error)
 
-	// See services.Presence.GetNode.
-	GetNode(ctx context.Context, namespace, name string) (types.Server, error)
+	// See services.Presence.GetSSHServer.
+	GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error)
 }
 
 // CertManager enables the usage of only select methods from [client.ProxyClient] so that there
@@ -432,7 +432,9 @@ func (n *NodeJoinWait) waitForNode(ctx context.Context, accessAndIdentity Access
 	//
 	// This means that we might return immediately if the node is still in the cache, even if
 	// technically the agent has not joined the cluster yet. We're fine with this edge case.
-	server, err := accessAndIdentity.GetNode(ctx, apidefaults.Namespace, nodeName)
+	server, err := accessAndIdentity.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name: nodeName,
+	}.Build())
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
@@ -547,7 +549,7 @@ func (n *NodeDelete) Run(ctx context.Context, presence Presence, cluster *cluste
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = presence.DeleteNode(ctx, apidefaults.Namespace, hostUUID)
+	err = presence.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: hostUUID}.Build())
 	if trace.IsNotFound(err) {
 		return nil
 	}
@@ -580,7 +582,7 @@ func (n *NodeDeleteConfig) checkAndSetDefaults() error {
 // During a normal operation, auth.ClientI is passed as this interface.
 type Presence interface {
 	// See services.Presence.GetNode.
-	DeleteNode(ctx context.Context, namespace, name string) error
+	DeleteSSHServer(ctx context.Context, req *presencev1.DeleteSSHServerRequest) error
 }
 
 type NodeName struct {

--- a/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go
+++ b/lib/teleterm/services/connectmycomputer/connectmycomputer_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -372,7 +373,7 @@ func (m *mockAccessAndIdentity) UpdateUser(ctx context.Context, user types.User)
 	return user, nil
 }
 
-func (m *mockAccessAndIdentity) GetNode(ctx context.Context, namespace, name string) (types.Server, error) {
+func (m *mockAccessAndIdentity) GetSSHServer(ctx context.Context, req *presencev1.GetSSHServerRequest) (types.Server, error) {
 	if m.nodeErr != nil {
 		return nil, m.nodeErr
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -97,6 +97,7 @@ import (
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	transportpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -7528,7 +7529,7 @@ func TestDiagnoseSSHConnection(t *testing.T) {
 
 	// Wait for node to show up
 	require.Eventually(t, func() bool {
-		_, err := env.server.Auth().GetNode(ctx, apidefaults.Namespace, nodeName)
+		_, err := env.server.Auth().GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: nodeName}.Build())
 		if trace.IsNotFound(err) {
 			return false
 		}

--- a/lib/web/servers_test.go
+++ b/lib/web/servers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/ui"
@@ -154,7 +155,7 @@ func TestCreateNode(t *testing.T) {
 			}
 
 			// Ensure node exists
-			node, err := env.proxies[0].client.GetNode(ctx, "default", tt.req.Name)
+			node, err := env.proxies[0].client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: tt.req.Name}.Build())
 			require.NoError(t, err)
 
 			require.Equal(t, tt.req.Name, node.GetName())

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -44,6 +44,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
@@ -888,7 +889,6 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 	_, err = clt.UpsertNode(ctx, classicNode)
 	require.NoError(t, err)
 
-	// scopedNode has scope "/" so SQN lookups with "/::scoped-node" succeed.
 	scopedNode, err := types.NewServer("scoped-node", types.KindNode, types.ServerSpecV2{
 		Hostname: "scoped-host",
 		Addr:     "127.0.0.1:23",
@@ -962,7 +962,7 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 
 		timeout := time.After(30 * time.Second)
 		for {
-			node, err := clt.GetNode(ctx, apidefaults.Namespace, "unscoped-node")
+			node, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "unscoped-node"}.Build())
 			if err == nil && node.GetHostname() == "unscoped-host-edited" {
 				break
 			}
@@ -989,7 +989,10 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 
 		timeout := time.After(30 * time.Second)
 		for {
-			node, err := clt.GetNode(ctx, apidefaults.Namespace, "scoped-node")
+			node, err := clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+				Scope: "/staging",
+				Name:  "scoped-node",
+			}.Build())
 			if err == nil && node.GetHostname() == "scoped-host-edited" {
 				break
 			}
@@ -1003,12 +1006,21 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 	})
 
 	t.Run("scope-qualified delete", func(t *testing.T) {
-		_, err := runResourceCommand(t, clt, []string{"rm", "node", "/staging::scoped-node"})
+		scopedNodeReq := presencev1.GetSSHServerRequest_builder{
+			Scope: "/staging",
+			Name:  "scoped-node",
+		}.Build()
+
+		// make sure the node exists
+		_, err := clt.GetSSHServer(ctx, scopedNodeReq)
+		require.NoError(t, err, "scoped-node should exist before deletion")
+
+		_, err = runResourceCommand(t, clt, []string{"rm", "node", "/staging::scoped-node"})
 		require.NoError(t, err)
 
 		timeout := time.After(30 * time.Second)
 		for {
-			_, err = clt.GetNode(ctx, apidefaults.Namespace, "scoped-node")
+			_, err = clt.GetSSHServer(ctx, scopedNodeReq)
 			if trace.IsNotFound(err) {
 				break
 			}
@@ -1027,7 +1039,7 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 
 		timeout := time.After(30 * time.Second)
 		for {
-			_, err = clt.GetNode(ctx, apidefaults.Namespace, "unscoped-node")
+			_, err = clt.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: "unscoped-node"}.Build())
 			if trace.IsNotFound(err) {
 				break
 			}

--- a/tool/tctl/common/resources/server.go
+++ b/tool/tctl/common/resources/server.go
@@ -20,20 +20,19 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/gravitational/trace"
 
-	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
-	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/tool/common"
 )
 
@@ -120,12 +119,12 @@ func getScopedNode(ctx context.Context, client *authclient.Client, subKind strin
 		// harm in falling back to the unscoped handler here.
 		return getServer(ctx, client, services.Ref{Kind: types.KindNode}, opts)
 	}
-	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
+	node, err := client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-	if node.GetScope() != sqn.Scope {
-		return nil, scopeMismatchNotFound(types.KindNode, *sqn, node.GetScope())
 	}
 	return &ServerCollection{servers: []types.Server{node}}, nil
 }
@@ -134,14 +133,10 @@ func deleteScopedNode(ctx context.Context, client *authclient.Client, subKind st
 	if subKind != "" {
 		return rejectSubKind(types.KindNode, subKind)
 	}
-	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if node.GetScope() != sqn.Scope {
-		return scopeMismatchNotFound(types.KindNode, sqn, node.GetScope())
-	}
-	if err := client.DeleteNode(ctx, defaults.Namespace, sqn.Name); err != nil {
+	if err := client.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf("node %v has been deleted\n", sqn.String())
@@ -155,7 +150,11 @@ func createServer(ctx context.Context, client *authclient.Client, raw services.U
 	}
 
 	name := server.GetName()
-	_, err = client.GetNode(ctx, server.GetNamespace(), name)
+	scope := server.GetScope()
+	_, err = client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Scope: scope,
+		Name:  name,
+	}.Build())
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
@@ -172,64 +171,52 @@ func createServer(ctx context.Context, client *authclient.Client, raw services.U
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("node %q has been %s\n", name, upsertVerb(exists, opts.Force))
+	fmt.Printf("node %q has been %s\n", scopes.QualifiedName{Name: name, Scope: scope}.String(), upsertVerb(exists, opts.Force))
 	return nil
 }
 
 func deleteServer(ctx context.Context, client *authclient.Client, ref services.Ref) error {
-	if err := client.DeleteNode(ctx, defaults.Namespace, ref.Name); err != nil {
+	sqn, err := scopes.ParseQualifiedName(ref.Name)
+	if err != nil {
+		sqn = scopes.QualifiedName{Name: ref.Name}
+	}
+	if err := client.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("node %v has been deleted\n", ref.Name)
+	fmt.Printf("node %v has been deleted\n", sqn.String())
 	return nil
 }
 
 func getServer(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	var search []string
-	if ref.Name != "" {
-		search = []string{ref.Name}
+	nodes, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+		return client.ListSSHServers(ctx, presencev1.ListSSHServersRequest_builder{
+			PageSize:    int32(pageSize),
+			PageToken:   pageToken,
+			ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+		}.Build())
+	}))
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	req := proto.ListUnifiedResourcesRequest{
-		Kinds:          []string{types.KindNode},
-		SearchKeywords: search,
-		SortBy:         types.SortBy{Field: types.ResourceKind},
+	if ref.Name == "" {
+		return NewServerCollection(nodes), nil
 	}
 
-	var collection ServerCollection
-	for {
-		page, next, err := apiclient.GetUnifiedResourcePage(ctx, client, &req)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		for _, r := range page {
-			srv, ok := r.ResourceWithLabels.(types.Server)
-			if !ok {
-				slog.WarnContext(ctx, "expected types.Server but received unexpected type", "resource_type", logutils.TypeAttr(r))
-				continue
-			}
-
-			if ref.Name == "" {
-				collection.servers = append(collection.servers, srv)
-				continue
-			}
-
-			if srv.GetName() == ref.Name || srv.GetHostname() == ref.Name {
-				collection.servers = []types.Server{srv}
-				return &collection, nil
-			}
-		}
-
-		req.StartKey = next
-		if req.StartKey == "" {
-			break
-		}
+	sqn, err := scopes.ParseQualifiedName(ref.Name)
+	if err != nil {
+		sqn = scopes.QualifiedName{Name: ref.Name}
 	}
 
-	if len(collection.servers) == 0 && ref.Name != "" {
-		return nil, trace.NotFound("node with ID %q not found", ref.Name)
+	// Nodes may be referenced by ID or by hostname, so hostname is supplied as
+	// an alternate name.
+	nodes = FilterBySQNOrDiscoveredName(nodes, sqn, types.Server.GetHostname)
+	if len(nodes) == 0 {
+		return nil, trace.NotFound("node with ID %q not found", sqn.String())
 	}
 
-	return &collection, nil
+	return NewServerCollection(nodes), nil
 }

--- a/tool/tctl/common/resources/server.go
+++ b/tool/tctl/common/resources/server.go
@@ -20,20 +20,19 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 
 	"github.com/gravitational/trace"
 
-	apiclient "github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
-	"github.com/gravitational/teleport/api/defaults"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
-	logutils "github.com/gravitational/teleport/lib/utils/log"
 	"github.com/gravitational/teleport/tool/common"
 )
 
@@ -120,12 +119,12 @@ func getScopedNode(ctx context.Context, client *authclient.Client, subKind strin
 		// harm in falling back to the unscoped handler here.
 		return getServer(ctx, client, services.Ref{Kind: types.KindNode}, opts)
 	}
-	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
+	node, err := client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-	if node.GetScope() != sqn.Scope {
-		return nil, scopeMismatchNotFound(types.KindNode, *sqn, node.GetScope())
 	}
 	return &ServerCollection{servers: []types.Server{node}}, nil
 }
@@ -134,14 +133,10 @@ func deleteScopedNode(ctx context.Context, client *authclient.Client, subKind st
 	if subKind != "" {
 		return rejectSubKind(types.KindNode, subKind)
 	}
-	node, err := client.GetNode(ctx, defaults.Namespace, sqn.Name)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if node.GetScope() != sqn.Scope {
-		return scopeMismatchNotFound(types.KindNode, sqn, node.GetScope())
-	}
-	if err := client.DeleteNode(ctx, defaults.Namespace, sqn.Name); err != nil {
+	if err := client.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf("node %v has been deleted\n", sqn.String())
@@ -155,7 +150,11 @@ func createServer(ctx context.Context, client *authclient.Client, raw services.U
 	}
 
 	name := server.GetName()
-	_, err = client.GetNode(ctx, server.GetNamespace(), name)
+	scope := server.GetScope()
+	_, err = client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Scope: scope,
+		Name:  name,
+	}.Build())
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
@@ -172,64 +171,67 @@ func createServer(ctx context.Context, client *authclient.Client, raw services.U
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("node %q has been %s\n", name, upsertVerb(exists, opts.Force))
+	fmt.Printf("node %q has been %s\n", scopes.QualifiedName{Name: name, Scope: scope}.String(), upsertVerb(exists, opts.Force))
 	return nil
 }
 
 func deleteServer(ctx context.Context, client *authclient.Client, ref services.Ref) error {
-	if err := client.DeleteNode(ctx, defaults.Namespace, ref.Name); err != nil {
+	sqn, err := scopes.ParseQualifiedName(ref.Name)
+	if err != nil {
+		sqn = scopes.QualifiedName{Name: ref.Name}
+	}
+	if err := client.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Scope: sqn.Scope,
+		Name:  sqn.Name,
+	}.Build()); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("node %v has been deleted\n", ref.Name)
+	fmt.Printf("node %v has been deleted\n", sqn.String())
 	return nil
 }
 
 func getServer(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	var search []string
+	var sqn scopes.QualifiedName
 	if ref.Name != "" {
-		search = []string{ref.Name}
-	}
-
-	req := proto.ListUnifiedResourcesRequest{
-		Kinds:          []string{types.KindNode},
-		SearchKeywords: search,
-		SortBy:         types.SortBy{Field: types.ResourceKind},
-	}
-
-	var collection ServerCollection
-	for {
-		page, next, err := apiclient.GetUnifiedResourcePage(ctx, client, &req)
+		var err error
+		sqn, err = scopes.ParseQualifiedName(ref.Name)
 		if err != nil {
+			sqn = scopes.QualifiedName{Name: ref.Name}
+		}
+
+		node, err := client.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+			Scope: sqn.Scope,
+			Name:  sqn.Name,
+		}.Build())
+		switch {
+		case err == nil:
+			return NewServerCollection([]types.Server{node}), nil
+		case !trace.IsNotFound(err):
 			return nil, trace.Wrap(err)
 		}
-
-		for _, r := range page {
-			srv, ok := r.ResourceWithLabels.(types.Server)
-			if !ok {
-				slog.WarnContext(ctx, "expected types.Server but received unexpected type", "resource_type", logutils.TypeAttr(r))
-				continue
-			}
-
-			if ref.Name == "" {
-				collection.servers = append(collection.servers, srv)
-				continue
-			}
-
-			if srv.GetName() == ref.Name || srv.GetHostname() == ref.Name {
-				collection.servers = []types.Server{srv}
-				return &collection, nil
-			}
-		}
-
-		req.StartKey = next
-		if req.StartKey == "" {
-			break
-		}
 	}
 
-	if len(collection.servers) == 0 && ref.Name != "" {
-		return nil, trace.NotFound("node with ID %q not found", ref.Name)
+	nodes, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+		return client.ListSSHServers(ctx, presencev1.ListSSHServersRequest_builder{
+			PageSize:    int32(pageSize),
+			PageToken:   pageToken,
+			ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+		}.Build())
+	}))
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	return &collection, nil
+	if ref.Name == "" {
+		return NewServerCollection(nodes), nil
+	}
+
+	// Nodes may be referenced by ID or by hostname, so hostname is supplied as
+	// an alternate name.
+	nodes = FilterBySQNOrDiscoveredName(nodes, sqn, types.Server.GetHostname)
+	if len(nodes) == 0 {
+		return nil, trace.NotFound("node with ID %q not found", sqn.String())
+	}
+
+	return NewServerCollection(nodes), nil
 }


### PR DESCRIPTION
This PR updates the node watcher, implements the protos defined in https://github.com/gravitational/teleport/pull/69213 in the presence service, and multiple call sites to use `DeleteNodeV2` and `GetNodeV2`.

This PR should be merged into the parent branch https://github.com/gravitational/teleport/pull/69213.

Testplans are in the "parent" PR.
