### PR TITLE
[v18] [Access Requests] Tolerate unknown constraint kinds when decoding ResourceAccessIDs

### DIFF
--- a/api/types/resource_constraints.go
+++ b/api/types/resource_constraints.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/json"
 
 	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
 	"github.com/gravitational/trace"
@@ -42,6 +43,8 @@ func (rc *ResourceConstraints) CheckAndSetDefaults() error {
 		if err := d.Validate(); err != nil {
 			return trace.Wrap(err)
 		}
+	case nil:
+		return trace.BadParameter("constraints carry no supported content; they are either empty or from a newer Teleport version")
 	default:
 		return trace.BadParameter("unsupported Details type %T", d)
 	}
@@ -65,10 +68,44 @@ func (rc *ResourceConstraints) MarshalJSON() ([]byte, error) {
 }
 
 func (rc *ResourceConstraints) UnmarshalJSON(b []byte) error {
-	u := &jsonpb.Unmarshaler{
+	strict := &jsonpb.Unmarshaler{
 		AllowUnknownFields: false,
 	}
-	return trace.Wrap(u.Unmarshal(bytes.NewReader(b), rc))
+	if err := strict.Unmarshal(bytes.NewReader(b), rc); err != nil {
+		// Content that doesn't strictly decode: an unknown kind, or an
+		// unknown field in a known one.
+		return trace.Wrap(rc.unmarshalVersionOnly(b, err))
+	}
+	if rc.Version != "" && rc.Version != ResourceConstraintVersionV1 {
+		// Fields all decoded, but the version is newer than this build
+		// understands. Keep only the version; the entry becomes
+		// unenforceable.
+		*rc = ResourceConstraints{Version: rc.Version}
+	}
+	return nil
+}
+
+// unmarshalVersionOnly resets rc to carry only the version found in b,
+// leaving it unenforceable for enforcement to deny. If b yields no version
+// at all, rc is zeroed and strictErr is returned so the caller doesn't use
+// a half-parsed value.
+func (rc *ResourceConstraints) unmarshalVersionOnly(b []byte, strictErr error) error {
+	var v struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(b, &v); err != nil {
+		*rc = ResourceConstraints{}
+		return strictErr
+	}
+	*rc = ResourceConstraints{Version: v.Version}
+	return nil
+}
+
+// Unenforceable reports whether the constraints carry content this build
+// cannot decode or validate. Such entries must deny their resource at
+// enforcement rather than being treated as unconstrained.
+func (rc *ResourceConstraints) Unenforceable() bool {
+	return rc != nil && rc.Details == nil
 }
 
 // Validate ensures RoleArns is non-nil and contains Role ARNs.

--- a/api/types/resource_ids.go
+++ b/api/types/resource_ids.go
@@ -91,8 +91,16 @@ func (idl *ResourceAccessIDList) CheckAndSetDefaults() error {
 		}
 		if rc == nil {
 			continue
-		} else if err := rc.CheckAndSetDefaults(); err != nil {
-			return trace.Wrap(err)
+		}
+		if rc.Unenforceable() {
+			// Keep the entry for enforcement to deny; erroring here would
+			// reject the whole identity.
+			continue
+		}
+		if err := rc.CheckAndSetDefaults(); err != nil {
+			// Treat invalid content like content we can't decode.
+			rc.Details = nil
+			continue
 		}
 	}
 	return nil

--- a/api/types/resource_ids_test.go
+++ b/api/types/resource_ids_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -801,6 +802,113 @@ func TestLegacyKubeResourceIDs(t *testing.T) {
 	}
 }
 
+// TestResourceConstraintsDecodeDegradesUnknown verifies that constraint
+// content this build can't strictly decode leaves a non-nil
+// ResourceConstraints with nil Details.
+func TestResourceConstraintsDecodeDegradesUnknown(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		wantVersion string
+	}{
+		{
+			name:        "unknown kind",
+			input:       `{"version":"v1","some_future_kind":{"names":["a"]}}`,
+			wantVersion: "v1",
+		},
+		{
+			name:        "unknown field inside known kind",
+			input:       `{"version":"v1","ssh":{"logins":["root"],"future_narrowing":["x"]}}`,
+			wantVersion: "v1",
+		},
+		{
+			name:        "unknown sibling field",
+			input:       `{"version":"v1","ssh":{"logins":["root"]},"future_field":true}`,
+			wantVersion: "v1",
+		},
+		{
+			name:        "type mismatch inside known kind",
+			input:       `{"version":"v1","ssh":{"logins":[123]}}`,
+			wantVersion: "v1",
+		},
+		{
+			name:        "unsupported version with known kind",
+			input:       `{"version":"v2","ssh":{"logins":["root"]}}`,
+			wantVersion: "v2",
+		},
+		{
+			name:        "unsupported version alone",
+			input:       `{"version":"v2"}`,
+			wantVersion: "v2",
+		},
+		{
+			name:        "unknown kind without version",
+			input:       `{"some_future_kind":{"names":["a"]}}`,
+			wantVersion: "",
+		},
+		{
+			name:        "empty object",
+			input:       `{}`,
+			wantVersion: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var rc ResourceConstraints
+			require.NoError(t, rc.UnmarshalJSON([]byte(tc.input)))
+			require.Equal(t, tc.wantVersion, rc.Version)
+			require.Nil(t, rc.Details, "unrecognized content must not decode to enforceable Details")
+			require.Error(t, rc.CheckAndSetDefaults())
+		})
+	}
+
+	t.Run("valid current-version content decodes fully", func(t *testing.T) {
+		var rc ResourceConstraints
+		require.NoError(t, rc.UnmarshalJSON([]byte(`{"version":"v1","ssh":{"logins":["root"]}}`)))
+		require.NotNil(t, rc.Details)
+		require.NoError(t, rc.CheckAndSetDefaults())
+	})
+
+	t.Run("malformed content errors at decode", func(t *testing.T) {
+		for _, input := range []string{`not json`, `{"version":42}`, `[]`} {
+			var rc ResourceConstraints
+			require.Error(t, rc.UnmarshalJSON([]byte(input)), "input: %s", input)
+		}
+	})
+}
+
+// TestResourceAccessIDsInvalidKnownKindDegrades verifies that decodable but
+// invalid constraint content of a known kind is kept with nil Details.
+func TestResourceAccessIDsInvalidKnownKindDegrades(t *testing.T) {
+	t.Parallel()
+
+	ids := []ResourceAccessID{
+		{
+			Id: ResourceID{ClusterName: "root", Kind: KindNode, Name: "n1"},
+			Constraints: &ResourceConstraints{
+				Version: "v1",
+				Details: &ResourceConstraints_Ssh{
+					Ssh: &SSHResourceConstraints{Logins: []string{"root"}},
+				},
+			},
+		},
+	}
+	encoded, err := ResourceAccessIDsToString(ids)
+	require.NoError(t, err)
+	require.Contains(t, encoded, `"logins":["root"]`)
+	invalid := strings.Replace(encoded, `"logins":["root"]`, "", 1)
+
+	decoded, err := ResourceAccessIDsFromString(invalid)
+	require.NoError(t, err)
+	require.Len(t, decoded, 1)
+	rc := decoded[0].GetConstraints()
+	require.NotNil(t, rc, "constraints must survive decoding")
+	require.Nil(t, rc.Details)
+	require.Equal(t, "v1", rc.Version)
+}
+
 func TestResourceIDsToResourceAccessIDs(t *testing.T) {
 	t.Parallel()
 
@@ -924,4 +1032,89 @@ func TestRiskyExtractResourceIDs(t *testing.T) {
 	require.Equal(t, []ResourceID{a1.Id, a2.Id}, out)
 
 	require.Empty(t, RiskyExtractResourceIDs(nil))
+}
+
+// TestResourceAccessIDsNewerConstraintContent verifies that constraint
+// content from a newer Auth (an unknown kind, or an unsupported version)
+// decodes to an entry with nil Details instead of failing the whole
+// list, and that the nil Details survive re-encoding.
+func TestResourceAccessIDsNewerConstraintContent(t *testing.T) {
+	t.Parallel()
+
+	ids := []ResourceAccessID{
+		{
+			Id: ResourceID{ClusterName: "root", Kind: KindNode, Name: "n1"},
+		},
+		{
+			Id: ResourceID{ClusterName: "root", Kind: KindApp, Name: "aws-console"},
+			Constraints: &ResourceConstraints{
+				Version: "v1",
+				Details: &ResourceConstraints_AwsConsole{
+					AwsConsole: &AWSConsoleResourceConstraints{RoleArns: []string{"arn:aws:iam::123:role/Allowed"}},
+				},
+			},
+		},
+	}
+	encoded, err := ResourceAccessIDsToString(ids)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		from, to    string
+		wantVersion string
+	}{
+		{
+			name:        "unknown kind",
+			from:        `"aws_console"`,
+			to:          `"some_future_kind"`,
+			wantVersion: "v1",
+		},
+		{
+			name:        "unsupported version",
+			from:        `"version":"v1"`,
+			to:          `"version":"v2"`,
+			wantVersion: "v2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Simulate the same cert created by a newer version.
+			require.Contains(t, encoded, tc.from)
+			fromNewer := strings.Replace(encoded, tc.from, tc.to, 1)
+
+			decoded, err := ResourceAccessIDsFromString(fromNewer)
+			require.NoError(t, err)
+			require.Len(t, decoded, 2)
+
+			// The plain entry is untouched.
+			require.Equal(t, ids[0].Id, decoded[0].Id)
+			require.Nil(t, decoded[0].GetConstraints())
+
+			rc := decoded[1].GetConstraints()
+			require.NotNil(t, rc, "constraints must survive decoding")
+			require.Nil(t, rc.Details)
+			require.Equal(t, tc.wantVersion, rc.Version)
+
+			require.Error(t, rc.CheckAndSetDefaults())
+
+			// The entry must stay in the constrained set; re-encoding it
+			// into the legacy AllowedResourceIDs extension would read as
+			// unconstrained access on builds without constraint support.
+			plainIDs, constrainedIDs := UnwrapResourceAccessIDs(decoded)
+			require.Len(t, plainIDs, 1)
+			require.Equal(t, ids[0].Id, plainIDs[0])
+			require.Len(t, constrainedIDs, 1)
+			require.NotNil(t, constrainedIDs[0].GetConstraints())
+
+			reencoded, err := ResourceAccessIDsToString(decoded)
+			require.NoError(t, err)
+			roundTripped, err := ResourceAccessIDsFromString(reencoded)
+			require.NoError(t, err)
+			require.Len(t, roundTripped, 2)
+			rt := roundTripped[1].GetConstraints()
+			require.NotNil(t, rt)
+			require.Nil(t, rt.Details)
+			require.Equal(t, tc.wantVersion, rt.Version)
+		})
+	}
 }

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -492,17 +492,34 @@ func (a *accessChecker) checkAllowedResources(r AccessCheckable) (allowedResourc
 	ctx := context.Background()
 	isLoggingEnabled := rbacLogger.Enabled(ctx, logutils.TraceLevel)
 
+	var match *types.ResourceAccessID
 	for _, resourceID := range a.info.AllowedResourceAccessIDs {
-		if id := resourceID.GetResourceID(); id.ClusterName == a.localCluster && matchesUCRResource(resourceID, r) {
-			// Allowed to access this resource by resource ID, move on to role checks.
+		id := resourceID.GetResourceID()
+		if id.ClusterName != a.localCluster || !matchesUCRResource(resourceID, r) {
+			continue
+		}
+		if resourceID.GetConstraints().Unenforceable() {
 			if isLoggingEnabled {
-				rbacLogger.LogAttrs(ctx, logutils.TraceLevel, "Matched allowed resource ID",
+				rbacLogger.LogAttrs(ctx, logutils.TraceLevel, "Access denied, matched resource ID carries constraints this component cannot enforce",
 					slog.String("resource_id", types.ResourceIDToString(id)),
 				)
 			}
-
-			return allowedResourceMatch{&resourceID}, nil
+			return allowedResourceMatch{}, trace.AccessDenied(
+				"access to %v %+q denied because it carries constraints this component cannot enforce; they may have been created by a newer Teleport version",
+				r.GetKind(), r.GetName())
 		}
+		if match == nil {
+			match = &resourceID
+		}
+	}
+	if match != nil {
+		// Allowed to access this resource by resource ID, move on to role checks.
+		if isLoggingEnabled {
+			rbacLogger.LogAttrs(ctx, logutils.TraceLevel, "Matched allowed resource ID",
+				slog.String("resource_id", types.ResourceIDToString(match.GetResourceID())),
+			)
+		}
+		return allowedResourceMatch{match}, nil
 	}
 
 	if isLoggingEnabled {

--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -1258,6 +1258,108 @@ func TestAccessChecker_Constraints_AwsConsole(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestAccessChecker_Constraints_UnknownKind verifies that nil-Details
+// constraints deny their resource even when no role matchers are passed.
+func TestAccessChecker_Constraints_UnknownKind(t *testing.T) {
+	const localCluster = "cluster"
+
+	role := newRole(func(rv *types.RoleV6) {
+		rv.Spec.Allow.AppLabels = types.Labels{types.Wildcard: {types.Wildcard}}
+		rv.Spec.Allow.Namespaces = []string{types.Wildcard}
+	})
+
+	newApp := func(name string) *types.AppServerV3 {
+		return &types.AppServerV3{
+			Kind: types.KindApp,
+			Metadata: types.Metadata{
+				Name: name,
+			},
+		}
+	}
+	appRID := func(name string, rc *types.ResourceConstraints) types.ResourceAccessID {
+		return types.ResourceAccessID{
+			Id: types.ResourceID{
+				ClusterName: localCluster,
+				Kind:        types.KindApp,
+				Name:        name,
+			},
+			Constraints: rc,
+		}
+	}
+	unknownConstraints := func() *types.ResourceConstraints {
+		return &types.ResourceConstraints{Version: "v1"}
+	}
+
+	info := &AccessInfo{AllowedResourceAccessIDs: []types.ResourceAccessID{
+		appRID("constrained-app", unknownConstraints()),
+		appRID("plain-app", nil),
+		// Duplicate entries for one resource; must deny regardless of order.
+		appRID("shadowed-app", nil),
+		appRID("shadowed-app", unknownConstraints()),
+	}}
+
+	ac := NewAccessCheckerWithRoleSet(info, localCluster, NewRoleSet(role))
+	state := AccessState{MFARequired: MFARequiredNever}
+
+	// No matchers, as when the app service authorizes a plain web app.
+	err := ac.CheckAccess(newApp("constrained-app"), state)
+	require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+
+	// Passing a matcher must not change the outcome.
+	err = ac.CheckAccess(newApp("constrained-app"), state, NewLoginMatcher("root"))
+	require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+
+	// A clean duplicate entry must not shadow the constrained one.
+	err = ac.CheckAccess(newApp("shadowed-app"), state)
+	require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+
+	// The rest of the identity keeps working.
+	require.NoError(t, ac.CheckAccess(newApp("plain-app"), state))
+}
+
+// TestAccessChecker_Constraints_UnknownKind_Kube verifies that a nil-Details
+// pod entry denies cluster access even alongside a clean pod entry.
+func TestAccessChecker_Constraints_UnknownKind_Kube(t *testing.T) {
+	const localCluster = "cluster"
+
+	role := newRole(func(rv *types.RoleV6) {
+		rv.Spec.Allow.KubernetesLabels = types.Labels{types.Wildcard: {types.Wildcard}}
+		rv.Spec.Allow.Namespaces = []string{types.Wildcard}
+	})
+
+	kubeCluster, err := types.NewKubernetesClusterV3(types.Metadata{Name: "kc"}, types.KubernetesClusterSpecV3{})
+	require.NoError(t, err)
+
+	podRID := func(pod string, rc *types.ResourceConstraints) types.ResourceAccessID {
+		return types.ResourceAccessID{
+			Id: types.ResourceID{
+				ClusterName:     localCluster,
+				Kind:            types.KindKubePod,
+				Name:            "kc",
+				SubResourceName: pod,
+			},
+			Constraints: rc,
+		}
+	}
+	state := AccessState{MFARequired: MFARequiredNever}
+
+	// Clean entry first, constrained entry second; still denied.
+	info := &AccessInfo{AllowedResourceAccessIDs: []types.ResourceAccessID{
+		podRID("ns/pod-a", nil),
+		podRID("ns/pod-b", &types.ResourceConstraints{Version: "v1"}),
+	}}
+	ac := NewAccessCheckerWithRoleSet(info, localCluster, NewRoleSet(role))
+	err = ac.CheckAccess(kubeCluster, state)
+	require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+
+	// Control: clean entries alone allow cluster access.
+	cleanInfo := &AccessInfo{AllowedResourceAccessIDs: []types.ResourceAccessID{
+		podRID("ns/pod-a", nil),
+	}}
+	cleanAC := NewAccessCheckerWithRoleSet(cleanInfo, localCluster, NewRoleSet(role))
+	require.NoError(t, cleanAC.CheckAccess(kubeCluster, state))
+}
+
 // TestUserSessionRoleNotFoundError ensures that role not found errors during user session access checks include UserSessionRoleNotFoundErrorMsg when appropriate,
 func TestUserSessionRoleNotFoundError(t *testing.T) {
 	// Create a mock RoleGetter that returns "role not found" error for a specific role

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -77,6 +77,14 @@ const (
 
 // ValidateAccessRequest validates the AccessRequest and sets default values
 func ValidateAccessRequest(ar types.AccessRequest) error {
+	return validateAccessRequest(ar, false)
+}
+
+// validateAccessRequest implements [ValidateAccessRequest]. With
+// allowUnenforceable set, unenforceable constraints (see
+// [types.ResourceConstraints.Unenforceable]) pass validation, keeping
+// requests written by newer Auths readable.
+func validateAccessRequest(ar types.AccessRequest, allowUnenforceable bool) error {
 	if err := CheckAndSetDefaults(ar); err != nil {
 		return trace.Wrap(err)
 	}
@@ -96,10 +104,15 @@ func ValidateAccessRequest(ar types.AccessRequest) error {
 	}
 
 	for _, r := range ar.GetRequestedResourceAccessIDs() {
-		if r.GetConstraints() == nil {
+		rc := r.GetConstraints()
+		if rc == nil {
 			continue
 		}
-		if err := r.GetConstraints().CheckAndSetDefaults(); err != nil {
+		if allowUnenforceable && rc.Unenforceable() {
+			// Skip all validation; these may carry a newer version.
+			continue
+		}
+		if err := rc.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
 		switch r.GetResourceID().Kind {
@@ -2344,7 +2357,8 @@ func UnmarshalAccessRequest(data []byte, opts ...MarshalOption) (*types.AccessRe
 	if err := utils.FastUnmarshal(data, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := ValidateAccessRequest(&req); err != nil {
+	// Requests written by newer Auths must stay readable.
+	if err := validateAccessRequest(&req, true); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if cfg.Revision != "" {
@@ -2358,6 +2372,9 @@ func UnmarshalAccessRequest(data []byte, opts ...MarshalOption) (*types.AccessRe
 
 // MarshalAccessRequest marshals the AccessRequest resource to JSON.
 func MarshalAccessRequest(accessRequest types.AccessRequest, opts ...MarshalOption) ([]byte, error) {
+	// Writes stay strict; re-persisting a request whose constraints
+	// this build couldn't decode would overwrite the newer content in
+	// the backend.
 	if err := ValidateAccessRequest(accessRequest); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -3138,6 +3138,65 @@ func TestValidate_RequestedMaxDuration(t *testing.T) {
 	}
 }
 
+// TestAccessRequestStorageToleratesUnenforceableConstraints verifies the
+// storage codec against a request written by a newer Auth: reads keep
+// working with the unknown constraint content zeroed to nil Details,
+// while writes and creation stay strict.
+func TestAccessRequestStorageToleratesUnenforceableConstraints(t *testing.T) {
+	t.Parallel()
+
+	req, err := types.NewAccessRequestWithResources(
+		uuid.New().String(), "some-user", nil, /* roles */
+		[]types.ResourceAccessID{
+			{
+				Id: types.ResourceID{ClusterName: "root", Kind: types.KindNode, Name: "n1"},
+			},
+			{
+				Id: types.ResourceID{ClusterName: "root", Kind: types.KindApp, Name: "aws-console"},
+				Constraints: &types.ResourceConstraints{
+					Version: "v1",
+					Details: &types.ResourceConstraints_AwsConsole{
+						AwsConsole: &types.AWSConsoleResourceConstraints{RoleArns: []string{"arn:aws:iam::123:role/Allowed"}},
+					},
+				},
+			},
+		})
+	require.NoError(t, err)
+
+	stored, err := MarshalAccessRequest(req)
+	require.NoError(t, err)
+
+	// Simulate the same request written by a newer Auth.
+	require.Contains(t, string(stored), `"aws_console"`)
+	fromNewer := []byte(strings.Replace(string(stored), `"aws_console"`, `"some_future_kind"`, 1))
+
+	decoded, err := UnmarshalAccessRequest(fromNewer)
+	require.NoError(t, err)
+	// The unconstrained node is unwrapped into RequestedResourceIDs at
+	// construction; only the constrained entry carries access IDs.
+	accessIDs := decoded.GetRequestedResourceAccessIDs()
+	require.Len(t, accessIDs, 1)
+	rc := accessIDs[0].GetConstraints()
+	require.NotNil(t, rc, "constraints must survive decoding")
+	require.Nil(t, rc.Details)
+	require.Equal(t, "v1", rc.Version)
+
+	// Creation stays strict.
+	require.Error(t, ValidateAccessRequest(decoded))
+
+	// Writes stay strict; re-persisting would overwrite the newer content.
+	_, err = MarshalAccessRequest(decoded)
+	require.Error(t, err)
+
+	// The stored request still reads.
+	roundTripped, err := UnmarshalAccessRequest(fromNewer)
+	require.NoError(t, err)
+	rt := roundTripped.GetRequestedResourceAccessIDs()[0].GetConstraints()
+	require.NotNil(t, rt)
+	require.Nil(t, rt.Details)
+	require.Equal(t, "v1", rt.Version)
+}
+
 func TestValidateAccessRequest_ExpandsUserNameAnnotations(t *testing.T) {
 	ctx := t.Context()
 	clock := clockwork.NewFakeClock()

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -20,6 +20,7 @@
 package sshca
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
@@ -256,4 +258,54 @@ func TestAllowedResources_SSHEncodeDecode(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAllowedResources_SSHUnknownConstraintKindDecodes verifies that a cert
+// from a newer Auth with a constraint kind this build doesn't understand
+// still decodes, keeping the unknown content as an unenforceable entry.
+func TestAllowedResources_SSHUnknownConstraintKindDecodes(t *testing.T) {
+	plainNode := types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "prod-node"}
+	constrainedApp := types.ResourceAccessID{
+		Id: types.ResourceID{ClusterName: "cluster", Kind: types.KindApp, Name: "aws-console"},
+		Constraints: &types.ResourceConstraints{
+			Version: types.V1,
+			Details: &types.ResourceConstraints_AwsConsole{
+				AwsConsole: &types.AWSConsoleResourceConstraints{
+					RoleArns: []string{"arn:aws:iam::123456789012:role/DevOps"},
+				},
+			},
+		},
+	}
+
+	ident := &Identity{
+		ValidBefore:              uint64(time.Now().Add(time.Hour).Unix()),
+		CertType:                 ssh.UserCert,
+		Username:                 "test-user",
+		Roles:                    []string{"access"},
+		AllowedResourceAccessIDs: append(types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}), constrainedApp),
+	}
+
+	cert, err := ident.Encode(constants.CertificateFormatStandard)
+	require.NoError(t, err)
+
+	ext, ok := cert.Permissions.Extensions[teleport.CertExtensionAllowedResourceAccessIDs]
+	require.True(t, ok, "AllowedResourceAccessIDs extension not found")
+	require.Contains(t, ext, `"aws_console"`)
+	cert.Permissions.Extensions[teleport.CertExtensionAllowedResourceAccessIDs] = strings.Replace(ext, `"aws_console"`, `"some_future_kind"`, 1)
+
+	decoded, err := DecodeIdentity(cert)
+	require.NoError(t, err)
+
+	byName := map[string]types.ResourceAccessID{}
+	for _, r := range decoded.AllowedResourceAccessIDs {
+		byName[r.GetResourceID().Name] = r
+	}
+	require.Len(t, byName, 2)
+	require.Contains(t, byName, "prod-node")
+	require.Nil(t, byName["prod-node"].Constraints)
+
+	rc := byName["aws-console"].Constraints
+	require.NotNil(t, rc, "constraints must survive decoding")
+	require.Nil(t, rc.Details)
+	require.Equal(t, types.V1, rc.Version)
 }

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"strings"
 	"testing"
 	"time"
 
@@ -604,6 +605,66 @@ func TestAllowedResources_EncodeDecodeCycle(t *testing.T) {
 			assert.ElementsMatch(t, decoded.AllowedResourceIDs, roundtripped.AllowedResourceIDs)
 		})
 	}
+}
+
+// TestAllowedResources_UnknownConstraintKindDecodes verifies that a cert
+// minted by a newer Auth with a constraint kind this build does not know
+// still decodes, keeping the unknown content as an unenforceable entry.
+func TestAllowedResources_UnknownConstraintKindDecodes(t *testing.T) {
+	plainNode := types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "prod-node"}
+	constrainedApp := types.ResourceAccessID{
+		Id: types.ResourceID{ClusterName: "cluster", Kind: types.KindApp, Name: "aws-console"},
+		Constraints: &types.ResourceConstraints{
+			Version: types.V1,
+			Details: &types.ResourceConstraints_AwsConsole{
+				AwsConsole: &types.AWSConsoleResourceConstraints{
+					RoleArns: []string{"arn:aws:iam::123456789012:role/DevOps"},
+				},
+			},
+		},
+	}
+
+	identity := &Identity{
+		Username:                 "test-user",
+		Groups:                   []string{"access"},
+		AllowedResourceAccessIDs: append(types.ResourceIDsToResourceAccessIDs([]types.ResourceID{plainNode}), constrainedApp),
+	}
+
+	subj, err := identity.Subject()
+	require.NoError(t, err)
+
+	// Simulate the same cert minted by a newer Auth.
+	tampered := false
+	for i, name := range subj.ExtraNames {
+		if !name.Type.Equal(AllowedResourceAccessIDsASN1ExtensionOID) {
+			continue
+		}
+		val, ok := name.Value.(string)
+		require.True(t, ok)
+		require.Contains(t, val, `"aws_console"`)
+		subj.ExtraNames[i].Value = strings.Replace(val, `"aws_console"`, `"some_future_kind"`, 1)
+		tampered = true
+	}
+	require.True(t, tampered, "AllowedResourceAccessIDs extension not found")
+
+	subj.Names = append(subj.Names, subj.ExtraNames...)
+	subj.ExtraNames = nil
+
+	decoded, err := FromSubject(subj, time.Time{})
+	require.NoError(t, err)
+
+	byName := map[string]types.ResourceAccessID{}
+	for _, r := range decoded.AllowedResourceAccessIDs {
+		byName[r.GetResourceID().Name] = r
+	}
+	require.Len(t, byName, 2)
+	require.Contains(t, byName, "prod-node")
+	require.Nil(t, byName["prod-node"].Constraints)
+
+	rc := byName["aws-console"].Constraints
+	require.NotNil(t, rc, "constraints must survive decoding")
+	require.Nil(t, rc.Details)
+	require.Equal(t, types.V1, rc.Version)
 }
 
 // legacyExtensionIDs extracts ResourceIDs from the legacy AllowedResources


### PR DESCRIPTION
## Context
Backport #68785 to branch/v18.

changelog: Certificates carrying resource constraints of a kind introduced in a newer Teleport version are no longer rejected entirely by older components.

## Manual Test Plan
### Test Environment
- Cluster A: single-node cluster (Auth, Proxy, SSH agent, app agent) built from this branch.
- Cluster B: same layout/config, with builds from a branch that adds a constraint kind this branch doesn't know (e.g., from `master` for the non-backported SSH kind). Auth, Proxy, and App agent built from branch/v18 to repro the failure, and from this branch to verify the fix.

### Test Cases
- [x] Known kinds, app constraints (cluster A): request an AWS console app constrained to a subset of role ARNs plus an unconstrained SSH node; approve and assume. Verify `tsh status` lists both resources, app login offers only the request ARNs, and SSH to the node succeeds.
- [x] Failure repro'd on branch/v18 (cluster B, v18-built Proxy/agent): request a plain App resource plus an SSH node with a `ssh_logins` constraint; approve and assume prior to switching Proxy/agent to their v18 builds. Verify connecting to the plain App resource fails, and the component logs show a ResourceAccessID parse err.
- [x] Fix verified on this branch (cluster B, this branch's Proxy/agent): with the same assumed cert (no need to re-request), connecting to the plain App resource succeeds and access to the constrained SSH node is denied.
- [x] Creation stays strict: a request whose constraints carry no known member (raw gRPC or a hand-edited dry-run) is rejected with "constraints carry no supported content".

