### PR TITLE
Add RequestKind validation for Slack review payloads

### DIFF
--- a/integrations/access/slack/review.go
+++ b/integrations/access/slack/review.go
@@ -226,9 +226,21 @@ func (a *ReviewApp) resolveReview(ctx context.Context, reqID, slackUserID string
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(reqs) > 0 && reqs[0].GetRequestKind().IsLongTerm() {
-		log.DebugContext(ctx, "Request is long-term, cannot apply review from Slack")
-		return trace.AccessDenied("cannot review long-term request")
+	if len(reqs) != 1 {
+		// `GetAccessRequests` can return empty list if request is expired or
+		// `access_request:list` permission is missing. To avoid bricking reviews
+		// on short-term requests due to missing permission, we opt to skip the long-term request kind check
+		// and proceed with review.
+		// `SubmitAccessReview` API only permits short-term access grant, so the worst case
+		// is an "Approve" can block a future access list promotion for the request, not long-term access escalation.
+		log.WarnContext(ctx, "Skipping long-term request kind check; request not found or plugin is missing `access_request:list` permission",
+			"num_requests", len(reqs),
+		)
+	} else {
+		if reqs[0].GetRequestKind().IsLongTerm() {
+			log.DebugContext(ctx, "Request is long-term, cannot apply review from Slack")
+			return trace.AccessDenied("cannot review long-term request")
+		}
 	}
 
 	username, err := utils.FnCacheGet(ctx, a.userCache, slackUserID, func(ctx context.Context) (string, error) {

--- a/integrations/access/slack/review.go
+++ b/integrations/access/slack/review.go
@@ -219,6 +219,18 @@ func (a *ReviewApp) resolveReview(ctx context.Context, reqID, slackUserID string
 		"proposed_state", proposedState,
 	)
 
+	// Validate the request is not long-term.
+	// The plugin must have read/list permissions for `access_request`,
+	// which is bundled by the preset role, ie. `access-plugin-with-review`.
+	reqs, err := a.apiClient.GetAccessRequests(ctx, types.AccessRequestFilter{ID: reqID})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if len(reqs) > 0 && reqs[0].GetRequestKind().IsLongTerm() {
+		log.DebugContext(ctx, "Request is long-term, cannot apply review from Slack")
+		return trace.AccessDenied("cannot review long-term request")
+	}
+
 	username, err := utils.FnCacheGet(ctx, a.userCache, slackUserID, func(ctx context.Context) (string, error) {
 		return a.resolveTeleportUser(ctx, slackUserID)
 	})

--- a/integrations/access/slack/review_test.go
+++ b/integrations/access/slack/review_test.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -219,19 +221,40 @@ func TestResolveTeleportUser(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		app := &ReviewApp{
-			apiClient: authServer,
-			bot:       mockBot,
-			conf:      tt.reviewConfig,
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			app := &ReviewApp{
+				apiClient: authServer,
+				bot:       mockBot,
+				conf:      tt.reviewConfig,
+			}
 
-		got, err := app.resolveTeleportUser(t.Context(), tt.slackUID)
-		if tt.wantErr {
-			require.Error(t, err)
-			continue
-		}
-		require.NoError(t, err)
+			got, err := app.resolveTeleportUser(t.Context(), tt.slackUID)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 
-		require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want, got)
+		})
 	}
+}
+
+func TestResolveReview_LongTerm(t *testing.T) {
+	authServer := newTestAuth(t, modulestest.OSSModules())
+
+	app := &ReviewApp{
+		apiClient: authServer,
+		bot:       &mockReviewBot{},
+	}
+
+	reqLongTerm, err := types.NewAccessRequest(uuid.NewString(), "test-user", "test-role")
+	require.NoError(t, err)
+	reqLongTerm.SetRequestKind(types.AccessRequestKind_LONG_TERM)
+
+	err = authServer.CreateAccessRequest(t.Context(), reqLongTerm)
+	require.NoError(t, err)
+
+	err = app.resolveReview(t.Context(), reqLongTerm.GetName(), "test-slack-uid", types.RequestState_APPROVED)
+	require.True(t, trace.IsAccessDenied(err))
 }


### PR DESCRIPTION
Improves payload validation for Slack plugin's native review feature. Reviews should not be sent to Auth Server for any long-term requests.

Also fixes table-driven test to use `t.Run()` in same testing file.

Context for reviewers: This supports the upcoming feature for native reviews in Slack, where the Slack plugin submits Access Request reviews to the Teleport Auth Server on behalf of human Slack users.

## Manual Test Plan
### Test Environment

Teleport Cloud and local Slack plugin.

### Test Cases
- [x] Short-term reviews in Slack behave as normal
- [x] Long-term reviews in Slack (forged when UI buttons are enabled for all requests) yield a user-facing error:
`Insufficient permissions to review request`
