### PR TITLE
Add `data-testid`'s to sidenav components

### DIFF
--- a/web/packages/teleport/src/Main/Main.test.tsx
+++ b/web/packages/teleport/src/Main/Main.test.tsx
@@ -184,7 +184,9 @@ test('toggle rendering of info guide panel', async () => {
 
   // render the component that has the guide info button
   fireEvent.click(screen.queryAllByText('Zero Trust Access')[0]);
-  fireEvent.click(screen.getByTestId(testFeature.route.path));
+  fireEvent.click(
+    screen.getByRole('link', { name: testFeature.navigationItem.title })
+  );
   expect(screen.getByText(/info guide title/i)).toBeInTheDocument();
 
   // test opening of panel
@@ -223,7 +225,9 @@ test('notification render and auto dismissal', async () => {
 
   // render the component that has the add note button
   fireEvent.click(screen.queryAllByText('Zero Trust Access')[0]);
-  fireEvent.click(screen.getByTestId(testFeature.route.path));
+  fireEvent.click(
+    screen.getByRole('link', { name: testFeature.navigationItem.title })
+  );
 
   expect(screen.queryAllByText(/some note/i)).toHaveLength(0);
 

--- a/web/packages/teleport/src/Navigation/Section.tsx
+++ b/web/packages/teleport/src/Navigation/Section.tsx
@@ -86,6 +86,7 @@ export function DefaultSection({
   return (
     <>
       <CategoryButton
+        data-testid="side-nav-category"
         ref={refs.setReference}
         $active={$active}
         isExpanded={isExpanded}
@@ -164,6 +165,7 @@ export const CustomChildrenSection = forwardRef<
   return (
     <>
       <CategoryButton
+        data-testid="side-nav-category"
         ref={ref}
         $active={$active}
         isExpanded={isExpanded}
@@ -193,7 +195,12 @@ export function StandaloneSection({
   $active: boolean;
 }) {
   return (
-    <CategoryButton as={NavLink} $active={$active} to={route}>
+    <CategoryButton
+      as={NavLink}
+      data-testid="side-nav-category"
+      $active={$active}
+      to={route}
+    >
       <Icon />
       {title}
     </CategoryButton>
@@ -388,7 +395,7 @@ export function SubsectionItem({
       end={exact}
       tabIndex={0}
       onClick={onClick}
-      data-testid={to}
+      data-testid="side-nav-item"
     >
       {children}
     </StyledSubsectionItem>


### PR DESCRIPTION
## Purpose

This PR adds `data-testid`'s to sidenav components. This allows unit tests and e2e tests to select and assert on the sidenav much more easily and reliably.
