### PR TITLE
gha: backport app id is not a secret

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -28,7 +28,7 @@ jobs:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
           values: |
-            BACKPORT_APP_ID,secret
+            BACKPORT_APP_ID,variable
             BACKPORT_PRIVATE_KEY,secret
             REVIEWERS,secret
       - name: Generate GitHub Token


### PR DESCRIPTION
Backport workflow runs are failing because "BACKPORT_APP_ID" (Github app) must be retrieved from the variables store rather than as a secret.  

Failure log: https://github.com/gravitational/teleport/actions/runs/30635878378/job/91173224228#step:2:233
