### PR TITLE
Fix erroneous rust toolchain warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2100,7 +2100,7 @@ export rust_shadowed_warning
 # on PATH is not rustup-managed (e.g. the Homebrew 'rust' formula), which
 # silently bypasses the toolchain file even though the checks below pass.
 .PHONY: rustup-toolchain-warning
-rustup-toolchain-warning: EXPECTED = $(shell $(MAKE) print-rust-toolchain-version)
+rustup-toolchain-warning: EXPECTED = $(shell $(MAKE) --no-print-directory print-rust-toolchain-version)
 rustup-toolchain-warning:
 	@if [ "$(shell rustup show active-toolchain | cut -d'-' -f1)" != "$(EXPECTED)" ]; then \
 		echo -en "\033[31m";\


### PR DESCRIPTION
The rust toolchain warning keeps appearing both in CI and when building locally in the buildbox because the `EXPECTED` target-specific variable was getting muddled with directory change messages.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Buildbox
### Test Cases
- [x] Warning no longer appears when building in buildbox
