### PR TITLE
Connect: Fix shadows in unified resources view

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -412,39 +412,25 @@ const CardOuterContainer = styled(Box)<{
   shouldDisplayWarning: boolean;
   showHoverState: boolean;
 }>`
-  border-radius: ${props => props.theme.radii[3]}px;
+  border-radius: ${({ theme }) => theme.radii[3]}px;
+  transition: all 150ms;
 
-  ${props =>
-    props.showAllLabels &&
+  ${({ showAllLabels, shouldDisplayWarning }) =>
+    showAllLabels &&
     css`
       position: absolute;
       left: 0;
       // The padding is required to show the WarningRightEdgeBadgeIcon
-      right: ${props.shouldDisplayWarning ? '28px' : 0};
+      right: ${shouldDisplayWarning ? '28px' : 0};
       z-index: 1;
     `}
-  transition: all 150ms;
 
-  ${p =>
-    (p.showHoverState || p.showAllLabels) &&
+  ${({ showHoverState, showAllLabels, theme }) =>
+    (showHoverState || showAllLabels) &&
     css`
-      // Using double ampersand because of https://github.com/styled-components/styled-components/issues/3678.
-      ${CardContainer}:hover && {
-        background-color: ${props => props.theme.colors.levels.surface};
-
-        // We use a pseudo element for the shadow with position: absolute in order to prevent
-        // the shadow from increasing the size of the layout and causing scrollbar flicker.
-        &:after {
-          box-shadow: ${props => props.theme.boxShadow[3]};
-          border-radius: ${props => props.theme.radii[3]}px;
-          content: '';
-          position: absolute;
-          top: 0;
-          left: 0;
-          z-index: -1;
-          width: 100%;
-          height: 100%;
-        }
+      ${CardContainer}:hover & {
+        background-color: ${theme.colors.levels.surface};
+        box-shadow: ${theme.boxShadow[3]};
       }
     `}
 `;

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -360,6 +360,8 @@ const RowContainer = styled(Box)<{
   &:hover {
     background-color: ${props =>
       props.showHoverState ? props.theme.colors.levels.surface : 'transparent'};
+    box-shadow: ${({ showHoverState, theme }) =>
+      showHoverState ? theme.boxShadow[3] : 'none'};
 
     ${p =>
       p.shouldDisplayWarning &&
@@ -371,23 +373,6 @@ const RowContainer = styled(Box)<{
           action: 'hover',
           viewType: 'list',
         })};
-      `}
-
-    ${p =>
-      p.showHoverState &&
-      css`
-        // We use a pseudo element for the shadow with position: absolute in order to prevent
-        // the shadow from increasing the size of the layout and causing scrollbar flicker.
-        &:after {
-          box-shadow: ${props => props.theme.boxShadow[3]};
-          content: '';
-          position: absolute;
-          top: 0;
-          left: 0;
-          z-index: -1;
-          width: 100%;
-          height: 100%;
-        }
       `}
   }
 `;


### PR DESCRIPTION
The shadows in Connect's unified resources view have been broken (stopped showing up) since the new design system was introduced.

The issue appears to affect only Connect, likely because it renders the unified resources in a more complex stacking context than the Web UI.

I haven't investigated exactly why the design system change caused this issue. Instead, I simplified the existing layout by removing the negative z-index and the `::after` pseudo-element.

The pseudo-element was originally introduced because hovering over list items caused scrollbars to appear in Firefox:
https://github.com/gravitational/teleport/pull/34203#issuecomment-1794811320. But I can't reproduce it anymore.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local builds.

### Test Cases
- [x] The shadows are visible in Chrome, Firefox, Safari, and Connect. 
