### PR TITLE
scoped verbs rework

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3882,7 +3882,8 @@ func (c *Client) UpdateKubernetesCluster(ctx context.Context, cluster types.Kube
 // TODO (eriktate): remove in v20
 func (c *Client) GetKubernetesCluster(ctx context.Context, name string) (types.KubeCluster, error) {
 	return c.GetKubeCluster(ctx, presencepb.GetKubeClusterRequest_builder{
-		Name: name,
+		Name:        name,
+		WithSecrets: true, // preserves legacy secret-inclusive default behavior
 	}.Build())
 }
 
@@ -3902,9 +3903,19 @@ func (c *Client) GetKubeCluster(ctx context.Context, req *presencepb.GetKubeClus
 
 		// fallback to legacy GetKubernetesCluster API
 		//nolint:staticcheck // TODO(eriktate): deprecated, to be removed in v20
-		return c.grpc.GetKubernetesCluster(ctx, &types.ResourceRequest{
+		cluster, err := c.grpc.GetKubernetesCluster(ctx, &types.ResourceRequest{
 			Name: req.GetName(),
 		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		// the legacy API is always secret-inclusive. if we didn't have permission to read secrets we'd
+		// have gotten a permission error, but we still want to respect the request's with_secrets flag
+		// and omit secrets locally to keep behavior consistent.
+		if !req.GetWithSecrets() {
+			return cluster.WithoutSecrets().(types.KubeCluster), nil
+		}
+		return cluster, nil
 	}
 	return res.GetCluster(), trace.Wrap(err)
 }
@@ -3930,8 +3941,9 @@ func (c *Client) GetKubernetesClusters(ctx context.Context) ([]types.KubeCluster
 // TODO (eriktate): remove in v20
 func (c *Client) ListKubernetesClusters(ctx context.Context, limit int, start string) ([]types.KubeCluster, string, error) {
 	return c.ListKubeClusters(ctx, presencepb.ListKubeClustersRequest_builder{
-		PageSize:  int32(limit),
-		PageToken: start,
+		PageSize:    int32(limit),
+		PageToken:   start,
+		WithSecrets: true, // preserves legacy secret-inclusive default behavior
 	}.Build())
 }
 
@@ -3973,12 +3985,18 @@ func (c *Client) ListKubeClusters(ctx context.Context, req *presencepb.ListKubeC
 	}
 	kubeClusters := make([]types.KubeCluster, len(clusters))
 	for i, cluster := range clusters {
+		// legacy fallback is always secret-inclusive.
+		if !req.GetWithSecrets() {
+			kubeClusters[i] = cluster.WithoutSecrets().(types.KubeCluster)
+			continue
+		}
 		kubeClusters[i] = cluster
 	}
 	return kubeClusters, nextPageToken, nil
 }
 
-// RangeKubernetesClusters returns kubernetes clusters within the range [start, end).
+// RangeKubernetesClusters returns kubernetes clusters within the range [start, end), including their
+// secrets.
 //
 // Deprecated: Use RangeKubeClusters instead.
 // TODO (eriktate): remove in v20
@@ -3991,6 +4009,7 @@ func (c *Client) RangeKubernetesClusters(ctx context.Context, start, end string)
 			ScopeFilter: scopesv1.Filter_builder{
 				Mode: scopesv1.Mode_MODE_UNSCOPED,
 			}.Build(),
+			WithSecrets: true, // preserves legacy secret-inclusive default behavior
 		}.Build())
 		return res.GetClusters(), res.GetNextPageToken(), err
 	}
@@ -4058,6 +4077,10 @@ func (c *Client) RangeKubeClusters(ctx context.Context, req *presencepb.ListKube
 		// fallback iterator
 		//nolint:staticcheck // TODO(eriktate): deprecated, to be removed in v20
 		for cluster, err := range clientutils.RangeResources(ctx, req.GetPageToken(), "", c.legacyListKubeClusters, nil) {
+			// the legacy API is always secret-inclusive.
+			if err == nil && !req.GetWithSecrets() {
+				cluster = cluster.WithoutSecrets().(*types.KubernetesClusterV3)
+			}
 			if !yield(cluster, err) {
 				return
 			}

--- a/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protohybrid.pb.go
@@ -1656,7 +1656,10 @@ type GetKubeClusterRequest struct {
 	// The name of the kube cluster resource.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// The scope the kube cluster resource belongs to. Can be empty.
-	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
+	Scope string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
+	// If true, include secrets in the response. Requires secret-inclusive read
+	// permission on kubernetes_cluster.
+	WithSecrets   bool `protobuf:"varint,3,opt,name=with_secrets,json=withSecrets,proto3" json:"with_secrets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1700,12 +1703,23 @@ func (x *GetKubeClusterRequest) GetScope() string {
 	return ""
 }
 
+func (x *GetKubeClusterRequest) GetWithSecrets() bool {
+	if x != nil {
+		return x.WithSecrets
+	}
+	return false
+}
+
 func (x *GetKubeClusterRequest) SetName(v string) {
 	x.Name = v
 }
 
 func (x *GetKubeClusterRequest) SetScope(v string) {
 	x.Scope = v
+}
+
+func (x *GetKubeClusterRequest) SetWithSecrets(v bool) {
+	x.WithSecrets = v
 }
 
 type GetKubeClusterRequest_builder struct {
@@ -1715,6 +1729,9 @@ type GetKubeClusterRequest_builder struct {
 	Name string
 	// The scope the kube cluster resource belongs to. Can be empty.
 	Scope string
+	// If true, include secrets in the response. Requires secret-inclusive read
+	// permission on kubernetes_cluster.
+	WithSecrets bool
 }
 
 func (b0 GetKubeClusterRequest_builder) Build() *GetKubeClusterRequest {
@@ -1723,6 +1740,7 @@ func (b0 GetKubeClusterRequest_builder) Build() *GetKubeClusterRequest {
 	_, _ = b, x
 	x.Name = b.Name
 	x.Scope = b.Scope
+	x.WithSecrets = b.WithSecrets
 	return m0
 }
 
@@ -1804,7 +1822,10 @@ type ListKubeClustersRequest struct {
 	// The next_page_token value returned from a previous List request, if any.
 	PageToken string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	// Filters kube clusters by scope.
-	ScopeFilter   *v1.Filter `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
+	ScopeFilter *v1.Filter `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
+	// If true, include secrets in the response. Requires secret-inclusive read
+	// permission on kubernetes_cluster.
+	WithSecrets   bool `protobuf:"varint,4,opt,name=with_secrets,json=withSecrets,proto3" json:"with_secrets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1855,6 +1876,13 @@ func (x *ListKubeClustersRequest) GetScopeFilter() *v1.Filter {
 	return nil
 }
 
+func (x *ListKubeClustersRequest) GetWithSecrets() bool {
+	if x != nil {
+		return x.WithSecrets
+	}
+	return false
+}
+
 func (x *ListKubeClustersRequest) SetPageSize(v int32) {
 	x.PageSize = v
 }
@@ -1865,6 +1893,10 @@ func (x *ListKubeClustersRequest) SetPageToken(v string) {
 
 func (x *ListKubeClustersRequest) SetScopeFilter(v *v1.Filter) {
 	x.ScopeFilter = v
+}
+
+func (x *ListKubeClustersRequest) SetWithSecrets(v bool) {
+	x.WithSecrets = v
 }
 
 func (x *ListKubeClustersRequest) HasScopeFilter() bool {
@@ -1888,6 +1920,9 @@ type ListKubeClustersRequest_builder struct {
 	PageToken string
 	// Filters kube clusters by scope.
 	ScopeFilter *v1.Filter
+	// If true, include secrets in the response. Requires secret-inclusive read
+	// permission on kubernetes_cluster.
+	WithSecrets bool
 }
 
 func (b0 ListKubeClustersRequest_builder) Build() *ListKubeClustersRequest {
@@ -1897,6 +1932,7 @@ func (b0 ListKubeClustersRequest_builder) Build() *ListKubeClustersRequest {
 	x.PageSize = b.PageSize
 	x.PageToken = b.PageToken
 	x.ScopeFilter = b.ScopeFilter
+	x.WithSecrets = b.WithSecrets
 	return m0
 }
 
@@ -2439,17 +2475,19 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x06server\x18\x01 \x01(\v2\x0f.types.ServerV2R\x06server\".\n" +
 	"\x18DeleteProxyServerRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"\x1b\n" +
-	"\x19DeleteProxyServerResponse\"A\n" +
+	"\x19DeleteProxyServerResponse\"d\n" +
 	"\x15GetKubeClusterRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
-	"\x05scope\x18\x02 \x01(\tR\x05scope\"N\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\x12!\n" +
+	"\fwith_secrets\x18\x03 \x01(\bR\vwithSecrets\"N\n" +
 	"\x16GetKubeClusterResponse\x124\n" +
-	"\acluster\x18\x01 \x01(\v2\x1a.types.KubernetesClusterV3R\acluster\"\x94\x01\n" +
+	"\acluster\x18\x01 \x01(\v2\x1a.types.KubernetesClusterV3R\acluster\"\xb7\x01\n" +
 	"\x17ListKubeClustersRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\x12=\n" +
-	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"z\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\x12!\n" +
+	"\fwith_secrets\x18\x04 \x01(\bR\vwithSecrets\"z\n" +
 	"\x18ListKubeClustersResponse\x126\n" +
 	"\bclusters\x18\x01 \x03(\v2\x1a.types.KubernetesClusterV3R\bclusters\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"D\n" +

--- a/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_protoopaque.pb.go
@@ -1620,11 +1620,12 @@ func (b0 DeleteProxyServerResponse_builder) Build() *DeleteProxyServerResponse {
 
 // The request for fetching a specific scoped or unscoped kube cluster resource.
 type GetKubeClusterRequest struct {
-	state            protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name  string                 `protobuf:"bytes,1,opt,name=name,proto3"`
-	xxx_hidden_Scope string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name        string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Scope       string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
+	xxx_hidden_WithSecrets bool                   `protobuf:"varint,3,opt,name=with_secrets,json=withSecrets,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *GetKubeClusterRequest) Reset() {
@@ -1666,12 +1667,23 @@ func (x *GetKubeClusterRequest) GetScope() string {
 	return ""
 }
 
+func (x *GetKubeClusterRequest) GetWithSecrets() bool {
+	if x != nil {
+		return x.xxx_hidden_WithSecrets
+	}
+	return false
+}
+
 func (x *GetKubeClusterRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
 
 func (x *GetKubeClusterRequest) SetScope(v string) {
 	x.xxx_hidden_Scope = v
+}
+
+func (x *GetKubeClusterRequest) SetWithSecrets(v bool) {
+	x.xxx_hidden_WithSecrets = v
 }
 
 type GetKubeClusterRequest_builder struct {
@@ -1681,6 +1693,9 @@ type GetKubeClusterRequest_builder struct {
 	Name string
 	// The scope the kube cluster resource belongs to. Can be empty.
 	Scope string
+	// If true, include secrets in the response. Requires secret-inclusive read
+	// permission on kubernetes_cluster.
+	WithSecrets bool
 }
 
 func (b0 GetKubeClusterRequest_builder) Build() *GetKubeClusterRequest {
@@ -1689,6 +1704,7 @@ func (b0 GetKubeClusterRequest_builder) Build() *GetKubeClusterRequest {
 	_, _ = b, x
 	x.xxx_hidden_Name = b.Name
 	x.xxx_hidden_Scope = b.Scope
+	x.xxx_hidden_WithSecrets = b.WithSecrets
 	return m0
 }
 
@@ -1767,6 +1783,7 @@ type ListKubeClustersRequest struct {
 	xxx_hidden_PageSize    int32                  `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3"`
 	xxx_hidden_PageToken   string                 `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3"`
 	xxx_hidden_ScopeFilter *v1.Filter             `protobuf:"bytes,3,opt,name=scope_filter,json=scopeFilter,proto3"`
+	xxx_hidden_WithSecrets bool                   `protobuf:"varint,4,opt,name=with_secrets,json=withSecrets,proto3"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -1817,6 +1834,13 @@ func (x *ListKubeClustersRequest) GetScopeFilter() *v1.Filter {
 	return nil
 }
 
+func (x *ListKubeClustersRequest) GetWithSecrets() bool {
+	if x != nil {
+		return x.xxx_hidden_WithSecrets
+	}
+	return false
+}
+
 func (x *ListKubeClustersRequest) SetPageSize(v int32) {
 	x.xxx_hidden_PageSize = v
 }
@@ -1827,6 +1851,10 @@ func (x *ListKubeClustersRequest) SetPageToken(v string) {
 
 func (x *ListKubeClustersRequest) SetScopeFilter(v *v1.Filter) {
 	x.xxx_hidden_ScopeFilter = v
+}
+
+func (x *ListKubeClustersRequest) SetWithSecrets(v bool) {
+	x.xxx_hidden_WithSecrets = v
 }
 
 func (x *ListKubeClustersRequest) HasScopeFilter() bool {
@@ -1850,6 +1878,9 @@ type ListKubeClustersRequest_builder struct {
 	PageToken string
 	// Filters kube clusters by scope.
 	ScopeFilter *v1.Filter
+	// If true, include secrets in the response. Requires secret-inclusive read
+	// permission on kubernetes_cluster.
+	WithSecrets bool
 }
 
 func (b0 ListKubeClustersRequest_builder) Build() *ListKubeClustersRequest {
@@ -1859,6 +1890,7 @@ func (b0 ListKubeClustersRequest_builder) Build() *ListKubeClustersRequest {
 	x.xxx_hidden_PageSize = b.PageSize
 	x.xxx_hidden_PageToken = b.PageToken
 	x.xxx_hidden_ScopeFilter = b.ScopeFilter
+	x.xxx_hidden_WithSecrets = b.WithSecrets
 	return m0
 }
 
@@ -2390,17 +2422,19 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x06server\x18\x01 \x01(\v2\x0f.types.ServerV2R\x06server\".\n" +
 	"\x18DeleteProxyServerRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"\x1b\n" +
-	"\x19DeleteProxyServerResponse\"A\n" +
+	"\x19DeleteProxyServerResponse\"d\n" +
 	"\x15GetKubeClusterRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
-	"\x05scope\x18\x02 \x01(\tR\x05scope\"N\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\x12!\n" +
+	"\fwith_secrets\x18\x03 \x01(\bR\vwithSecrets\"N\n" +
 	"\x16GetKubeClusterResponse\x124\n" +
-	"\acluster\x18\x01 \x01(\v2\x1a.types.KubernetesClusterV3R\acluster\"\x94\x01\n" +
+	"\acluster\x18\x01 \x01(\v2\x1a.types.KubernetesClusterV3R\acluster\"\xb7\x01\n" +
 	"\x17ListKubeClustersRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x02 \x01(\tR\tpageToken\x12=\n" +
-	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"z\n" +
+	"\fscope_filter\x18\x03 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\x12!\n" +
+	"\fwith_secrets\x18\x04 \x01(\bR\vwithSecrets\"z\n" +
 	"\x18ListKubeClustersResponse\x126\n" +
 	"\bclusters\x18\x01 \x03(\v2\x1a.types.KubernetesClusterV3R\bclusters\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"D\n" +

--- a/api/proto/teleport/presence/v1/service.proto
+++ b/api/proto/teleport/presence/v1/service.proto
@@ -249,6 +249,9 @@ message GetKubeClusterRequest {
   string name = 1;
   // The scope the kube cluster resource belongs to. Can be empty.
   string scope = 2;
+  // If true, include secrets in the response. Requires secret-inclusive read
+  // permission on kubernetes_cluster.
+  bool with_secrets = 3;
 }
 
 // The response for fetching a kube cluster.
@@ -267,6 +270,10 @@ message ListKubeClustersRequest {
 
   // Filters kube clusters by scope.
   teleport.scopes.v1.Filter scope_filter = 3;
+
+  // If true, include secrets in the response. Requires secret-inclusive read
+  // permission on kubernetes_cluster.
+  bool with_secrets = 4;
 }
 
 // The response for listing kube cluster resources within the backend.

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -36,6 +36,8 @@ var _ compare.IsEqual[KubeCluster] = (*KubernetesClusterV3)(nil)
 type KubeCluster interface {
 	// ResourceWithLabels provides common resource methods.
 	ResourceWithLabels
+	// ResourceWithSecrets provides WithoutSecrets method.
+	ResourceWithSecrets
 	// GetNamespace returns the kube cluster namespace.
 	GetNamespace() string
 	// GetStaticLabels returns the kube cluster static labels.
@@ -361,6 +363,18 @@ func (k *KubernetesClusterV3) String() string {
 // Copy returns a copy of this resource.
 func (k *KubernetesClusterV3) Copy() KubeCluster {
 	return utils.CloneProtoMsg(k)
+}
+
+// WithoutSecrets returns a shallow copy of this kube cluster with its kubeconfig removed. Note that this function
+// is a lot less aggressive than the existing [NewKubernetesClusterV3WithoutSecrets] which the heartbeat
+// path uses. That function removes all fields except for name/labels/scope.
+func (k *KubernetesClusterV3) WithoutSecrets() Resource {
+	if !k.IsKubeconfig() {
+		return k
+	}
+	k2 := *k
+	k2.Spec.Kubeconfig = nil
+	return &k2
 }
 
 // GetStatus gets the kube cluster status.

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
@@ -56,10 +56,16 @@ resource "teleport_scoped_role" "scoped_admin" {
   scope = local.scope_path
   spec = {
     assignable_scopes = [local.scope_path]
-    rules = [{
-      resources = ["scoped_role", "scoped_token", "scoped_role_assignment"]
-      verbs     = ["create", "readnosecrets", "list", "update", "delete"]
-    }]
+    rules = [
+      {
+        resources = ["scoped_role", "scoped_role_assignment"]
+        verbs     = ["create", "read", "list", "update", "delete"]
+      },
+      {
+        resources = ["scoped_token"]
+        verbs     = ["create", "read", "secrets", "list", "update", "delete"]
+      },
+    ]
   }
 }
 

--- a/docs/pages/zero-trust-access/rbac-get-started/scopes.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/scopes.mdx
@@ -120,7 +120,8 @@ are expected to work. The following commands are officially supported in
 scoped mode:
 
 - `tsh login --scope=<scope> ...`
-- `tsh logout` (required to exit a scoped session)
+- `tsh logout`
+- `tsh scopes ls` (lists the scopes at which the user has assigned privileges)
 - `tsh ls` (lists SSH instances available at the current scope)
 - `tsh ssh <login>@<host>` (for SSH instances available at the current scope)
 - `tsh kube ls` (lists Kubernetes clusters available at the current scope)
@@ -189,9 +190,9 @@ spec:
         values: ['*']
   rules:
     - resources: [scoped_role, scoped_role_assignment, bot, bot_instance, access_list]
-      verbs: [create, list, readnosecrets, update, delete]
-    - resources: [scoped_token, kube_cluster]
       verbs: [create, list, read, update, delete]
+    - resources: [scoped_token, kube_cluster]
+      verbs: [create, list, read, secrets, update, delete]
 version: v1
 EOF
 ```
@@ -798,7 +799,7 @@ spec:
         - bot_instance
       verbs:
         - list
-        - readnosecrets
+        - read
         - create
         - update
         - delete
@@ -807,7 +808,7 @@ spec:
       verbs:
         - list
         - read
-        - readnosecrets
+        - secrets
         - create
         - update
         - delete
@@ -948,7 +949,7 @@ The following rules apply to the SPIFFE ID of a scoped Workload Identity:
 
 Issuance is controlled by the `workload_identity` section of a scoped role,
 which selects the Workload Identities that the role permits issuance with
-by label. Issuance additionally requires the `readnosecrets` verb (and,
+by label. Issuance additionally requires the `read` verb (and,
 when issuing by label selector, `list`) for the `workload_identity`
 resource in the role's `rules`.
 
@@ -998,7 +999,7 @@ spec:
         values: [payments]
   rules:
     - resources: [workload_identity]
-      verbs: [list, readnosecrets]
+      verbs: [list, read]
 ---
 kind: scoped_role_assignment
 version: v1
@@ -1301,6 +1302,7 @@ spec:
         - create
         - list
         - read
+        - secrets
         - update
         - delete
 version: v1
@@ -1328,11 +1330,10 @@ version: v1
 EOF
 ```
 
-Log out of your current session, then log in to the `/examples/kube` scope so
-the scoped role assignment is active for the following `tctl` commands:
+Log in to the `/examples/kube` scope so the scoped role assignment is active
+for the following `tctl` commands:
 
 ```code
-$ tsh logout
 $ tsh login --user=<Var name="user" /> --scope=/examples/kube --proxy=<Var name="example.teleport.sh:443" />
 ```
 

--- a/integrations/lib/embeddedtbot/bot_test.go
+++ b/integrations/lib/embeddedtbot/bot_test.go
@@ -303,7 +303,7 @@ func TestScopedBotJoinAuth(t *testing.T) {
 				// The role can read scoped roles. We will use this to validate its permissions later.
 				scopedaccessv1.ScopedRule_builder{
 					Resources: []string{scopedaccess.KindScopedRole},
-					Verbs:     []string{types.VerbReadNoSecrets},
+					Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read),
 				}.Build(),
 			},
 		}.Build(),

--- a/integrations/operator/controllers/resources/scopedrole_controller_test.go
+++ b/integrations/operator/controllers/resources/scopedrole_controller_test.go
@@ -44,7 +44,7 @@ var scopedRoleSpec = accessv1.ScopedRoleSpec_builder{
 	Rules: []*accessv1.ScopedRule{
 		accessv1.ScopedRule_builder{
 			Resources: []string{"scoped_role"},
-			Verbs:     []string{"readnosecrets", "list"},
+			Verbs:     access.EncodeScopedVerbs(access.Read, access.List),
 		}.Build(),
 	},
 }.Build()

--- a/integrations/terraform/examples/provider/scoped-provider-role.yaml
+++ b/integrations/terraform/examples/provider/scoped-provider-role.yaml
@@ -10,7 +10,7 @@ spec:
       verbs:
         - list
         - create
-        - readnosecrets
+        - read
         - update
         - delete
     - resources: ["scoped_token"]
@@ -18,5 +18,6 @@ spec:
         - list
         - create
         - read
+        - secrets
         - update
         - delete

--- a/integrations/terraform/examples/resources/teleport_bot/scoped-resource.tf
+++ b/integrations/terraform/examples/resources/teleport_bot/scoped-resource.tf
@@ -15,10 +15,16 @@ resource "teleport_scoped_role" "scoped_admin" {
   scope = local.scope_path
   spec = {
     assignable_scopes = [local.scope_path]
-    rules = [{
-      resources = ["scoped_role", "scoped_token", "scoped_role_assignment"]
-      verbs     = ["create", "readnosecrets", "list", "update", "delete"]
-    }]
+    rules = [
+      {
+        resources = ["scoped_role", "scoped_role_assignment"]
+        verbs     = ["create", "read", "list", "update", "delete"]
+      },
+      {
+        resources = ["scoped_token"]
+        verbs     = ["create", "read", "secrets", "list", "update", "delete"]
+      },
+    ]
   }
 }
 

--- a/integrations/terraform/provider/internal/teleport/kubernetes.go
+++ b/integrations/terraform/provider/internal/teleport/kubernetes.go
@@ -41,8 +41,9 @@ type KubernetesClient struct {
 // Get reads a Kubernetes Cluster by name.
 func (r KubernetesClient) Get(ctx context.Context, id tfdriver.ScopeQualifiedNameIdentifier) (*types.KubernetesClusterV3, error) {
 	cluster, err := r.client.GetKubeCluster(ctx, presencev1.GetKubeClusterRequest_builder{
-		Name:  id.Name,
-		Scope: id.Scope,
+		Name:        id.Name,
+		Scope:       id.Scope,
+		WithSecrets: true,
 	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/integrations/terraform/testlib/fixtures/bot_scoped_0_create.tf
+++ b/integrations/terraform/testlib/fixtures/bot_scoped_0_create.tf
@@ -14,7 +14,7 @@ resource "teleport_scoped_role" "scoped_operator" {
     assignable_scopes = [local.scope_path]
     rules = [{
       resources = ["scoped_role", "scoped_token", "scoped_role_assignment"]
-      verbs     = ["create", "readnosecrets", "list", "update", "delete"]
+      verbs     = ["create", "read", "list", "update", "delete"]
     }]
   }
 }

--- a/integrations/terraform/testlib/fixtures/bot_scoped_1_update.tf
+++ b/integrations/terraform/testlib/fixtures/bot_scoped_1_update.tf
@@ -14,7 +14,7 @@ resource "teleport_scoped_role" "scoped_operator" {
     assignable_scopes = [local.scope_path]
     rules = [{
       resources = ["scoped_role", "scoped_token", "scoped_role_assignment"]
-      verbs     = ["create", "readnosecrets", "list", "update", "delete"]
+      verbs     = ["create", "read", "list", "update", "delete"]
     }]
   }
 }

--- a/integrations/terraform/testlib/fixtures/bot_scoped_2_change_scope.tf
+++ b/integrations/terraform/testlib/fixtures/bot_scoped_2_change_scope.tf
@@ -14,7 +14,7 @@ resource "teleport_scoped_role" "scoped_operator" {
     assignable_scopes = [local.scope_path]
     rules = [{
       resources = ["scoped_role", "scoped_token", "scoped_role_assignment"]
-      verbs     = ["create", "readnosecrets", "list", "update", "delete"]
+      verbs     = ["create", "read", "list", "update", "delete"]
     }]
   }
 }

--- a/integrations/terraform/testlib/machineid_join_test.go
+++ b/integrations/terraform/testlib/machineid_join_test.go
@@ -406,7 +406,14 @@ func TestTerraformJoinScoped(t *testing.T) {
 			Rules: []*scopedaccessv1.ScopedRule{
 				scopedaccessv1.ScopedRule_builder{
 					Resources: []string{scopedaccess.KindScopedToken},
-					Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbUpdate, types.VerbCreate, types.VerbDelete, types.VerbRead},
+					Verbs: scopedaccess.EncodeScopedVerbs(
+						scopedaccess.List,
+						scopedaccess.Read,
+						scopedaccess.Secrets,
+						scopedaccess.Create,
+						scopedaccess.Update,
+						scopedaccess.Delete,
+					),
 				}.Build(),
 			},
 		}.Build(),

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -1095,7 +1096,7 @@ func (a *ScopedServerWithRoles) UpsertNode(ctx context.Context, s types.Server) 
 		if err := a.scopedContext.AgentOwnedResourceAction(s.GetScope(), s.GetName(), types.RoleNode); err == nil {
 			return nil
 		}
-		return checker.CheckAccessToRules(&ruleCtx, types.KindNode, types.VerbCreate, types.VerbUpdate)
+		return checker.CheckAccessToRules(&ruleCtx, types.KindNode, scopedaccess.Create, scopedaccess.Update)
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1186,6 +1187,7 @@ func (a *ScopedServerWithRoles) authorizeWatchRequest(ctx context.Context, watch
 	}
 	validKinds := make([]types.WatchKind, 0, len(watch.Kinds))
 	for _, kind := range watch.Kinds {
+		applyLegacyWatchSecretsCompat(ctx, &kind)
 		filter, err := a.authorizeWatchKind(ctx, kind)
 		if err != nil {
 			if watch.AllowPartialSuccess {
@@ -1269,6 +1271,29 @@ func (a *ServerWithRoles) hasWatchPermissionForKind(
 		return nil
 	}
 	return trace.Wrap(a.authorizeAction(kind.Kind, verb))
+}
+
+// minKubeClusterWatchSecretsVersion is the client version after which we assume the caller would have explicitly requested
+// kube cluster secrets if they intended to make a secrets-inclusive watch.
+var minKubeClusterWatchSecretsVersion = &semver.Version{Major: 18, Minor: 12}
+
+// applyLegacyWatchSecretsCompat forces LoadSecrets on kubernetes_cluster watches from clients too old
+// to know they have to ask for it. Kube clusters used to always be a secrets-inclusive watch, and we
+// have retroactively added the ability to express secrets-exclusive watch permissions for them.
+//
+// TODO(fspmarshall): DELETE IN v21
+func applyLegacyWatchSecretsCompat(ctx context.Context, kind *types.WatchKind) {
+	if kind.Kind != types.KindKubernetesCluster || kind.LoadSecrets {
+		return
+	}
+
+	if clientVersion, ok := metadata.ClientVersionFromContext(ctx); ok {
+		if current, err := utils.MinVerWithoutPreRelease(clientVersion, minKubeClusterWatchSecretsVersion.String()); err == nil && current {
+			return
+		}
+	}
+
+	kind.LoadSecrets = true
 }
 
 // supportedScopedWatchKind matches the set of resource kinds that have been converted to support scoped watch
@@ -1455,9 +1480,9 @@ func (a *ScopedServerWithRoles) authorizeWatchKindCore(ctx context.Context, kind
 		return nil, trace.BadParameter("cannot watch kind %q with unknown mode %v", kind.Kind, filter.GetMode())
 	}
 
-	verb := types.VerbReadNoSecrets
+	verb := scopedaccess.Read
 	if kind.LoadSecrets {
-		verb = types.VerbRead
+		verb = scopedaccess.Secrets
 	}
 
 	ruleCtx := a.scopedContext.RuleContext()
@@ -1876,7 +1901,7 @@ func (a *ScopedServerWithRoles) ListUnifiedResources(ctx context.Context, req *p
 
 	ruleCtx := a.scopedContext.RuleContext()
 
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbList); err != nil {
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, scopedaccess.List); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -2264,7 +2289,9 @@ func (a *ScopedServerWithRoles) ListResources(ctx context.Context, req proto.Lis
 	}
 
 	ruleCtx := a.scopedContext.RuleContext()
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, req.ResourceType, types.VerbList, types.VerbRead); err != nil {
+	// secret-exclusive read is the right requirement even for resource types that do carry secrets,
+	// since this pre-check must never be stricter than the per-resource checks it precedes.
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, req.ResourceType, scopedaccess.List, scopedaccess.Read); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -6834,7 +6861,7 @@ func (a *ServerWithRoles) canDeleteWebSession(username string) error {
 func (a *ScopedServerWithRoles) GenerateAppToken(ctx context.Context, req types.GenerateAppTokenRequest) (string, error) {
 	ruleCtx := a.scopedContext.RuleContext()
 	if err := a.scopedContext.CheckerContext.Decision(ctx, req.Scope, func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, types.KindJWT, types.VerbCreate)
+		return checker.CheckAccessToRules(&ruleCtx, types.KindJWT, scopedaccess.Create)
 	}); err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -6929,7 +6956,7 @@ func (a *ServerWithRoles) checkAccessToKubeCluster(cluster types.KubeCluster) er
 		services.AccessState{MFAVerified: true})
 }
 
-func (a *ScopedServerWithRoles) checkAccessToKubeClusterWithVerbs(ctx context.Context, cluster types.KubeCluster, verbs ...string) error {
+func (a *ScopedServerWithRoles) checkAccessToKubeClusterWithVerbs(ctx context.Context, cluster types.KubeCluster, verbs ...scopedaccess.Verb) error {
 	ruleCtx := a.scopedContext.RuleContext()
 	return a.scopedContext.CheckerContext.Decision(ctx, cmp.Or(cluster.GetScope(), scopes.Root), func(checker *services.ScopedAccessChecker) error {
 		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, verbs...); err != nil {
@@ -6974,7 +7001,7 @@ func (a *ScopedServerWithRoles) GetKubernetesServers(ctx context.Context) ([]typ
 	}
 	var filtered []types.KubeServer
 	for _, server := range servers {
-		err := a.checkAccessToKubeClusterWithVerbs(ctx, server.GetCluster(), types.VerbList, types.VerbRead)
+		err := a.checkAccessToKubeClusterWithVerbs(ctx, server.GetCluster(), scopedaccess.List, scopedaccess.Read)
 		if err != nil && !trace.IsAccessDenied(err) {
 			return nil, trace.Wrap(err)
 		} else if err == nil {
@@ -7003,7 +7030,7 @@ func (a *ScopedServerWithRoles) GetApplicationServers(ctx context.Context, names
 		}
 
 		err := a.scopedContext.CheckerContext.Decision(ctx, server.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			if err := checker.CheckAccessToRules(&ruleCtx, types.KindAppServer, types.VerbRead, types.VerbList); err != nil {
+			if err := checker.CheckAccessToRules(&ruleCtx, types.KindAppServer, scopedaccess.Read, scopedaccess.List); err != nil {
 				return trace.Wrap(err)
 			}
 			return checker.App().CanAccessApp(server.GetApp())
@@ -7054,7 +7081,7 @@ func (a *ScopedServerWithRoles) DeleteKubernetesServer(ctx context.Context, req 
 	if err := a.scopedContext.AgentOwnedResourceAction(existingServer.GetScope(), existingServer.GetHostID(), types.RoleKube); err != nil {
 		ruleCtx := a.scopedContext.RuleContext()
 		if err := a.scopedContext.CheckerContext.Decision(ctx, existingServer.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindKubeServer, types.VerbDelete)
+			return checker.CheckAccessToRules(&ruleCtx, types.KindKubeServer, scopedaccess.Delete)
 		}); err != nil {
 			return trace.Wrap(err)
 		}
@@ -7595,7 +7622,7 @@ func (a *ServerWithRoles) DeleteAllApps(ctx context.Context) error {
 func (a *ScopedServerWithRoles) CreateKubernetesCluster(ctx context.Context, cluster types.KubeCluster) error {
 	ruleCtx := a.scopedContext.RuleContext()
 	if err := a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbCreate); err != nil {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Create); err != nil {
 			return err
 		}
 		// Don't allow users to create clusters they wouldn't have access to (e.g.
@@ -7614,7 +7641,7 @@ func (a *ScopedServerWithRoles) CreateKubernetesCluster(ctx context.Context, clu
 // UpdateKubernetesCluster updates existing kubernetes cluster resource.
 func (a *ScopedServerWithRoles) UpdateKubernetesCluster(ctx context.Context, cluster types.KubeCluster) error {
 	ruleCtx := a.scopedContext.RuleContext()
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbUpdate); err != nil {
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Update); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -7628,7 +7655,7 @@ func (a *ScopedServerWithRoles) UpdateKubernetesCluster(ctx context.Context, clu
 		return trace.Wrap(err)
 	}
 	if err := a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbUpdate); err != nil {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Update); err != nil {
 			return err
 		}
 		if err := checker.Kube().CanAccessCluster(existing); err != nil {
@@ -7659,23 +7686,28 @@ func (a *ScopedServerWithRoles) UpdateKubernetesCluster(ctx context.Context, clu
 
 // GetKubernetesCluster returns specified kubernetes cluster resource.
 //
+// NOTE: this and the other legacy kube cluster reads below are what outdated clients reach, so they
+// must retain their legacy secret-inclusive behavior, hence with_secrets and the Secrets verb. The
+// secret-exclusive-by-default model is implemented by the newere presencev1 service methods.
+//
 // Deprecated: Use GetKubeCluster from lib/auth/presence/presencev1/service.go instead.
 // TODO (eriktate): Remove in v20
 func (a *ScopedServerWithRoles) GetKubernetesCluster(ctx context.Context, name string) (types.KubeCluster, error) {
 	ruleCtx := a.scopedContext.RuleContext()
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead); err != nil {
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Secrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	kubeCluster, err := a.authServer.GetKubeCluster(ctx, presencev1.GetKubeClusterRequest_builder{
-		Name: name,
+		Name:        name,
+		WithSecrets: true,
 	}.Build())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if err := a.scopedContext.CheckerContext.Decision(ctx, kubeCluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead); err != nil {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Secrets); err != nil {
 			return err
 		}
 		return checker.Kube().CanAccessCluster(kubeCluster)
@@ -7689,7 +7721,7 @@ func (a *ScopedServerWithRoles) GetKubernetesCluster(ctx context.Context, name s
 // GetKubernetesClusters returns all kubernetes cluster resources.
 func (a *ScopedServerWithRoles) GetKubernetesClusters(ctx context.Context) (result []types.KubeCluster, err error) {
 	ruleCtx := a.scopedContext.RuleContext()
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead, types.VerbList); err != nil {
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Secrets, scopedaccess.List); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -7697,11 +7729,12 @@ func (a *ScopedServerWithRoles) GetKubernetesClusters(ctx context.Context) (resu
 		iterstream.FilterMap(
 			a.authServer.RangeKubeClusters(ctx, presencev1.ListKubeClustersRequest_builder{
 				ScopeFilter: a.scopedContext.CheckerContext.ResolveScopeFilter(nil),
+				WithSecrets: true,
 			}.Build()),
 			func(cluster types.KubeCluster) (types.KubeCluster, bool) {
 				// Filter out kube clusters user doesn't have access to.
 				if err := a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-					if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead, types.VerbList); err != nil {
+					if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Secrets, scopedaccess.List); err != nil {
 						return err
 					}
 					return checker.Kube().CanAccessCluster(cluster)
@@ -7725,7 +7758,7 @@ func (a *ScopedServerWithRoles) GetKubernetesClusters(ctx context.Context) (resu
 // TODO (eriktate): Remove in v20
 func (a *ScopedServerWithRoles) ListKubernetesClusters(ctx context.Context, limit int, start string) ([]types.KubeCluster, string, error) {
 	ruleCtx := a.scopedContext.RuleContext()
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead, types.VerbList); err != nil {
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Secrets, scopedaccess.List); err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
@@ -7734,11 +7767,12 @@ func (a *ScopedServerWithRoles) ListKubernetesClusters(ctx context.Context, limi
 			a.authServer.RangeKubeClusters(ctx, presencev1.ListKubeClustersRequest_builder{
 				PageToken:   start,
 				ScopeFilter: a.scopedContext.CheckerContext.ResolveScopeFilter(nil),
+				WithSecrets: true,
 			}.Build()),
 			func(cluster types.KubeCluster) (types.KubeCluster, bool) {
 				// Filter out kube clusters user doesn't have access to.
 				if err := a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-					if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead, types.VerbList); err != nil {
+					if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Secrets, scopedaccess.List); err != nil {
 						return err
 					}
 					return checker.Kube().CanAccessCluster(cluster)
@@ -7759,7 +7793,7 @@ func (a *ScopedServerWithRoles) ListKubernetesClusters(ctx context.Context, limi
 // TODO (eriktate): Remove in v20
 func (a *ScopedServerWithRoles) DeleteKubernetesCluster(ctx context.Context, name string) error {
 	ruleCtx := a.scopedContext.RuleContext()
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbDelete); err != nil {
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Delete); err != nil {
 		return trace.Wrap(err)
 	}
 	// Make sure user has access to the kubernetes cluster before deleting.
@@ -7770,7 +7804,7 @@ func (a *ScopedServerWithRoles) DeleteKubernetesCluster(ctx context.Context, nam
 		return trace.Wrap(err)
 	}
 	if err := a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbDelete); err != nil {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Delete); err != nil {
 			return err
 		}
 		return checker.Kube().CanAccessCluster(cluster)
@@ -7785,7 +7819,7 @@ func (a *ScopedServerWithRoles) DeleteKubernetesCluster(ctx context.Context, nam
 // DeleteAllKubernetesClusters removes all kubernetes cluster resources.
 func (a *ScopedServerWithRoles) DeleteAllKubernetesClusters(ctx context.Context) error {
 	ruleCtx := a.scopedContext.RuleContext()
-	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbList, types.VerbDelete); err != nil {
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.List, scopedaccess.Delete); err != nil {
 		return trace.Wrap(err)
 	}
 	// Make sure to only delete kubernetes cluster user has access to.
@@ -7797,7 +7831,7 @@ func (a *ScopedServerWithRoles) DeleteAllKubernetesClusters(ctx context.Context)
 	var deletedAtLeastOneCluster bool
 	for _, cluster := range clusters {
 		if err := a.scopedContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbDelete, types.VerbList); err != nil {
+			if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Delete, scopedaccess.List); err != nil {
 				return err
 			}
 			return checker.Kube().CanAccessCluster(cluster)

--- a/lib/auth/auth_with_roles_watch_authz_test.go
+++ b/lib/auth/auth_with_roles_watch_authz_test.go
@@ -22,8 +22,10 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	grpcmetadata "google.golang.org/grpc/metadata"
 
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -520,6 +522,66 @@ func TestUnscopedWatchKindAuthz(t *testing.T) {
 				return
 			}
 			require.Equal(t, tt.wantMode, got.GetMode())
+		})
+	}
+}
+
+// TestApplyLegacyWatchSecretsCompat verifies the version gate that keeps kube cluster event streams
+// secret-inclusive for clients predating minKubeClusterWatchSecretsVersion.
+//
+// TODO(fspmarshall): DELETE IN v21, along with applyLegacyWatchSecretsCompat.
+func TestApplyLegacyWatchSecretsCompat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		kind                string
+		clientVersion       string
+		expectedLoadSecrets bool
+	}{
+		{
+			name:                "outdated client is forced to load kube cluster secrets",
+			kind:                types.KindKubernetesCluster,
+			clientVersion:       "18.11.0",
+			expectedLoadSecrets: true,
+		},
+		{
+			name:          "client at the boundary asks for itself",
+			kind:          types.KindKubernetesCluster,
+			clientVersion: minKubeClusterWatchSecretsVersion.String(),
+		},
+		{
+			name:                "unversioned client is treated as outdated",
+			kind:                types.KindKubernetesCluster,
+			expectedLoadSecrets: true,
+		},
+		{
+			name:                "unparsable version is treated outdated",
+			kind:                types.KindKubernetesCluster,
+			clientVersion:       "not-a-semver",
+			expectedLoadSecrets: true,
+		},
+		{
+			name:          "other kinds are untouched",
+			kind:          types.KindKubeServer,
+			clientVersion: "18.11.0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			if test.clientVersion != "" {
+				ctx = grpcmetadata.NewIncomingContext(ctx, grpcmetadata.Pairs(
+					metadata.VersionKey, test.clientVersion,
+				))
+			}
+
+			kind := types.WatchKind{Kind: test.kind}
+			applyLegacyWatchSecretsCompat(ctx, &kind)
+			require.Equal(t, test.expectedLoadSecrets, kind.LoadSecrets)
 		})
 	}
 }

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -1777,11 +1777,11 @@ func (f fakeChecker) CheckAccessToRule(context services.RuleContext, namespace s
 		return trace.AccessDenied("no allow rules for kind")
 	}
 
-	if !slices.Contains(verbs, verb) {
-		return trace.AccessDenied("verb %s not allowed", verb)
+	if slices.Contains(verbs, verb) || (verb == types.VerbReadNoSecrets && slices.Contains(verbs, types.VerbRead)) {
+		return nil
 	}
 
-	return nil
+	return trace.AccessDenied("verb %s not allowed", verb)
 }
 
 type envConfig struct {

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -128,7 +129,7 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 	// reading cache or backend if unauthorized.
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
-		&ruleCtx, types.KindBotInstance, types.VerbDelete,
+		&ruleCtx, types.KindBotInstance, scopedaccess.Delete,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -150,7 +151,7 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 			return checker.CheckAccessToRules(
 				&ruleCtx,
 				types.KindBotInstance,
-				types.VerbDelete,
+				scopedaccess.Delete,
 			)
 		},
 	); err != nil {
@@ -183,7 +184,7 @@ func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *pb.GetBotI
 	// reading cache or backend if unauthorized.
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
-		&ruleCtx, types.KindBotInstance, types.VerbReadNoSecrets,
+		&ruleCtx, types.KindBotInstance, scopedaccess.Read,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -201,7 +202,7 @@ func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *pb.GetBotI
 			return checker.CheckAccessToRules(
 				&ruleCtx,
 				types.KindBotInstance,
-				types.VerbReadNoSecrets,
+				scopedaccess.Read,
 			)
 		},
 	); err != nil {
@@ -251,7 +252,7 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 	// reading cache or backend if unauthorized.
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
-		&ruleCtx, types.KindBotInstance, types.VerbReadNoSecrets, types.VerbList,
+		&ruleCtx, types.KindBotInstance, scopedaccess.Read, scopedaccess.List,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -308,8 +309,8 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 						return checker.CheckAccessToRules(
 							&ruleCtx,
 							types.KindBotInstance,
-							types.VerbReadNoSecrets,
-							types.VerbList,
+							scopedaccess.Read,
+							scopedaccess.List,
 						)
 					},
 				)

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils/set"
@@ -187,7 +188,7 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 	// state backend.
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
-		&ruleCtx, types.KindBot, types.VerbReadNoSecrets,
+		&ruleCtx, types.KindBot, scopedaccess.Read,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -204,7 +205,7 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 	ruleCtx.Resource153 = bot
 	if err := authCtx.CheckerContext.Decision(
 		ctx, bot.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbReadNoSecrets)
+			return checker.CheckAccessToRules(&ruleCtx, types.KindBot, scopedaccess.Read)
 		},
 	); err != nil {
 		// Return NotFound rather than Forbidden to avoid leaking existence of
@@ -256,7 +257,7 @@ func (bs *BotService) ListBots(
 	// Check generally if this user may have the ability to list bots - ignoring
 	// where conditions.
 	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
-		&ruleCtx, types.KindBot, types.VerbList,
+		&ruleCtx, types.KindBot, scopedaccess.List,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -320,7 +321,7 @@ func (bs *BotService) ListBots(
 		ruleCtx := authCtx.RuleContext()
 		ruleCtx.Resource153 = bot
 		if err := authCtx.CheckerContext.Decision(ctx, bot.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbList)
+			return checker.CheckAccessToRules(&ruleCtx, types.KindBot, scopedaccess.List)
 		}); err != nil {
 			// Ignore resources the user cannot access.
 			continue
@@ -357,7 +358,7 @@ func (bs *BotService) CreateBot(
 	ruleCtx := authCtx.RuleContext()
 	ruleCtx.Resource153 = req.GetBot()
 	if err := authCtx.CheckerContext.Decision(ctx, req.GetBot().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbCreate)
+		return checker.CheckAccessToRules(&ruleCtx, types.KindBot, scopedaccess.Create)
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -588,7 +589,7 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 		req.GetBot().GetScope(),
 		func(checker *services.ScopedAccessChecker) error {
 			return checker.CheckAccessToRules(
-				&ruleCtx, types.KindBot, types.VerbCreate, types.VerbUpdate,
+				&ruleCtx, types.KindBot, scopedaccess.Create, scopedaccess.Update,
 			)
 		},
 	); err != nil {
@@ -839,7 +840,7 @@ func (bs *BotService) DeleteBot(
 	// Perform maybe-check before we hit the backend.
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
-		&ruleCtx, types.KindBot, types.VerbDelete,
+		&ruleCtx, types.KindBot, scopedaccess.Delete,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -855,7 +856,7 @@ func (bs *BotService) DeleteBot(
 
 	ruleCtx.Resource153 = dummyBotWithName(req.GetBotName())
 	if err := authCtx.CheckerContext.Decision(ctx, scope, func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, types.KindBot, types.VerbDelete)
+		return checker.CheckAccessToRules(&ruleCtx, types.KindBot, scopedaccess.Delete)
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -2052,7 +2052,7 @@ func TestGetBot(t *testing.T) {
 				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
-						Verbs:     []string{types.VerbReadNoSecrets},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read),
 						Resources: []string{types.KindBot},
 					}.Build(),
 				},
@@ -3300,7 +3300,7 @@ func TestBotInstanceService_GetBotInstance(t *testing.T) {
 				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted"},
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
-						Verbs:     []string{types.VerbReadNoSecrets},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read),
 						Resources: []string{types.KindBotInstance},
 					}.Build(),
 				},
@@ -3431,7 +3431,7 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 				AssignableScopes: []string{"/scopes/granted", "/scopes/ungranted", "/scopes/other"},
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List),
 						Resources: []string{types.KindBotInstance},
 					}.Build(),
 				},

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/jwt"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -241,7 +242,7 @@ func (s *IssuanceService) IssueWorkloadIdentity(
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.authorizeIssuance(ctx, authCtx, wi, types.VerbReadNoSecrets); err != nil {
+	if err := s.authorizeIssuance(ctx, authCtx, wi, scopedaccess.Read); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -331,7 +332,7 @@ func (s *IssuanceService) IssueWorkloadIdentities(
 	// /any/ workload identity at all.
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
-		&ruleCtx, types.KindWorkloadIdentity, types.VerbReadNoSecrets, types.VerbList,
+		&ruleCtx, types.KindWorkloadIdentity, scopedaccess.Read, scopedaccess.List,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1197,7 +1198,7 @@ func (s *IssuanceService) matchingAndAuthorizedWorkloadIdentities(
 
 			// Silently skip WI the caller is not authorized to issue using.
 			if err := s.authorizeIssuance(
-				ctx, authCtx, wid, types.VerbReadNoSecrets, types.VerbList,
+				ctx, authCtx, wid, scopedaccess.Read, scopedaccess.List,
 			); err != nil {
 				continue
 			}
@@ -1213,7 +1214,7 @@ func (s *IssuanceService) authorizeIssuance(
 	ctx context.Context,
 	authCtx *authz.ScopedContext,
 	wi *workloadidentityv1pb.WorkloadIdentity,
-	verbs ...string,
+	verbs ...scopedaccess.Verb,
 ) error {
 	ruleCtx := authCtx.RuleContext()
 	ruleCtx.Resource153 = wi

--- a/lib/auth/machineid/workloadidentityv1/resource_service.go
+++ b/lib/auth/machineid/workloadidentityv1/resource_service.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 )
@@ -128,7 +129,7 @@ func (s *ResourceService) GetWorkloadIdentity(
 	// cluster state backend.
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
-		&ruleCtx, types.KindWorkloadIdentity, types.VerbReadNoSecrets,
+		&ruleCtx, types.KindWorkloadIdentity, scopedaccess.Read,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -145,7 +146,7 @@ func (s *ResourceService) GetWorkloadIdentity(
 	ruleCtx.Resource153 = resource
 	if err := authCtx.CheckerContext.Decision(
 		ctx, resource.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, types.VerbReadNoSecrets)
+			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, scopedaccess.Read)
 		},
 	); err != nil {
 		// Return NotFound rather than AccessDenied to avoid leaking the
@@ -188,8 +189,8 @@ func (s *ResourceService) ListWorkloadIdentitiesV2(
 	if err := authCtx.CheckerContext.CheckMaybeHasAccessToRules(
 		new(authCtx.RuleContext()),
 		types.KindWorkloadIdentity,
-		types.VerbReadNoSecrets,
-		types.VerbList,
+		scopedaccess.Read,
+		scopedaccess.List,
 	); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -234,8 +235,8 @@ func (s *ResourceService) ListWorkloadIdentitiesV2(
 			return checker.CheckAccessToRules(
 				&ruleCtx,
 				types.KindWorkloadIdentity,
-				types.VerbReadNoSecrets,
-				types.VerbList,
+				scopedaccess.Read,
+				scopedaccess.List,
 			)
 		}); err != nil {
 			return nil, false
@@ -271,7 +272,7 @@ func (s *ResourceService) DeleteWorkloadIdentity(
 	ruleCtx := authCtx.RuleContext()
 	if err := authCtx.CheckerContext.Decision(
 		ctx, req.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, types.VerbDelete)
+			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, scopedaccess.Delete)
 		},
 	); err != nil {
 		return nil, trace.Wrap(err)
@@ -324,7 +325,7 @@ func (s *ResourceService) CreateWorkloadIdentity(
 	ruleCtx.Resource153 = req.GetWorkloadIdentity()
 	if err := authCtx.CheckerContext.Decision(
 		ctx, req.GetWorkloadIdentity().GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, types.VerbCreate)
+			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, scopedaccess.Create)
 		},
 	); err != nil {
 		return nil, trace.Wrap(err)
@@ -393,7 +394,7 @@ func (s *ResourceService) UpdateWorkloadIdentity(
 	ruleCtx.Resource153 = req.GetWorkloadIdentity()
 	if err := authCtx.CheckerContext.Decision(
 		ctx, req.GetWorkloadIdentity().GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, types.VerbUpdate)
+			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, scopedaccess.Update)
 		},
 	); err != nil {
 		return nil, trace.Wrap(err)
@@ -462,7 +463,7 @@ func (s *ResourceService) UpsertWorkloadIdentity(
 	ruleCtx.Resource153 = req.GetWorkloadIdentity()
 	if err := authCtx.CheckerContext.Decision(
 		ctx, req.GetWorkloadIdentity().GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, types.VerbCreate, types.VerbUpdate)
+			return checker.CheckAccessToRules(&ruleCtx, types.KindWorkloadIdentity, scopedaccess.Create, scopedaccess.Update)
 		},
 	); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -682,7 +682,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 	// the same scope. Issuance requires a single role to hold both grants.
 	splitRulesRole := createScopedWorkloadIdentityRole(
 		t, adminClient, "split-rules-role", scopedScope,
-		[]string{types.VerbReadNoSecrets, types.VerbList}, nil,
+		scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List), nil,
 	)
 	splitLabelsRole := createScopedWorkloadIdentityRole(
 		t, adminClient, "split-labels-role", scopedScope,
@@ -2176,7 +2176,7 @@ func TestResourceService_CreateWorkloadIdentity(t *testing.T) {
 	t.Cleanup(func() { _ = adminClient.Close() })
 	const grantedScope = "/scopes/granted"
 	const otherScope = "/scopes/other"
-	scopedCreator := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-creator", grantedScope, types.VerbCreate)
+	scopedCreator := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-creator", grantedScope, scopedaccess.Create)
 	scopedCreatorClient, err := srv.NewClient(authtest.TestScopedUser(scopedCreator, grantedScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = scopedCreatorClient.Close() })
@@ -2440,11 +2440,11 @@ func TestResourceService_DeleteWorkloadIdentity(t *testing.T) {
 	t.Cleanup(func() { _ = adminClient.Close() })
 	const grantedScope = "/scopes/granted"
 	const otherScope = "/scopes/other"
-	grantedDeleter := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-delete-granted", grantedScope, types.VerbDelete)
+	grantedDeleter := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-delete-granted", grantedScope, scopedaccess.Delete)
 	grantedClient, err := srv.NewClient(authtest.TestScopedUser(grantedDeleter, grantedScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = grantedClient.Close() })
-	otherDeleter := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-delete-other", otherScope, types.VerbDelete)
+	otherDeleter := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-delete-other", otherScope, scopedaccess.Delete)
 	otherClient, err := srv.NewClient(authtest.TestScopedUser(otherDeleter, otherScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = otherClient.Close() })
@@ -2621,11 +2621,11 @@ func TestResourceService_GetWorkloadIdentity(t *testing.T) {
 	t.Cleanup(func() { _ = adminClient.Close() })
 	const grantedScope = "/scopes/granted"
 	const otherScope = "/scopes/other"
-	grantedReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-get-granted", grantedScope, types.VerbReadNoSecrets, types.VerbList)
+	grantedReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-get-granted", grantedScope, scopedaccess.Read, scopedaccess.List)
 	grantedClient, err := srv.NewClient(authtest.TestScopedUser(grantedReader, grantedScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = grantedClient.Close() })
-	otherReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-get-other", otherScope, types.VerbReadNoSecrets, types.VerbList)
+	otherReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-get-other", otherScope, scopedaccess.Read, scopedaccess.List)
 	otherClient, err := srv.NewClient(authtest.TestScopedUser(otherReader, otherScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = otherClient.Close() })
@@ -2800,11 +2800,11 @@ func TestResourceService_ListWorkloadIdentities(t *testing.T) {
 	t.Cleanup(func() { _ = adminClient.Close() })
 	const grantedScope = "/scopes/granted"
 	const otherScope = "/scopes/other"
-	grantedReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-list-granted", grantedScope, types.VerbReadNoSecrets, types.VerbList)
+	grantedReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-list-granted", grantedScope, scopedaccess.Read, scopedaccess.List)
 	grantedClient, err := srv.NewClient(authtest.TestScopedUser(grantedReader, grantedScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = grantedClient.Close() })
-	otherReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-list-other", otherScope, types.VerbReadNoSecrets, types.VerbList)
+	otherReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-list-other", otherScope, scopedaccess.Read, scopedaccess.List)
 	otherClient, err := srv.NewClient(authtest.TestScopedUser(otherReader, otherScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = otherClient.Close() })
@@ -2996,7 +2996,7 @@ func TestResourceService_ListWorkloadIdentitiesScopeFilter(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = adminClient.Close() })
 
-	scopedReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scope-filter-scoped", grantedScope, types.VerbReadNoSecrets, types.VerbList)
+	scopedReader := newScopedWorkloadIdentityUser(t, srv, adminClient, "scope-filter-scoped", grantedScope, scopedaccess.Read, scopedaccess.List)
 	scopedClient, err := srv.NewClient(authtest.TestScopedUser(scopedReader, grantedScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = scopedClient.Close() })
@@ -3178,11 +3178,11 @@ func TestResourceService_UpdateWorkloadIdentity(t *testing.T) {
 	t.Cleanup(func() { _ = adminClient.Close() })
 	const grantedScope = "/scopes/granted"
 	const otherScope = "/scopes/other"
-	grantedUpdater := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-update-granted", grantedScope, types.VerbUpdate)
+	grantedUpdater := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-update-granted", grantedScope, scopedaccess.Update)
 	grantedClient, err := srv.NewClient(authtest.TestScopedUser(grantedUpdater, grantedScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = grantedClient.Close() })
-	otherUpdater := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-update-other", otherScope, types.VerbUpdate)
+	otherUpdater := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-update-other", otherScope, scopedaccess.Update)
 	otherClient, err := srv.NewClient(authtest.TestScopedUser(otherUpdater, otherScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = otherClient.Close() })
@@ -3379,7 +3379,7 @@ func TestResourceService_UpsertWorkloadIdentity(t *testing.T) {
 	t.Cleanup(func() { _ = adminClient.Close() })
 	const grantedScope = "/scopes/granted"
 	const otherScope = "/scopes/other"
-	scopedUpserter := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-upserter", grantedScope, types.VerbCreate, types.VerbUpdate)
+	scopedUpserter := newScopedWorkloadIdentityUser(t, srv, adminClient, "scoped-upserter", grantedScope, scopedaccess.Create, scopedaccess.Update)
 	scopedUpserterClient, err := srv.NewClient(authtest.TestScopedUser(scopedUpserter, grantedScope))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = scopedUpserterClient.Close() })
@@ -4765,7 +4765,7 @@ func newScopedWorkloadIdentityUser(
 	adminClient *authclient.Client,
 	username string,
 	scope string,
-	verbs ...string,
+	verbs ...scopedaccess.Verb,
 ) string {
 	t.Helper()
 	ctx := t.Context()
@@ -4784,7 +4784,7 @@ func newScopedWorkloadIdentityUser(
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{types.KindWorkloadIdentity},
-						Verbs:     verbs,
+						Verbs:     scopedaccess.EncodeScopedVerbs(verbs...),
 					}.Build(),
 				},
 			}.Build(),
@@ -4979,7 +4979,7 @@ func newScopedWorkloadIdentityIssuer(
 	t.Helper()
 	role := createScopedWorkloadIdentityRole(
 		t, adminClient, username+"-role", scope,
-		[]string{types.VerbReadNoSecrets, types.VerbList}, labels,
+		scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List), labels,
 	)
 	return createScopedWorkloadIdentityUser(t, srv, adminClient, username, scope, role)
 }

--- a/lib/auth/presence/presencev1/service.go
+++ b/lib/auth/presence/presencev1/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
@@ -374,7 +375,7 @@ func (s *Service) DeleteAppServer(
 	ruleCtx := authzCtx.RuleContext()
 	if err := authzCtx.CheckerContext.Decision(ctx, req.GetScope(), func(checker *services.ScopedAccessChecker) error {
 		if err := authzCtx.AgentOwnedResourceAction(req.GetScope(), req.GetHostId(), types.RoleApp); err != nil {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindAppServer, types.VerbDelete)
+			return checker.CheckAccessToRules(&ruleCtx, types.KindAppServer, scopedaccess.Delete)
 		}
 		return nil
 	}); err != nil {
@@ -687,8 +688,13 @@ func (s *Service) GetKubeCluster(ctx context.Context, req *presencepb.GetKubeClu
 		return nil, trace.Wrap(err)
 	}
 
+	verb := scopedaccess.Read
+	if req.GetWithSecrets() {
+		verb = scopedaccess.Secrets
+	}
+
 	ruleCtx := authContext.RuleContext()
-	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead); err != nil {
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, verb); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -698,7 +704,7 @@ func (s *Service) GetKubeCluster(ctx context.Context, req *presencepb.GetKubeClu
 	}
 
 	if err := authContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead); err != nil {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, verb); err != nil {
 			return err
 		}
 		return checker.Kube().CanAccessCluster(cluster)
@@ -729,8 +735,13 @@ func (s *Service) ListKubeClusters(ctx context.Context, req *presencepb.ListKube
 		return nil, trace.Wrap(err)
 	}
 
+	verb := scopedaccess.Read
+	if req.GetWithSecrets() {
+		verb = scopedaccess.Secrets
+	}
+
 	ruleCtx := authContext.RuleContext()
-	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead, types.VerbList); err != nil {
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, verb, scopedaccess.List); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -743,7 +754,7 @@ func (s *Service) ListKubeClusters(ctx context.Context, req *presencepb.ListKube
 			func(cluster types.KubeCluster) (*types.KubernetesClusterV3, bool) {
 				// Filter out kube clusters user doesn't have access to.
 				if err := authContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-					if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbRead, types.VerbList); err != nil {
+					if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, verb, scopedaccess.List); err != nil {
 						return err
 					}
 					return checker.Kube().CanAccessCluster(cluster)
@@ -775,7 +786,7 @@ func (s *Service) DeleteKubeCluster(ctx context.Context, req *presencepb.DeleteK
 	}
 
 	ruleCtx := authContext.RuleContext()
-	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbDelete); err != nil {
+	if err := authContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Delete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -788,7 +799,7 @@ func (s *Service) DeleteKubeCluster(ctx context.Context, req *presencepb.DeleteK
 		return nil, trace.Wrap(err)
 	}
 	if err := authContext.CheckerContext.Decision(ctx, cluster.GetScope(), func(checker *services.ScopedAccessChecker) error {
-		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, types.VerbDelete); err != nil {
+		if err := checker.CheckAccessToRules(&ruleCtx, types.KindKubernetesCluster, scopedaccess.Delete); err != nil {
 			return err
 		}
 		return checker.Kube().CanAccessCluster(cluster)
@@ -840,7 +851,7 @@ func (s *Service) DeleteKubeServer(
 		if err := authzCtx.AgentOwnedResourceAction(req.GetScope(), req.GetHostId(), types.RoleKube); err == nil {
 			return nil
 		}
-		return checker.CheckAccessToRules(&ruleCtx, types.KindKubeServer, types.VerbDelete)
+		return checker.CheckAccessToRules(&ruleCtx, types.KindKubeServer, scopedaccess.Delete)
 	}); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/presence/presencev1/service_kube_test.go
+++ b/lib/auth/presence/presencev1/service_kube_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -458,4 +459,287 @@ func newKubeCluster(t *testing.T, srv *auth.Server, scope, name string, labels m
 	require.NoError(t, err)
 
 	return res
+}
+
+// TestKubeClusterWithSecrets verifies the behavior of the with_secrets flag.
+func TestKubeClusterWithSecrets(t *testing.T) {
+	t.Parallel()
+	srv := newTestTLSServer(t)
+
+	user, _, err := authtest.CreateUserAndRole(
+		srv.Auth(),
+		"kube-reader",
+		[]string{},
+		[]types.Rule{
+			{
+				Resources: []string{types.KindKubernetesCluster},
+				Verbs:     []string{types.VerbRead, types.VerbList},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	const kubeconfig = "kubeconfig-payload"
+	cluster, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name:   "dynamic-cluster",
+		Labels: map[string]string{"env": "test"},
+	}, types.KubernetesClusterSpecV3{
+		Kubeconfig: []byte(kubeconfig),
+	})
+	require.NoError(t, err)
+	require.NoError(t, srv.Auth().CreateKubernetesCluster(t.Context(), cluster))
+
+	client, err := srv.NewClient(authtest.TestUser(user.GetName()))
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+
+	t.Run("GetKubeCluster omits the kubeconfig by default", func(t *testing.T) {
+		got, err := client.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
+			Name: "dynamic-cluster",
+		}.Build())
+		require.NoError(t, err)
+		require.Empty(t, got.GetKubeconfig())
+		// the rest of the resource is still there.
+		require.Equal(t, "dynamic-cluster", got.GetName())
+		require.Equal(t, "test", got.GetAllLabels()["env"])
+	})
+
+	t.Run("GetKubeCluster returns the kubeconfig with_secrets", func(t *testing.T) {
+		got, err := client.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
+			Name:        "dynamic-cluster",
+			WithSecrets: true,
+		}.Build())
+		require.NoError(t, err)
+		require.Equal(t, kubeconfig, string(got.GetKubeconfig()))
+	})
+
+	t.Run("ListKubeClusters omits the kubeconfig by default", func(t *testing.T) {
+		got, _, err := client.ListKubeClusters(t.Context(), presencev1pb.ListKubeClustersRequest_builder{}.Build())
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		for _, c := range got {
+			require.Empty(t, c.GetKubeconfig(), "cluster %q", c.GetName())
+		}
+	})
+
+	t.Run("ListKubeClusters returns kubeconfigs with_secrets", func(t *testing.T) {
+		got, _, err := client.ListKubeClusters(t.Context(), presencev1pb.ListKubeClustersRequest_builder{
+			WithSecrets: true,
+		}.Build())
+		require.NoError(t, err)
+		found := false
+		for _, c := range got {
+			if c.GetName() == "dynamic-cluster" {
+				require.Equal(t, kubeconfig, string(c.GetKubeconfig()))
+				found = true
+			}
+		}
+		require.True(t, found, "expected to find dynamic-cluster in %v", got)
+	})
+
+	// The methods below are the ones outdated clients reach. They predate with_secrets and must
+	// always be secrets-inclusive.
+	t.Run("legacy GetKubernetesCluster is secret-inclusive", func(t *testing.T) {
+		//nolint:staticcheck // deliberately exercising the deprecated compatibility path
+		got, err := client.GetKubernetesCluster(t.Context(), "dynamic-cluster")
+		require.NoError(t, err)
+		require.Equal(t, kubeconfig, string(got.GetKubeconfig()))
+	})
+
+	t.Run("legacy ListKubernetesClusters is secret-inclusive", func(t *testing.T) {
+		//nolint:staticcheck // deliberately exercising the deprecated compatibility path
+		got, _, err := client.ListKubernetesClusters(t.Context(), 0, "")
+		require.NoError(t, err)
+		found := false
+		for _, c := range got {
+			if c.GetName() == "dynamic-cluster" {
+				require.Equal(t, kubeconfig, string(c.GetKubeconfig()))
+				found = true
+			}
+		}
+		require.True(t, found, "expected to find dynamic-cluster in %v", got)
+	})
+
+	t.Run("legacy GetKubernetesClusters is secret-inclusive", func(t *testing.T) {
+		//nolint:staticcheck // deliberately exercising the deprecated compatibility path
+		got, err := client.GetKubernetesClusters(t.Context())
+		require.NoError(t, err)
+		found := false
+		for _, c := range got {
+			if c.GetName() == "dynamic-cluster" {
+				require.Equal(t, kubeconfig, string(c.GetKubeconfig()))
+				found = true
+			}
+		}
+		require.True(t, found, "expected to find dynamic-cluster in %v", got)
+	})
+}
+
+// TestScopedKubeClusterWithSecretsAuthz verifies that a scoped identity must hold the
+// `secrets` verb to retrieve a kube cluster's kubeconfig, and that holding only `read` still permits
+// the censored read.
+func TestScopedKubeClusterWithSecretsAuthz(t *testing.T) {
+	t.Parallel()
+	srv := newTestTLSServer(t)
+
+	const (
+		parentScope = "/aa"
+		scope       = "/aa/aa"
+		kubeconfig  = "kubeconfig-payload"
+	)
+
+	createScopedRole := func(name string, verbs []string) *scopedaccessv1.ScopedRole {
+		rsp, err := srv.Auth().ScopedAccess().CreateScopedRole(t.Context(), scopedaccessv1.CreateScopedRoleRequest_builder{
+			Role: scopedaccessv1.ScopedRole_builder{
+				Kind:    scopedaccess.KindScopedRole,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: name,
+				}.Build(),
+				Scope: parentScope,
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{scope},
+					// the kube block is required for the CanAccessCluster checks.
+					Kube: scopedaccessv1.ScopedRoleKube_builder{
+						Labels: []*labelv1.Label{
+							labelv1.Label_builder{
+								Name:   types.Wildcard,
+								Values: []string{types.Wildcard},
+							}.Build(),
+						},
+						Resources: []*scopedaccessv1.KubeResource{
+							scopedaccessv1.KubeResource_builder{
+								Kind:      types.Wildcard,
+								Name:      types.Wildcard,
+								Namespace: types.Wildcard,
+								ApiGroup:  types.Wildcard,
+								Verbs:     []string{types.Wildcard},
+							}.Build(),
+						},
+					}.Build(),
+					Rules: []*scopedaccessv1.ScopedRule{
+						scopedaccessv1.ScopedRule_builder{
+							Resources: []string{types.KindKubernetesCluster},
+							Verbs:     verbs,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		return rsp.GetRole()
+	}
+
+	createUserWithScopedRole := func(username string, verbs []string) *authclient.Client {
+		user, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{}, nil)
+		require.NoError(t, err)
+
+		role := createScopedRole(username+"-role", verbs)
+		sra, err := srv.Auth().ScopedAccess().CreateScopedRoleAssignment(t.Context(), scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+				Kind:    scopedaccess.KindScopedRoleAssignment,
+				SubKind: scopedaccess.SubKindDynamic,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: uuid.NewString(),
+				}.Build(),
+				Scope: scope,
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					User: user.GetName(),
+					Assignments: []*scopedaccessv1.Assignment{
+						scopedaccessv1.Assignment_builder{
+							Role:  scopes.QualifiedName{Scope: parentScope, Name: role.GetMetadata().GetName()}.String(),
+							Scope: scope,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		waitForSRACache(t, srv, sra.GetAssignment())
+
+		client, err := srv.NewClient(authtest.TestScopedUser(user.GetName(), scope))
+		require.NoError(t, err)
+		t.Cleanup(func() { client.Close() })
+		return client
+	}
+
+	// a scoped identity granted the secret-exclusive read verb.
+	readClient := createUserWithScopedRole("scoped-reader", []string{
+		scopedaccess.List.String(), scopedaccess.Read.String(),
+	})
+	// a scoped identity that additionally opted in to secret material.
+	secretsClient := createUserWithScopedRole("scoped-secrets", []string{
+		scopedaccess.List.String(), scopedaccess.Read.String(), scopedaccess.Secrets.String(),
+	})
+
+	cluster, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name:   "dynamic-cluster",
+		Labels: map[string]string{"env": "test"},
+	}, types.KubernetesClusterSpecV3{
+		Kubeconfig: []byte(kubeconfig),
+	}, types.KubeClusterWithScope(scope))
+	require.NoError(t, err)
+	require.NoError(t, srv.Auth().CreateKubernetesCluster(t.Context(), cluster))
+
+	t.Run("read verb permits the censored read", func(t *testing.T) {
+		got, err := readClient.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
+			Scope: scope,
+			Name:  "dynamic-cluster",
+		}.Build())
+		require.NoError(t, err)
+		require.Empty(t, got.GetKubeconfig())
+		require.Equal(t, "dynamic-cluster", got.GetName())
+	})
+
+	t.Run("read verb is denied with_secrets", func(t *testing.T) {
+		_, err := readClient.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
+			Scope:       scope,
+			Name:        "dynamic-cluster",
+			WithSecrets: true,
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+	})
+
+	t.Run("secrets verb permits with_secrets", func(t *testing.T) {
+		got, err := secretsClient.GetKubeCluster(t.Context(), presencev1pb.GetKubeClusterRequest_builder{
+			Scope:       scope,
+			Name:        "dynamic-cluster",
+			WithSecrets: true,
+		}.Build())
+		require.NoError(t, err)
+		require.Equal(t, kubeconfig, string(got.GetKubeconfig()))
+	})
+
+	t.Run("list is censored without the secrets verb", func(t *testing.T) {
+		got, _, err := readClient.ListKubeClusters(t.Context(), presencev1pb.ListKubeClustersRequest_builder{
+			ScopeFilter: scopesv1.Filter_builder{Scope: scope, Mode: scopesv1.Mode_MODE_EXACT}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
+		for _, c := range got {
+			require.Empty(t, c.GetKubeconfig(), "cluster %q", c.GetName())
+		}
+	})
+
+	// a quirk of how scoped access works is that one can have a mix of secret-inclusive and secret-exclusive permissions
+	// for different scopes.  As such we must filter instead of blanket deny when the with_secrets flag is set.
+	t.Run("with_secrets list filters rather than denying", func(t *testing.T) {
+		got, _, err := readClient.ListKubeClusters(t.Context(), presencev1pb.ListKubeClustersRequest_builder{
+			ScopeFilter: scopesv1.Filter_builder{Scope: scope, Mode: scopesv1.Mode_MODE_EXACT}.Build(),
+			WithSecrets: true,
+		}.Build())
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("secrets verb permits a with_secrets list", func(t *testing.T) {
+		got, _, err := secretsClient.ListKubeClusters(t.Context(), presencev1pb.ListKubeClustersRequest_builder{
+			ScopeFilter: scopesv1.Filter_builder{Scope: scope, Mode: scopesv1.Mode_MODE_EXACT}.Build(),
+			WithSecrets: true,
+		}.Build())
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, kubeconfig, string(got[0].GetKubeconfig()))
+	})
 }

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/teleport"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
@@ -103,7 +102,7 @@ func (s *Server) CreateScopedRole(ctx context.Context, req *scopedaccessv1.Creat
 	ruleCtx := authzContext.RuleContext()
 
 	if err := authzContext.CheckerContext.Decision(ctx, req.GetRole().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbCreate)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, scopedaccess.Create)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped roles in the requested scope",
 			"user", authzContext.DisplayName(),
@@ -130,7 +129,7 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 	ruleCtx := authzContext.RuleContext()
 
 	// do a pre-check to weed out requests that definitely won't be authorized.
-	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbCreate); err != nil {
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Create); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -155,7 +154,7 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 	}
 
 	if err := authzContext.CheckerContext.Decision(ctx, req.GetAssignment().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbCreate)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Create)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped role assignments in the requested scope",
 			"user", authzContext.DisplayName(),
@@ -181,7 +180,7 @@ func (s *Server) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.Delet
 	// and perform an unconditional delete. this is not strictly necessary, but allows us to
 	// have an escape hatch for deleting roles that are so malformed that they cannot be read.
 	if err := authzContext.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbDelete)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, scopedaccess.Delete)
 	}); err == nil {
 		return s.cfg.Writer.DeleteScopedRole(ctx, req)
 	}
@@ -203,7 +202,7 @@ func (s *Server) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.Delet
 
 	// evaluate the access to the role based on its scope
 	if err := authzContext.CheckerContext.Decision(ctx, grsp.GetRole().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbDelete)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, scopedaccess.Delete)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete scoped roles in the requested scope",
 			"user", authzContext.DisplayName(),
@@ -236,7 +235,7 @@ func (s *Server) DeleteScopedRoleAssignment(ctx context.Context, req *scopedacce
 	// and perform an unconditional delete. this is not strictly necessary, but allows us to
 	// have an escape hatch for deleting assignments that are so malformed that they cannot be read.
 	if err := authzContext.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbDelete)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Delete)
 	}); err == nil {
 		return s.cfg.Writer.DeleteScopedRoleAssignment(ctx, req)
 	}
@@ -259,7 +258,7 @@ func (s *Server) DeleteScopedRoleAssignment(ctx context.Context, req *scopedacce
 
 	// evaluate the access to the assignment based on its scope
 	if err := authzContext.CheckerContext.Decision(ctx, grsp.GetAssignment().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbDelete)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Delete)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete scoped role assignments in the requested scope",
 			"user", authzContext.DisplayName(),
@@ -289,7 +288,7 @@ func (s *Server) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScope
 	ruleCtx := authzContext.RuleContext()
 
 	// do a pre-check to weed out requests that definitely won't be authorized.
-	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets); err != nil {
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, scopedaccess.Read); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -308,7 +307,7 @@ func (s *Server) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScope
 			preAuthzRsp.GetRole().GetScope())
 	} else {
 		err = authzContext.CheckerContext.Decision(ctx, preAuthzRsp.GetRole().GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets)
+			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, scopedaccess.Read)
 		})
 	}
 	if err != nil {
@@ -340,7 +339,7 @@ func (s *Server) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv
 	ruleCtx := authzContext.RuleContext()
 
 	// do a pre-check to weed out requests that definitely won't be authorized.
-	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets); err != nil {
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Read); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -352,7 +351,7 @@ func (s *Server) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv
 
 	// evaluate the access to the assignment based on its scope
 	if err := authzContext.CheckerContext.Decision(ctx, preAuthzRsp.GetAssignment().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Read)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to read scoped role assignment",
 			"user", authzContext.DisplayName(),
@@ -394,7 +393,7 @@ func (s *Server) ListScopedRoleAssignments(ctx context.Context, req *scopedacces
 		req.SetUser(authzContext.User.GetName())
 	} else {
 		// do a pre-check to weed out requests that definitely won't be authorized.
-		if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets, types.VerbList); err != nil {
+		if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Read, scopedaccess.List); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -412,7 +411,7 @@ func (s *Server) ListScopedRoleAssignments(ctx context.Context, req *scopedacces
 			return authzContext.User.GetName() == assignment.GetSpec().GetUser()
 		}
 		err := authzContext.CheckerContext.Decision(ctx, assignment.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets, types.VerbList)
+			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Read, scopedaccess.List)
 		})
 		return err == nil
 	})
@@ -433,7 +432,7 @@ func (s *Server) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListSc
 	ruleCtx := authzContext.RuleContext()
 
 	// do a pre-check to weed out requests that definitely won't be authorized.
-	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets, types.VerbList); err != nil {
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, scopedaccess.Read, scopedaccess.List); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -449,7 +448,7 @@ func (s *Server) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListSc
 	// list scoped roles with a filter that only passes roles the user has access to.
 	rsp, err := s.cfg.Reader.ListScopedRolesWithFilter(ctx, req, func(role *scopedaccessv1.ScopedRole) bool {
 		err := authzContext.CheckerContext.Decision(ctx, role.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets, types.VerbList)
+			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, scopedaccess.Read, scopedaccess.List)
 		})
 		return err == nil
 	})
@@ -475,7 +474,7 @@ func (s *Server) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.Updat
 	// the sanity of this check is dependent on the invariant enforced by the backend that updates cannot change
 	// resource scope.
 	if err := authzContext.CheckerContext.Decision(ctx, req.GetRole().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbUpdate)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, scopedaccess.Update)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to update scoped roles in the requested scope",
 			"user", authzContext.DisplayName(),
@@ -504,7 +503,7 @@ func (s *Server) UpdateScopedRoleAssignment(ctx context.Context, req *scopedacce
 	// the sanity of this check is dependent on the invariant enforced by the backend that updates cannot change
 	// resource scope.
 	if err := authzContext.CheckerContext.Decision(ctx, req.GetAssignment().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbUpdate)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Update)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to update scoped role assignments in the requested scope",
 			"user", authzContext.DisplayName(),
@@ -536,7 +535,7 @@ func (s *Server) UpsertScopedRole(ctx context.Context, req *scopedaccessv1.Upser
 	ruleCtx := authzContext.RuleContext()
 
 	if err := authzContext.CheckerContext.Decision(ctx, req.GetRole().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbCreate, types.VerbUpdate)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, scopedaccess.Create, scopedaccess.Update)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to upsert scoped roles in the requested scope",
 			"user", authzContext.DisplayName(),
@@ -561,7 +560,7 @@ func (s *Server) UpsertScopedRoleAssignment(ctx context.Context, req *scopedacce
 	ruleCtx := authzContext.RuleContext()
 
 	if err := authzContext.CheckerContext.Decision(ctx, req.GetAssignment().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbCreate, types.VerbUpdate)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, scopedaccess.Create, scopedaccess.Update)
 	}); err != nil {
 		s.cfg.Logger.WarnContext(ctx, "user does not have permission to upsert scoped role assignments in the requested scope",
 			"user", authzContext.DisplayName(),

--- a/lib/auth/scopes/access/service_test.go
+++ b/lib/auth/scopes/access/service_test.go
@@ -178,7 +178,7 @@ func TestGetScopedRoleAgentReadsAncestorScope(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole},
-						Verbs:     []string{types.VerbReadNoSecrets},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read),
 					}.Build(),
 				},
 			}.Build(),
@@ -281,7 +281,7 @@ func TestRoleBasics(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List, scopedaccess.Create, scopedaccess.Update, scopedaccess.Delete),
 					}.Build(),
 				},
 			}.Build(),
@@ -298,7 +298,7 @@ func TestRoleBasics(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List, scopedaccess.Create, scopedaccess.Update, scopedaccess.Delete),
 					}.Build(),
 				},
 			}.Build(),
@@ -371,7 +371,7 @@ func TestRoleBasics(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List),
 					}.Build(),
 				},
 			}.Build(),
@@ -399,7 +399,7 @@ func TestRoleBasics(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List),
 					}.Build(),
 				},
 			}.Build(),
@@ -603,7 +603,7 @@ func TestAssignmentBasics(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List, scopedaccess.Create, scopedaccess.Update, scopedaccess.Delete),
 					}.Build(),
 				},
 			}.Build(),
@@ -620,7 +620,7 @@ func TestAssignmentBasics(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List, scopedaccess.Create, scopedaccess.Update, scopedaccess.Delete),
 					}.Build(),
 				},
 			}.Build(),
@@ -1255,7 +1255,7 @@ func TestAccessChecksSkipInconsistentAssignments(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List),
 					}.Build(),
 				},
 			}.Build(),
@@ -1272,7 +1272,7 @@ func TestAccessChecksSkipInconsistentAssignments(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List, scopedaccess.Create, scopedaccess.Update, scopedaccess.Delete),
 					}.Build(),
 				},
 			}.Build(),
@@ -1424,7 +1424,7 @@ func TestListScopedRolesFilterDefaulting(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{scopedaccess.KindScopedRole},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List),
 					}.Build(),
 				},
 			}.Build(),

--- a/lib/auth/scopes/joining/service.go
+++ b/lib/auth/scopes/joining/service.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gravitational/teleport"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
-	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
@@ -104,7 +103,7 @@ func (s *Server) CreateScopedToken(ctx context.Context, req *scopedjoiningv1.Cre
 	}()
 	ruleCtx := authzContext.RuleContext()
 	if err := authzContext.CheckerContext.Decision(ctx, req.GetToken().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbCreate)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, scopedaccess.Create)
 	}); err != nil {
 		s.logger.WarnContext(ctx, "user does not have permission to create scoped tokens in the requested scope", "user", authzContext.User.GetName(), "scope", req.GetToken().GetScope())
 		return nil, trace.Wrap(err)
@@ -141,7 +140,7 @@ func (s *Server) DeleteScopedToken(ctx context.Context, req *scopedjoiningv1.Del
 	// and perform an unconditional delete. this is not strictly necessary, but allows us to
 	// have an escape hatch for deleting tokens that are so malformed that they cannot be read.
 	if err := authzContext.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbDelete)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, scopedaccess.Delete)
 	}); err == nil {
 		res, err := s.backend.DeleteScopedToken(ctx, req)
 		if err != nil {
@@ -162,7 +161,7 @@ func (s *Server) DeleteScopedToken(ctx context.Context, req *scopedjoiningv1.Del
 	// capture token to be used in deferred event emission
 	tokenForEvent = preAuthzRes.GetToken()
 	if err := authzContext.CheckerContext.Decision(ctx, preAuthzRes.GetToken().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbDelete)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, scopedaccess.Delete)
 	}); err != nil {
 		s.logger.WarnContext(ctx, "user does not have permission to delete scoped tokens in the requested scope", "user", authzContext.User.GetName(), "scope", preAuthzRes.GetToken().GetScope())
 		return nil, trace.Wrap(err)
@@ -183,9 +182,9 @@ func (s *Server) GetScopedToken(ctx context.Context, req *scopedjoiningv1.GetSco
 		return nil, trace.Wrap(err)
 	}
 
-	readVerb := types.VerbReadNoSecrets
+	readVerb := scopedaccess.Read
 	if req.GetWithSecret() {
-		readVerb = types.VerbRead
+		readVerb = scopedaccess.Secrets
 	}
 
 	ruleCtx := authzContext.RuleContext()
@@ -260,13 +259,13 @@ func (s *Server) ListScopedTokens(ctx context.Context, req *scopedjoiningv1.List
 		return nil, trace.Wrap(err)
 	}
 
-	readVerb := types.VerbReadNoSecrets
+	readVerb := scopedaccess.Read
 	if req.GetWithSecrets() {
-		readVerb = types.VerbRead
+		readVerb = scopedaccess.Secrets
 	}
 
 	ruleCtx := authzContext.RuleContext()
-	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, readVerb, types.VerbList); err != nil {
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, readVerb, scopedaccess.List); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -285,7 +284,7 @@ func (s *Server) ListScopedTokens(ctx context.Context, req *scopedjoiningv1.List
 		}
 
 		if err := authzContext.CheckerContext.Decision(ctx, token.GetScope(), func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, readVerb, types.VerbList)
+			return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, readVerb, scopedaccess.List)
 		}); err != nil {
 			continue
 		}
@@ -324,7 +323,7 @@ func (s *Server) UpsertScopedToken(ctx context.Context, req *scopedjoiningv1.Ups
 	// We rely on the backend guarantee that scoped tokens updates won't overwrite an existing token if it has a different scope, usage mode, or secret.
 	ruleCtx := authzContext.RuleContext()
 	if err := authzContext.CheckerContext.Decision(ctx, req.GetToken().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbUpdate, types.VerbCreate)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, scopedaccess.Update, scopedaccess.Create)
 	}); err != nil {
 		s.logger.WarnContext(ctx, "user does not have permission to upsert scoped tokens in the requested scope", "user", authzContext.User.GetName(), "scope", req.GetToken().GetScope())
 		return nil, trace.Wrap(err)
@@ -354,7 +353,7 @@ func (s *Server) UpdateScopedToken(ctx context.Context, req *scopedjoiningv1.Upd
 	ruleCtx := authzContext.RuleContext()
 
 	// do a pre-check to weed out requests that definitely won't be authorized.
-	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbUpdate); err != nil {
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, scopedaccess.Update); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -371,7 +370,7 @@ func (s *Server) UpdateScopedToken(ctx context.Context, req *scopedjoiningv1.Upd
 	}
 
 	if err := authzContext.CheckerContext.Decision(ctx, req.GetToken().GetScope(), func(checker *services.ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbUpdate)
+		return checker.CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, scopedaccess.Update)
 	}); err != nil {
 		s.logger.WarnContext(ctx, "user does not have permission to update scoped tokens in the requested scope", "user", authzContext.User.GetName(), "scope", req.GetToken().GetScope())
 		return nil, trace.Wrap(err)

--- a/lib/auth/scopes/joining/service_test.go
+++ b/lib/auth/scopes/joining/service_test.go
@@ -650,7 +650,7 @@ func newBackendPack(t *testing.T) *backendPack {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{types.KindScopedToken},
-						Verbs:     []string{types.VerbCreate, types.VerbRead, types.VerbList, types.VerbDelete, types.VerbUpdate},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Create, scopedaccess.Read, scopedaccess.Secrets, scopedaccess.List, scopedaccess.Delete, scopedaccess.Update),
 					}.Build(),
 				},
 			}.Build(),
@@ -666,7 +666,7 @@ func newBackendPack(t *testing.T) *backendPack {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{types.KindScopedToken},
-						Verbs:     []string{types.VerbCreate},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Create),
 					}.Build(),
 				},
 			}.Build(),
@@ -682,7 +682,7 @@ func newBackendPack(t *testing.T) *backendPack {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{types.KindScopedToken},
-						Verbs:     []string{types.VerbRead, types.VerbList},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.Secrets, scopedaccess.List),
 					}.Build(),
 				},
 			}.Build(),
@@ -698,7 +698,7 @@ func newBackendPack(t *testing.T) *backendPack {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{types.KindScopedToken},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List),
 					}.Build(),
 				},
 			}.Build(),
@@ -714,7 +714,7 @@ func newBackendPack(t *testing.T) *backendPack {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{types.KindScopedToken},
-						Verbs:     []string{types.VerbDelete},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Delete),
 					}.Build(),
 				},
 			}.Build(),
@@ -730,7 +730,7 @@ func newBackendPack(t *testing.T) *backendPack {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{types.KindScopedToken},
-						Verbs:     []string{types.VerbUpdate, types.VerbCreate},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Update, scopedaccess.Create),
 					}.Build(),
 				},
 			}.Build(),
@@ -746,7 +746,7 @@ func newBackendPack(t *testing.T) *backendPack {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{types.KindScopedToken},
-						Verbs:     []string{types.VerbRead, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.Secrets, scopedaccess.List, scopedaccess.Create, scopedaccess.Update, scopedaccess.Delete),
 					}.Build(),
 				},
 			}.Build(),

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -131,7 +132,7 @@ func (s *Service) GetCertAuthority(ctx context.Context, req *trustpb.GetCertAuth
 	checkAccess := func(ruleCtx services.RuleContext) error {
 		if req.GetIncludeKey() {
 			return authCtx.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
-				return checker.CheckAccessToRules(ruleCtx, types.KindCertAuthority, types.VerbRead)
+				return checker.CheckAccessToRules(ruleCtx, types.KindCertAuthority, scopedaccess.Secrets)
 			})
 		}
 		// For read without secrets we use RiskyAuthorizeUnpinnedRead, this is to
@@ -267,7 +268,8 @@ func (s *Service) GetCertAuthorities(ctx context.Context, req *trustpb.GetCertAu
 		// All cert authorities can be considered as being "root" resources from
 		// the perspective of scoped RBAC, so we just hard-code root as the resource scope for the decision.
 		if err := authCtx.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&ruleCtx, types.KindCertAuthority, types.VerbList, types.VerbRead, types.VerbReadNoSecrets)
+			// note that Secrets implies Read; there is no need to require both.
+			return checker.CheckAccessToRules(&ruleCtx, types.KindCertAuthority, scopedaccess.List, scopedaccess.Secrets)
 		}); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -352,7 +352,6 @@ func TestRBAC(t *testing.T) {
 			},
 			expectChecks: []check{
 				{types.KindCertAuthority, types.VerbList},
-				{types.KindCertAuthority, types.VerbReadNoSecrets},
 				{types.KindCertAuthority, types.VerbRead},
 			},
 		},

--- a/lib/auth/users/usersv1/service_test.go
+++ b/lib/auth/users/usersv1/service_test.go
@@ -677,7 +677,7 @@ func TestRBAC(t *testing.T) {
 			},
 			expectChecks: []check{
 				{kind: types.KindUser, verb: types.VerbCreate},
-				{kind: types.KindUser, verb: types.VerbRead},
+				{kind: types.KindUser, verb: types.VerbReadNoSecrets},
 			},
 		},
 		{
@@ -744,7 +744,7 @@ func TestRBAC(t *testing.T) {
 				},
 			},
 			expectChecks: []check{
-				{kind: types.KindUser, verb: types.VerbRead},
+				{kind: types.KindUser, verb: types.VerbReadNoSecrets},
 				{kind: types.KindUser, verb: types.VerbCreate},
 			},
 		},

--- a/lib/auth/vnetconfig/vnetconfigv1/service.go
+++ b/lib/auth/vnetconfig/vnetconfigv1/service.go
@@ -32,6 +32,7 @@ import (
 	typesvnet "github.com/gravitational/teleport/api/types/vnet"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -100,7 +101,7 @@ func (s *Service) GetVnetConfig(ctx context.Context, _ *vnet.GetVnetConfigReques
 
 // CreateVnetConfig creates a VnetConfig resource.
 func (s *Service) CreateVnetConfig(ctx context.Context, req *vnet.CreateVnetConfigRequest) (*vnet.VnetConfig, error) {
-	if err := s.authorizeWrite(ctx, types.VerbCreate); err != nil {
+	if err := s.authorizeWrite(ctx, scopedaccess.Create); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -119,7 +120,7 @@ func (s *Service) CreateVnetConfig(ctx context.Context, req *vnet.CreateVnetConf
 
 // UpdateVnetConfig updates a VnetConfig resource.
 func (s *Service) UpdateVnetConfig(ctx context.Context, req *vnet.UpdateVnetConfigRequest) (*vnet.VnetConfig, error) {
-	if err := s.authorizeWrite(ctx, types.VerbUpdate); err != nil {
+	if err := s.authorizeWrite(ctx, scopedaccess.Update); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -138,7 +139,7 @@ func (s *Service) UpdateVnetConfig(ctx context.Context, req *vnet.UpdateVnetConf
 
 // UpsertVnetConfig does basic validation and upserts a VnetConfig resource.
 func (s *Service) UpsertVnetConfig(ctx context.Context, req *vnet.UpsertVnetConfigRequest) (*vnet.VnetConfig, error) {
-	if err := s.authorizeWrite(ctx, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := s.authorizeWrite(ctx, scopedaccess.Create, scopedaccess.Update); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -157,7 +158,7 @@ func (s *Service) UpsertVnetConfig(ctx context.Context, req *vnet.UpsertVnetConf
 
 // DeleteVnetConfig deletes the singleton VnetConfig resource.
 func (s *Service) DeleteVnetConfig(ctx context.Context, _ *vnet.DeleteVnetConfigRequest) (*emptypb.Empty, error) {
-	if err := s.authorizeWrite(ctx, types.VerbDelete); err != nil {
+	if err := s.authorizeWrite(ctx, scopedaccess.Delete); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -170,7 +171,7 @@ func (s *Service) DeleteVnetConfig(ctx context.Context, _ *vnet.DeleteVnetConfig
 	return &emptypb.Empty{}, nil
 }
 
-func (s *Service) authorizeWrite(ctx context.Context, verbs ...string) error {
+func (s *Service) authorizeWrite(ctx context.Context, verbs ...scopedaccess.Verb) error {
 	authCtx, err := s.scopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/vnetconfig/vnetconfigv1/service_test.go
+++ b/lib/auth/vnetconfig/vnetconfigv1/service_test.go
@@ -149,7 +149,7 @@ func TestServiceAccess(t *testing.T) {
 				authz.AdminActionAuthUnauthorized, authz.AdminActionAuthNotRequired,
 				authz.AdminActionAuthMFAVerified, authz.AdminActionAuthMFAVerifiedWithReuse,
 			},
-			allowedVerbs: []string{types.VerbRead},
+			allowedVerbs: []string{types.VerbReadNoSecrets},
 			action: func(service *Service) error {
 				if _, err := service.storage.CreateVnetConfig(ctx, vnetConfig); err != nil {
 					return trace.Wrap(err, "creating vnet_config as pre-req for Get test")

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -185,7 +185,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindLinuxDesktop},
 		{Kind: types.KindKubeServer, ScopeFilter: allScopes},
 		{Kind: types.KindInstaller},
-		{Kind: types.KindKubernetesCluster, ScopeFilter: allScopes},
+		{Kind: types.KindKubernetesCluster, ScopeFilter: allScopes, LoadSecrets: true},
 		{Kind: types.KindCrownJewel},
 		{Kind: types.KindSAMLIdPServiceProvider},
 		{Kind: types.KindUserGroup},
@@ -393,7 +393,7 @@ func ForKubernetes(cfg Config) Config {
 		{Kind: types.KindUser},
 		{Kind: types.KindRole},
 		{Kind: types.KindKubeServer},
-		{Kind: types.KindKubernetesCluster},
+		{Kind: types.KindKubernetesCluster, LoadSecrets: true},
 		{Kind: types.KindKubeWaitingContainer},
 		{Kind: types.KindHealthCheckConfig},
 	}

--- a/lib/cache/kube.go
+++ b/lib/cache/kube.go
@@ -220,6 +220,7 @@ func newKubernetesClusterCollection(upstream KubeClusterUpstream, w types.WatchK
 					PageSize:    int32(pageSize),
 					PageToken:   pageToken,
 					ScopeFilter: w.ScopeFilter.ToProto(),
+					WithSecrets: loadSecrets,
 				}.Build())
 			}))
 		},
@@ -239,6 +240,11 @@ func newKubernetesClusterCollection(upstream KubeClusterUpstream, w types.WatchK
 }
 
 // GetKubernetesClusters returns all kubernetes cluster resources.
+//
+// Deprecated: this predates both scope filtering and with_secrets, so whether the returned clusters
+// carry secrets depends on whether this cache's watch loads them (as with the cert authority getters).
+// Use RangeKubeClusters, which is explicit about it.
+// TODO(okraport): remove in v21, along with the legacy GetKubernetesClusters RPC.
 func (c *Cache) GetKubernetesClusters(ctx context.Context) ([]types.KubeCluster, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetKubernetesClusters")
 	defer span.End()
@@ -283,7 +289,18 @@ func (c *Cache) ListKubeClusters(ctx context.Context, req *presencev1.ListKubeCl
 			return scopes.MatchScope(scopeFilter, cluster.GetScope())
 		},
 	}
-	return lister.list(ctx, int(req.GetPageSize()), req.GetPageToken())
+	clusters, next, err := lister.list(ctx, int(req.GetPageSize()), req.GetPageToken())
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	// censor here rather than relying on the store (which holds secrets whenever this cache's watch
+	// loads them) or the upstream (which is only consulted when the cache is unhealthy).
+	if !req.GetWithSecrets() {
+		for i, cluster := range clusters {
+			clusters[i] = cluster.WithoutSecrets().(types.KubeCluster)
+		}
+	}
+	return clusters, next, nil
 }
 
 // RangeKubeClusters returns kubernetes clusters within the range [start, end).
@@ -304,6 +321,7 @@ func (c *Cache) RangeKubeClusters(ctx context.Context, req *presencev1.ListKubeC
 				PageSize:    int32(pageSize),
 				PageToken:   pageToken,
 				ScopeFilter: scopeFilter,
+				WithSecrets: req.GetWithSecrets(),
 			}.Build())
 		},
 		filter: func(cluster types.KubeCluster) bool {
@@ -312,7 +330,13 @@ func (c *Cache) RangeKubeClusters(ctx context.Context, req *presencev1.ListKubeC
 		nextToken: services.GetCursorForKubeCluster,
 	}
 
-	return lister.Range(ctx, req.GetPageToken(), "")
+	clusters := lister.Range(ctx, req.GetPageToken(), "")
+	if req.GetWithSecrets() {
+		return clusters
+	}
+	return stream.FilterMap(clusters, func(cluster types.KubeCluster) (types.KubeCluster, bool) {
+		return cluster.WithoutSecrets().(types.KubeCluster), true
+	})
 }
 
 // GetKubeCluster returns the specified kubernetes cluster resource.
@@ -334,6 +358,9 @@ func (c *Cache) GetKubeCluster(ctx context.Context, req *presencev1.GetKubeClust
 	out, err := getter.get(ctx, clusterCursor)
 	if out == nil {
 		return nil, trace.Wrap(err)
+	}
+	if !req.GetWithSecrets() {
+		out = out.WithoutSecrets().(types.KubeCluster)
 	}
 	return out.Copy(), trace.Wrap(err)
 }

--- a/lib/cache/kube_test.go
+++ b/lib/cache/kube_test.go
@@ -53,9 +53,9 @@ func TestKubernetes(t *testing.T) {
 				}, types.KubernetesClusterSpecV3{})
 			},
 			create:    p.kubernetes.CreateKubernetesCluster,
-			list:      getAllAdapter(p.kubernetes.GetKubernetesClusters),
+			list:      getAllAdapter(p.kubernetes.GetKubernetesClusters), //nolint:staticcheck // SA1019 test cov of deprecated method
 			cacheGet:  cacheGetKubeClusterWithScope(p.cache, ""),
-			cacheList: getAllAdapter(p.cache.GetKubernetesClusters),
+			cacheList: getAllAdapter(p.cache.GetKubernetesClusters), //nolint:staticcheck // SA1019 test cov of deprecated method
 			update:    p.kubernetes.UpdateKubernetesCluster,
 			deleteAll: p.kubernetes.DeleteAllKubernetesClusters,
 		}, withSkipPaginationTest())
@@ -97,9 +97,9 @@ func TestKubernetes(t *testing.T) {
 				}, types.KubernetesClusterSpecV3{}, types.KubeClusterWithScope(scope))
 			},
 			create:    p.kubernetes.CreateKubernetesCluster,
-			list:      getAllAdapter(p.kubernetes.GetKubernetesClusters),
+			list:      getAllAdapter(p.kubernetes.GetKubernetesClusters), //nolint:staticcheck // SA1019 test cov of deprecated method
 			cacheGet:  cacheGetKubeClusterWithScope(p.cache, scope),
-			cacheList: getAllAdapter(p.cache.GetKubernetesClusters),
+			cacheList: getAllAdapter(p.cache.GetKubernetesClusters), //nolint:staticcheck // SA1019 test cov of deprecated method
 			update:    p.kubernetes.UpdateKubernetesCluster,
 			deleteAll: p.kubernetes.DeleteAllKubernetesClusters,
 		}, withSkipPaginationTest())

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -106,6 +106,9 @@ func (s *TLSServer) startKubeClusterResourceWatcher(ctx context.Context) (*servi
 			Client:    s.AccessPoint,
 		},
 		KubernetesClusterGetter: s.AccessPoint,
+		// dynamically registered clusters may contain secrets which are necessary in order
+		// for the agent to connect to the cluster.
+		LoadSecrets: true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -197,13 +197,23 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 
 	// verify that all rules are allowed for scoped roles
 	for _, rule := range role.GetSpec().GetRules() {
+		grantsRead := slices.Contains(rule.GetVerbs(), Read.String())
 		for _, resource := range rule.GetResources() {
 			for _, verb := range rule.GetVerbs() {
 				if !isAllowedScopedRule(resource, verb) {
-					if verb == types.VerbRead && isAllowedScopedRule(resource, types.VerbReadNoSecrets) {
-						return trace.BadParameter("scoped role %q has rule with verb %q that is too permissive for resource %q, use %q instead", role.GetMetadata().GetName(), verb, resource, types.VerbReadNoSecrets)
+					if verb == Secrets.String() && isAllowedScopedRule(resource, Read.String()) {
+						return trace.BadParameter("scoped role %q has rule with verb %q that is too permissive for resource %q, use %q instead", role.GetMetadata().GetName(), verb, resource, Read)
+					}
+					if verb == types.VerbReadNoSecrets {
+						return trace.BadParameter("scoped role %q has rule with legacy verb %q for resource %q, use %q instead (scoped read permission is secret-exclusive)", role.GetMetadata().GetName(), verb, resource, Read)
 					}
 					return trace.BadParameter("scoped role %q has rule with unsupported resource/verb combination: %q/%q", role.GetMetadata().GetName(), resource, verb)
+				}
+
+				// require secrets is always accompanied by read for ledgibility. our authz internals do not actually
+				// require this treat secret-inclusive read permissions as implying secret-exclusive read permissions.
+				if verb == Secrets.String() && !grantsRead {
+					return trace.BadParameter("scoped role %q has rule granting %q without %q for resource %q", role.GetMetadata().GetName(), Secrets, Read, resource)
 				}
 			}
 		}

--- a/lib/scopes/access/access_test.go
+++ b/lib/scopes/access/access_test.go
@@ -1013,13 +1013,7 @@ func TestValidateRole(t *testing.T) {
 					Rules: []*scopedaccessv1.ScopedRule{
 						scopedaccessv1.ScopedRule_builder{
 							Resources: []string{types.KindWorkloadIdentity},
-							Verbs: []string{
-								types.VerbCreate,
-								types.VerbUpdate,
-								types.VerbDelete,
-								types.VerbList,
-								types.VerbReadNoSecrets,
-							},
+							Verbs:     EncodeScopedVerbs(Create, Update, Delete, List, Read),
 						}.Build(),
 					},
 				}.Build(),
@@ -1041,7 +1035,7 @@ func TestValidateRole(t *testing.T) {
 					Rules: []*scopedaccessv1.ScopedRule{
 						scopedaccessv1.ScopedRule_builder{
 							Resources: []string{types.KindWorkloadIdentity},
-							Verbs:     []string{types.VerbRead},
+							Verbs:     EncodeScopedVerbs(Read, Secrets),
 						}.Build(),
 					},
 				}.Build(),
@@ -2264,7 +2258,7 @@ func TestStrongValidateRoleSpecAllFieldsValidated(t *testing.T) {
 		Rules: []*scopedaccessv1.ScopedRule{
 			scopedaccessv1.ScopedRule_builder{
 				Resources: []string{KindScopedRole},
-				Verbs:     []string{types.VerbReadNoSecrets},
+				Verbs:     EncodeScopedVerbs(Read),
 			}.Build(),
 		},
 		Ssh: scopedaccessv1.ScopedRoleSSH_builder{

--- a/lib/scopes/access/compat.go
+++ b/lib/scopes/access/compat.go
@@ -121,7 +121,8 @@ func applyRules(src []*scopedaccessv1.ScopedRule, dst *types.RoleConditions) {
 		for _, resource := range r.GetResources() {
 			var verbs []string
 			for _, verb := range r.GetVerbs() {
-				if !isAllowedScopedRule(resource, verb) {
+				classicVerb, ok := compileScopedVerb(resource, verb)
+				if !ok {
 					// skip verbs that are not allowed for the resource kind. note that this differs from
 					// classic teleport role behavior, where we don't worry about unsupported resource:verb
 					// combinations because we theoretically won't have any access checks for unsupported
@@ -134,7 +135,7 @@ func applyRules(src []*scopedaccessv1.ScopedRule, dst *types.RoleConditions) {
 					// the new rule.
 					continue
 				}
-				verbs = append(verbs, verb)
+				verbs = append(verbs, classicVerb)
 			}
 			if len(verbs) == 0 {
 				// skip rules that have no allowed verbs.

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -149,17 +149,18 @@ func TestRulesConversion(t *testing.T) {
 			rules: []*scopedaccessv1.ScopedRule{
 				scopedaccessv1.ScopedRule_builder{
 					Resources: []string{KindScopedRole},
-					Verbs:     []string{types.VerbList, types.VerbReadNoSecrets},
+					Verbs:     EncodeScopedVerbs(List, Read),
 				}.Build(),
 				scopedaccessv1.ScopedRule_builder{
 					Resources: []string{KindScopedRoleAssignment},
-					Verbs:     []string{types.VerbList, types.VerbReadNoSecrets, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+					Verbs:     EncodeScopedVerbs(List, Read, Create, Update, Delete),
 				}.Build(),
 			},
 			expect: []types.Rule{
 				{
 					Resources: []string{KindScopedRole},
-					Verbs:     []string{types.VerbList, types.VerbReadNoSecrets},
+					// the secret-exclusive spec "read" compiles to the classic "readnosecrets".
+					Verbs: []string{types.VerbList, types.VerbReadNoSecrets},
 				},
 				{
 					Resources: []string{KindScopedRoleAssignment},
@@ -168,11 +169,44 @@ func TestRulesConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "unsupported verb",
+			name: "secrets opt-in on secret-bearing kind",
+			rules: []*scopedaccessv1.ScopedRule{
+				scopedaccessv1.ScopedRule_builder{
+					Resources: []string{types.KindScopedToken},
+					Verbs:     EncodeScopedVerbs(List, Read, Secrets),
+				}.Build(),
+			},
+			expect: []types.Rule{
+				{
+					Resources: []string{types.KindScopedToken},
+					// scoped "read" verb becomes classic "readnosecrets" verb, and the scoped "secrets" verb becomes classic "read" verb.
+					Verbs: []string{types.VerbList, types.VerbReadNoSecrets, types.VerbRead},
+				},
+			},
+		},
+		{
+			name: "secrets dropped on non-secret kind",
 			rules: []*scopedaccessv1.ScopedRule{
 				scopedaccessv1.ScopedRule_builder{
 					Resources: []string{KindScopedRole},
-					Verbs:     []string{types.VerbList, types.VerbRead},
+					Verbs:     EncodeScopedVerbs(List, Secrets),
+				}.Build(),
+			},
+			expect: []types.Rule{
+				{
+					Resources: []string{KindScopedRole},
+					// "secrets" is not valid on a kind that carries no secrets, and is dropped during compilation.
+					Verbs: []string{types.VerbList},
+				},
+			},
+		},
+		{
+			name: "legacy readnosecrets dropped",
+			rules: []*scopedaccessv1.ScopedRule{
+				scopedaccessv1.ScopedRule_builder{
+					Resources: []string{KindScopedRole},
+					// the classic "readnosecrets" string is not a scoped verb and is dropped during compilation.
+					Verbs: []string{List.String(), types.VerbReadNoSecrets},
 				}.Build(),
 			},
 			expect: []types.Rule{
@@ -187,11 +221,11 @@ func TestRulesConversion(t *testing.T) {
 			rules: []*scopedaccessv1.ScopedRule{
 				scopedaccessv1.ScopedRule_builder{
 					Resources: []string{types.KindCertAuthority},
-					Verbs:     []string{types.VerbList, types.VerbReadNoSecrets},
+					Verbs:     EncodeScopedVerbs(List, Read),
 				}.Build(),
 				scopedaccessv1.ScopedRule_builder{
 					Resources: []string{KindScopedRole},
-					Verbs:     []string{types.VerbList, types.VerbReadNoSecrets},
+					Verbs:     EncodeScopedVerbs(List, Read),
 				}.Build(),
 			},
 			expect: []types.Rule{

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -15,25 +15,112 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package access
 
-import "github.com/gravitational/teleport/api/types"
+import (
+	"fmt"
 
-// Verb is an alias that allows current teleport code to import a scopedaccess.Verb type
-// compatible with the current ScopedAccessChecker.CheckAccessToRules signature. A future commit
-// will switch this over to being a proper enum type, but we need this intermediate state to
-// avoid breaking CI.
-type Verb = string
+	"github.com/gravitational/trace"
 
-const (
-	Create  Verb = types.VerbCreate
-	Read    Verb = types.VerbReadNoSecrets
-	Update  Verb = types.VerbUpdate
-	Delete  Verb = types.VerbDelete
-	List    Verb = types.VerbList
-	Secrets Verb = types.VerbRead
+	"github.com/gravitational/teleport/api/types"
 )
 
-// isAllowedScopedVerb returns true if the given verb is allowed for the given scoped resource kind. Scoped roles are not sane
-// for use with all resource kind/verb combinations, so we restrict the allowed combinations here.
+// Verb represents a verb in an access check. This type is intended to help code abstract over scoped and
+// unscoped verbs, which differ slightly in their meanings. Unscoped access treats 'read' as secrets-inclusive
+// and has a separate 'readnosecrets' verb.  Scoped access treats 'read' as secrets-exclusive and has a
+// separate 'secrets' verb.
+type Verb int
+
+const (
+	// unspecifiedVerb is the zero value and not a valid verb.
+	unspecifiedVerb Verb = iota
+
+	// List grants the ability to list resources of a kind.
+	List
+	// Read grants secrets-exclusive read access (corresponds to 'readnosecrets' in classic RBAC).
+	Read
+	// Secrets grants secrets-inclusive read access (corresponds to 'read' in classic RBAC).
+	Secrets
+	// Create grants the ability to create resources of a kind.
+	Create
+	// Update grants the ability to update resources of a kind.
+	Update
+	// Delete grants the ability to delete resources of a kind.
+	Delete
+
+	// lastVerb is used for iteration and not a valid verb.
+	lastVerb
+)
+
+// verbStrings holds the two string encodings of a [Verb].
+type verbStrings struct {
+	// scoped is the string the verb is written as in a scoped role spec.
+	scoped string
+	// classic is the classic RBAC verb the verb compiles to (in a spec) and encodes to (in a check).
+	classic string
+}
+
+// strings returns the string encodings of v, or false if v is not a valid verb. This switch is the
+// single source of truth for the mapping between the verb type and its scoped/unscoped string representations.
+func (v Verb) strings() (verbStrings, bool) {
+	switch v {
+	case List:
+		return verbStrings{scoped: "list", classic: types.VerbList}, true
+	case Read:
+		return verbStrings{scoped: "read", classic: types.VerbReadNoSecrets}, true
+	case Secrets:
+		return verbStrings{scoped: "secrets", classic: types.VerbRead}, true
+	case Create:
+		return verbStrings{scoped: "create", classic: types.VerbCreate}, true
+	case Update:
+		return verbStrings{scoped: "update", classic: types.VerbUpdate}, true
+	case Delete:
+		return verbStrings{scoped: "delete", classic: types.VerbDelete}, true
+	default:
+		return verbStrings{}, false
+	}
+}
+
+// String returns the string used to express this verb in a scoped role spec. It is *not* the classic
+// RBAC verb string, see [Verb.ClassicVerb].
+func (v Verb) String() string {
+	s, ok := v.strings()
+	if !ok {
+		return fmt.Sprintf("Verb(%d)", int(v))
+	}
+	return s.scoped
+}
+
+// ClassicVerb returns the classic RBAC verb string that this verb encodes to at check time. It
+// exists for the scoped access checker; code performing access checks should pass verbs to the
+// checker rather than encoding them itself.
+func (v Verb) ClassicVerb() (string, error) {
+	s, ok := v.strings()
+	if !ok {
+		return "", trace.BadParameter("invalid scoped verb %d (this is a bug)", int(v))
+	}
+	return s.classic, nil
+}
+
+// EncodeScopedVerbs encodes typed verbs into the verb strings used by scoped role specs.
+func EncodeScopedVerbs(verbs ...Verb) []string {
+	out := make([]string, 0, len(verbs))
+	for _, v := range verbs {
+		out = append(out, v.String())
+	}
+	return out
+}
+
+// verbByScopedString parses a scoped-role-spec verb string.
+func verbByScopedString(scoped string) (Verb, bool) {
+	for v := unspecifiedVerb + 1; v < lastVerb; v++ {
+		if s, ok := v.strings(); ok && s.scoped == scoped {
+			return v, true
+		}
+	}
+	return unspecifiedVerb, false
+}
+
+// isAllowedScopedRule returns true if the given scoped spec verb is allowed for the given scoped resource kind. Scoped roles
+// are not sane for use with all resource kind/verb combinations, so we restrict the allowed combinations here.
 func isAllowedScopedRule(kind string, verb string) bool {
 	switch kind {
 	case KindScopedRole:
@@ -43,8 +130,8 @@ func isAllowedScopedRule(kind string, verb string) bool {
 		// scoped role assignments can be read/written, and do not currently contain a concept of a secret.
 		return isReadWriteNoSecrets(verb)
 	case types.KindScopedToken:
-		// scoped tokens can be read/written, and contain secrets.
-		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
+		// scoped tokens can be read/written, and carry a join secret.
+		return isReadWriteWithSecrets(verb)
 	case types.KindBot:
 		// bots can be read/written, and do not currently contain a concept of a secret.
 		return isReadWriteNoSecrets(verb)
@@ -55,9 +142,11 @@ func isAllowedScopedRule(kind string, verb string) bool {
 		// workload identities can be read/written, and do not contain a concept of a secret.
 		return isReadWriteNoSecrets(verb)
 	case types.KindKubernetesCluster:
-		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
+		// kube clusters can be read/written, and may carry a kubeconfig payload that grants access to the cluster.
+		return isReadWriteWithSecrets(verb)
 	case types.KindAppServer:
-		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
+		// app servers can be read/written, and embed an app resource that carries no credential material.
+		return isReadWriteNoSecrets(verb)
 	case types.KindAccessList:
 		// access lists can be read/written, and do not contain a concept of a secret.
 		// permissions for access list members are conferred by permissions for
@@ -75,23 +164,13 @@ func isReadWriteNoSecrets(verb string) bool {
 
 // isReadWriteWithSecrets returns true if the given verb conforms to the "read-write-with-secrets" category of verbs.
 func isReadWriteWithSecrets(verb string) bool {
-	return isReadWithSecrets(verb) || isWrite(verb)
+	return isReadWriteNoSecrets(verb) || verb == Secrets.String()
 }
 
 // isReadNoSecrets returns true if the given verb conforms to the "read-no-secrets" category of verbs.
 func isReadNoSecrets(verb string) bool {
 	switch verb {
-	case types.VerbList, types.VerbReadNoSecrets:
-		return true
-	default:
-		return false
-	}
-}
-
-// isReadWithSecrets returns true if the given verb conforms to the "read-with-secrets" category of verbs.
-func isReadWithSecrets(verb string) bool {
-	switch verb {
-	case types.VerbList, types.VerbRead:
+	case List.String(), Read.String():
 		return true
 	default:
 		return false
@@ -101,9 +180,23 @@ func isReadWithSecrets(verb string) bool {
 // isWrite returns true if the given verb conforms to the "write" category of verbs.
 func isWrite(verb string) bool {
 	switch verb {
-	case types.VerbCreate, types.VerbUpdate, types.VerbDelete:
+	case Create.String(), Update.String(), Delete.String():
 		return true
 	default:
 		return false
 	}
+}
+
+// compileScopedVerb returns the classic RBAC verb that the given scoped spec verb compiles to for the
+// given kind, or false if the combination isn't allowed (and should therefore be dropped at compile time).
+func compileScopedVerb(kind, scopedVerb string) (string, bool) {
+	if !isAllowedScopedRule(kind, scopedVerb) {
+		return "", false
+	}
+	v, ok := verbByScopedString(scopedVerb)
+	if !ok {
+		return "", false
+	}
+	classic, err := v.ClassicVerb()
+	return classic, err == nil
 }

--- a/lib/services/fanoutv2_test.go
+++ b/lib/services/fanoutv2_test.go
@@ -29,6 +29,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
@@ -234,4 +235,59 @@ func TestFanoutV2StreamOrdering(t *testing.T) {
 	for range 100 {
 		require.Equal(t, inputs, <-results)
 	}
+}
+
+// TestFanoutV2KubeClusterSecretFiltering verifies that kube cluster events have secret
+// filtering correctly applied.
+func TestFanoutV2KubeClusterSecretFiltering(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+	defer cancel()
+
+	f := NewFanoutV2(FanoutV2Config{})
+
+	censored := f.NewStream(ctx, types.Watch{
+		Name:  "censored",
+		Kinds: []types.WatchKind{{Kind: types.KindKubernetesCluster}},
+	})
+	withSecrets := f.NewStream(ctx, types.Watch{
+		Name:  "with-secrets",
+		Kinds: []types.WatchKind{{Kind: types.KindKubernetesCluster, LoadSecrets: true}},
+	})
+
+	f.SetInit([]types.WatchKind{
+		{Kind: types.KindKubernetesCluster},
+		{Kind: types.KindKubernetesCluster, LoadSecrets: true},
+	})
+
+	for _, s := range []stream.Stream[types.Event]{censored, withSecrets} {
+		require.True(t, s.Next())
+		require.Equal(t, types.OpInit, s.Item().Type)
+	}
+
+	const kubeconfig = "kubeconfig-payload"
+	cluster, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name:   "dynamic",
+		Labels: map[string]string{"env": "prod"},
+	}, types.KubernetesClusterSpecV3{
+		Kubeconfig: []byte(kubeconfig),
+	})
+	require.NoError(t, err)
+
+	f.Emit(types.Event{Type: types.OpPut, Resource: cluster})
+
+	require.True(t, censored.Next())
+	got := censored.Item().Resource.(types.KubeCluster)
+	require.Empty(t, got.GetKubeconfig(), "a watch that did not set LoadSecrets must not receive kubeconfigs")
+	// the rest of the resource must survive censorship.
+	require.Equal(t, "dynamic", got.GetName())
+	require.Equal(t, "prod", got.GetAllLabels()["env"])
+
+	require.True(t, withSecrets.Next())
+	require.Equal(t, kubeconfig, string(withSecrets.Item().Resource.(types.KubeCluster).GetKubeconfig()))
+
+	// filtering must not have mutated the caller's resource.
+	require.Equal(t, kubeconfig, string(cluster.GetKubeconfig()))
+
+	require.NoError(t, censored.Done())
+	require.NoError(t, withSecrets.Done())
 }

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -195,7 +195,7 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 		case types.KindInstaller:
 			parser = newInstallerParser()
 		case types.KindKubernetesCluster:
-			parser = newKubeClusterParser()
+			parser = newKubeClusterParser(kind.LoadSecrets)
 		case types.KindCrownJewel:
 			parser = newCrownJewelParser()
 		case types.KindPlugin:
@@ -1809,8 +1809,9 @@ func (p *databaseServiceParser) parse(event backend.Event) (types.Resource, erro
 	}
 }
 
-func newKubeClusterParser() *kubeClusterParser {
+func newKubeClusterParser(loadSecrets bool) *kubeClusterParser {
 	return &kubeClusterParser{
+		loadSecrets: loadSecrets,
 		baseParser: newBaseParser(
 			kubeUnscopedPrefix(),
 			kubeScopedPrefix(),
@@ -1820,6 +1821,7 @@ func newKubeClusterParser() *kubeClusterParser {
 
 type kubeClusterParser struct {
 	baseParser
+	loadSecrets bool
 }
 
 func (p *kubeClusterParser) parse(event backend.Event) (types.Resource, error) {
@@ -1840,10 +1842,17 @@ func (p *kubeClusterParser) parse(event backend.Event) (types.Resource, error) {
 			Scope: sqn.Scope,
 		}, nil
 	case types.OpPut:
-		return services.UnmarshalKubeCluster(event.Item.Value,
+		cluster, err := services.UnmarshalKubeCluster(event.Item.Value,
 			services.WithExpires(event.Item.Expires),
 			services.WithRevision(event.Item.Revision),
 		)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !p.loadSecrets {
+			return cluster.WithoutSecrets(), nil
+		}
+		return cluster, nil
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
 	}

--- a/lib/services/local/kube.go
+++ b/lib/services/local/kube.go
@@ -72,8 +72,14 @@ func NewKubernetesService(b backend.Backend) (*KubernetesService, error) {
 }
 
 // GetKubernetesClusters returns all kubernetes cluster resources.
+//
+// Deprecated: this predates both scope filtering and with_secrets, and is secret-inclusive because the
+// legacy RPC it backs must keep behaving as it does for outdated clients. Prefer RangeKubeClusters.
+// TODO(okraport): remove in v21, along with the legacy GetKubernetesClusters RPC.
 func (s *KubernetesService) GetKubernetesClusters(ctx context.Context) ([]types.KubeCluster, error) {
-	out, err := stream.Collect(s.RangeKubeClusters(ctx, nil))
+	out, err := stream.Collect(s.RangeKubeClusters(ctx, presencev1.ListKubeClustersRequest_builder{
+		WithSecrets: true,
+	}.Build()))
 
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -92,7 +98,17 @@ func (s *KubernetesService) ListKubeClusters(ctx context.Context, req *presencev
 		return scopes.MatchScope(scopeFilter, kc.GetScope())
 	}
 
-	return s.svc.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), filterFn)
+	clusters, next, err := s.svc.ListResourcesWithFilter(ctx, int(req.GetPageSize()), req.GetPageToken(), filterFn)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	if !req.GetWithSecrets() {
+		for i, cluster := range clusters {
+			clusters[i] = cluster.WithoutSecrets().(types.KubeCluster)
+		}
+	}
+
+	return clusters, next, nil
 }
 
 // RangeKubeClusters returns kubernetes clusters within the range [start, end).
@@ -101,8 +117,15 @@ func (s *KubernetesService) RangeKubeClusters(ctx context.Context, req *presence
 	if err := scopes.ValidateFilter(scopeFilter); err != nil {
 		return stream.Fail[types.KubeCluster](trace.Wrap(err))
 	}
+	withSecrets := req.GetWithSecrets()
 	filterFn := func(kc types.KubeCluster) (types.KubeCluster, bool) {
-		return kc, scopes.MatchScope(scopeFilter, kc.GetScope())
+		if !scopes.MatchScope(scopeFilter, kc.GetScope()) {
+			return nil, false
+		}
+		if !withSecrets {
+			kc = kc.WithoutSecrets().(types.KubeCluster)
+		}
+		return kc, true
 	}
 
 	return stream.FilterMap(s.svc.Resources(ctx, req.GetPageToken(), ""), filterFn)
@@ -119,7 +142,14 @@ func (s *KubernetesService) GetKubeCluster(ctx context.Context, req *presencev1.
 			return nil, trace.Wrap(err)
 		}
 	}
-	return s.svc.GetResource(ctx, sqn)
+	cluster, err := s.svc.GetResource(ctx, sqn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if !req.GetWithSecrets() {
+		cluster = cluster.WithoutSecrets().(types.KubeCluster)
+	}
+	return cluster, nil
 }
 
 // CreateKubernetesCluster creates a new kubernetes cluster resource.

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1044,6 +1044,13 @@ func (s *PresenceService) DeleteSemaphore(ctx context.Context, filter types.Sema
 
 // UpsertKubernetesServer registers an kubernetes server.
 func (s *PresenceService) UpsertKubernetesServer(ctx context.Context, server types.KubeServer) (*types.KeepAlive, error) {
+	if cluster := server.GetCluster(); cluster != nil {
+		server = server.Copy()
+		if err := server.SetCluster(cluster.WithoutSecrets().(types.KubeCluster)); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	svc, err := s.kubeServers.WithScopedResourcePrefix(scopes.QualifiedName{
 		Scope: server.GetScope(),
 		Name:  server.GetHostID(),

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -132,6 +132,29 @@ func RoleNameForCertAuthority(name string) string {
 // NewImplicitRole is the default implicit role that gets added to all
 // RoleSets.
 func NewImplicitRole() types.Role {
+	return newImplicitRole(types.CopyRulesSlice(DefaultImplicitRules))
+}
+
+// newScopedImplicitRole is the default implicit role as it applies to scoped identities. It confers
+// the same privileges as [NewImplicitRole], except that secret-inclusive read is replaced with
+// secret-exclusive read.
+func newScopedImplicitRole() types.Role {
+	rules := types.CopyRulesSlice(DefaultImplicitRules)
+	for i, rule := range rules {
+		// CopyRulesSlice is a shallow copy, so build a replacement slice rather than assigning into it.
+		verbs := make([]string, len(rule.Verbs))
+		for j, verb := range rule.Verbs {
+			if verb == types.VerbRead {
+				verb = types.VerbReadNoSecrets
+			}
+			verbs[j] = verb
+		}
+		rules[i].Verbs = verbs
+	}
+	return newImplicitRole(rules)
+}
+
+func newImplicitRole(rules []types.Rule) types.Role {
 	return &types.RoleV6{
 		Kind:    types.KindRole,
 		Version: types.V3,
@@ -148,7 +171,7 @@ func NewImplicitRole() types.Role {
 			},
 			Allow: types.RoleConditions{
 				Namespaces: []string{defaults.Namespace},
-				Rules:      types.CopyRulesSlice(DefaultImplicitRules),
+				Rules:      rules,
 			},
 		},
 	}

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -11948,3 +11948,14 @@ func TestCheckImpersonateRoles(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaultImplicitRulesHaveNoWildcardVerbs verifies the assumption newScopedImplicitRole relies on,
+// that the default implicit rules contain no wildcards (if they did, our secret-inclusive -> secret-exclusive
+// conversion would break).
+func TestDefaultImplicitRulesHaveNoWildcardVerbs(t *testing.T) {
+	t.Parallel()
+
+	for _, rule := range DefaultImplicitRules {
+		require.NotContains(t, rule.Verbs, types.Wildcard, "resources %v", rule.Resources)
+	}
+}

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -120,7 +120,7 @@ func (b *scopedAccessCheckerBuilder) newCheckerForRole(ctx context.Context, key 
 
 	// Create an access checker with this single role. Single-role evaluation is a core principle
 	// of the scoped access model - the first role that permits access determines all parameters.
-	checker := newAccessChecker(b.info, b.localCluster, NewRoleSet(role))
+	checker := newAccessChecker(b.info, b.localCluster, newScopedRoleSet(role))
 
 	return &ScopedAccessChecker{
 		scopeOfOrigin:       key.ScopeOfOrigin,
@@ -130,17 +130,24 @@ func (b *scopedAccessCheckerBuilder) newCheckerForRole(ctx context.Context, key 
 	}, nil
 }
 
+// newScopedRoleSet builds the classic role set backing a scoped identity's compat checker. It exists
+// instead of [NewRoleSet] because that appends the classic default implicit role, which grants
+// secret-inclusive read; scoped identities get [newScopedImplicitRole] instead. Note that this must be
+// used for *every* scoped checker, since the implicit role is appended to each single-role checker.
+func newScopedRoleSet(roles ...types.Role) RoleSet {
+	return append(roles, newScopedImplicitRole())
+}
+
 // newDefaultImplicitChecker builds a scoped access checker representing the default implicit role. We rely on the privileges conferred
 // by the default implicit role always being "assigned" at root as if they came from a root scoped role assignment. We achieve this by
-// creating a fake scoped access checker that wraps an "empty" unscoped access checker. Since all unscoped access checkers automatically
-// include the default implicit role, this effectively simulates the presence of the default implicit role at root scope. Note that as
-// functionality of scoped roles further diverges from unscoped roles, we may need to revisit this approach in favor of defining our
-// own default implicit scoped role instead.
+// creating a fake scoped access checker that wraps an unscoped access checker holding only the scoped implicit role, which effectively
+// simulates the presence of the default implicit role at root scope. Note that as functionality of scoped roles further diverges from
+// unscoped roles, we may need to revisit this approach in favor of defining our own default implicit scoped role instead.
 func (b *scopedAccessCheckerBuilder) newDefaultImplicitChecker(_ context.Context) *ScopedAccessChecker {
 	return &ScopedAccessChecker{
 		scopeOfOrigin:       scopes.Root,
 		scopeOfEffect:       scopes.Root,
-		scopedCompatChecker: newAccessChecker(b.info, b.localCluster, NewRoleSet()), // default implicit role definition is auto-populated by NewRoleSet()
+		scopedCompatChecker: newAccessChecker(b.info, b.localCluster, newScopedRoleSet()),
 		role: scopedaccessv1.ScopedRole_builder{
 			Metadata: headerv1.Metadata_builder{
 				Name: constants.DefaultImplicitRole,
@@ -259,7 +266,7 @@ func (c *ScopedAccessChecker) Traits() wrappers.Traits {
 }
 
 // CheckAccessToRules verifies that *all* of a series of verbs are permitted for the specified resource.
-func (c *ScopedAccessChecker) CheckAccessToRules(ctx RuleContext, resource string, verbs ...string) error {
+func (c *ScopedAccessChecker) CheckAccessToRules(ctx RuleContext, resource string, verbs ...scopedaccess.Verb) error {
 	if !c.isScoped() {
 		return checkAccessToRulesImpl(c.unscopedChecker, ctx, resource, verbs...)
 	}
@@ -344,12 +351,16 @@ func (c *ScopedAccessChecker) DelegationSessionID() string {
 // checkAccessToRulesImpl verifies that *all* of a series of verbs are permitted for the specified resource. This
 // function differs from AccessChecker.CheckAccessToRule in that it does not support advanced context-based features
 // or namespacing, and accepts a set of verbs all of which must evaluate to allow for the check to succeed.
-func checkAccessToRulesImpl(checker AccessChecker, ctx RuleContext, resource string, verbs ...string) error {
+func checkAccessToRulesImpl(checker AccessChecker, ctx RuleContext, resource string, verbs ...scopedaccess.Verb) error {
 	if len(verbs) == 0 {
 		return trace.BadParameter("malformed rule check for %q, no verbs provided (this is a bug)", resource)
 	}
 	for _, verb := range verbs {
-		if err := checker.CheckAccessToRule(ctx, apidefaults.Namespace, resource, verb); err != nil {
+		classicVerb, err := verb.ClassicVerb()
+		if err != nil {
+			return trace.Wrap(err, "malformed rule check for %q", resource)
+		}
+		if err := checker.CheckAccessToRule(ctx, apidefaults.Namespace, resource, classicVerb); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -357,12 +368,16 @@ func checkAccessToRulesImpl(checker AccessChecker, ctx RuleContext, resource str
 }
 
 // checkMaybeHasAccessToRulesImpl returns an error if the checker definitely does not have access to the provided rules.
-func checkMaybeHasAccessToRulesImpl(checker AccessChecker, ctx RuleContext, resource string, verbs ...string) error {
+func checkMaybeHasAccessToRulesImpl(checker AccessChecker, ctx RuleContext, resource string, verbs ...scopedaccess.Verb) error {
 	if len(verbs) == 0 {
 		return trace.BadParameter("malformed maybe has access to rule check for %q, no verbs provided (this is a bug)", resource)
 	}
 	for _, verb := range verbs {
-		if err := checker.GuessIfAccessIsPossible(ctx, apidefaults.Namespace, resource, verb); err != nil {
+		classicVerb, err := verb.ClassicVerb()
+		if err != nil {
+			return trace.Wrap(err, "malformed maybe has access to rule check for %q", resource)
+		}
+		if err := checker.GuessIfAccessIsPossible(ctx, apidefaults.Namespace, resource, classicVerb); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/lib/services/scoped_access_checker_context.go
+++ b/lib/services/scoped_access_checker_context.go
@@ -341,7 +341,7 @@ func (c *ScopedAccessCheckerContext) ResolveScopeFilter(filter *scopesv1.Filter)
 
 // CheckMaybeHasAccessToRules returns an error if the context definitely does not have access to the provided
 // rules. For scoped identities, always returns nil — the scoped access model evaluates permissions per-resource.
-func (c *ScopedAccessCheckerContext) CheckMaybeHasAccessToRules(ctx RuleContext, resource string, verbs ...string) error {
+func (c *ScopedAccessCheckerContext) CheckMaybeHasAccessToRules(ctx RuleContext, resource string, verbs ...scopedaccess.Verb) error {
 	if !c.isScoped() {
 		return checkMaybeHasAccessToRulesImpl(c.unscopedChecker, ctx, resource, verbs...)
 	}
@@ -518,7 +518,7 @@ func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedEmitEvent(
 	return c.decision(
 		c.riskyUnpinnedCheckersForResourceScope(ctx, scopes.Root),
 		func(checker *ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(ruleCtx, types.KindEvent, types.VerbCreate)
+			return checker.CheckAccessToRules(ruleCtx, types.KindEvent, scopedaccess.Create)
 		},
 	)
 }
@@ -539,7 +539,7 @@ func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedWriteEvent(
 	return c.decision(
 		c.riskyUnpinnedCheckersForResourceScope(ctx, scopes.Root),
 		func(checker *ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(ruleCtx, types.KindEvent, types.VerbCreate, types.VerbUpdate)
+			return checker.CheckAccessToRules(ruleCtx, types.KindEvent, scopedaccess.Create, scopedaccess.Update)
 		},
 	)
 }
@@ -551,7 +551,7 @@ func (c *ScopedAccessCheckerContext) RiskyAuthorizeUnpinnedWriteEvent(
 type UnpinnedReadAuthorization struct {
 	resourceScope string
 	kind          string
-	verbs         []string
+	verbs         []scopedaccess.Verb
 }
 
 func (a UnpinnedReadAuthorization) check() error {
@@ -563,8 +563,10 @@ func (a UnpinnedReadAuthorization) check() error {
 	}
 	for _, verb := range a.verbs {
 		switch verb {
-		case types.VerbList, types.VerbReadNoSecrets, types.VerbRead:
+		case scopedaccess.List, scopedaccess.Read:
 		default:
+			// note that Secrets verb in particular is not allowed here, unpinned reads should
+			// never include secrets.
 			return trace.BadParameter("invalid verb for unpinned read authorization: %q", verb)
 		}
 	}
@@ -580,97 +582,97 @@ var (
 	UnpinnedReadCertAuthority = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindCertAuthority,
-		verbs:         []string{types.VerbReadNoSecrets},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 	// UnpinnedReadCertAuthorities is a special authorization to complete an
 	// unscoped access check to list and read a cert authorities without secrets.
 	UnpinnedReadCertAuthorities = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindCertAuthority,
-		verbs:         []string{types.VerbList, types.VerbReadNoSecrets},
+		verbs:         []scopedaccess.Verb{scopedaccess.List, scopedaccess.Read},
 	}
 	// UnpinnedReadAuthServers is a special authorization to complete an
 	// unscoped access check to list and read auth server resources.
 	UnpinnedReadAuthServers = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindAuthServer,
-		verbs:         []string{types.VerbList, types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.List, scopedaccess.Read},
 	}
 	// UnpinnedReadProxies is a special authorization to complete an
 	// unscoped access check to list and read proxy resources.
 	UnpinnedReadProxies = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindProxy,
-		verbs:         []string{types.VerbList, types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.List, scopedaccess.Read},
 	}
 	// UnpinnedReadAuthPreference is a special authorization to complete an
 	// unscoped access check to read a cluster auth preference.
 	UnpinnedReadAuthPreference = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindClusterAuthPreference,
-		verbs:         []string{types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 	// UnpinnedReadVnetConfig is a special authorization to complete an
 	// unscoped access check to read a cluster VNet config.
 	UnpinnedReadVnetConfig = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindVnetConfig,
-		verbs:         []string{types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 	// UnpinnedReadSPIFFEFederation is a special authorization to complete an
 	// unscoped access check to read a SPIFFE federation.
 	UnpinnedReadSPIFFEFederation = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindSPIFFEFederation,
-		verbs:         []string{types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 	// UnpinnedReadSPIFFEFederations is a special authorization to complete an
 	// unscoped access check to list and read SPIFFE federations.
 	UnpinnedReadSPIFFEFederations = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindSPIFFEFederation,
-		verbs:         []string{types.VerbList, types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.List, scopedaccess.Read},
 	}
 	// UnpinnedReadClusterNetworkingConfig is a special authorization to complete an
 	// unscoped access check to read a cluster networking config.
 	UnpinnedReadClusterNetworkingConfig = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindClusterNetworkingConfig,
-		verbs:         []string{types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 	// UnpinnedReadClusterName is a special authorization to complete an
 	// unscoped access check to read a cluster name.
 	UnpinnedReadClusterName = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindClusterName,
-		verbs:         []string{types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 	// UnpinnedReadSessionRecordingConfig is a special authorization to complete an
 	// unscoped access check to read a cluster session recording config.
 	UnpinnedReadSessionRecordingConfig = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindSessionRecordingConfig,
-		verbs:         []string{types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 	// UnpinnedReadScopedRole is a special authorization to complete an
 	// unscoped access check to read a scoped role.
 	UnpinnedReadScopedRole = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          scopedaccess.KindScopedRole,
-		verbs:         []string{types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 	// UnpinnedReadUser is a special authorization to complete a unscoped access check
 	// to read a user.
 	UnpinnedReadUser = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindUser,
-		verbs:         []string{types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 	// UnpinnedReadRole is a special authorization to complete an unscoped access check
 	// to read a role.
 	UnpinnedReadRole = UnpinnedReadAuthorization{
 		resourceScope: scopes.Root,
 		kind:          types.KindRole,
-		verbs:         []string{types.VerbRead},
+		verbs:         []scopedaccess.Verb{scopedaccess.Read},
 	}
 )

--- a/lib/services/scoped_access_checker_context_test.go
+++ b/lib/services/scoped_access_checker_context_test.go
@@ -27,6 +27,7 @@ import (
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 )
 
 func TestScopedAccessCheckerContextRiskyAuthorizeUnpinnedRead(t *testing.T) {
@@ -46,7 +47,7 @@ func TestScopedAccessCheckerContextRiskyAuthorizeUnpinnedRead(t *testing.T) {
 	// is pinned away from root before any checker, including the default implicit
 	// role checker, is evaluated.
 	err = checkerContext.Decision(ctx, scopes.Root, func(checker *ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(ruleCtx, types.KindCertAuthority, types.VerbReadNoSecrets)
+		return checker.CheckAccessToRules(ruleCtx, types.KindCertAuthority, scopedaccess.Read)
 	})
 	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
 
@@ -209,7 +210,7 @@ func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 		called := false
 		err := checkerCtx.Decision(t.Context(), pinScope, func(c *ScopedAccessChecker) error {
 			called = true
-			return c.CheckAccessToRules(&Context{}, types.KindNode, types.VerbRead)
+			return c.CheckAccessToRules(&Context{}, types.KindNode, scopedaccess.Secrets)
 		})
 		require.NoError(t, err, "Decision at pin scope should succeed")
 		require.True(t, called, "fn should have been called")
@@ -224,7 +225,7 @@ func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 		called := false
 		err := checkerCtx.Decision(t.Context(), childScope, func(c *ScopedAccessChecker) error {
 			called = true
-			return c.CheckAccessToRules(&Context{}, types.KindNode, types.VerbRead)
+			return c.CheckAccessToRules(&Context{}, types.KindNode, scopedaccess.Secrets)
 		})
 		require.NoError(t, err, "Decision at child scope should succeed")
 		require.True(t, called, "fn should have been called for child scope")
@@ -253,9 +254,24 @@ func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 		err := checkerCtx.RiskyAuthorizeUnpinnedRead(t.Context(), UnpinnedReadAuthorization{
 			resourceScope: scopes.Root,
 			kind:          types.KindNode,
-			verbs:         []string{types.VerbRead},
+			verbs:         []scopedaccess.Verb{scopedaccess.Read},
 		}, &Context{})
 		require.NoError(t, err, "RiskyAuthorizeUnpinnedRead should bypass pin enforcement and succeed")
+	})
+
+	t.Run("RiskyAuthorizeUnpinnedRead rejects secret-inclusive reads", func(t *testing.T) {
+		t.Parallel()
+		pin := newAgentPin(pinScope, types.RoleNode)
+		checkerCtx := newAgentPinCheckerContext(t, pin)
+
+		// an unpinned read bypasses pin enforcement, so it must never be usable to authorize access
+		// to secret material.
+		err := checkerCtx.RiskyAuthorizeUnpinnedRead(t.Context(), UnpinnedReadAuthorization{
+			resourceScope: scopes.Root,
+			kind:          types.KindNode,
+			verbs:         []scopedaccess.Verb{scopedaccess.Secrets},
+		}, &Context{})
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got %v", err)
 	})
 
 	t.Run("RiskyAuthorizeUnpinnedEmitEvent bypasses pin enforcement", func(t *testing.T) {
@@ -267,7 +283,7 @@ func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 		// is pinned away from root before any checker, including the default implicit
 		// role checker, is evaluated.
 		err := checkerCtx.Decision(t.Context(), scopes.Root, func(checker *ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&Context{}, types.KindEvent, types.VerbCreate)
+			return checker.CheckAccessToRules(&Context{}, types.KindEvent, scopedaccess.Create)
 		})
 		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
 
@@ -283,7 +299,7 @@ func TestScopedAccessCheckerContextAgentPin(t *testing.T) {
 		// is pinned away from root before any checker, including the default implicit
 		// role checker, is evaluated.
 		err := checkerCtx.Decision(t.Context(), scopes.Root, func(checker *ScopedAccessChecker) error {
-			return checker.CheckAccessToRules(&Context{}, types.KindEvent, types.VerbCreate, types.VerbUpdate)
+			return checker.CheckAccessToRules(&Context{}, types.KindEvent, scopedaccess.Create, scopedaccess.Update)
 		})
 		require.ErrorAs(t, err, new(*trace.AccessDeniedError))
 
@@ -321,7 +337,7 @@ func TestScopedAccessCheckerContextUnpinnedUserEventWrites(t *testing.T) {
 	// is pinned away from root before any checker, including the default implicit
 	// role checker, is evaluated.
 	err = userCheckerContext.Decision(ctx, scopes.Root, func(checker *ScopedAccessChecker) error {
-		return checker.CheckAccessToRules(ruleCtx, types.KindEvent, types.VerbCreate)
+		return checker.CheckAccessToRules(ruleCtx, types.KindEvent, scopedaccess.Create)
 	})
 	require.ErrorAs(t, err, new(*trace.AccessDeniedError))
 

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -647,6 +648,10 @@ type KubeClusterWatcherConfig struct {
 	KubeClustersC chan []types.KubeCluster
 	// ResourceWatcherConfig is the resource watcher configuration.
 	ResourceWatcherConfig
+	// LoadSecrets specifies whether the watched kube clusters include their kubeconfig. Only the
+	// kube agent needs this, to connect to dynamically-registered clusters, and it requires
+	// secret-inclusive read permission on kubernetes_cluster.
+	LoadSecrets bool
 }
 
 // NewKubeClusterWatcher returns a new instance of KubeClusterWatcher.
@@ -659,8 +664,11 @@ func NewKubeClusterWatcher(ctx context.Context, cfg KubeClusterWatcherConfig) (*
 	w, err := NewGenericResourceWatcher(ctx, GenericWatcherConfig[types.KubeCluster, readonly.KubeCluster]{
 		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
 		ResourceKind:          types.KindKubernetesCluster,
+		LoadSecrets:           cfg.LoadSecrets,
 		ResourceGetter: func(ctx context.Context) ([]types.KubeCluster, error) {
-			return iterstream.Collect(getter.RangeKubeClusters(ctx, nil))
+			return iterstream.Collect(getter.RangeKubeClusters(ctx, presencev1.ListKubeClustersRequest_builder{
+				WithSecrets: cfg.LoadSecrets,
+			}.Build()))
 		},
 		ResourceKey: GetCursorForKubeCluster,
 		DeleteKey: func(res types.Resource) string {

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1919,7 +1919,7 @@ func TestScopedBotWorkloadIdentity(t *testing.T) {
 				Rules: []*scopedaccessv1.ScopedRule{
 					scopedaccessv1.ScopedRule_builder{
 						Resources: []string{types.KindWorkloadIdentity},
-						Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						Verbs:     scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List),
 					}.Build(),
 				},
 				WorkloadIdentity: scopedaccessv1.ScopedRoleWorkloadIdentity_builder{

--- a/tool/tctl/common/resources/kube_cluster.go
+++ b/tool/tctl/common/resources/kube_cluster.go
@@ -101,6 +101,7 @@ func getKubeCluster(ctx context.Context, client *authclient.Client, ref services
 			ScopeFilter: scopesv1.Filter_builder{
 				Mode: scopesv1.Mode_MODE_ALL,
 			}.Build(),
+			WithSecrets: opts.WithSecrets,
 		}.Build())
 	}
 	// TODO(okraport) DELETE IN v21.0.0, replace with regular Collect
@@ -193,15 +194,16 @@ func scopedKubeClusterHandler() ScopedHandler {
 	}
 }
 
-func getScopedKubeCluster(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, _ GetOpts) (Collection, error) {
+func getScopedKubeCluster(ctx context.Context, client *authclient.Client, subKind string, sqn *scopes.QualifiedName, opts GetOpts) (Collection, error) {
 	if subKind != "" {
 		return nil, rejectSubKind(types.KindKubernetesCluster, subKind)
 	}
 
 	if sqn != nil {
 		cluster, err := client.GetKubeCluster(ctx, presencev1.GetKubeClusterRequest_builder{
-			Scope: sqn.Scope,
-			Name:  sqn.Name,
+			Scope:       sqn.Scope,
+			Name:        sqn.Name,
+			WithSecrets: opts.WithSecrets,
 		}.Build())
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -217,6 +219,7 @@ func getScopedKubeCluster(ctx context.Context, client *authclient.Client, subKin
 			PageSize:    int32(pageSize),
 			PageToken:   pageKey,
 			ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			WithSecrets: opts.WithSecrets,
 		}.Build())
 	}))
 	if err != nil {


### PR DESCRIPTION
NOTE: This PR must be merged *after* https://github.com/gravitational/teleport/pull/69305 and https://github.com/gravitational/teleport.e/pull/9321 (which should be merged in that order).

This PR does a rework of the way scoped roles and authz checks handle verbs.  Specifically it drops `readnosecrets` in favor of making `read` secret-exclusive, and adds a new `secrets` verb for expressing secret-inclusive read permissions.

The intent of this change is to make it harder for role authors to accidentally grant more permissions than intended, and to make it harder for developers to accidentally authz APIs that demand more permissions than necessary.

This is technically a breaking change, but is acceptable due to the fact that scoped roles are still behind an unstable flag.  Prior to this PR, a common scoped role `rules` block might look something like this:

```yaml
rules:
  - resources: [scoped_role, scoped_role_assignment]
    verbs: [create, list, readnosecrets, update, delete]
  - resources: [scoped_token]
    verbs: [create, list, read, update, delete]
```

After this change, the same role would be written like so:

```yaml
rules:
  - resources: [scoped_role, scoped_role_assignment]
    verbs: [create, list, read, update, delete]
  - resources: [scoped_token]
    verbs: [create, list, read, secrets, update, delete]
```

Note that the secret-exclusive grants now are cleaner and more intuitive, and that it is much more obvious at a glance that a given grant includes secrets.

---

As part of this work, the kube cluster kind has also been updated to support a `WithSecrets` flag.  Previously we _only_ supported secret-inclusive privileges/reads for kube clusters, which forced admins to grant secret-inclusive read if the wanted to allow someone to list kube clusters (note: this is for the dynamically registered kube cluster config resources, we've always allowed secret-exclusive _access_ to kube clusters via the `kube_server` type).  It is now possible to grant users the ability to list kube cluster config resources without secrets.


## Manual Test Plan
### Test Environment

Local evn

### Test Cases
- [x] Verify that `read` permissions now work with non-secret kinds (e.g. `scoped_role`).
- [x] Verify that `read` no longer confers secret-inclusive privileges for secret-bearing kinds (e.g. `scoped_token`).
- [x] Verify that `secrets` grants secret-inclusive privileges.
- [x] Verify that resource kinds that do not support secrets cannot have the `secrets` verb assigned.
- [x] Verify that access and label based reads (e.g. `tsh ssh` and `tsh ls`) are unaffected by the change to default implicit role.
