### PR TITLE
[v18] ui: update mwi guide link for generic linux

### DIFF
--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -193,7 +193,7 @@ export const integrations: BotIntegration[] = [
     title: 'Generic Linux',
     description:
       'Use Machine & Workload Identity (MWI) to eliminate long-lived credentials on Linux servers.',
-    link: ' https://goteleport.com/docs/machine-workload-identity/deployment/linux/',
+    link: 'https://goteleport.com/docs/machine-workload-identity/deployment/linux/',
     icon: 'server',
     kind: IntegrationEnrollKind.MachineID,
     type: 'bot',

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -193,7 +193,7 @@ export const integrations: BotIntegration[] = [
     title: 'Generic Linux',
     description:
       'Use Machine & Workload Identity (MWI) to eliminate long-lived credentials on Linux servers.',
-    link: 'https://goteleport.com/docs/enroll-resources/machine-id/getting-started/',
+    link: 'https://goteleport.com/docs/machine-workload-identity/access-guides/ssh/',
     icon: 'server',
     kind: IntegrationEnrollKind.MachineID,
     type: 'bot',

--- a/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
+++ b/web/packages/teleport/src/Bots/Add/AddBotsPicker.tsx
@@ -193,7 +193,7 @@ export const integrations: BotIntegration[] = [
     title: 'Generic Linux',
     description:
       'Use Machine & Workload Identity (MWI) to eliminate long-lived credentials on Linux servers.',
-    link: 'https://goteleport.com/docs/machine-workload-identity/access-guides/ssh/',
+    link: ' https://goteleport.com/docs/machine-workload-identity/deployment/linux/',
     icon: 'server',
     kind: IntegrationEnrollKind.MachineID,
     type: 'bot',


### PR DESCRIPTION
Backport #69122 to branch/v18

## Manual Test Plan
### Test Environment
  Dev
### Test Cases
- [x] Confirm new integration link shows and works for linux machine-id 