### PR TITLE
[v18] Validate MFA challenge scopes provided by the client

### DIFF
--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -18,6 +18,7 @@ package mfa
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"slices"
 
@@ -51,6 +52,14 @@ type MFACeremonyConstructor func(ctx context.Context) (CallbackCeremony, error)
 
 // CreateAuthenticateChallengeFunc is a function that creates an authentication challenge.
 type CreateAuthenticateChallengeFunc func(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error)
+
+// isMFANotSupportedForClient reports whether err is the Auth server's response
+// indicating that the caller is not an end user and therefore cannot perform an
+// MFA ceremony.
+func isMFANotSupportedForClient(err error) bool {
+	return errors.Is(err, &ErrMFANotSupportedContextUser) ||
+		errors.Is(err, &ErrMFANotSupportedMFARequiredCheck)
+}
 
 // Run the MFA ceremony.
 //
@@ -91,10 +100,10 @@ func (c *Ceremony) Run(ctx context.Context, req *proto.CreateAuthenticateChallen
 
 	chal, err := c.CreateAuthenticateChallenge(ctx, req)
 	if err != nil {
-		// CreateAuthenticateChallenge returns a bad parameter error when the client
-		// user is not a Teleport user - for example, the AdminRole. Treat this as an MFA
-		// not supported error so the client knows when it can be ignored.
-		if trace.IsBadParameter(err) {
+		// CreateAuthenticateChallenge returns a "NotSupported" error when the client
+		// user is not a Teleport user - for example, the AdminRole. Treat this as an
+		// MFA not supported error so the client knows when it can be ignored.
+		if isMFANotSupportedForClient(err) {
 			return nil, &ErrMFANotSupported
 		}
 		return nil, trace.Wrap(err)

--- a/api/mfa/ceremony_test.go
+++ b/api/mfa/ceremony_test.go
@@ -116,6 +116,54 @@ func TestMFACeremony(t *testing.T) {
 				assert.ErrorContains(t, err, "prompt mfa failure")
 				assert.Nil(t, mr)
 			},
+		}, {
+			name: "OK ErrMFANotSupportedContextUser maps to ErrMFANotSupported",
+			ceremony: &mfa.Ceremony{
+				CreateAuthenticateChallenge: func(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
+					return nil, trace.Wrap(&mfa.ErrMFANotSupportedContextUser)
+				},
+				PromptConstructor: func(opts ...mfa.PromptOpt) mfa.Prompt {
+					return mfa.PromptFunc(func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+						return nil, trace.BadParameter("prompt should not be reached")
+					})
+				},
+			},
+			assertCeremonyResponse: func(t *testing.T, mr *proto.MFAAuthenticateResponse, err error, i ...interface{}) {
+				assert.ErrorIs(t, err, &mfa.ErrMFANotSupported)
+				assert.Nil(t, mr)
+			},
+		}, {
+			name: "OK ErrMFANotSupportedMFARequiredCheck maps to ErrMFANotSupported",
+			ceremony: &mfa.Ceremony{
+				CreateAuthenticateChallenge: func(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
+					return nil, trace.Wrap(&mfa.ErrMFANotSupportedMFARequiredCheck)
+				},
+				PromptConstructor: func(opts ...mfa.PromptOpt) mfa.Prompt {
+					return mfa.PromptFunc(func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+						return nil, trace.BadParameter("prompt should not be reached")
+					})
+				},
+			},
+			assertCeremonyResponse: func(t *testing.T, mr *proto.MFAAuthenticateResponse, err error, i ...interface{}) {
+				assert.ErrorIs(t, err, &mfa.ErrMFANotSupported)
+				assert.Nil(t, mr)
+			},
+		}, {
+			name: "OK unrelated bad parameter is surfaced",
+			ceremony: &mfa.Ceremony{
+				CreateAuthenticateChallenge: func(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
+					return nil, trace.BadParameter("stored session lacks challenge extensions")
+				},
+				PromptConstructor: func(opts ...mfa.PromptOpt) mfa.Prompt {
+					return mfa.PromptFunc(func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+						return nil, trace.BadParameter("prompt should not be reached")
+					})
+				},
+			},
+			assertCeremonyResponse: func(t *testing.T, mr *proto.MFAAuthenticateResponse, err error, i ...interface{}) {
+				assert.ErrorContains(t, err, "stored session lacks challenge extensions")
+				assert.Nil(t, mr)
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 )
 
 // ResponseMetadataKey is the context metadata key for an MFA response in a gRPC request.
@@ -47,12 +48,42 @@ var (
 	// the client user.
 	ErrMFANotSupported = trace.BadParameterError{Message: "re-authentication with MFA is not supported for this client"}
 
+	// ErrMFANotSupportedContextUser is returned by the Auth server's
+	// CreateAuthenticateChallenge when a caller that is not an end user (for
+	// example, the built-in admin identity) requests a challenge for itself via
+	// ContextUser. Such callers cannot perform an MFA ceremony.
+	//
+	// The message must not change: MFA ceremonies detect this condition by message
+	// so it remains recognizable across version skew, including against older Auth
+	// servers that returned it as a bare bad-parameter error.
+	ErrMFANotSupportedContextUser = trace.BadParameterError{Message: "only end users are allowed to issue authentication challenges using ContextUser"}
+
+	// ErrMFANotSupportedMFARequiredCheck is returned by the Auth server's
+	// CreateAuthenticateChallenge when a caller that is not an end user supplies an
+	// MFARequiredCheck. Such callers cannot perform an MFA ceremony.
+	//
+	// The message must not change, for the same backwards-compatibility reason as
+	// [ErrMFANotSupportedContextUser].
+	ErrMFANotSupportedMFARequiredCheck = trace.BadParameterError{Message: "only end users are allowed to supply MFARequiredCheck"}
+
 	// ErrExpiredReusableMFAResponse is returned by Auth APIs like
 	// GenerateUserCerts when an expired reusable MFA response is provided.
 	ErrExpiredReusableMFAResponse = trace.AccessDeniedError{
 		Message: "Reusable MFA response validation failed and possibly expired",
 	}
+
+	// ErrUnknownChallengeScope is returned if the requested challenge scope is
+	// unknown, usually indicating an out of date auth server.
+	ErrUnknownChallengeScope = trace.BadParameterError{Message: "challenge scope unknown; auth server may be out of date"}
 )
+
+// ValidateChallengeScope checks that the given challenge is valid.
+func ValidateChallengeScope(scope mfav1.ChallengeScope) error {
+	if _, ok := mfav1.ChallengeScope_name[int32(scope)]; !ok {
+		return trace.Wrap(&ErrUnknownChallengeScope)
+	}
+	return nil
+}
 
 // WithCredentials can be called on a GRPC client request to attach
 // MFA credentials to the GRPC metadata for requests that require MFA,

--- a/api/mfa/mfa_test.go
+++ b/api/mfa/mfa_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/testhelpers/mtls"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
@@ -105,4 +106,44 @@ func TestMFAPerRPCCredentials(t *testing.T) {
 
 	_, err = client.Ping(context.Background(), &proto.PingRequest{}, mfa.WithCredentials(mfaTestResp))
 	assert.NoError(t, err)
+}
+
+func TestValidateChallengeScope(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		scope     mfav1.ChallengeScope
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "unspecified is known",
+			scope:     mfav1.ChallengeScope_CHALLENGE_SCOPE_UNSPECIFIED,
+			assertErr: require.NoError,
+		},
+		{
+			name:      "defined scope",
+			scope:     mfav1.ChallengeScope_CHALLENGE_SCOPE_USER_SESSION,
+			assertErr: require.NoError,
+		},
+		{
+			name:  "out of range scope",
+			scope: mfav1.ChallengeScope(99),
+			assertErr: func(t require.TestingT, err error, args ...any) {
+				require.ErrorIs(t, err, &mfa.ErrUnknownChallengeScope)
+			},
+		},
+		{
+			name:  "negative scope",
+			scope: mfav1.ChallengeScope(-1),
+			assertErr: func(t require.TestingT, err error, args ...any) {
+				require.ErrorIs(t, err, &mfa.ErrUnknownChallengeScope)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.assertErr(t, mfa.ValidateChallengeScope(tt.scope))
+		})
+	}
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -4588,6 +4588,10 @@ func (a *Server) CreateAuthenticateChallenge(ctx context.Context, req *proto.Cre
 		}
 	}
 
+	if err := mfa.ValidateChallengeScope(challengeExtensions.Scope); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	switch req.GetRequest().(type) {
 	case *proto.CreateAuthenticateChallengeRequest_UserCredentials:
 		username = req.GetUserCredentials().GetUsername()

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -41,6 +41,7 @@ import (
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
@@ -677,6 +678,69 @@ func TestCreateAuthenticateChallenge_failedLoginAudit(t *testing.T) {
 		assert.Equal(t, events.UserLoginEvent, event.GetType(), "event.Type mismatch")
 		assert.Equal(t, events.UserLocalLoginFailureCode, event.GetCode(), "event.Code mismatch")
 	})
+}
+
+// TestCreateAuthenticateChallenge_errors verifies that CreateAuthenticateChallenge
+// returns the expected sentinel errors and that they survive the gRPC round trip,
+// so mfa.(*Ceremony).Run can detect them on the client.
+func TestCreateAuthenticateChallenge_errors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+
+	// An end user gets past the "only end users" gate, exercising errors that
+	// occur deeper in challenge creation.
+	u, err := createUserWithSecondFactors(srv)
+	require.NoError(t, err)
+	endUserClient, err := srv.NewClient(authtest.TestUser(u.username))
+	require.NoError(t, err)
+
+	// A built-in identity (here, the admin role) is not an end user and cannot
+	// perform an MFA ceremony.
+	builtinClient, err := srv.NewClient(authtest.TestBuiltin(types.RoleAdmin))
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name    string
+		client  *authclient.Client
+		req     *proto.CreateAuthenticateChallengeRequest
+		wantErr error
+	}{
+		{
+			name:   "unknown challenge scope",
+			client: endUserClient,
+			req: &proto.CreateAuthenticateChallengeRequest{
+				ChallengeExtensions: &mfav1.ChallengeExtensions{
+					Scope: mfav1.ChallengeScope(99), // out of range, unknown scope
+				},
+			},
+			wantErr: &mfa.ErrUnknownChallengeScope,
+		},
+		{
+			name:    "non-end-user ContextUser challenge",
+			client:  builtinClient,
+			req:     &proto.CreateAuthenticateChallengeRequest{},
+			wantErr: &mfa.ErrMFANotSupportedContextUser,
+		},
+		{
+			name:   "non-end-user MFARequiredCheck",
+			client: builtinClient,
+			// A non-default request type skips the ContextUser gate above, so the
+			// MFARequiredCheck gate is what rejects the non-end-user caller.
+			req: &proto.CreateAuthenticateChallengeRequest{
+				Request:          &proto.CreateAuthenticateChallengeRequest_Passwordless{Passwordless: &proto.Passwordless{}},
+				MFARequiredCheck: &proto.IsMFARequiredRequest{},
+			},
+			wantErr: &mfa.ErrMFANotSupportedMFARequiredCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// Requests go over gRPC to ensure the error shapes survive the round trip.
+			_, err := tt.client.CreateAuthenticateChallenge(ctx, tt.req)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
 }
 
 func TestCreateRegisterChallenge(t *testing.T) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -51,6 +51,7 @@ import (
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/metadata"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -8394,7 +8395,7 @@ func (a *ServerWithRoles) CreateAuthenticateChallenge(ctx context.Context, req *
 	case *proto.CreateAuthenticateChallengeRequest_Passwordless:
 	default: // nil or *proto.CreateAuthenticateChallengeRequest_ContextUser:
 		if !isLocalOrRemoteUser {
-			return nil, trace.BadParameter("only end users are allowed to issue authentication challenges using ContextUser")
+			return nil, trace.Wrap(&mfa.ErrMFANotSupportedContextUser)
 		}
 	}
 
@@ -8406,7 +8407,7 @@ func (a *ServerWithRoles) CreateAuthenticateChallenge(ctx context.Context, req *
 	if req.MFARequiredCheck != nil {
 		// Return a nicer error message.
 		if !isLocalOrRemoteUser {
-			return nil, trace.BadParameter("only end users are allowed to supply MFARequiredCheck")
+			return nil, trace.Wrap(&mfa.ErrMFANotSupportedMFARequiredCheck)
 		}
 
 		mfaRequiredResp, err := a.IsMFARequired(ctx, req.MFARequiredCheck)


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/69028 to branch/v18

## Manual Test Plan
Manual tests to cover the adjustments to `ErrMFANotSupported` error handling.

### Test Environment
### Test Cases
- [x] `tctl get tokens --with-secrets` (or any admin action)
  - [x] With user's credentials prompts for MFA
  - [x] With built-in admin credentials does not prompt for MFA
- [x] Test again with v17 server, updated client
- [x] Test again with v17 client, updated server