### PR TITLE
Fix `google.protobuf.Struct` handling in the Kubernetes operator

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_provisiontokens.yaml
@@ -420,7 +420,6 @@ spec:
                       and JWKS keys.
                     type: string
                   must_match_fields:
-                    additionalProperties: true
                     description: 'MustMatchFields perform simple comparison matches
                       using "AND" semantics. Rules are specified by mirroring the
                       structure of the JWT, using values that are expected to be equal
@@ -441,6 +440,7 @@ spec:
                       any join attempts to succeed.'
                     nullable: true
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   static_jwks:
                     description: StaticJWKS is an optional static JWKS value that
                       can be used to specify JWKS keys when either OIDC discovery

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -313,7 +313,6 @@ spec:
                       and JWKS keys.
                     type: string
                   must_match_fields:
-                    additionalProperties: true
                     description: '"Must match" fields perform simple comparison matches
                       using "AND" semantics. Rules are specified by mirroring the
                       structure of the JWT, using values that are expected to be equal
@@ -334,6 +333,7 @@ spec:
                       any join attempts to succeed.'
                     nullable: true
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   static_jwks:
                     description: An optional static JWKS value that can be used to
                       specify JWKS keys when either OIDC discovery is either not supported

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_workloadidentitiesv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_workloadidentitiesv1.yaml
@@ -137,10 +137,10 @@ spec:
                     nullable: true
                     properties:
                       extra_claims:
-                        additionalProperties: true
                         description: Additional claims that will be added to the JWT.
                         nullable: true
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       maximum_ttl:
                         description: Control the maximum TTL of JWT-SVIDs issued using
                           this WorkloadIdentity.  If a JWT-SVID is requested with

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
@@ -420,7 +420,6 @@ spec:
                       and JWKS keys.
                     type: string
                   must_match_fields:
-                    additionalProperties: true
                     description: 'MustMatchFields perform simple comparison matches
                       using "AND" semantics. Rules are specified by mirroring the
                       structure of the JWT, using values that are expected to be equal
@@ -441,6 +440,7 @@ spec:
                       any join attempts to succeed.'
                     nullable: true
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   static_jwks:
                     description: StaticJWKS is an optional static JWKS value that
                       can be used to specify JWKS keys when either OIDC discovery

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -313,7 +313,6 @@ spec:
                       and JWKS keys.
                     type: string
                   must_match_fields:
-                    additionalProperties: true
                     description: '"Must match" fields perform simple comparison matches
                       using "AND" semantics. Rules are specified by mirroring the
                       structure of the JWT, using values that are expected to be equal
@@ -334,6 +333,7 @@ spec:
                       any join attempts to succeed.'
                     nullable: true
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   static_jwks:
                     description: An optional static JWKS value that can be used to
                       specify JWKS keys when either OIDC discovery is either not supported

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_workloadidentitiesv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_workloadidentitiesv1.yaml
@@ -137,10 +137,10 @@ spec:
                     nullable: true
                     properties:
                       extra_claims:
-                        additionalProperties: true
                         description: Additional claims that will be added to the JWT.
                         nullable: true
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       maximum_ttl:
                         description: Control the maximum TTL of JWT-SVIDs issued using
                           this WorkloadIdentity.  If a JWT-SVID is requested with

--- a/integrations/operator/crdgen/schema_test.go
+++ b/integrations/operator/crdgen/schema_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -59,20 +61,37 @@ func TestCRDSchemaValidation(t *testing.T) {
 			validator := validators[obj.GroupVersionKind()]
 			require.NotNil(t, validator)
 
-			result := validator.Validate(obj.Object)
+			result := validator.validator.Validate(obj.Object)
 			require.Empty(t, result.Errors)
+
+			// Also run it through the structured schema pruning to make sure
+			// nothing gets removed.
+			pruned := pruning.PruneWithOptions(
+				obj.Object,
+				validator.structural,
+				true,
+				structuralschema.UnknownFieldPathOptions{
+					TrackUnknownFieldPaths: true,
+				},
+			)
+			require.Empty(t, pruned, "no fields should be unexpectedly pruned")
 		})
 	}
 }
 
+type crdSchema struct {
+	validator  validation.SchemaCreateValidator
+	structural *structuralschema.Structural
+}
+
 // buildValidators parses all CRDs in the specified directory and returns a map of GVK and SchemaCreateValidator.
-func buildValidators(t *testing.T, crdDir string) map[schema.GroupVersionKind]validation.SchemaCreateValidator {
+func buildValidators(t *testing.T, crdDir string) map[schema.GroupVersionKind]crdSchema {
 	t.Helper()
 
 	crdFiles, err := filepath.Glob(filepath.Join(crdDir, "*.yaml"))
 	require.NoError(t, err)
 
-	validators := make(map[schema.GroupVersionKind]validation.SchemaCreateValidator, len(crdFiles))
+	validators := make(map[schema.GroupVersionKind]crdSchema, len(crdFiles))
 	for _, crdFile := range crdFiles {
 		data, err := os.ReadFile(crdFile)
 		require.NoError(t, err)
@@ -95,13 +114,21 @@ func buildValidators(t *testing.T, crdDir string) map[schema.GroupVersionKind]va
 		validator, _, err := validation.NewSchemaValidator(internalSchema)
 		require.NoError(t, err)
 
+		structural, err := structuralschema.NewStructural(internalSchema)
+		require.NoError(t, err)
+		require.Empty(t, structuralschema.ValidateStructural(nil, structural))
+
 		gvk := schema.GroupVersionKind{
 			Group:   crd.Spec.Group,
 			Version: ver.Name,
 			Kind:    crd.Spec.Names.Kind,
 		}
 
-		validators[gvk] = validator
+		validators[gvk] = crdSchema{
+			validator:  validator,
+			structural: structural,
+		}
+
 	}
 	return validators
 }

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -524,9 +524,16 @@ func (generator *SchemaGenerator) singularProp(field *Field, prop *apiextv1.JSON
 		// JSON object. We can't know the structure ahead of time and there can
 		// be many levels of nesting within this.
 		prop.Type = "object"
-		prop.AdditionalProperties = &apiextv1.JSONSchemaPropsOrBool{
-			Allows: true,
-		}
+
+		// Structs have no defined schema and may be entirely user-defined /
+		// free-form, so set XPreserveUnknownFields to disable pruning for child
+		// fields to ensure Kubernetes doesn't prune them in the validator.
+		//
+		// Note that AdditionalProperties cannot be set: if it's non-nil, all
+		// child fields get pruned before the validator bothers to check
+		// XPreserveUnknownFields. In practice this means nested structs get
+		// pruned or rejected at runtime.
+		prop.XPreserveUnknownFields = new(true)
 	case field.IsMessage():
 		inner := field.TypeMessage()
 		if inner == nil {

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -530,9 +530,8 @@ func (generator *SchemaGenerator) singularProp(field *Field, prop *apiextv1.JSON
 		// fields to ensure Kubernetes doesn't prune them in the validator.
 		//
 		// Note that AdditionalProperties cannot be set: if it's non-nil, all
-		// child fields get pruned before the validator bothers to check
-		// XPreserveUnknownFields. In practice this means nested structs get
-		// pruned or rejected at runtime.
+		// child fields get pruned regardless of `XPreserveUnknownFields`, which
+		// in practice means nested structs get pruned or rejected at runtime.
 		prop.XPreserveUnknownFields = new(true)
 	case field.IsMessage():
 		inner := field.TypeMessage()

--- a/integrations/operator/crdgen/test/fixtures/provision_token_generic_oidc.yaml
+++ b/integrations/operator/crdgen/test/fixtures/provision_token_generic_oidc.yaml
@@ -1,0 +1,27 @@
+apiVersion: resources.teleport.dev/v2
+kind: TeleportProvisionToken
+metadata:
+  name: test-generic-oidc-token
+  namespace: default
+spec:
+  roles:
+    - Node
+  join_method: generic_oidc
+  generic_oidc:
+    issuer: "https://idp.example.com"
+    audience: "example.teleport.sh/generic-oidc"
+    # google.protobuf.Struct: free-form, and explicitly documented as supporting
+    # nested fields. Every value below must survive pruning unchanged.
+    must_match_fields:
+      org: acme
+      enabled: true
+      count: 42
+      nested:
+        deep: value
+        deeper:
+          deepest: value
+    allow_any:
+      - conditions:
+          - attribute: sub
+            eq:
+              value: "test-subject"

--- a/integrations/operator/crdgen/test/fixtures/scoped_role_assignment.yaml
+++ b/integrations/operator/crdgen/test/fixtures/scoped_role_assignment.yaml
@@ -1,10 +1,10 @@
 apiVersion: resources.teleport.dev/v1
 kind: TeleportScopedRoleAssignmentV1
 scope: /foo
-sub_kind: dynamic
 spec:
   user: "test"
   assignments:
     - role: some-role
       scope: /foo/bar
-version: v1
+# note: the operator adds version and sub_kind so they don't need to be set here
+# (and would be pruned anyway, since they aren't declared.)

--- a/integrations/operator/crdgen/test/fixtures/scoped_token_generic_oidc.yaml
+++ b/integrations/operator/crdgen/test/fixtures/scoped_token_generic_oidc.yaml
@@ -1,0 +1,24 @@
+apiVersion: resources.teleport.dev/v1
+kind: TeleportScopedTokenV1
+metadata:
+  name: test-scoped-generic-oidc-token
+  namespace: default
+scope: "/test"
+spec:
+  roles:
+    - Node
+  assigned_scope: "/test/stag"
+  join_method: generic_oidc
+  usage_mode: unlimited
+  generic_oidc:
+    issuer: "https://idp.example.com"
+    audience: "example.teleport.sh/generic-oidc"
+    must_match_fields:
+      org: acme
+      nested:
+        deep: value
+    allow_any:
+      - conditions:
+          - attribute: sub
+            eq:
+              value: "test-subject"

--- a/integrations/operator/crdgen/test/fixtures/workload_identity.yaml
+++ b/integrations/operator/crdgen/test/fixtures/workload_identity.yaml
@@ -1,0 +1,13 @@
+apiVersion: resources.teleport.dev/v1
+kind: TeleportWorkloadIdentityV1
+metadata:
+  name: test-workload-identity
+  namespace: default
+spec:
+  spiffe:
+    id: /test/workload
+    jwt:
+      extra_claims:
+        team: platform
+        nested:
+          foo: bar


### PR DESCRIPTION
This fixes a bug in the Kubernetes operator where nested fields in a `google.protobuf.Struct` object would be silently pruned by the validator. This matters to the `generic_oidc` join method where the `must_match_fields` field (which accepts structured fields to match against an incoming JWT) could get pruned and then silently ignored, bypassing join rules.

Note that use of nested fields _usually_ results in an error, but only in strict mode. It's the default now, but could still plausibly be disabled causing silent loss of rules.

The bug itself is in how we configured struct schemas. We specified `additionalProperties: true`, which would be valid way to indicate free-form content in a JSON Schema, but Kubernetes structural schemas handle that differently. If set, it takes a code path that results in child fields (or, well, non scalars) getting pruned. The correct way to indicate to the validator that a field contains arbitrary JSON is with [`XPreserveUnknownFields`](https://kubernetes.io/docs/reference/kubernetes-api/apiextensions/custom-resource-definition-v1/#CustomResourceDefinitionSpec).

This "worked" before because of the explanation above: the validator only prunes child fields. The top level dict was untouched regardless and you'd need to nest values for anything to get pruned. Thankfully users (_by default_) get an error when this happens, with the client being in strict mode by default.

Changelog: Fixed an issue where the Kubernetes operator could prune or reject nested fields in Generic OIDC join tokens and Workload Identity resources

## Manual Test Plan
### Test Environment

Tested using my [`teleport-harness` project](https://github.com/timothyb89/teleport-harness/commit/3fe50b95adcf44d286655326e14d17896132fba9), with Claude-generated test cases against a temporary Teleport cluster. Full report: https://gist.github.com/timothyb89/8b1d56e6714de198c2275dada86e7d56

### Test Cases
- [x] generic_oidc tokens can now accept nested claims in `must_match_fields`
   - [x] provision tokens preserve nested `must_match_fields` values 
   - [x] scoped tokens preserve nested `must_match_fields` values
   - [x] `generic_oidc` both allows (matching) and denies (mismatched) nested field values
- [x] nested fields in `workload_identity` resources can now round-trip
