### PR TITLE
[master] Update typo in manual binary download code-block for FedRAMP

### DIFF
--- a/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
@@ -103,14 +103,14 @@ Teleport Enterprise customers can download the custom FIPS package from their
 [Teleport account](https://teleport.sh). Look for `Linux 64-bit (FedRAMP/FIPS)`.
 
 
-$ curl https://cdn.teleport.dev/teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz.sha256
+$ curl https://cdn.teleport.dev/teleport-ent-v(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz.sha256
 <checksum> <filename>
-$ curl -O https://cdn.teleport.dev/teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
+$ curl -O https://cdn.teleport.dev/teleport-ent-v(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
 
 # Verify that the checksums match
-$ shasum -a 256 teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
+$ shasum -a 256 teleport-ent-v(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
 
-$ tar -xvf teleport-ent-(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
+$ tar -xvf teleport-ent-v(= teleport.version =)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
 $ cd teleport-ent
 $ sudo ./install
 ```


### PR DESCRIPTION
This commit adds the missing "v" in our code-block for manually downloading the FIPS binary, resolving the "The specified key does not exist" error.

BEFORE:
`https://cdn.teleport.dev/teleport-ent-${TELEPORT_VERSION?}-linux-${SYSTEM_ARCH?}-fips-bin`

AFTER COMMIT:
`https://cdn.teleport.dev/teleport-ent-v${TELEPORT_VERSION?}-linux-${SYSTEM_ARCH?}-fips-bin`

~ Tested July 30, 2026.
~ Clone of this [v18](https://github.com/gravitational/teleport/pull/69183) commit.