### PR TITLE
[v18] Update changelog for 18.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 18.10.3 (7/31/26)
+
+This is a follow up to the 18.10.1 private security release.
+
+In addition to the previous release it includes the following bug fixes:
+
+* Fixed Kubernetes requests using the `proxy` special-verb URL path prefix being rejected as unknown resource kinds.
+
 ## 18.10.1 (07/17/26)
 
 This is a private security release. The changelog will be publicly announced in a later version.
@@ -1830,5 +1838,3 @@ or `alpn-ping` as upgrade types was left as a fallback until v17.
 
 Teleport v18 removes the legacy upgrade mode entirely including the use of the
 `TELEPORT_TLS_ROUTING_CONN_UPGRADE_MODE` environment variable.
-
-

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=18.10.0
+VERSION=18.10.3
 
 DOCKER_IMAGE ?= teleport
 


### PR DESCRIPTION
18.10.2 is a bug-fix follow up to the private 18.10.1 release, which failed due to expired signing certs.

18.10.3 is the same bug fix, rebuilt with updated signing certs.