### PR TITLE
Fix some drift in the builds for Windows binaries

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -407,6 +407,33 @@ function Build-WindowsAuthenticationPackage {
     Write-Host $("Built Windows authentication package in {0:g}" -f $CommandDuration)
 }
 
+function Get-KubectlVersionLDFlag {
+    <#
+    .SYNOPSIS
+        Returns the linker flag that adds the bundled kubectl version.
+
+    .OUTPUTS
+    string
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $TeleportSourceDirectory
+    )
+
+    Push-Location "$TeleportSourceDirectory"
+    try {
+        $KubectlVersion = (go list -m -f '{{.Version}}' k8s.io/kubectl) -replace '^v0\.', 'v1.'
+        if ($LastExitCode -ne 0) {
+            exit $LastExitCode
+        }
+    } finally {
+        Pop-Location
+    }
+
+    return "-X k8s.io/component-base/version.gitVersion=$KubectlVersion"
+}
+
 function Build-Tsh {
     [CmdletBinding()]
     param(
@@ -422,6 +449,7 @@ function Build-Tsh {
     $BuildDirectory = "$TeleportSourceDirectory\build"
     $SignedBinaryPath = "$BuildDirectory\$BinaryName"
     $BuildTypeLDFlags = "-X github.com/gravitational/teleport/lib/modules.teleportBuildType=community"
+    $KubectlLDFlags = Get-KubectlVersionLDFlag -TeleportSourceDirectory "$TeleportSourceDirectory"
 
     $CommandDuration = Measure-Block {
         Write-Host "::group::Building tsh..."
@@ -432,7 +460,7 @@ function Build-Tsh {
         cargo build -p rdp-decoder --release --locked --target x86_64-pc-windows-gnu
         $UnsignedBinaryPath = "$BuildDirectory\unsigned-$BinaryName"
         # -Wl,--gc-sections lets the linker drop unreachable native code.
-        go build -tags "piv rust_rdp_decoder" -trimpath -ldflags "-s -w $BuildTypeLDFlags -extldflags=-Wl,--gc-sections" -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tsh"
+        go build -tags "grpcnotrace piv rust_rdp_decoder kustomize_disable_go_plugin_support" -trimpath -ldflags "-s -w $BuildTypeLDFlags $KubectlLDFlags -extldflags=-Wl,--gc-sections" -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tsh"
         if ($LastExitCode -ne 0) {
             exit $LastExitCode
         }
@@ -462,11 +490,12 @@ function Build-Tctl {
     $BuildDirectory = "$TeleportSourceDirectory\build"
     $SignedBinaryPath = "$BuildDirectory\$BinaryName"
     $BuildTypeLDFlags = "-X github.com/gravitational/teleport/lib/modules.teleportBuildType=community"
+    $KubectlLDFlags = Get-KubectlVersionLDFlag -TeleportSourceDirectory "$TeleportSourceDirectory"
 
     $CommandDuration = Measure-Block {
         Write-Host "::group::Building tctl..."
         $UnsignedBinaryPath = "$BuildDirectory\unsigned-$BinaryName"
-        go build -tags piv -trimpath -ldflags "-s -w $BuildTypeLDFlags" -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tctl"
+        go build -tags "grpcnotrace piv kustomize_disable_go_plugin_support" -trimpath -ldflags "-s -w $BuildTypeLDFlags $KubectlLDFlags" -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tctl"
         if ($LastExitCode -ne 0) {
             exit $LastExitCode
         }
@@ -495,11 +524,13 @@ function Build-Tbot {
     $BinaryName = "tbot.exe"
     $BuildDirectory = "$TeleportSourceDirectory\build"
     $SignedBinaryPath = "$BuildDirectory\$BinaryName"
+    $BuildTypeLDFlags = "-X github.com/gravitational/teleport/lib/modules.teleportBuildType=community"
+    $KubectlLDFlags = Get-KubectlVersionLDFlag -TeleportSourceDirectory "$TeleportSourceDirectory"
 
     $CommandDuration = Measure-Block {
         Write-Host "::group::Building tbot..."
         $UnsignedBinaryPath = "$BuildDirectory\unsigned-$BinaryName"
-        go build -trimpath -ldflags "-s -w" -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tbot"
+        go build -tags "grpcnotrace kustomize_disable_go_plugin_support" -trimpath -ldflags "-s -w $BuildTypeLDFlags $KubectlLDFlags" -o "$UnsignedBinaryPath" "$TeleportSourceDirectory\tool\tbot"
         if ($LastExitCode -ne 0) {
             exit $LastExitCode
         }


### PR DESCRIPTION
Windows release builds don't run via the Makefile, they are built with the build.ps1 script. There are a few settings/flags that we added to the Makefile but forgot to add to the build script:

- The kubectl version for tsh's embedded kubectl. (See #69223)
- The grpcnotrace build tag, for dead code elimination
- The kustomize_disable_go_plugin_support, for smaller binaries

Additionally, we weren't passing the "build type" variable to all binaries, so some of our community edition downloads would report that they are OSS/AGPL builds instead of Community Edition builds.

Closes #69223


## Manual Test Plan

### Test Environment

Tag build.

### Test Cases
- [x] Tag build succeeds.
- [x] `tsh kubectl version` on Windows no longer prints the `v0.0.0-master+$Format:%H$` placeholder.
