### PR TITLE
[v18] MWI Scopes: Github Join Method

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token_protohybrid.pb.go
@@ -274,7 +274,9 @@ type ScopedTokenSpec struct {
 	// Mutually exclusive with assigned_scope.
 	Bot string `protobuf:"bytes,15,opt,name=bot,proto3" json:"bot,omitempty"`
 	// Configuration specific to the "generic_oidc" join method.
-	GenericOidc   *GenericOIDC `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3" json:"generic_oidc,omitempty"`
+	GenericOidc *GenericOIDC `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3" json:"generic_oidc,omitempty"`
+	// Configuration specific to the "github" join method.
+	Github        *Github `protobuf:"bytes,17,opt,name=github,proto3" json:"github,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -402,6 +404,13 @@ func (x *ScopedTokenSpec) GetGenericOidc() *GenericOIDC {
 	return nil
 }
 
+func (x *ScopedTokenSpec) GetGithub() *Github {
+	if x != nil {
+		return x.Github
+	}
+	return nil
+}
+
 func (x *ScopedTokenSpec) SetAssignedScope(v string) {
 	x.AssignedScope = v
 }
@@ -456,6 +465,10 @@ func (x *ScopedTokenSpec) SetBot(v string) {
 
 func (x *ScopedTokenSpec) SetGenericOidc(v *GenericOIDC) {
 	x.GenericOidc = v
+}
+
+func (x *ScopedTokenSpec) SetGithub(v *Github) {
+	x.Github = v
 }
 
 func (x *ScopedTokenSpec) HasImmutableLabels() bool {
@@ -521,6 +534,13 @@ func (x *ScopedTokenSpec) HasGenericOidc() bool {
 	return x.GenericOidc != nil
 }
 
+func (x *ScopedTokenSpec) HasGithub() bool {
+	if x == nil {
+		return false
+	}
+	return x.Github != nil
+}
+
 func (x *ScopedTokenSpec) ClearImmutableLabels() {
 	x.ImmutableLabels = nil
 }
@@ -555,6 +575,10 @@ func (x *ScopedTokenSpec) ClearBoundKeypair() {
 
 func (x *ScopedTokenSpec) ClearGenericOidc() {
 	x.GenericOidc = nil
+}
+
+func (x *ScopedTokenSpec) ClearGithub() {
+	x.Github = nil
 }
 
 type ScopedTokenSpec_builder struct {
@@ -601,6 +625,8 @@ type ScopedTokenSpec_builder struct {
 	Bot string
 	// Configuration specific to the "generic_oidc" join method.
 	GenericOidc *GenericOIDC
+	// Configuration specific to the "github" join method.
+	Github *Github
 }
 
 func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
@@ -621,6 +647,7 @@ func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
 	x.BoundKeypair = b.BoundKeypair
 	x.Bot = b.Bot
 	x.GenericOidc = b.GenericOidc
+	x.Github = b.Github
 	return m0
 }
 
@@ -2598,6 +2625,152 @@ func (b0 GenericOIDC_builder) Build() *GenericOIDC {
 	return m0
 }
 
+// Configuration for Github token.
+type Github struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// enterprise_server_host allows joining from runners associated with a
+	// GitHub Enterprise Server instance. When unconfigured, tokens will be
+	// validated against github.com, but when configured to the host of a GHES
+	// instance, then the tokens will be validated against host.
+	//
+	// This value should be the hostname of the GHES instance, and should not
+	// include the scheme or a path. The instance must be accessible over HTTPS
+	// at this hostname and the certificate must be trusted by the Auth Service.
+	EnterpriseServerHost string `protobuf:"bytes,1,opt,name=enterprise_server_host,json=enterpriseServerHost,proto3" json:"enterprise_server_host,omitempty"`
+	// enterprise_slug allows the slug of a GitHub Enterprise organisation to be
+	// included in the expected issuer of the OIDC tokens. This is for
+	// compatibility with the `include_enterprise_slug` option in GHE.
+	//
+	// This field should be set to the slug of your enterprise if this is enabled. If
+	// this is not enabled, then this field must be left empty. This field cannot
+	// be specified if `enterprise_server_host` is specified.
+	//
+	// See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+	// for more information about customized issuer values.
+	EnterpriseSlug string `protobuf:"bytes,2,opt,name=enterprise_slug,json=enterpriseSlug,proto3" json:"enterprise_slug,omitempty"`
+	// static_jwks disables fetching of the GHES signing keys via the JWKS/OIDC
+	// endpoints, and allows them to be directly specified. This allows joining
+	// from GitHub Actions in GHES instances that are not reachable by the
+	// Teleport Auth Service.
+	StaticJwks string `protobuf:"bytes,3,opt,name=static_jwks,json=staticJwks,proto3" json:"static_jwks,omitempty"`
+	// allow is a set of claim-matching fields evaluated against the GitHub Actions OIDC token.
+	Allow         []*Github_Rule `protobuf:"bytes,4,rep,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Github) Reset() {
+	*x = Github{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Github) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Github) ProtoMessage() {}
+
+func (x *Github) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *Github) GetEnterpriseServerHost() string {
+	if x != nil {
+		return x.EnterpriseServerHost
+	}
+	return ""
+}
+
+func (x *Github) GetEnterpriseSlug() string {
+	if x != nil {
+		return x.EnterpriseSlug
+	}
+	return ""
+}
+
+func (x *Github) GetStaticJwks() string {
+	if x != nil {
+		return x.StaticJwks
+	}
+	return ""
+}
+
+func (x *Github) GetAllow() []*Github_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *Github) SetEnterpriseServerHost(v string) {
+	x.EnterpriseServerHost = v
+}
+
+func (x *Github) SetEnterpriseSlug(v string) {
+	x.EnterpriseSlug = v
+}
+
+func (x *Github) SetStaticJwks(v string) {
+	x.StaticJwks = v
+}
+
+func (x *Github) SetAllow(v []*Github_Rule) {
+	x.Allow = v
+}
+
+type Github_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// enterprise_server_host allows joining from runners associated with a
+	// GitHub Enterprise Server instance. When unconfigured, tokens will be
+	// validated against github.com, but when configured to the host of a GHES
+	// instance, then the tokens will be validated against host.
+	//
+	// This value should be the hostname of the GHES instance, and should not
+	// include the scheme or a path. The instance must be accessible over HTTPS
+	// at this hostname and the certificate must be trusted by the Auth Service.
+	EnterpriseServerHost string
+	// enterprise_slug allows the slug of a GitHub Enterprise organisation to be
+	// included in the expected issuer of the OIDC tokens. This is for
+	// compatibility with the `include_enterprise_slug` option in GHE.
+	//
+	// This field should be set to the slug of your enterprise if this is enabled. If
+	// this is not enabled, then this field must be left empty. This field cannot
+	// be specified if `enterprise_server_host` is specified.
+	//
+	// See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+	// for more information about customized issuer values.
+	EnterpriseSlug string
+	// static_jwks disables fetching of the GHES signing keys via the JWKS/OIDC
+	// endpoints, and allows them to be directly specified. This allows joining
+	// from GitHub Actions in GHES instances that are not reachable by the
+	// Teleport Auth Service.
+	StaticJwks string
+	// allow is a set of claim-matching fields evaluated against the GitHub Actions OIDC token.
+	Allow []*Github_Rule
+}
+
+func (b0 Github_builder) Build() *Github {
+	m0 := &Github{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.EnterpriseServerHost = b.EnterpriseServerHost
+	x.EnterpriseSlug = b.EnterpriseSlug
+	x.StaticJwks = b.StaticJwks
+	x.Allow = b.Allow
+	return m0
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -2622,7 +2795,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2634,7 +2807,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2747,7 +2920,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2759,7 +2932,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2840,7 +3013,7 @@ type Azure_Rule struct {
 
 func (x *Azure_Rule) Reset() {
 	*x = Azure_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2852,7 +3025,7 @@ func (x *Azure_Rule) String() string {
 func (*Azure_Rule) ProtoMessage() {}
 
 func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2959,7 +3132,7 @@ type AzureDevops_Rule struct {
 
 func (x *AzureDevops_Rule) Reset() {
 	*x = AzureDevops_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2971,7 +3144,7 @@ func (x *AzureDevops_Rule) String() string {
 func (*AzureDevops_Rule) ProtoMessage() {}
 
 func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3143,7 +3316,7 @@ type Oracle_Rule struct {
 
 func (x *Oracle_Rule) Reset() {
 	*x = Oracle_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3155,7 +3328,7 @@ func (x *Oracle_Rule) String() string {
 func (*Oracle_Rule) ProtoMessage() {}
 
 func (x *Oracle_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3249,7 +3422,7 @@ type Kubernetes_StaticJWKSConfig struct {
 
 func (x *Kubernetes_StaticJWKSConfig) Reset() {
 	*x = Kubernetes_StaticJWKSConfig{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3261,7 +3434,7 @@ func (x *Kubernetes_StaticJWKSConfig) String() string {
 func (*Kubernetes_StaticJWKSConfig) ProtoMessage() {}
 
 func (x *Kubernetes_StaticJWKSConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3314,7 +3487,7 @@ type Kubernetes_OIDCConfig struct {
 
 func (x *Kubernetes_OIDCConfig) Reset() {
 	*x = Kubernetes_OIDCConfig{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3326,7 +3499,7 @@ func (x *Kubernetes_OIDCConfig) String() string {
 func (*Kubernetes_OIDCConfig) ProtoMessage() {}
 
 func (x *Kubernetes_OIDCConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3406,7 +3579,7 @@ type Kubernetes_Rule struct {
 
 func (x *Kubernetes_Rule) Reset() {
 	*x = Kubernetes_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3418,7 +3591,7 @@ func (x *Kubernetes_Rule) String() string {
 func (*Kubernetes_Rule) ProtoMessage() {}
 
 func (x *Kubernetes_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3521,7 +3694,7 @@ type BoundKeypairSpec_OnboardingSpec struct {
 
 func (x *BoundKeypairSpec_OnboardingSpec) Reset() {
 	*x = BoundKeypairSpec_OnboardingSpec{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3533,7 +3706,7 @@ func (x *BoundKeypairSpec_OnboardingSpec) String() string {
 func (*BoundKeypairSpec_OnboardingSpec) ProtoMessage() {}
 
 func (x *BoundKeypairSpec_OnboardingSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3656,7 +3829,7 @@ type BoundKeypairSpec_RecoverySpec struct {
 
 func (x *BoundKeypairSpec_RecoverySpec) Reset() {
 	*x = BoundKeypairSpec_RecoverySpec{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3668,7 +3841,7 @@ func (x *BoundKeypairSpec_RecoverySpec) String() string {
 func (*BoundKeypairSpec_RecoverySpec) ProtoMessage() {}
 
 func (x *BoundKeypairSpec_RecoverySpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3749,7 +3922,7 @@ type GenericOIDC_ConditionEq struct {
 
 func (x *GenericOIDC_ConditionEq) Reset() {
 	*x = GenericOIDC_ConditionEq{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3761,7 +3934,7 @@ func (x *GenericOIDC_ConditionEq) String() string {
 func (*GenericOIDC_ConditionEq) ProtoMessage() {}
 
 func (x *GenericOIDC_ConditionEq) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3809,7 +3982,7 @@ type GenericOIDC_ConditionNotEq struct {
 
 func (x *GenericOIDC_ConditionNotEq) Reset() {
 	*x = GenericOIDC_ConditionNotEq{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3821,7 +3994,7 @@ func (x *GenericOIDC_ConditionNotEq) String() string {
 func (*GenericOIDC_ConditionNotEq) ProtoMessage() {}
 
 func (x *GenericOIDC_ConditionNotEq) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3869,7 +4042,7 @@ type GenericOIDC_ConditionIn struct {
 
 func (x *GenericOIDC_ConditionIn) Reset() {
 	*x = GenericOIDC_ConditionIn{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3881,7 +4054,7 @@ func (x *GenericOIDC_ConditionIn) String() string {
 func (*GenericOIDC_ConditionIn) ProtoMessage() {}
 
 func (x *GenericOIDC_ConditionIn) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3929,7 +4102,7 @@ type GenericOIDC_ConditionNotIn struct {
 
 func (x *GenericOIDC_ConditionNotIn) Reset() {
 	*x = GenericOIDC_ConditionNotIn{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3941,7 +4114,7 @@ func (x *GenericOIDC_ConditionNotIn) String() string {
 func (*GenericOIDC_ConditionNotIn) ProtoMessage() {}
 
 func (x *GenericOIDC_ConditionNotIn) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3998,7 +4171,7 @@ type GenericOIDC_Condition struct {
 
 func (x *GenericOIDC_Condition) Reset() {
 	*x = GenericOIDC_Condition{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4010,7 +4183,7 @@ func (x *GenericOIDC_Condition) String() string {
 func (*GenericOIDC_Condition) ProtoMessage() {}
 
 func (x *GenericOIDC_Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4166,7 +4339,7 @@ type GenericOIDC_Rule struct {
 
 func (x *GenericOIDC_Rule) Reset() {
 	*x = GenericOIDC_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4178,7 +4351,7 @@ func (x *GenericOIDC_Rule) String() string {
 func (*GenericOIDC_Rule) ProtoMessage() {}
 
 func (x *GenericOIDC_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4233,6 +4406,274 @@ func (b0 GenericOIDC_Rule_builder) Build() *GenericOIDC_Rule {
 	return m0
 }
 
+// A rule that a joining node must match in order to use the associated token
+// with the "github" join method. All specified fields within a rule must
+// match (AND). At least one rule in the allow list must match (OR).
+type Github_Rule struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// sub also known as Subject is a string that roughly uniquely identifies
+	// the workload. The format of this varies depending on the type of
+	// github action run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Sub string `protobuf:"bytes,1,opt,name=sub,proto3" json:"sub,omitempty"`
+	// repository from where the workflow is running.
+	// This includes the name of the owner e.g `gravitational/teleport`
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Repository string `protobuf:"bytes,2,opt,name=repository,proto3" json:"repository,omitempty"`
+	// repository_owner is the name of the organization in which the repository is stored.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	RepositoryOwner string `protobuf:"bytes,3,opt,name=repository_owner,json=repositoryOwner,proto3" json:"repository_owner,omitempty"`
+	// workflow name.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Workflow string `protobuf:"bytes,4,opt,name=workflow,proto3" json:"workflow,omitempty"`
+	// environment name used by the job.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Environment string `protobuf:"bytes,5,opt,name=environment,proto3" json:"environment,omitempty"`
+	// actor is the personal account that initiated the workflow run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Actor string `protobuf:"bytes,6,opt,name=actor,proto3" json:"actor,omitempty"`
+	// ref (git) that triggered the workflow run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Ref string `protobuf:"bytes,7,opt,name=ref,proto3" json:"ref,omitempty"`
+	// ref_type for example: "branch".
+	RefType string `protobuf:"bytes,8,opt,name=ref_type,json=refType,proto3" json:"ref_type,omitempty"`
+	// enterprise name in which the repository is stored.
+	Enterprise string `protobuf:"bytes,9,opt,name=enterprise,proto3" json:"enterprise,omitempty"`
+	// enterprise_id in which the repository is stored.
+	EnterpriseId  string `protobuf:"bytes,10,opt,name=enterprise_id,json=enterpriseId,proto3" json:"enterprise_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Github_Rule) Reset() {
+	*x = Github_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Github_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Github_Rule) ProtoMessage() {}
+
+func (x *Github_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *Github_Rule) GetSub() string {
+	if x != nil {
+		return x.Sub
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRepository() string {
+	if x != nil {
+		return x.Repository
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRepositoryOwner() string {
+	if x != nil {
+		return x.RepositoryOwner
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetWorkflow() string {
+	if x != nil {
+		return x.Workflow
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetEnvironment() string {
+	if x != nil {
+		return x.Environment
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRef() string {
+	if x != nil {
+		return x.Ref
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRefType() string {
+	if x != nil {
+		return x.RefType
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetEnterprise() string {
+	if x != nil {
+		return x.Enterprise
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetEnterpriseId() string {
+	if x != nil {
+		return x.EnterpriseId
+	}
+	return ""
+}
+
+func (x *Github_Rule) SetSub(v string) {
+	x.Sub = v
+}
+
+func (x *Github_Rule) SetRepository(v string) {
+	x.Repository = v
+}
+
+func (x *Github_Rule) SetRepositoryOwner(v string) {
+	x.RepositoryOwner = v
+}
+
+func (x *Github_Rule) SetWorkflow(v string) {
+	x.Workflow = v
+}
+
+func (x *Github_Rule) SetEnvironment(v string) {
+	x.Environment = v
+}
+
+func (x *Github_Rule) SetActor(v string) {
+	x.Actor = v
+}
+
+func (x *Github_Rule) SetRef(v string) {
+	x.Ref = v
+}
+
+func (x *Github_Rule) SetRefType(v string) {
+	x.RefType = v
+}
+
+func (x *Github_Rule) SetEnterprise(v string) {
+	x.Enterprise = v
+}
+
+func (x *Github_Rule) SetEnterpriseId(v string) {
+	x.EnterpriseId = v
+}
+
+type Github_Rule_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// sub also known as Subject is a string that roughly uniquely identifies
+	// the workload. The format of this varies depending on the type of
+	// github action run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Sub string
+	// repository from where the workflow is running.
+	// This includes the name of the owner e.g `gravitational/teleport`
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Repository string
+	// repository_owner is the name of the organization in which the repository is stored.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	RepositoryOwner string
+	// workflow name.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Workflow string
+	// environment name used by the job.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Environment string
+	// actor is the personal account that initiated the workflow run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Actor string
+	// ref (git) that triggered the workflow run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Ref string
+	// ref_type for example: "branch".
+	RefType string
+	// enterprise name in which the repository is stored.
+	Enterprise string
+	// enterprise_id in which the repository is stored.
+	EnterpriseId string
+}
+
+func (b0 Github_Rule_builder) Build() *Github_Rule {
+	m0 := &Github_Rule{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Sub = b.Sub
+	x.Repository = b.Repository
+	x.RepositoryOwner = b.RepositoryOwner
+	x.Workflow = b.Workflow
+	x.Environment = b.Environment
+	x.Actor = b.Actor
+	x.Ref = b.Ref
+	x.RefType = b.RefType
+	x.Enterprise = b.Enterprise
+	x.EnterpriseId = b.EnterpriseId
+	return m0
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -4245,7 +4686,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xa7\x06\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xe3\x06\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -4265,7 +4706,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"kubernetes\x12Q\n" +
 	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x10\n" +
 	"\x03bot\x18\x0f \x01(\tR\x03bot\x12J\n" +
-	"\fgeneric_oidc\x18\x10 \x01(\v2'.teleport.scopes.joining.v1.GenericOIDCR\vgenericOidcJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
+	"\fgeneric_oidc\x18\x10 \x01(\v2'.teleport.scopes.joining.v1.GenericOIDCR\vgenericOidc\x12:\n" +
+	"\x06github\x18\x11 \x01(\v2\".teleport.scopes.joining.v1.GithubR\x06githubJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -4411,9 +4853,31 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"conditions\x12\x1e\n" +
 	"\n" +
 	"expression\x18\x02 \x01(\tR\n" +
-	"expressionBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"expression\"\xf3\x03\n" +
+	"\x06Github\x124\n" +
+	"\x16enterprise_server_host\x18\x01 \x01(\tR\x14enterpriseServerHost\x12'\n" +
+	"\x0fenterprise_slug\x18\x02 \x01(\tR\x0eenterpriseSlug\x12\x1f\n" +
+	"\vstatic_jwks\x18\x03 \x01(\tR\n" +
+	"staticJwks\x12=\n" +
+	"\x05allow\x18\x04 \x03(\v2'.teleport.scopes.joining.v1.Github.RuleR\x05allow\x1a\xa9\x02\n" +
+	"\x04Rule\x12\x10\n" +
+	"\x03sub\x18\x01 \x01(\tR\x03sub\x12\x1e\n" +
+	"\n" +
+	"repository\x18\x02 \x01(\tR\n" +
+	"repository\x12)\n" +
+	"\x10repository_owner\x18\x03 \x01(\tR\x0frepositoryOwner\x12\x1a\n" +
+	"\bworkflow\x18\x04 \x01(\tR\bworkflow\x12 \n" +
+	"\venvironment\x18\x05 \x01(\tR\venvironment\x12\x14\n" +
+	"\x05actor\x18\x06 \x01(\tR\x05actor\x12\x10\n" +
+	"\x03ref\x18\a \x01(\tR\x03ref\x12\x19\n" +
+	"\bref_type\x18\b \x01(\tR\arefType\x12\x1e\n" +
+	"\n" +
+	"enterprise\x18\t \x01(\tR\n" +
+	"enterprise\x12#\n" +
+	"\renterprise_id\x18\n" +
+	" \x01(\tR\fenterpriseIdBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),                     // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),                 // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -4433,29 +4897,31 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*BoundKeypairSpec)(nil),                // 15: teleport.scopes.joining.v1.BoundKeypairSpec
 	(*BoundKeypairStatus)(nil),              // 16: teleport.scopes.joining.v1.BoundKeypairStatus
 	(*GenericOIDC)(nil),                     // 17: teleport.scopes.joining.v1.GenericOIDC
-	nil,                                     // 18: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),                        // 19: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),                        // 20: teleport.scopes.joining.v1.GCP.Rule
-	(*Azure_Rule)(nil),                      // 21: teleport.scopes.joining.v1.Azure.Rule
-	(*AzureDevops_Rule)(nil),                // 22: teleport.scopes.joining.v1.AzureDevops.Rule
-	(*Oracle_Rule)(nil),                     // 23: teleport.scopes.joining.v1.Oracle.Rule
-	(*Kubernetes_StaticJWKSConfig)(nil),     // 24: teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
-	(*Kubernetes_OIDCConfig)(nil),           // 25: teleport.scopes.joining.v1.Kubernetes.OIDCConfig
-	(*Kubernetes_Rule)(nil),                 // 26: teleport.scopes.joining.v1.Kubernetes.Rule
-	(*BoundKeypairSpec_OnboardingSpec)(nil), // 27: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
-	(*BoundKeypairSpec_RecoverySpec)(nil),   // 28: teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
-	(*GenericOIDC_ConditionEq)(nil),         // 29: teleport.scopes.joining.v1.GenericOIDC.ConditionEq
-	(*GenericOIDC_ConditionNotEq)(nil),      // 30: teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
-	(*GenericOIDC_ConditionIn)(nil),         // 31: teleport.scopes.joining.v1.GenericOIDC.ConditionIn
-	(*GenericOIDC_ConditionNotIn)(nil),      // 32: teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
-	(*GenericOIDC_Condition)(nil),           // 33: teleport.scopes.joining.v1.GenericOIDC.Condition
-	(*GenericOIDC_Rule)(nil),                // 34: teleport.scopes.joining.v1.GenericOIDC.Rule
-	(*v1.Metadata)(nil),                     // 35: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),           // 36: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                 // 37: google.protobuf.Struct
+	(*Github)(nil),                          // 18: teleport.scopes.joining.v1.Github
+	nil,                                     // 19: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),                        // 20: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),                        // 21: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),                      // 22: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),                // 23: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*Oracle_Rule)(nil),                     // 24: teleport.scopes.joining.v1.Oracle.Rule
+	(*Kubernetes_StaticJWKSConfig)(nil),     // 25: teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	(*Kubernetes_OIDCConfig)(nil),           // 26: teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	(*Kubernetes_Rule)(nil),                 // 27: teleport.scopes.joining.v1.Kubernetes.Rule
+	(*BoundKeypairSpec_OnboardingSpec)(nil), // 28: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
+	(*BoundKeypairSpec_RecoverySpec)(nil),   // 29: teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
+	(*GenericOIDC_ConditionEq)(nil),         // 30: teleport.scopes.joining.v1.GenericOIDC.ConditionEq
+	(*GenericOIDC_ConditionNotEq)(nil),      // 31: teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
+	(*GenericOIDC_ConditionIn)(nil),         // 32: teleport.scopes.joining.v1.GenericOIDC.ConditionIn
+	(*GenericOIDC_ConditionNotIn)(nil),      // 33: teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
+	(*GenericOIDC_Condition)(nil),           // 34: teleport.scopes.joining.v1.GenericOIDC.Condition
+	(*GenericOIDC_Rule)(nil),                // 35: teleport.scopes.joining.v1.GenericOIDC.Rule
+	(*Github_Rule)(nil),                     // 36: teleport.scopes.joining.v1.Github.Rule
+	(*v1.Metadata)(nil),                     // 37: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),           // 38: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                 // 39: google.protobuf.Struct
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	35, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	37, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	8,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
@@ -4467,42 +4933,44 @@ var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
 	14, // 9: teleport.scopes.joining.v1.ScopedTokenSpec.kubernetes:type_name -> teleport.scopes.joining.v1.Kubernetes
 	15, // 10: teleport.scopes.joining.v1.ScopedTokenSpec.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec
 	17, // 11: teleport.scopes.joining.v1.ScopedTokenSpec.generic_oidc:type_name -> teleport.scopes.joining.v1.GenericOIDC
-	36, // 12: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	36, // 13: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 14: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 15: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	16, // 16: teleport.scopes.joining.v1.UsageStatus.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairStatus
-	4,  // 17: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	35, // 18: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	7,  // 19: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 20: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	18, // 21: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	19, // 22: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	20, // 23: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	21, // 24: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
-	22, // 25: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
-	23, // 26: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
-	26, // 27: teleport.scopes.joining.v1.Kubernetes.allow:type_name -> teleport.scopes.joining.v1.Kubernetes.Rule
-	24, // 28: teleport.scopes.joining.v1.Kubernetes.static_jwks:type_name -> teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
-	25, // 29: teleport.scopes.joining.v1.Kubernetes.oidc:type_name -> teleport.scopes.joining.v1.Kubernetes.OIDCConfig
-	27, // 30: teleport.scopes.joining.v1.BoundKeypairSpec.onboarding:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
-	28, // 31: teleport.scopes.joining.v1.BoundKeypairSpec.recovery:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
-	36, // 32: teleport.scopes.joining.v1.BoundKeypairSpec.rotate_after:type_name -> google.protobuf.Timestamp
-	36, // 33: teleport.scopes.joining.v1.BoundKeypairStatus.last_recovered_at:type_name -> google.protobuf.Timestamp
-	36, // 34: teleport.scopes.joining.v1.BoundKeypairStatus.last_rotated_at:type_name -> google.protobuf.Timestamp
-	37, // 35: teleport.scopes.joining.v1.GenericOIDC.must_match_fields:type_name -> google.protobuf.Struct
-	34, // 36: teleport.scopes.joining.v1.GenericOIDC.allow_any:type_name -> teleport.scopes.joining.v1.GenericOIDC.Rule
-	36, // 37: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec.must_register_before:type_name -> google.protobuf.Timestamp
-	29, // 38: teleport.scopes.joining.v1.GenericOIDC.Condition.eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionEq
-	30, // 39: teleport.scopes.joining.v1.GenericOIDC.Condition.not_eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
-	31, // 40: teleport.scopes.joining.v1.GenericOIDC.Condition.in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionIn
-	32, // 41: teleport.scopes.joining.v1.GenericOIDC.Condition.not_in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
-	33, // 42: teleport.scopes.joining.v1.GenericOIDC.Rule.conditions:type_name -> teleport.scopes.joining.v1.GenericOIDC.Condition
-	43, // [43:43] is the sub-list for method output_type
-	43, // [43:43] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	18, // 12: teleport.scopes.joining.v1.ScopedTokenSpec.github:type_name -> teleport.scopes.joining.v1.Github
+	38, // 13: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	38, // 14: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 15: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 16: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	16, // 17: teleport.scopes.joining.v1.UsageStatus.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairStatus
+	4,  // 18: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	37, // 19: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	7,  // 20: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 21: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	19, // 22: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	20, // 23: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	21, // 24: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	22, // 25: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	23, // 26: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	24, // 27: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
+	27, // 28: teleport.scopes.joining.v1.Kubernetes.allow:type_name -> teleport.scopes.joining.v1.Kubernetes.Rule
+	25, // 29: teleport.scopes.joining.v1.Kubernetes.static_jwks:type_name -> teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	26, // 30: teleport.scopes.joining.v1.Kubernetes.oidc:type_name -> teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	28, // 31: teleport.scopes.joining.v1.BoundKeypairSpec.onboarding:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
+	29, // 32: teleport.scopes.joining.v1.BoundKeypairSpec.recovery:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
+	38, // 33: teleport.scopes.joining.v1.BoundKeypairSpec.rotate_after:type_name -> google.protobuf.Timestamp
+	38, // 34: teleport.scopes.joining.v1.BoundKeypairStatus.last_recovered_at:type_name -> google.protobuf.Timestamp
+	38, // 35: teleport.scopes.joining.v1.BoundKeypairStatus.last_rotated_at:type_name -> google.protobuf.Timestamp
+	39, // 36: teleport.scopes.joining.v1.GenericOIDC.must_match_fields:type_name -> google.protobuf.Struct
+	35, // 37: teleport.scopes.joining.v1.GenericOIDC.allow_any:type_name -> teleport.scopes.joining.v1.GenericOIDC.Rule
+	36, // 38: teleport.scopes.joining.v1.Github.allow:type_name -> teleport.scopes.joining.v1.Github.Rule
+	38, // 39: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec.must_register_before:type_name -> google.protobuf.Timestamp
+	30, // 40: teleport.scopes.joining.v1.GenericOIDC.Condition.eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionEq
+	31, // 41: teleport.scopes.joining.v1.GenericOIDC.Condition.not_eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
+	32, // 42: teleport.scopes.joining.v1.GenericOIDC.Condition.in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionIn
+	33, // 43: teleport.scopes.joining.v1.GenericOIDC.Condition.not_in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
+	34, // 44: teleport.scopes.joining.v1.GenericOIDC.Rule.conditions:type_name -> teleport.scopes.joining.v1.GenericOIDC.Condition
+	45, // [45:45] is the sub-list for method output_type
+	45, // [45:45] is the sub-list for method input_type
+	45, // [45:45] is the sub-list for extension type_name
+	45, // [45:45] is the sub-list for extension extendee
+	0,  // [0:45] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -4520,7 +4988,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   35,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token_protoopaque.pb.go
@@ -241,6 +241,7 @@ type ScopedTokenSpec struct {
 	xxx_hidden_BoundKeypair    *BoundKeypairSpec      `protobuf:"bytes,12,opt,name=bound_keypair,json=boundKeypair,proto3"`
 	xxx_hidden_Bot             string                 `protobuf:"bytes,15,opt,name=bot,proto3"`
 	xxx_hidden_GenericOidc     *GenericOIDC           `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3"`
+	xxx_hidden_Github          *Github                `protobuf:"bytes,17,opt,name=github,proto3"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -368,6 +369,13 @@ func (x *ScopedTokenSpec) GetGenericOidc() *GenericOIDC {
 	return nil
 }
 
+func (x *ScopedTokenSpec) GetGithub() *Github {
+	if x != nil {
+		return x.xxx_hidden_Github
+	}
+	return nil
+}
+
 func (x *ScopedTokenSpec) SetAssignedScope(v string) {
 	x.xxx_hidden_AssignedScope = v
 }
@@ -422,6 +430,10 @@ func (x *ScopedTokenSpec) SetBot(v string) {
 
 func (x *ScopedTokenSpec) SetGenericOidc(v *GenericOIDC) {
 	x.xxx_hidden_GenericOidc = v
+}
+
+func (x *ScopedTokenSpec) SetGithub(v *Github) {
+	x.xxx_hidden_Github = v
 }
 
 func (x *ScopedTokenSpec) HasImmutableLabels() bool {
@@ -487,6 +499,13 @@ func (x *ScopedTokenSpec) HasGenericOidc() bool {
 	return x.xxx_hidden_GenericOidc != nil
 }
 
+func (x *ScopedTokenSpec) HasGithub() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Github != nil
+}
+
 func (x *ScopedTokenSpec) ClearImmutableLabels() {
 	x.xxx_hidden_ImmutableLabels = nil
 }
@@ -521,6 +540,10 @@ func (x *ScopedTokenSpec) ClearBoundKeypair() {
 
 func (x *ScopedTokenSpec) ClearGenericOidc() {
 	x.xxx_hidden_GenericOidc = nil
+}
+
+func (x *ScopedTokenSpec) ClearGithub() {
+	x.xxx_hidden_Github = nil
 }
 
 type ScopedTokenSpec_builder struct {
@@ -567,6 +590,8 @@ type ScopedTokenSpec_builder struct {
 	Bot string
 	// Configuration specific to the "generic_oidc" join method.
 	GenericOidc *GenericOIDC
+	// Configuration specific to the "github" join method.
+	Github *Github
 }
 
 func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
@@ -587,6 +612,7 @@ func (b0 ScopedTokenSpec_builder) Build() *ScopedTokenSpec {
 	x.xxx_hidden_BoundKeypair = b.BoundKeypair
 	x.xxx_hidden_Bot = b.Bot
 	x.xxx_hidden_GenericOidc = b.GenericOidc
+	x.xxx_hidden_Github = b.Github
 	return m0
 }
 
@@ -2422,6 +2448,131 @@ func (b0 GenericOIDC_builder) Build() *GenericOIDC {
 	return m0
 }
 
+// Configuration for Github token.
+type Github struct {
+	state                           protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_EnterpriseServerHost string                 `protobuf:"bytes,1,opt,name=enterprise_server_host,json=enterpriseServerHost,proto3"`
+	xxx_hidden_EnterpriseSlug       string                 `protobuf:"bytes,2,opt,name=enterprise_slug,json=enterpriseSlug,proto3"`
+	xxx_hidden_StaticJwks           string                 `protobuf:"bytes,3,opt,name=static_jwks,json=staticJwks,proto3"`
+	xxx_hidden_Allow                *[]*Github_Rule        `protobuf:"bytes,4,rep,name=allow,proto3"`
+	unknownFields                   protoimpl.UnknownFields
+	sizeCache                       protoimpl.SizeCache
+}
+
+func (x *Github) Reset() {
+	*x = Github{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Github) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Github) ProtoMessage() {}
+
+func (x *Github) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *Github) GetEnterpriseServerHost() string {
+	if x != nil {
+		return x.xxx_hidden_EnterpriseServerHost
+	}
+	return ""
+}
+
+func (x *Github) GetEnterpriseSlug() string {
+	if x != nil {
+		return x.xxx_hidden_EnterpriseSlug
+	}
+	return ""
+}
+
+func (x *Github) GetStaticJwks() string {
+	if x != nil {
+		return x.xxx_hidden_StaticJwks
+	}
+	return ""
+}
+
+func (x *Github) GetAllow() []*Github_Rule {
+	if x != nil {
+		if x.xxx_hidden_Allow != nil {
+			return *x.xxx_hidden_Allow
+		}
+	}
+	return nil
+}
+
+func (x *Github) SetEnterpriseServerHost(v string) {
+	x.xxx_hidden_EnterpriseServerHost = v
+}
+
+func (x *Github) SetEnterpriseSlug(v string) {
+	x.xxx_hidden_EnterpriseSlug = v
+}
+
+func (x *Github) SetStaticJwks(v string) {
+	x.xxx_hidden_StaticJwks = v
+}
+
+func (x *Github) SetAllow(v []*Github_Rule) {
+	x.xxx_hidden_Allow = &v
+}
+
+type Github_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// enterprise_server_host allows joining from runners associated with a
+	// GitHub Enterprise Server instance. When unconfigured, tokens will be
+	// validated against github.com, but when configured to the host of a GHES
+	// instance, then the tokens will be validated against host.
+	//
+	// This value should be the hostname of the GHES instance, and should not
+	// include the scheme or a path. The instance must be accessible over HTTPS
+	// at this hostname and the certificate must be trusted by the Auth Service.
+	EnterpriseServerHost string
+	// enterprise_slug allows the slug of a GitHub Enterprise organisation to be
+	// included in the expected issuer of the OIDC tokens. This is for
+	// compatibility with the `include_enterprise_slug` option in GHE.
+	//
+	// This field should be set to the slug of your enterprise if this is enabled. If
+	// this is not enabled, then this field must be left empty. This field cannot
+	// be specified if `enterprise_server_host` is specified.
+	//
+	// See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+	// for more information about customized issuer values.
+	EnterpriseSlug string
+	// static_jwks disables fetching of the GHES signing keys via the JWKS/OIDC
+	// endpoints, and allows them to be directly specified. This allows joining
+	// from GitHub Actions in GHES instances that are not reachable by the
+	// Teleport Auth Service.
+	StaticJwks string
+	// allow is a set of claim-matching fields evaluated against the GitHub Actions OIDC token.
+	Allow []*Github_Rule
+}
+
+func (b0 Github_builder) Build() *Github {
+	m0 := &Github{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_EnterpriseServerHost = b.EnterpriseServerHost
+	x.xxx_hidden_EnterpriseSlug = b.EnterpriseSlug
+	x.xxx_hidden_StaticJwks = b.StaticJwks
+	x.xxx_hidden_Allow = &b.Allow
+	return m0
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -2437,7 +2588,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2449,7 +2600,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2559,7 +2710,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2571,7 +2722,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2649,7 +2800,7 @@ type Azure_Rule struct {
 
 func (x *Azure_Rule) Reset() {
 	*x = Azure_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2661,7 +2812,7 @@ func (x *Azure_Rule) String() string {
 func (*Azure_Rule) ProtoMessage() {}
 
 func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2744,7 +2895,7 @@ type AzureDevops_Rule struct {
 
 func (x *AzureDevops_Rule) Reset() {
 	*x = AzureDevops_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2756,7 +2907,7 @@ func (x *AzureDevops_Rule) String() string {
 func (*AzureDevops_Rule) ProtoMessage() {}
 
 func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2921,7 +3072,7 @@ type Oracle_Rule struct {
 
 func (x *Oracle_Rule) Reset() {
 	*x = Oracle_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2933,7 +3084,7 @@ func (x *Oracle_Rule) String() string {
 func (*Oracle_Rule) ProtoMessage() {}
 
 func (x *Oracle_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3025,7 +3176,7 @@ type Kubernetes_StaticJWKSConfig struct {
 
 func (x *Kubernetes_StaticJWKSConfig) Reset() {
 	*x = Kubernetes_StaticJWKSConfig{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3037,7 +3188,7 @@ func (x *Kubernetes_StaticJWKSConfig) String() string {
 func (*Kubernetes_StaticJWKSConfig) ProtoMessage() {}
 
 func (x *Kubernetes_StaticJWKSConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[24]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3086,7 +3237,7 @@ type Kubernetes_OIDCConfig struct {
 
 func (x *Kubernetes_OIDCConfig) Reset() {
 	*x = Kubernetes_OIDCConfig{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3098,7 +3249,7 @@ func (x *Kubernetes_OIDCConfig) String() string {
 func (*Kubernetes_OIDCConfig) ProtoMessage() {}
 
 func (x *Kubernetes_OIDCConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[25]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3167,7 +3318,7 @@ type Kubernetes_Rule struct {
 
 func (x *Kubernetes_Rule) Reset() {
 	*x = Kubernetes_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3179,7 +3330,7 @@ func (x *Kubernetes_Rule) String() string {
 func (*Kubernetes_Rule) ProtoMessage() {}
 
 func (x *Kubernetes_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[26]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3264,7 +3415,7 @@ type BoundKeypairSpec_OnboardingSpec struct {
 
 func (x *BoundKeypairSpec_OnboardingSpec) Reset() {
 	*x = BoundKeypairSpec_OnboardingSpec{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3276,7 +3427,7 @@ func (x *BoundKeypairSpec_OnboardingSpec) String() string {
 func (*BoundKeypairSpec_OnboardingSpec) ProtoMessage() {}
 
 func (x *BoundKeypairSpec_OnboardingSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[27]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3378,7 +3529,7 @@ type BoundKeypairSpec_RecoverySpec struct {
 
 func (x *BoundKeypairSpec_RecoverySpec) Reset() {
 	*x = BoundKeypairSpec_RecoverySpec{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3390,7 +3541,7 @@ func (x *BoundKeypairSpec_RecoverySpec) String() string {
 func (*BoundKeypairSpec_RecoverySpec) ProtoMessage() {}
 
 func (x *BoundKeypairSpec_RecoverySpec) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[28]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3470,7 +3621,7 @@ type GenericOIDC_ConditionEq struct {
 
 func (x *GenericOIDC_ConditionEq) Reset() {
 	*x = GenericOIDC_ConditionEq{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3482,7 +3633,7 @@ func (x *GenericOIDC_ConditionEq) String() string {
 func (*GenericOIDC_ConditionEq) ProtoMessage() {}
 
 func (x *GenericOIDC_ConditionEq) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[29]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3529,7 +3680,7 @@ type GenericOIDC_ConditionNotEq struct {
 
 func (x *GenericOIDC_ConditionNotEq) Reset() {
 	*x = GenericOIDC_ConditionNotEq{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3541,7 +3692,7 @@ func (x *GenericOIDC_ConditionNotEq) String() string {
 func (*GenericOIDC_ConditionNotEq) ProtoMessage() {}
 
 func (x *GenericOIDC_ConditionNotEq) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[30]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3588,7 +3739,7 @@ type GenericOIDC_ConditionIn struct {
 
 func (x *GenericOIDC_ConditionIn) Reset() {
 	*x = GenericOIDC_ConditionIn{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3600,7 +3751,7 @@ func (x *GenericOIDC_ConditionIn) String() string {
 func (*GenericOIDC_ConditionIn) ProtoMessage() {}
 
 func (x *GenericOIDC_ConditionIn) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[31]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3647,7 +3798,7 @@ type GenericOIDC_ConditionNotIn struct {
 
 func (x *GenericOIDC_ConditionNotIn) Reset() {
 	*x = GenericOIDC_ConditionNotIn{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3659,7 +3810,7 @@ func (x *GenericOIDC_ConditionNotIn) String() string {
 func (*GenericOIDC_ConditionNotIn) ProtoMessage() {}
 
 func (x *GenericOIDC_ConditionNotIn) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[32]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3710,7 +3861,7 @@ type GenericOIDC_Condition struct {
 
 func (x *GenericOIDC_Condition) Reset() {
 	*x = GenericOIDC_Condition{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3722,7 +3873,7 @@ func (x *GenericOIDC_Condition) String() string {
 func (*GenericOIDC_Condition) ProtoMessage() {}
 
 func (x *GenericOIDC_Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[33]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3872,7 +4023,7 @@ type GenericOIDC_Rule struct {
 
 func (x *GenericOIDC_Rule) Reset() {
 	*x = GenericOIDC_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3884,7 +4035,7 @@ func (x *GenericOIDC_Rule) String() string {
 func (*GenericOIDC_Rule) ProtoMessage() {}
 
 func (x *GenericOIDC_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[34]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3941,6 +4092,233 @@ func (b0 GenericOIDC_Rule_builder) Build() *GenericOIDC_Rule {
 	return m0
 }
 
+// A rule that a joining node must match in order to use the associated token
+// with the "github" join method. All specified fields within a rule must
+// match (AND). At least one rule in the allow list must match (OR).
+type Github_Rule struct {
+	state                      protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Sub             string                 `protobuf:"bytes,1,opt,name=sub,proto3"`
+	xxx_hidden_Repository      string                 `protobuf:"bytes,2,opt,name=repository,proto3"`
+	xxx_hidden_RepositoryOwner string                 `protobuf:"bytes,3,opt,name=repository_owner,json=repositoryOwner,proto3"`
+	xxx_hidden_Workflow        string                 `protobuf:"bytes,4,opt,name=workflow,proto3"`
+	xxx_hidden_Environment     string                 `protobuf:"bytes,5,opt,name=environment,proto3"`
+	xxx_hidden_Actor           string                 `protobuf:"bytes,6,opt,name=actor,proto3"`
+	xxx_hidden_Ref             string                 `protobuf:"bytes,7,opt,name=ref,proto3"`
+	xxx_hidden_RefType         string                 `protobuf:"bytes,8,opt,name=ref_type,json=refType,proto3"`
+	xxx_hidden_Enterprise      string                 `protobuf:"bytes,9,opt,name=enterprise,proto3"`
+	xxx_hidden_EnterpriseId    string                 `protobuf:"bytes,10,opt,name=enterprise_id,json=enterpriseId,proto3"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *Github_Rule) Reset() {
+	*x = Github_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Github_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Github_Rule) ProtoMessage() {}
+
+func (x *Github_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *Github_Rule) GetSub() string {
+	if x != nil {
+		return x.xxx_hidden_Sub
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRepository() string {
+	if x != nil {
+		return x.xxx_hidden_Repository
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRepositoryOwner() string {
+	if x != nil {
+		return x.xxx_hidden_RepositoryOwner
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetWorkflow() string {
+	if x != nil {
+		return x.xxx_hidden_Workflow
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetEnvironment() string {
+	if x != nil {
+		return x.xxx_hidden_Environment
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetActor() string {
+	if x != nil {
+		return x.xxx_hidden_Actor
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRef() string {
+	if x != nil {
+		return x.xxx_hidden_Ref
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRefType() string {
+	if x != nil {
+		return x.xxx_hidden_RefType
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetEnterprise() string {
+	if x != nil {
+		return x.xxx_hidden_Enterprise
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetEnterpriseId() string {
+	if x != nil {
+		return x.xxx_hidden_EnterpriseId
+	}
+	return ""
+}
+
+func (x *Github_Rule) SetSub(v string) {
+	x.xxx_hidden_Sub = v
+}
+
+func (x *Github_Rule) SetRepository(v string) {
+	x.xxx_hidden_Repository = v
+}
+
+func (x *Github_Rule) SetRepositoryOwner(v string) {
+	x.xxx_hidden_RepositoryOwner = v
+}
+
+func (x *Github_Rule) SetWorkflow(v string) {
+	x.xxx_hidden_Workflow = v
+}
+
+func (x *Github_Rule) SetEnvironment(v string) {
+	x.xxx_hidden_Environment = v
+}
+
+func (x *Github_Rule) SetActor(v string) {
+	x.xxx_hidden_Actor = v
+}
+
+func (x *Github_Rule) SetRef(v string) {
+	x.xxx_hidden_Ref = v
+}
+
+func (x *Github_Rule) SetRefType(v string) {
+	x.xxx_hidden_RefType = v
+}
+
+func (x *Github_Rule) SetEnterprise(v string) {
+	x.xxx_hidden_Enterprise = v
+}
+
+func (x *Github_Rule) SetEnterpriseId(v string) {
+	x.xxx_hidden_EnterpriseId = v
+}
+
+type Github_Rule_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// sub also known as Subject is a string that roughly uniquely identifies
+	// the workload. The format of this varies depending on the type of
+	// github action run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Sub string
+	// repository from where the workflow is running.
+	// This includes the name of the owner e.g `gravitational/teleport`
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Repository string
+	// repository_owner is the name of the organization in which the repository is stored.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	RepositoryOwner string
+	// workflow name.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Workflow string
+	// environment name used by the job.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Environment string
+	// actor is the personal account that initiated the workflow run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Actor string
+	// ref (git) that triggered the workflow run.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Ref string
+	// ref_type for example: "branch".
+	RefType string
+	// enterprise name in which the repository is stored.
+	Enterprise string
+	// enterprise_id in which the repository is stored.
+	EnterpriseId string
+}
+
+func (b0 Github_Rule_builder) Build() *Github_Rule {
+	m0 := &Github_Rule{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Sub = b.Sub
+	x.xxx_hidden_Repository = b.Repository
+	x.xxx_hidden_RepositoryOwner = b.RepositoryOwner
+	x.xxx_hidden_Workflow = b.Workflow
+	x.xxx_hidden_Environment = b.Environment
+	x.xxx_hidden_Actor = b.Actor
+	x.xxx_hidden_Ref = b.Ref
+	x.xxx_hidden_RefType = b.RefType
+	x.xxx_hidden_Enterprise = b.Enterprise
+	x.xxx_hidden_EnterpriseId = b.EnterpriseId
+	return m0
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -3953,7 +4331,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xa7\x06\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xe3\x06\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -3973,7 +4351,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"kubernetes\x12Q\n" +
 	"\rbound_keypair\x18\f \x01(\v2,.teleport.scopes.joining.v1.BoundKeypairSpecR\fboundKeypair\x12\x10\n" +
 	"\x03bot\x18\x0f \x01(\tR\x03bot\x12J\n" +
-	"\fgeneric_oidc\x18\x10 \x01(\v2'.teleport.scopes.joining.v1.GenericOIDCR\vgenericOidcJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
+	"\fgeneric_oidc\x18\x10 \x01(\v2'.teleport.scopes.joining.v1.GenericOIDCR\vgenericOidc\x12:\n" +
+	"\x06github\x18\x11 \x01(\v2\".teleport.scopes.joining.v1.GithubR\x06githubJ\x04\b\r\x10\x0eJ\x04\b\x0e\x10\x0fR\bbot_nameR\tbot_scope\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -4119,9 +4498,31 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"conditions\x12\x1e\n" +
 	"\n" +
 	"expression\x18\x02 \x01(\tR\n" +
-	"expressionBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"expression\"\xf3\x03\n" +
+	"\x06Github\x124\n" +
+	"\x16enterprise_server_host\x18\x01 \x01(\tR\x14enterpriseServerHost\x12'\n" +
+	"\x0fenterprise_slug\x18\x02 \x01(\tR\x0eenterpriseSlug\x12\x1f\n" +
+	"\vstatic_jwks\x18\x03 \x01(\tR\n" +
+	"staticJwks\x12=\n" +
+	"\x05allow\x18\x04 \x03(\v2'.teleport.scopes.joining.v1.Github.RuleR\x05allow\x1a\xa9\x02\n" +
+	"\x04Rule\x12\x10\n" +
+	"\x03sub\x18\x01 \x01(\tR\x03sub\x12\x1e\n" +
+	"\n" +
+	"repository\x18\x02 \x01(\tR\n" +
+	"repository\x12)\n" +
+	"\x10repository_owner\x18\x03 \x01(\tR\x0frepositoryOwner\x12\x1a\n" +
+	"\bworkflow\x18\x04 \x01(\tR\bworkflow\x12 \n" +
+	"\venvironment\x18\x05 \x01(\tR\venvironment\x12\x14\n" +
+	"\x05actor\x18\x06 \x01(\tR\x05actor\x12\x10\n" +
+	"\x03ref\x18\a \x01(\tR\x03ref\x12\x19\n" +
+	"\bref_type\x18\b \x01(\tR\arefType\x12\x1e\n" +
+	"\n" +
+	"enterprise\x18\t \x01(\tR\n" +
+	"enterprise\x12#\n" +
+	"\renterprise_id\x18\n" +
+	" \x01(\tR\fenterpriseIdBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),                     // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),                 // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -4141,29 +4542,31 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*BoundKeypairSpec)(nil),                // 15: teleport.scopes.joining.v1.BoundKeypairSpec
 	(*BoundKeypairStatus)(nil),              // 16: teleport.scopes.joining.v1.BoundKeypairStatus
 	(*GenericOIDC)(nil),                     // 17: teleport.scopes.joining.v1.GenericOIDC
-	nil,                                     // 18: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),                        // 19: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),                        // 20: teleport.scopes.joining.v1.GCP.Rule
-	(*Azure_Rule)(nil),                      // 21: teleport.scopes.joining.v1.Azure.Rule
-	(*AzureDevops_Rule)(nil),                // 22: teleport.scopes.joining.v1.AzureDevops.Rule
-	(*Oracle_Rule)(nil),                     // 23: teleport.scopes.joining.v1.Oracle.Rule
-	(*Kubernetes_StaticJWKSConfig)(nil),     // 24: teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
-	(*Kubernetes_OIDCConfig)(nil),           // 25: teleport.scopes.joining.v1.Kubernetes.OIDCConfig
-	(*Kubernetes_Rule)(nil),                 // 26: teleport.scopes.joining.v1.Kubernetes.Rule
-	(*BoundKeypairSpec_OnboardingSpec)(nil), // 27: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
-	(*BoundKeypairSpec_RecoverySpec)(nil),   // 28: teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
-	(*GenericOIDC_ConditionEq)(nil),         // 29: teleport.scopes.joining.v1.GenericOIDC.ConditionEq
-	(*GenericOIDC_ConditionNotEq)(nil),      // 30: teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
-	(*GenericOIDC_ConditionIn)(nil),         // 31: teleport.scopes.joining.v1.GenericOIDC.ConditionIn
-	(*GenericOIDC_ConditionNotIn)(nil),      // 32: teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
-	(*GenericOIDC_Condition)(nil),           // 33: teleport.scopes.joining.v1.GenericOIDC.Condition
-	(*GenericOIDC_Rule)(nil),                // 34: teleport.scopes.joining.v1.GenericOIDC.Rule
-	(*v1.Metadata)(nil),                     // 35: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),           // 36: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                 // 37: google.protobuf.Struct
+	(*Github)(nil),                          // 18: teleport.scopes.joining.v1.Github
+	nil,                                     // 19: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),                        // 20: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),                        // 21: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),                      // 22: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),                // 23: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*Oracle_Rule)(nil),                     // 24: teleport.scopes.joining.v1.Oracle.Rule
+	(*Kubernetes_StaticJWKSConfig)(nil),     // 25: teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	(*Kubernetes_OIDCConfig)(nil),           // 26: teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	(*Kubernetes_Rule)(nil),                 // 27: teleport.scopes.joining.v1.Kubernetes.Rule
+	(*BoundKeypairSpec_OnboardingSpec)(nil), // 28: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
+	(*BoundKeypairSpec_RecoverySpec)(nil),   // 29: teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
+	(*GenericOIDC_ConditionEq)(nil),         // 30: teleport.scopes.joining.v1.GenericOIDC.ConditionEq
+	(*GenericOIDC_ConditionNotEq)(nil),      // 31: teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
+	(*GenericOIDC_ConditionIn)(nil),         // 32: teleport.scopes.joining.v1.GenericOIDC.ConditionIn
+	(*GenericOIDC_ConditionNotIn)(nil),      // 33: teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
+	(*GenericOIDC_Condition)(nil),           // 34: teleport.scopes.joining.v1.GenericOIDC.Condition
+	(*GenericOIDC_Rule)(nil),                // 35: teleport.scopes.joining.v1.GenericOIDC.Rule
+	(*Github_Rule)(nil),                     // 36: teleport.scopes.joining.v1.Github.Rule
+	(*v1.Metadata)(nil),                     // 37: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),           // 38: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                 // 39: google.protobuf.Struct
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	35, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	37, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	8,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
@@ -4175,42 +4578,44 @@ var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
 	14, // 9: teleport.scopes.joining.v1.ScopedTokenSpec.kubernetes:type_name -> teleport.scopes.joining.v1.Kubernetes
 	15, // 10: teleport.scopes.joining.v1.ScopedTokenSpec.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec
 	17, // 11: teleport.scopes.joining.v1.ScopedTokenSpec.generic_oidc:type_name -> teleport.scopes.joining.v1.GenericOIDC
-	36, // 12: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	36, // 13: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 14: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 15: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	16, // 16: teleport.scopes.joining.v1.UsageStatus.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairStatus
-	4,  // 17: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	35, // 18: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	7,  // 19: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 20: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	18, // 21: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	19, // 22: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	20, // 23: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	21, // 24: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
-	22, // 25: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
-	23, // 26: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
-	26, // 27: teleport.scopes.joining.v1.Kubernetes.allow:type_name -> teleport.scopes.joining.v1.Kubernetes.Rule
-	24, // 28: teleport.scopes.joining.v1.Kubernetes.static_jwks:type_name -> teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
-	25, // 29: teleport.scopes.joining.v1.Kubernetes.oidc:type_name -> teleport.scopes.joining.v1.Kubernetes.OIDCConfig
-	27, // 30: teleport.scopes.joining.v1.BoundKeypairSpec.onboarding:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
-	28, // 31: teleport.scopes.joining.v1.BoundKeypairSpec.recovery:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
-	36, // 32: teleport.scopes.joining.v1.BoundKeypairSpec.rotate_after:type_name -> google.protobuf.Timestamp
-	36, // 33: teleport.scopes.joining.v1.BoundKeypairStatus.last_recovered_at:type_name -> google.protobuf.Timestamp
-	36, // 34: teleport.scopes.joining.v1.BoundKeypairStatus.last_rotated_at:type_name -> google.protobuf.Timestamp
-	37, // 35: teleport.scopes.joining.v1.GenericOIDC.must_match_fields:type_name -> google.protobuf.Struct
-	34, // 36: teleport.scopes.joining.v1.GenericOIDC.allow_any:type_name -> teleport.scopes.joining.v1.GenericOIDC.Rule
-	36, // 37: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec.must_register_before:type_name -> google.protobuf.Timestamp
-	29, // 38: teleport.scopes.joining.v1.GenericOIDC.Condition.eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionEq
-	30, // 39: teleport.scopes.joining.v1.GenericOIDC.Condition.not_eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
-	31, // 40: teleport.scopes.joining.v1.GenericOIDC.Condition.in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionIn
-	32, // 41: teleport.scopes.joining.v1.GenericOIDC.Condition.not_in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
-	33, // 42: teleport.scopes.joining.v1.GenericOIDC.Rule.conditions:type_name -> teleport.scopes.joining.v1.GenericOIDC.Condition
-	43, // [43:43] is the sub-list for method output_type
-	43, // [43:43] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	18, // 12: teleport.scopes.joining.v1.ScopedTokenSpec.github:type_name -> teleport.scopes.joining.v1.Github
+	38, // 13: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	38, // 14: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 15: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 16: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	16, // 17: teleport.scopes.joining.v1.UsageStatus.bound_keypair:type_name -> teleport.scopes.joining.v1.BoundKeypairStatus
+	4,  // 18: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	37, // 19: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	7,  // 20: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 21: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	19, // 22: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	20, // 23: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	21, // 24: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	22, // 25: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	23, // 26: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	24, // 27: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
+	27, // 28: teleport.scopes.joining.v1.Kubernetes.allow:type_name -> teleport.scopes.joining.v1.Kubernetes.Rule
+	25, // 29: teleport.scopes.joining.v1.Kubernetes.static_jwks:type_name -> teleport.scopes.joining.v1.Kubernetes.StaticJWKSConfig
+	26, // 30: teleport.scopes.joining.v1.Kubernetes.oidc:type_name -> teleport.scopes.joining.v1.Kubernetes.OIDCConfig
+	28, // 31: teleport.scopes.joining.v1.BoundKeypairSpec.onboarding:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec
+	29, // 32: teleport.scopes.joining.v1.BoundKeypairSpec.recovery:type_name -> teleport.scopes.joining.v1.BoundKeypairSpec.RecoverySpec
+	38, // 33: teleport.scopes.joining.v1.BoundKeypairSpec.rotate_after:type_name -> google.protobuf.Timestamp
+	38, // 34: teleport.scopes.joining.v1.BoundKeypairStatus.last_recovered_at:type_name -> google.protobuf.Timestamp
+	38, // 35: teleport.scopes.joining.v1.BoundKeypairStatus.last_rotated_at:type_name -> google.protobuf.Timestamp
+	39, // 36: teleport.scopes.joining.v1.GenericOIDC.must_match_fields:type_name -> google.protobuf.Struct
+	35, // 37: teleport.scopes.joining.v1.GenericOIDC.allow_any:type_name -> teleport.scopes.joining.v1.GenericOIDC.Rule
+	36, // 38: teleport.scopes.joining.v1.Github.allow:type_name -> teleport.scopes.joining.v1.Github.Rule
+	38, // 39: teleport.scopes.joining.v1.BoundKeypairSpec.OnboardingSpec.must_register_before:type_name -> google.protobuf.Timestamp
+	30, // 40: teleport.scopes.joining.v1.GenericOIDC.Condition.eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionEq
+	31, // 41: teleport.scopes.joining.v1.GenericOIDC.Condition.not_eq:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotEq
+	32, // 42: teleport.scopes.joining.v1.GenericOIDC.Condition.in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionIn
+	33, // 43: teleport.scopes.joining.v1.GenericOIDC.Condition.not_in:type_name -> teleport.scopes.joining.v1.GenericOIDC.ConditionNotIn
+	34, // 44: teleport.scopes.joining.v1.GenericOIDC.Rule.conditions:type_name -> teleport.scopes.joining.v1.GenericOIDC.Condition
+	45, // [45:45] is the sub-list for method output_type
+	45, // [45:45] is the sub-list for method input_type
+	45, // [45:45] is the sub-list for extension type_name
+	45, // [45:45] is the sub-list for extension extendee
+	0,  // [0:45] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -4228,7 +4633,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   35,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -108,6 +108,9 @@ message ScopedTokenSpec {
 
   // Configuration specific to the "generic_oidc" join method.
   GenericOIDC generic_oidc = 16;
+
+  // Configuration specific to the "github" join method.
+  Github github = 17;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -636,4 +639,104 @@ message GenericOIDC {
   // Note that at least one rule, either in `must_match_fields` or `allow_any`,
   // must be specified for any join attempts to succeed.
   repeated Rule allow_any = 7;
+}
+
+// Configuration for Github token.
+message Github {
+  // enterprise_server_host allows joining from runners associated with a
+  // GitHub Enterprise Server instance. When unconfigured, tokens will be
+  // validated against github.com, but when configured to the host of a GHES
+  // instance, then the tokens will be validated against host.
+  //
+  // This value should be the hostname of the GHES instance, and should not
+  // include the scheme or a path. The instance must be accessible over HTTPS
+  // at this hostname and the certificate must be trusted by the Auth Service.
+  string enterprise_server_host = 1;
+
+  // enterprise_slug allows the slug of a GitHub Enterprise organisation to be
+  // included in the expected issuer of the OIDC tokens. This is for
+  // compatibility with the `include_enterprise_slug` option in GHE.
+  //
+  // This field should be set to the slug of your enterprise if this is enabled. If
+  // this is not enabled, then this field must be left empty. This field cannot
+  // be specified if `enterprise_server_host` is specified.
+  //
+  // See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+  // for more information about customized issuer values.
+  string enterprise_slug = 2;
+
+  // static_jwks disables fetching of the GHES signing keys via the JWKS/OIDC
+  // endpoints, and allows them to be directly specified. This allows joining
+  // from GitHub Actions in GHES instances that are not reachable by the
+  // Teleport Auth Service.
+  string static_jwks = 3;
+
+  // allow is a set of claim-matching fields evaluated against the GitHub Actions OIDC token.
+  repeated Rule allow = 4;
+
+  // A rule that a joining node must match in order to use the associated token
+  // with the "github" join method. All specified fields within a rule must
+  // match (AND). At least one rule in the allow list must match (OR).
+  message Rule {
+    // sub also known as Subject is a string that roughly uniquely identifies
+    // the workload. The format of this varies depending on the type of
+    // github action run.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string sub = 1;
+
+    // repository from where the workflow is running.
+    // This includes the name of the owner e.g `gravitational/teleport`
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string repository = 2;
+
+    // repository_owner is the name of the organization in which the repository is stored.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string repository_owner = 3;
+
+    // workflow name.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string workflow = 4;
+
+    // environment name used by the job.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string environment = 5;
+
+    // actor is the personal account that initiated the workflow run.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string actor = 6;
+
+    // ref (git) that triggered the workflow run.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string ref = 7;
+
+    // ref_type for example: "branch".
+    string ref_type = 8;
+
+    // enterprise name in which the repository is stored.
+    string enterprise = 9;
+
+    // enterprise_id in which the repository is stored.
+    string enterprise_id = 10;
+  }
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -178,6 +178,8 @@ type ProvisionToken interface {
 	GetBoundKeypairStatus() *ProvisionTokenStatusV2BoundKeypair
 	// GetGenericOIDC returns generic_oidc-specific configuration for this token.
 	GetGenericOIDC() (*ProvisionTokenSpecV2GenericOIDC, error)
+	// GetGithub returns github-specific configuration for this token.
+	GetGithub() *ProvisionTokenSpecV2GitHub
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -619,6 +621,11 @@ func (p *ProvisionTokenV2) GetBoundKeypairStatus() *ProvisionTokenStatusV2BoundK
 // GetGenericOIDC returns generic_oidc-specific configuration for this token.
 func (p *ProvisionTokenV2) GetGenericOIDC() (*ProvisionTokenSpecV2GenericOIDC, error) {
 	return p.Spec.GenericOIDC, nil
+}
+
+// GetGithub returns github-specific configuration for this token.
+func (p *ProvisionTokenV2) GetGithub() *ProvisionTokenSpecV2GitHub {
+	return p.Spec.GitHub
 }
 
 // GetJoinMethod returns joining method that must be used with this token.
@@ -1089,7 +1096,6 @@ func (a *ProvisionTokenSpecV2TPM) validate() error {
 				"ekcert_allowed_cas[%d]: parsing certificate",
 				i,
 			)
-
 		}
 	}
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-scopedtokensv1.mdx
@@ -34,6 +34,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |bound_keypair|[object](#specbound_keypair)|Configuration specific to the "bound_keypair" join method.|
 |gcp|[object](#specgcp)|The GCP-specific configuration used with the "gcp" join method.|
 |generic_oidc|[object](#specgeneric_oidc)|Configuration specific to the "generic_oidc" join method.|
+|github|[object](#specgithub)|Configuration specific to the "github" join method.|
 |immutable_labels|[object](#specimmutable_labels)|Immutable labels that should be applied to any resulting resources provisioned using this token.|
 |join_method|string|The joining method required in order to use this token. Note that not all join methods support joining with scoped tokens.|
 |kubernetes|[object](#speckubernetes)|The Kubernetes-specific configuration used with the "kubernetes" join method.|
@@ -182,6 +183,30 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |Field|Type|Description|
 |---|---|---|
 |values|[]string||
+
+### spec.github
+
+|Field|Type|Description|
+|---|---|---|
+|allow|[][object](#specgithuballow-items)|allow is a set of claim-matching fields evaluated against the GitHub Actions OIDC token.|
+|enterprise_server_host|string|enterprise_server_host allows joining from runners associated with a GitHub Enterprise Server instance. When unconfigured, tokens will be validated against github.com, but when configured to the host of a GHES instance, then the tokens will be validated against host.  This value should be the hostname of the GHES instance, and should not include the scheme or a path. The instance must be accessible over HTTPS at this hostname and the certificate must be trusted by the Auth Service.|
+|enterprise_slug|string|enterprise_slug allows the slug of a GitHub Enterprise organisation to be included in the expected issuer of the OIDC tokens. This is for compatibility with the `include_enterprise_slug` option in GHE.  This field should be set to the slug of your enterprise if this is enabled. If this is not enabled, then this field must be left empty. This field cannot be specified if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise for more information about customized issuer values.|
+|static_jwks|string|static_jwks disables fetching of the GHES signing keys via the JWKS/OIDC endpoints, and allows them to be directly specified. This allows joining from GitHub Actions in GHES instances that are not reachable by the Teleport Auth Service.|
+
+### spec.github.allow items
+
+|Field|Type|Description|
+|---|---|---|
+|actor|string||
+|enterprise|string||
+|enterprise_id|string||
+|environment|string||
+|ref|string||
+|ref_type|string||
+|repository|string||
+|repository_owner|string||
+|sub|string||
+|workflow|string||
 
 ### spec.immutable_labels
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/scoped_token.mdx
@@ -59,6 +59,7 @@ Optional:
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `generic_oidc` (Attributes) Configuration specific to the "generic_oidc" join method. (see [below for nested schema](#nested-schema-for-specgeneric_oidc))
+- `github` (Attributes) Configuration specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))
 - `kubernetes` (Attributes) The Kubernetes-specific configuration used with the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `oracle` (Attributes) The Oracle-specific configuration used with the "oracle" join method. (see [below for nested schema](#nested-schema-for-specoracle))
@@ -219,6 +220,32 @@ Optional:
 - `values` (List of String) The list of values to compare the attribute against.
 
 
+
+
+
+### Nested Schema for `spec.github`
+
+Optional:
+
+- `allow` (Attributes List) allow is a set of claim-matching fields evaluated against the GitHub Actions OIDC token. (see [below for nested schema](#nested-schema-for-specgithuballow))
+- `enterprise_server_host` (String) enterprise_server_host allows joining from runners associated with a GitHub Enterprise Server instance. When unconfigured, tokens will be validated against github.com, but when configured to the host of a GHES instance, then the tokens will be validated against host.  This value should be the hostname of the GHES instance, and should not include the scheme or a path. The instance must be accessible over HTTPS at this hostname and the certificate must be trusted by the Auth Service.
+- `enterprise_slug` (String) enterprise_slug allows the slug of a GitHub Enterprise organisation to be included in the expected issuer of the OIDC tokens. This is for compatibility with the `include_enterprise_slug` option in GHE.  This field should be set to the slug of your enterprise if this is enabled. If this is not enabled, then this field must be left empty. This field cannot be specified if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise for more information about customized issuer values.
+- `static_jwks` (String) static_jwks disables fetching of the GHES signing keys via the JWKS/OIDC endpoints, and allows them to be directly specified. This allows joining from GitHub Actions in GHES instances that are not reachable by the Teleport Auth Service.
+
+### Nested Schema for `spec.github.allow`
+
+Optional:
+
+- `actor` (String) actor is the personal account that initiated the workflow run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `enterprise` (String) enterprise name in which the repository is stored.
+- `enterprise_id` (String) enterprise_id in which the repository is stored.
+- `environment` (String) environment name used by the job.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `ref` (String) ref (git) that triggered the workflow run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `ref_type` (String) ref_type for example: "branch".
+- `repository` (String) repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `repository_owner` (String) repository_owner is the name of the organization in which the repository is stored.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `sub` (String) sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `workflow` (String) workflow name.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/scoped_token.mdx
@@ -103,6 +103,7 @@ Optional:
 - `bound_keypair` (Attributes) Configuration specific to the "bound_keypair" join method. (see [below for nested schema](#nested-schema-for-specbound_keypair))
 - `gcp` (Attributes) The GCP-specific configuration used with the "gcp" join method. (see [below for nested schema](#nested-schema-for-specgcp))
 - `generic_oidc` (Attributes) Configuration specific to the "generic_oidc" join method. (see [below for nested schema](#nested-schema-for-specgeneric_oidc))
+- `github` (Attributes) Configuration specific to the "github" join method. (see [below for nested schema](#nested-schema-for-specgithub))
 - `immutable_labels` (Attributes) Immutable labels that should be applied to any resulting resources provisioned using this token. (see [below for nested schema](#nested-schema-for-specimmutable_labels))
 - `kubernetes` (Attributes) The Kubernetes-specific configuration used with the "kubernetes" join method. (see [below for nested schema](#nested-schema-for-speckubernetes))
 - `oracle` (Attributes) The Oracle-specific configuration used with the "oracle" join method. (see [below for nested schema](#nested-schema-for-specoracle))
@@ -263,6 +264,32 @@ Optional:
 - `values` (List of String) The list of values to compare the attribute against.
 
 
+
+
+
+### Nested Schema for `spec.github`
+
+Optional:
+
+- `allow` (Attributes List) allow is a set of claim-matching fields evaluated against the GitHub Actions OIDC token. (see [below for nested schema](#nested-schema-for-specgithuballow))
+- `enterprise_server_host` (String) enterprise_server_host allows joining from runners associated with a GitHub Enterprise Server instance. When unconfigured, tokens will be validated against github.com, but when configured to the host of a GHES instance, then the tokens will be validated against host.  This value should be the hostname of the GHES instance, and should not include the scheme or a path. The instance must be accessible over HTTPS at this hostname and the certificate must be trusted by the Auth Service.
+- `enterprise_slug` (String) enterprise_slug allows the slug of a GitHub Enterprise organisation to be included in the expected issuer of the OIDC tokens. This is for compatibility with the `include_enterprise_slug` option in GHE.  This field should be set to the slug of your enterprise if this is enabled. If this is not enabled, then this field must be left empty. This field cannot be specified if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise for more information about customized issuer values.
+- `static_jwks` (String) static_jwks disables fetching of the GHES signing keys via the JWKS/OIDC endpoints, and allows them to be directly specified. This allows joining from GitHub Actions in GHES instances that are not reachable by the Teleport Auth Service.
+
+### Nested Schema for `spec.github.allow`
+
+Optional:
+
+- `actor` (String) actor is the personal account that initiated the workflow run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `enterprise` (String) enterprise name in which the repository is stored.
+- `enterprise_id` (String) enterprise_id in which the repository is stored.
+- `environment` (String) environment name used by the job.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `ref` (String) ref (git) that triggered the workflow run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `ref_type` (String) ref_type for example: "branch".
+- `repository` (String) repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `repository_owner` (String) repository_owner is the name of the organization in which the repository is stored.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `sub` (String) sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
+- `workflow` (String) workflow name.  This field supports "glob-style" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.
 
 
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_scopedtokensv1.yaml
@@ -344,6 +344,65 @@ spec:
                       updated manually if the remote CA is updated.
                     type: string
                 type: object
+              github:
+                description: Configuration specific to the "github" join method.
+                nullable: true
+                properties:
+                  allow:
+                    description: allow is a set of claim-matching fields evaluated
+                      against the GitHub Actions OIDC token.
+                    items:
+                      properties:
+                        actor:
+                          type: string
+                        enterprise:
+                          type: string
+                        enterprise_id:
+                          type: string
+                        environment:
+                          type: string
+                        ref:
+                          type: string
+                        ref_type:
+                          type: string
+                        repository:
+                          type: string
+                        repository_owner:
+                          type: string
+                        sub:
+                          type: string
+                        workflow:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  enterprise_server_host:
+                    description: enterprise_server_host allows joining from runners
+                      associated with a GitHub Enterprise Server instance. When unconfigured,
+                      tokens will be validated against github.com, but when configured
+                      to the host of a GHES instance, then the tokens will be validated
+                      against host.  This value should be the hostname of the GHES
+                      instance, and should not include the scheme or a path. The instance
+                      must be accessible over HTTPS at this hostname and the certificate
+                      must be trusted by the Auth Service.
+                    type: string
+                  enterprise_slug:
+                    description: enterprise_slug allows the slug of a GitHub Enterprise
+                      organisation to be included in the expected issuer of the OIDC
+                      tokens. This is for compatibility with the `include_enterprise_slug`
+                      option in GHE.  This field should be set to the slug of your
+                      enterprise if this is enabled. If this is not enabled, then
+                      this field must be left empty. This field cannot be specified
+                      if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+                      for more information about customized issuer values.
+                    type: string
+                  static_jwks:
+                    description: static_jwks disables fetching of the GHES signing
+                      keys via the JWKS/OIDC endpoints, and allows them to be directly
+                      specified. This allows joining from GitHub Actions in GHES instances
+                      that are not reachable by the Teleport Auth Service.
+                    type: string
+                type: object
               immutable_labels:
                 description: Immutable labels that should be applied to any resulting
                   resources provisioned using this token.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_scopedtokensv1.yaml
@@ -344,6 +344,65 @@ spec:
                       updated manually if the remote CA is updated.
                     type: string
                 type: object
+              github:
+                description: Configuration specific to the "github" join method.
+                nullable: true
+                properties:
+                  allow:
+                    description: allow is a set of claim-matching fields evaluated
+                      against the GitHub Actions OIDC token.
+                    items:
+                      properties:
+                        actor:
+                          type: string
+                        enterprise:
+                          type: string
+                        enterprise_id:
+                          type: string
+                        environment:
+                          type: string
+                        ref:
+                          type: string
+                        ref_type:
+                          type: string
+                        repository:
+                          type: string
+                        repository_owner:
+                          type: string
+                        sub:
+                          type: string
+                        workflow:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  enterprise_server_host:
+                    description: enterprise_server_host allows joining from runners
+                      associated with a GitHub Enterprise Server instance. When unconfigured,
+                      tokens will be validated against github.com, but when configured
+                      to the host of a GHES instance, then the tokens will be validated
+                      against host.  This value should be the hostname of the GHES
+                      instance, and should not include the scheme or a path. The instance
+                      must be accessible over HTTPS at this hostname and the certificate
+                      must be trusted by the Auth Service.
+                    type: string
+                  enterprise_slug:
+                    description: enterprise_slug allows the slug of a GitHub Enterprise
+                      organisation to be included in the expected issuer of the OIDC
+                      tokens. This is for compatibility with the `include_enterprise_slug`
+                      option in GHE.  This field should be set to the slug of your
+                      enterprise if this is enabled. If this is not enabled, then
+                      this field must be left empty. This field cannot be specified
+                      if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+                      for more information about customized issuer values.
+                    type: string
+                  static_jwks:
+                    description: static_jwks disables fetching of the GHES signing
+                      keys via the JWKS/OIDC endpoints, and allows them to be directly
+                      specified. This allows joining from GitHub Actions in GHES instances
+                      that are not reachable by the Teleport Auth Service.
+                    type: string
+                type: object
               immutable_labels:
                 description: Immutable labels that should be applied to any resulting
                   resources provisioned using this token.

--- a/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
+++ b/integrations/terraform/tfschema/scopes/joining/v1/token_terraform.go
@@ -402,6 +402,83 @@ func GenSchemaScopedToken(ctx context.Context) (github_com_hashicorp_terraform_p
 					Description: "Configuration specific to the \"generic_oidc\" join method.",
 					Optional:    true,
 				},
+				"github": {
+					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+						"allow": {
+							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+								"actor": {
+									Description: "actor is the personal account that initiated the workflow run.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"enterprise": {
+									Description: "enterprise name in which the repository is stored.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"enterprise_id": {
+									Description: "enterprise_id in which the repository is stored.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"environment": {
+									Description: "environment name used by the job.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"ref": {
+									Description: "ref (git) that triggered the workflow run.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"ref_type": {
+									Description: "ref_type for example: \"branch\".",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"repository": {
+									Description: "repository from where the workflow is running. This includes the name of the owner e.g `gravitational/teleport`  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"repository_owner": {
+									Description: "repository_owner is the name of the organization in which the repository is stored.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"sub": {
+									Description: "sub also known as Subject is a string that roughly uniquely identifies the workload. The format of this varies depending on the type of github action run.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+								"workflow": {
+									Description: "workflow name.  This field supports \"glob-style\" matching: - Use '*' to match zero or more characters. - Use '?' to match any single character.",
+									Optional:    true,
+									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+								},
+							}),
+							Description: "allow is a set of claim-matching fields evaluated against the GitHub Actions OIDC token.",
+							Optional:    true,
+						},
+						"enterprise_server_host": {
+							Description: "enterprise_server_host allows joining from runners associated with a GitHub Enterprise Server instance. When unconfigured, tokens will be validated against github.com, but when configured to the host of a GHES instance, then the tokens will be validated against host.  This value should be the hostname of the GHES instance, and should not include the scheme or a path. The instance must be accessible over HTTPS at this hostname and the certificate must be trusted by the Auth Service.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"enterprise_slug": {
+							Description: "enterprise_slug allows the slug of a GitHub Enterprise organisation to be included in the expected issuer of the OIDC tokens. This is for compatibility with the `include_enterprise_slug` option in GHE.  This field should be set to the slug of your enterprise if this is enabled. If this is not enabled, then this field must be left empty. This field cannot be specified if `enterprise_server_host` is specified.  See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise for more information about customized issuer values.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+						"static_jwks": {
+							Description: "static_jwks disables fetching of the GHES signing keys via the JWKS/OIDC endpoints, and allows them to be directly specified. This allows joining from GitHub Actions in GHES instances that are not reachable by the Teleport Auth Service.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+						},
+					}),
+					Description: "Configuration specific to the \"github\" join method.",
+					Optional:    true,
+				},
 				"immutable_labels": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"ssh": {
 						Description: "Labels that should be applied to SSH nodes.",
@@ -2298,6 +2375,274 @@ func CopyScopedTokenFromTerraform(_ context.Context, tf github_com_hashicorp_ter
 																}
 															}
 															obj.AllowAny[k] = t
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					{
+						a, ok := tf.Attrs["github"]
+						if !ok {
+							diags.Append(attrReadMissingDiag{"ScopedToken.spec.github"})
+						} else {
+							v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+							if !ok {
+								diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github", "github.com/hashicorp/terraform-plugin-framework/types.Object"})
+							} else {
+								obj.Github = nil
+								if !v.Null && !v.Unknown {
+									tf := v
+									obj.Github = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Github{}
+									obj := obj.Github
+									{
+										a, ok := tf.Attrs["enterprise_server_host"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.enterprise_server_host"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.enterprise_server_host", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.EnterpriseServerHost = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["enterprise_slug"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.enterprise_slug"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.enterprise_slug", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.EnterpriseSlug = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["static_jwks"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.static_jwks"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.static_jwks", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+											} else {
+												var t string
+												if !v.Null && !v.Unknown {
+													t = string(v.Value)
+												}
+												obj.StaticJwks = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["allow"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.List)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow", "github.com/hashicorp/terraform-plugin-framework/types.List"})
+											} else {
+												obj.Allow = make([]*github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Github_Rule, len(v.Elems))
+												if !v.Null && !v.Unknown {
+													for k, a := range v.Elems {
+														v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow", "github_com_hashicorp_terraform_plugin_framework_types.Object"})
+														} else {
+															var t *github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Github_Rule
+															if !v.Null && !v.Unknown {
+																tf := v
+																t = &github_com_gravitational_teleport_api_gen_proto_go_teleport_scopes_joining_v1.Github_Rule{}
+																obj := t
+																{
+																	a, ok := tf.Attrs["sub"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.sub"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.sub", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Sub = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["repository"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.repository"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.repository", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Repository = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["repository_owner"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.repository_owner"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.repository_owner", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.RepositoryOwner = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["workflow"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.workflow"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.workflow", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Workflow = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["environment"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.environment"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.environment", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Environment = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["actor"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.actor"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.actor", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Actor = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["ref"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.ref"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.ref", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Ref = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["ref_type"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.ref_type"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.ref_type", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.RefType = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["enterprise"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.enterprise"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.enterprise", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Enterprise = t
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["enterprise_id"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"ScopedToken.spec.github.allow.enterprise_id"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"ScopedToken.spec.github.allow.enterprise_id", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.EnterpriseId = t
+																		}
+																	}
+																}
+															}
+															obj.Allow[k] = t
 														}
 													}
 												}
@@ -5174,6 +5519,382 @@ func CopyScopedTokenToTerraform(ctx context.Context, obj *github_com_gravitation
 								}
 								v.Unknown = false
 								tf.Attrs["generic_oidc"] = v
+							}
+						}
+					}
+					{
+						a, ok := tf.AttrTypes["github"]
+						if !ok {
+							diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github"})
+						} else {
+							o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+							if !ok {
+								diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github", "github.com/hashicorp/terraform-plugin-framework/types.ObjectType"})
+							} else {
+								v, ok := tf.Attrs["github"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+								if !ok {
+									v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+										AttrTypes: o.AttrTypes,
+										Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+									}
+								} else {
+									if v.Attrs == nil {
+										v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+									}
+								}
+								if obj.Github == nil {
+									v.Null = true
+								} else {
+									obj := obj.Github
+									tf := &v
+									{
+										t, ok := tf.AttrTypes["enterprise_server_host"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.enterprise_server_host"})
+										} else {
+											v, ok := tf.Attrs["enterprise_server_host"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.enterprise_server_host", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.enterprise_server_host", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.EnterpriseServerHost) == ""
+											}
+											v.Value = string(obj.EnterpriseServerHost)
+											v.Unknown = false
+											tf.Attrs["enterprise_server_host"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["enterprise_slug"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.enterprise_slug"})
+										} else {
+											v, ok := tf.Attrs["enterprise_slug"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.enterprise_slug", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.enterprise_slug", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.EnterpriseSlug) == ""
+											}
+											v.Value = string(obj.EnterpriseSlug)
+											v.Unknown = false
+											tf.Attrs["enterprise_slug"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["static_jwks"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.static_jwks"})
+										} else {
+											v, ok := tf.Attrs["static_jwks"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.static_jwks", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.static_jwks", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+												}
+												v.Null = string(obj.StaticJwks) == ""
+											}
+											v.Value = string(obj.StaticJwks)
+											v.Unknown = false
+											tf.Attrs["static_jwks"] = v
+										}
+									}
+									{
+										a, ok := tf.AttrTypes["allow"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow"})
+										} else {
+											o, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.ListType)
+											if !ok {
+												diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow", "github.com/hashicorp/terraform-plugin-framework/types.ListType"})
+											} else {
+												c, ok := tf.Attrs["allow"].(github_com_hashicorp_terraform_plugin_framework_types.List)
+												if !ok {
+													c = github_com_hashicorp_terraform_plugin_framework_types.List{
+
+														ElemType: o.ElemType,
+														Elems:    make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Allow)),
+														Null:     true,
+													}
+												} else {
+													if c.Elems == nil {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Allow))
+													}
+												}
+												if obj.Allow != nil {
+													o := o.ElemType.(github_com_hashicorp_terraform_plugin_framework_types.ObjectType)
+													if len(obj.Allow) != len(c.Elems) {
+														c.Elems = make([]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(obj.Allow))
+													}
+													for k, a := range obj.Allow {
+														v, ok := tf.Attrs["allow"].(github_com_hashicorp_terraform_plugin_framework_types.Object)
+														if !ok {
+															v = github_com_hashicorp_terraform_plugin_framework_types.Object{
+
+																AttrTypes: o.AttrTypes,
+																Attrs:     make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(o.AttrTypes)),
+															}
+														} else {
+															if v.Attrs == nil {
+																v.Attrs = make(map[string]github_com_hashicorp_terraform_plugin_framework_attr.Value, len(tf.AttrTypes))
+															}
+														}
+														if a == nil {
+															v.Null = true
+														} else {
+															obj := a
+															tf := &v
+															{
+																t, ok := tf.AttrTypes["sub"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.sub"})
+																} else {
+																	v, ok := tf.Attrs["sub"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.sub", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.sub", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Sub) == ""
+																	}
+																	v.Value = string(obj.Sub)
+																	v.Unknown = false
+																	tf.Attrs["sub"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["repository"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.repository"})
+																} else {
+																	v, ok := tf.Attrs["repository"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.repository", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.repository", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Repository) == ""
+																	}
+																	v.Value = string(obj.Repository)
+																	v.Unknown = false
+																	tf.Attrs["repository"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["repository_owner"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.repository_owner"})
+																} else {
+																	v, ok := tf.Attrs["repository_owner"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.repository_owner", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.repository_owner", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.RepositoryOwner) == ""
+																	}
+																	v.Value = string(obj.RepositoryOwner)
+																	v.Unknown = false
+																	tf.Attrs["repository_owner"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["workflow"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.workflow"})
+																} else {
+																	v, ok := tf.Attrs["workflow"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.workflow", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.workflow", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Workflow) == ""
+																	}
+																	v.Value = string(obj.Workflow)
+																	v.Unknown = false
+																	tf.Attrs["workflow"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["environment"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.environment"})
+																} else {
+																	v, ok := tf.Attrs["environment"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.environment", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.environment", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Environment) == ""
+																	}
+																	v.Value = string(obj.Environment)
+																	v.Unknown = false
+																	tf.Attrs["environment"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["actor"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.actor"})
+																} else {
+																	v, ok := tf.Attrs["actor"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.actor", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.actor", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Actor) == ""
+																	}
+																	v.Value = string(obj.Actor)
+																	v.Unknown = false
+																	tf.Attrs["actor"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["ref"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.ref"})
+																} else {
+																	v, ok := tf.Attrs["ref"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.ref", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.ref", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Ref) == ""
+																	}
+																	v.Value = string(obj.Ref)
+																	v.Unknown = false
+																	tf.Attrs["ref"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["ref_type"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.ref_type"})
+																} else {
+																	v, ok := tf.Attrs["ref_type"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.ref_type", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.ref_type", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.RefType) == ""
+																	}
+																	v.Value = string(obj.RefType)
+																	v.Unknown = false
+																	tf.Attrs["ref_type"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["enterprise"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.enterprise"})
+																} else {
+																	v, ok := tf.Attrs["enterprise"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.enterprise", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.enterprise", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Enterprise) == ""
+																	}
+																	v.Value = string(obj.Enterprise)
+																	v.Unknown = false
+																	tf.Attrs["enterprise"] = v
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["enterprise_id"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"ScopedToken.spec.github.allow.enterprise_id"})
+																} else {
+																	v, ok := tf.Attrs["enterprise_id"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"ScopedToken.spec.github.allow.enterprise_id", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"ScopedToken.spec.github.allow.enterprise_id", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.EnterpriseId) == ""
+																	}
+																	v.Value = string(obj.EnterpriseId)
+																	v.Unknown = false
+																	tf.Attrs["enterprise_id"] = v
+																}
+															}
+														}
+														v.Unknown = false
+														c.Elems[k] = v
+													}
+													if len(obj.Allow) > 0 {
+														c.Null = false
+													}
+												}
+												c.Unknown = false
+												tf.Attrs["allow"] = c
+											}
+										}
+									}
+								}
+								v.Unknown = false
+								tf.Attrs["github"] = v
 							}
 						}
 					}

--- a/lib/join/githubactions/githubactions.go
+++ b/lib/join/githubactions/githubactions.go
@@ -195,15 +195,15 @@ func CheckGithubIDToken(ctx context.Context, params *CheckGithubIDTokenParams) (
 		return nil, trace.AccessDenied("%s", err.Error())
 	}
 
-	token, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, trace.BadParameter("github join method only supports ProvisionTokenV2, '%T' was provided", params.ProvisionToken)
+	githubCfg := params.ProvisionToken.GetGithub()
+	if githubCfg == nil {
+		return nil, trace.BadParameter("required github configuration is missing from the join token")
 	}
 
 	// enterpriseOverride is a hostname to use instead of github.com when
 	// validating tokens. This allows GHES instances to be connected.
-	enterpriseOverride := token.Spec.GitHub.EnterpriseServerHost
-	enterpriseSlug := token.Spec.GitHub.EnterpriseSlug
+	enterpriseOverride := githubCfg.EnterpriseServerHost
+	enterpriseSlug := githubCfg.EnterpriseSlug
 	if enterpriseOverride != "" || enterpriseSlug != "" {
 		if modules.GetModules().BuildType() != modules.BuildEnterprise {
 			return nil, trace.Wrap(services.ErrRequiresEnterprise, "github enterprise server joining")
@@ -212,10 +212,10 @@ func CheckGithubIDToken(ctx context.Context, params *CheckGithubIDTokenParams) (
 
 	var claims *IDTokenClaims
 	var err error
-	if token.Spec.GitHub.StaticJWKS != "" {
+	if githubCfg.StaticJWKS != "" {
 		claims, err = params.JWKSValidator(
 			params.Clock.Now().UTC(),
-			[]byte(token.Spec.GitHub.StaticJWKS),
+			[]byte(githubCfg.StaticJWKS),
 			string(params.IDToken),
 		)
 		if err != nil {
@@ -235,12 +235,12 @@ func CheckGithubIDToken(ctx context.Context, params *CheckGithubIDTokenParams) (
 		"token", params.ProvisionToken.GetName(),
 	)
 
-	return claims, trace.Wrap(checkGithubAllowRules(token, claims))
+	return claims, trace.Wrap(checkGithubAllowRules(githubCfg.Allow, claims))
 }
 
-func checkGithubAllowRules(token *types.ProvisionTokenV2, claims *IDTokenClaims) error {
+func checkGithubAllowRules(rules []*types.ProvisionTokenSpecV2GitHub_Rule, claims *IDTokenClaims) error {
 	// If a single rule passes, accept the IDToken
-	for i, rule := range token.Spec.GitHub.Allow {
+	for i, rule := range rules {
 		// Please consider keeping these field validators in the same order they
 		// are defined within the ProvisionTokenSpecV2Github proto spec.
 		subMatches, err := joinutils.GlobMatchAllowEmptyPattern(rule.Sub, claims.Sub)

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
-	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -58,7 +56,6 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/scopes"
-	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -1830,72 +1827,6 @@ func TestJoinBoundKeypair_JoinStateFailure_Instance(t *testing.T) {
 	require.Contains(t, locks[0].Message(), "failed to verify its join state")
 }
 
-// createScopedBot creates a scoped bot with necessary role assignments for testing.
-func createScopedBot(t *testing.T, srv *authtest.TLSServer, adminClient *authclient.Client) {
-	t.Helper()
-
-	// Create a scoped role for the bot.
-	scopedSvc := adminClient.ScopedAccessServiceClient()
-	_, err := scopedSvc.CreateScopedRole(t.Context(), &scopedaccessv1.CreateScopedRoleRequest{
-		Role: &scopedaccessv1.ScopedRole{
-			Kind:    scopedaccess.KindScopedRole,
-			Version: types.V1,
-			Metadata: &headerv1.Metadata{
-				Name: "scoped-example",
-			},
-			Scope: "/test",
-			Spec: &scopedaccessv1.ScopedRoleSpec{
-				AssignableScopes: []string{"/test"},
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	// Create the scoped bot.
-	_, err = adminClient.BotServiceClient().CreateBot(t.Context(), &machineidv1pb.CreateBotRequest{
-		Bot: &machineidv1pb.Bot{
-			Kind:    types.KindBot,
-			Version: types.V1,
-			Scope:   "/test",
-			Metadata: &headerv1.Metadata{
-				Name: "test-scoped",
-			},
-			Spec: &machineidv1pb.BotSpec{},
-		},
-	})
-	require.NoError(t, err)
-
-	// Create a scoped role assignment for the bot.
-	resp, err := srv.Auth().ScopedAccess().CreateScopedRoleAssignment(t.Context(), &scopedaccessv1.CreateScopedRoleAssignmentRequest{
-		Assignment: &scopedaccessv1.ScopedRoleAssignment{
-			Kind:    scopedaccess.KindScopedRoleAssignment,
-			Version: types.V1,
-			Metadata: &headerv1.Metadata{
-				Name: uuid.NewString(),
-			},
-			SubKind: scopedaccess.SubKindDynamic,
-			Scope:   "/test",
-			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
-				Bot: scopes.QualifiedName{Scope: "/test", Name: "test-scoped"}.String(),
-				Assignments: []*scopedaccessv1.Assignment{
-					scopedaccessv1.Assignment_builder{Role: "/test::scoped-example", Scope: "/test"}.Build(),
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	ctx := t.Context()
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		_, err := srv.Auth().ScopedAccessCache.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
-			Name:    resp.GetAssignment().GetMetadata().GetName(),
-			SubKind: resp.GetAssignment().GetSubKind(),
-			Scope:   resp.GetAssignment().GetScope(),
-		})
-		require.NoError(t, err)
-	}, time.Second*10, 100*time.Millisecond)
-}
-
 func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 	t.Parallel()
 
@@ -1931,7 +1862,7 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	createScopedBot(t, srv, adminClient)
+	CreateScopedBot(t, srv.Auth(), "test-scoped")
 
 	scopedToken := &joiningv1.ScopedToken{
 		Kind:    types.KindScopedToken,

--- a/lib/join/join_github_test.go
+++ b/lib/join/join_github_test.go
@@ -28,14 +28,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/join/githubactions"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/jointest"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 type mockIDTokenValidator struct {
@@ -118,7 +124,8 @@ func TestJoinGHA(t *testing.T) {
 
 	authServer, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
+			Dir:            t.TempDir(),
+			ScopesFeatures: scopes.Features{Enabled: true},
 		},
 	})
 	require.NoError(t, err)
@@ -697,15 +704,36 @@ func TestJoinGHA(t *testing.T) {
 					modulestest.Modules{TestBuildType: modules.BuildEnterprise},
 				)
 			}
+			nopClient, err := authServer.NewClient(authtest.TestNop())
+			require.NoError(t, err)
+
+			t.Run("scoped joinclient", func(t *testing.T) {
+				scopedToken := CreateScopedToken(t, authServer.Auth(), tt.tokenSpec, "scoped_"+tt.name)
+				result, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token:      scopedToken.GetMetadata().GetName(),
+					JoinMethod: types.JoinMethodGitHub,
+					ID: state.IdentityID{
+						Role:     types.RoleInstance,
+						NodeName: "testnode",
+					},
+					IDToken:    tt.request.IDToken,
+					AuthClient: nopClient,
+				})
+				tt.assertError(t, err)
+				if err != nil {
+					return
+				}
+
+				checkMockGithubValidatorState(t, idTokenValidator, tt.tokenSpec)
+				RequireScopedHostResult(t, result, scopedToken)
+			})
+
 			token, err := types.NewProvisionTokenFromSpec(
 				tt.name, time.Now().Add(time.Minute), tt.tokenSpec,
 			)
 			require.NoError(t, err)
 			require.NoError(t, authServer.Auth().CreateToken(t.Context(), token))
 			tt.request.Token = tt.name
-
-			nopClient, err := authServer.NewClient(authtest.TestNop())
-			require.NoError(t, err)
 
 			t.Run("legacy joinclient", func(t *testing.T) {
 				_, err := joinclient.LegacyJoin(t.Context(), joinclient.JoinParams{
@@ -745,7 +773,6 @@ func TestJoinGHA(t *testing.T) {
 
 				checkMockGithubValidatorState(t, idTokenValidator, tt.tokenSpec)
 			})
-
 			t.Run("legacy", func(t *testing.T) {
 				_, err = authServer.Auth().RegisterUsingToken(t.Context(), tt.request)
 				tt.assertError(t, err)
@@ -757,4 +784,145 @@ func TestJoinGHA(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestJoinGHABot(t *testing.T) {
+	validIDToken := "test.fake.jwt"
+	idTokenValidator := &mockIDTokenValidator{
+		tokens: map[string]githubactions.IDTokenClaims{
+			validIDToken: {
+				Sub:             "repo:octo-org/octo-repo:environment:prod",
+				Repository:      "octo-org/octo-repo",
+				RepositoryOwner: "octo-org",
+				Workflow:        "example-workflow",
+				Environment:     "prod",
+				Actor:           "octocat",
+				Ref:             "refs/heads/main",
+				RefType:         "branch",
+				Enterprise:      "my-enterprise",
+				EnterpriseID:    "123456",
+			},
+		},
+	}
+
+	authServer, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			Dir:            t.TempDir(),
+			ScopesFeatures: scopes.Features{Enabled: true},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, authServer.Shutdown(t.Context())) })
+
+	authServer.Auth().SetGHAIDTokenValidator(idTokenValidator)
+	authServer.Auth().SetGHAIDTokenJWKSValidator(idTokenValidator.ValidateJWKS)
+
+	// Create a scoped bot.
+	qualifiedBotName := CreateScopedBot(t, authServer.Auth(), "gha-bot")
+
+	// Create the scoped token for bot joining.
+	tokenSpec := types.ProvisionTokenSpecV2{
+		JoinMethod: types.JoinMethodGitHub,
+		Roles:      []types.SystemRole{types.RoleBot},
+		GitHub: &types.ProvisionTokenSpecV2GitHub{
+			Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+				{
+					Sub:             "repo:octo-org/octo-repo:environment:prod",
+					Repository:      "octo-org/octo-repo",
+					RepositoryOwner: "octo-org",
+				},
+			},
+		},
+	}
+
+	scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(tokenSpec, joiningv1.ScopedToken_builder{
+		Scope: "/test",
+		Metadata: headerv1.Metadata_builder{
+			Name: "github-bot-token",
+		}.Build(),
+		Spec: joiningv1.ScopedTokenSpec_builder{
+			UsageMode: joining.TokenUsageModeBot,
+			Bot:       qualifiedBotName,
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	_, err = authServer.Auth().CreateScopedToken(t.Context(), joiningv1.CreateScopedTokenRequest_builder{
+		Token: scopedToken,
+	}.Build())
+	require.NoError(t, err)
+
+	nopClient, err := authServer.NewClient(authtest.TestNop())
+	require.NoError(t, err)
+
+	result, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+		Token:      scopedToken.GetMetadata().GetName(),
+		JoinMethod: types.JoinMethodGitHub,
+		ID: state.IdentityID{
+			Role: types.RoleBot,
+		},
+		IDToken:    validIDToken,
+		AuthClient: nopClient,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Certs)
+
+	// Parse the TLS certificate and verify bot identity.
+	cert, err := tlsca.ParseCertificatePEM(result.Certs.TLS)
+	require.NoError(t, err)
+	identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+	require.NoError(t, err)
+
+	require.Equal(t, "gha-bot", identity.BotName)
+	require.NotEmpty(t, identity.BotInstanceID)
+	require.NotNil(t, identity.ScopePin)
+	require.Equal(t, "/test", identity.ScopePin.GetScope())
+	require.Equal(t, "/test", identity.BotScope)
+	require.True(t, identity.BotInternal)
+
+	// Bot results should not contain immutable labels (host-only).
+	require.Nil(t, result.ImmutableLabels)
+
+	t.Run("must fail when claims do not match allow rules", func(t *testing.T) {
+		nonMatchingToken, err := jointest.ScopedTokenFromProvisionTokenSpec(types.ProvisionTokenSpecV2{
+			JoinMethod: types.JoinMethodGitHub,
+			Roles:      []types.SystemRole{types.RoleBot},
+			GitHub: &types.ProvisionTokenSpecV2GitHub{
+				Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+					{
+						Repository:      "other-org/other-repo",
+						RepositoryOwner: "other-org",
+					},
+				},
+			},
+		}, joiningv1.ScopedToken_builder{
+			Scope: "/test",
+			Metadata: headerv1.Metadata_builder{
+				Name: "github-bot-token-no-match",
+			}.Build(),
+			Spec: joiningv1.ScopedTokenSpec_builder{
+				UsageMode: joining.TokenUsageModeBot,
+				Bot:       qualifiedBotName,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+
+		_, err = authServer.Auth().CreateScopedToken(t.Context(), joiningv1.CreateScopedTokenRequest_builder{
+			Token: nonMatchingToken,
+		}.Build())
+		require.NoError(t, err)
+
+		_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
+			Token:      nonMatchingToken.GetMetadata().GetName(),
+			JoinMethod: types.JoinMethodGitHub,
+			ID: state.IdentityID{
+				Role: types.RoleBot,
+			},
+			IDToken:    validIDToken,
+			AuthClient: nopClient,
+		})
+		require.ErrorContains(t, err, "id token claims did not match any allow rules")
+		require.True(t, trace.IsAccessDenied(err))
+	})
 }

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -18,8 +18,11 @@ package jointest
 
 import (
 	"cmp"
+	"encoding/json"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -49,10 +52,12 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 		Scope:    override.GetScope(),
 		Metadata: override.GetMetadata(),
 		Spec: &joiningv1.ScopedTokenSpec{
-			AssignedScope: override.GetSpec().GetAssignedScope(),
-			JoinMethod:    cmp.Or(override.GetSpec().GetJoinMethod(), string(base.JoinMethod)),
-			Roles:         roles,
-			UsageMode:     override.GetSpec().GetUsageMode(),
+			AssignedScope:   override.GetSpec().GetAssignedScope(),
+			JoinMethod:      cmp.Or(override.GetSpec().GetJoinMethod(), string(base.JoinMethod)),
+			Roles:           roles,
+			UsageMode:       override.GetSpec().GetUsageMode(),
+			Bot:             override.GetSpec().GetBot(),
+			ImmutableLabels: override.GetSpec().GetImmutableLabels(),
 		},
 	}
 
@@ -176,9 +181,45 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 			StaticJwks: staticJWKS,
 			Oidc:       oidc,
 		}
+	case types.JoinMethodGitHub:
+		if err := setProviderConfig(scopedToken.GetSpec(), "github", base.GitHub); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.JoinMethod)
 	}
 
 	return scopedToken, nil
+}
+
+// setProviderConfig populates a provider message by protobuf field name. This
+// keeps forward-looking integration tests buildable before the generated scoped
+// provider type exists, while still failing until the production schema defines
+// and can decode the expected field.
+func setProviderConfig(spec *joiningv1.ScopedTokenSpec, fieldName string, config any) error {
+	if config == nil {
+		return trace.BadParameter("missing %s configuration", fieldName)
+	}
+
+	message := spec.ProtoReflect()
+	field := message.Descriptor().Fields().ByName(protoreflect.Name(fieldName))
+	if field == nil {
+		return trace.NotImplemented("scoped token proto does not define %q configuration", fieldName)
+	}
+	if field.Kind() != protoreflect.MessageKind {
+		return trace.BadParameter("scoped token field %q must be a message", fieldName)
+	}
+
+	encoded, err := json.Marshal(config)
+	if err != nil {
+		return trace.Wrap(err, "marshaling classic %s configuration", fieldName)
+	}
+
+	value := message.NewField(field)
+	if err := (protojson.UnmarshalOptions{}).Unmarshal(encoded, value.Message().Interface()); err != nil {
+		return trace.Wrap(err, "converting classic %s configuration to scoped form", fieldName)
+	}
+	message.Set(field, value)
+
+	return nil
 }

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -79,4 +79,6 @@ type Token interface {
 	GetBoundKeypairStatus() *types.ProvisionTokenStatusV2BoundKeypair
 	// GetGenericOIDC returns the generic_oidc-specific configuration for this token.
 	GetGenericOIDC() (*types.ProvisionTokenSpecV2GenericOIDC, error)
+	// GetGithub returns the Github-specific configuration for this token.
+	GetGithub() *types.ProvisionTokenSpecV2GitHub
 }

--- a/lib/join/scope_helpers_test.go
+++ b/lib/join/scope_helpers_test.go
@@ -1,0 +1,189 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package join_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
+	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+const (
+	testTokenScope         = "/test"
+	testTokenAssignedScope = "/test/one"
+)
+
+// ScopedTokenClient is the subset of the scoped token service used by join
+// integration tests.
+type ScopedTokenClient interface {
+	CreateScopedToken(context.Context, *joiningv1.CreateScopedTokenRequest) (*joiningv1.CreateScopedTokenResponse, error)
+	DeleteScopedToken(context.Context, *joiningv1.DeleteScopedTokenRequest) (*joiningv1.DeleteScopedTokenResponse, error)
+}
+
+// CreateScopedToken creates a dynamic scoped token equivalent to base and
+// registers cleanup. Provider configuration is intentionally derived from the
+// classic token so the same high-level test matrix can exercise both forms.
+func CreateScopedToken(
+	t testing.TB,
+	client ScopedTokenClient,
+	base types.ProvisionTokenSpecV2,
+	name string,
+) *joiningv1.ScopedToken {
+	t.Helper()
+
+	token, err := jointest.ScopedTokenFromProvisionTokenSpec(base, joiningv1.ScopedToken_builder{
+		Scope: testTokenScope,
+		Metadata: headerv1.Metadata_builder{
+			Name: name,
+		}.Build(),
+		Spec: joiningv1.ScopedTokenSpec_builder{
+			AssignedScope: testTokenAssignedScope,
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
+			ImmutableLabels: joiningv1.ImmutableLabels_builder{
+				Ssh: map[string]string{"scoped-join-test": "true"},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	_, err = client.CreateScopedToken(t.Context(), joiningv1.CreateScopedTokenRequest_builder{
+		Token: token,
+	}.Build())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, err := client.DeleteScopedToken(context.Background(), joiningv1.DeleteScopedTokenRequest_builder{
+			Name:  token.GetMetadata().GetName(),
+			Scope: token.GetScope(),
+		}.Build())
+		require.NoError(t, err)
+	})
+
+	return token
+}
+
+// RequireScopedHostResult verifies the scoped controls returned by a
+// successful host join instead of treating a nil error as sufficient coverage.
+func RequireScopedHostResult(t testing.TB, result *joinclient.JoinResult, token *joiningv1.ScopedToken) {
+	t.Helper()
+
+	require.NotNil(t, result)
+	require.NotNil(t, result.Certs)
+
+	cert, err := tlsca.ParseCertificatePEM(result.Certs.TLS)
+	require.NoError(t, err)
+	identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+	require.NoError(t, err)
+
+	require.Equal(t, token.GetSpec().GetAssignedScope(), identity.AgentScope)
+	require.Equal(t, joining.HashImmutableLabels(token.GetSpec().GetImmutableLabels()), identity.ImmutableLabelHash)
+	require.Equal(t, token.GetSpec().GetImmutableLabels().GetSsh(), result.ImmutableLabels.GetSsh())
+}
+
+// CreateScopedBot creates a scoped Bot in the test scope ("/test") with a
+// scoped role and role assignment, then waits for cache propagation. Returns
+// the qualified bot name (e.g., "/test::botName") for use in scoped token
+// spec.bot.
+func CreateScopedBot(t testing.TB, authServer *auth.Server, botName string) string {
+	t.Helper()
+
+	ctx := t.Context()
+	scope := testTokenScope // "/test"
+	roleName := "jointest-role-" + botName
+
+	// Create a scoped role for the bot.
+	_, err := authServer.ScopedAccess().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: roleName,
+			}.Build(),
+			Scope: scope,
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scope},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Create the scoped bot.
+	_, err = machineidv1.UpsertBot(ctx, authServer, machineidv1pb.Bot_builder{
+		Kind:    types.KindBot,
+		Version: types.V1,
+		Scope:   scope,
+		Metadata: headerv1.Metadata_builder{
+			Name: botName,
+		}.Build(),
+		Spec: &machineidv1pb.BotSpec{},
+	}.Build(), authServer.GetClock().Now(), "", scopes.Features{Enabled: true})
+	require.NoError(t, err)
+
+	// Create a scoped role assignment for the bot.
+	qualifiedBotName := scopes.QualifiedName{Scope: scope, Name: botName}.String()
+	resp, err := authServer.ScopedAccess().CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: uuid.NewString(),
+			}.Build(),
+			SubKind: scopedaccess.SubKindDynamic,
+			Scope:   scope,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: qualifiedBotName,
+				Assignments: []*scopedaccessv1.Assignment{
+					scopedaccessv1.Assignment_builder{
+						Role:  scope + "::" + roleName,
+						Scope: scope,
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Wait for the cache to propagate the assignment.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		_, err := authServer.ScopedAccessCache.GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+			Name:    resp.GetAssignment().GetMetadata().GetName(),
+			SubKind: resp.GetAssignment().GetSubKind(),
+			Scope:   resp.GetAssignment().GetScope(),
+		}.Build())
+		assert.NoError(ct, err)
+	}, time.Second*10, 100*time.Millisecond)
+
+	return qualifiedBotName
+}

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -348,6 +348,43 @@ func validateGenericOIDC(spec *joiningv1.GenericOIDC) error {
 	return nil
 }
 
+// validateGithub validates the GitHub-specific scoped token configuration.
+// It checks that the token usage mode is compatible, that enterprise_server_host
+// does not contain a scheme or path, that enterprise_server_host and enterprise_slug
+// are mutually exclusive, and that at least one allow rule with a non-empty
+// field is set.
+func validateGithub(spec *joiningv1.Github, tokenUsageMode TokenUsageMode) error {
+	if spec == nil {
+		return trace.BadParameter("github configuration must be defined for a scoped token when using the github join method")
+	}
+	if tokenUsageMode == TokenUsageModeSingle {
+		return trace.BadParameter("usage mode %q is not supported for github join method", TokenUsageModeSingle)
+	}
+	if strings.Contains(spec.GetEnterpriseServerHost(), "/") {
+		return trace.BadParameter("'github.enterprise_server_host' should not contain the scheme or path")
+	}
+	if spec.GetEnterpriseServerHost() != "" && spec.GetEnterpriseSlug() != "" {
+		return trace.BadParameter("'github.enterprise_server_host' and 'github.enterprise_slug' cannot both be set")
+	}
+
+	if len(spec.GetAllow()) == 0 {
+		return trace.BadParameter("the github join method requires at least one token allow rule")
+	}
+
+	for _, rule := range spec.GetAllow() {
+		repoSet := rule.GetRepository() != ""
+		ownerSet := rule.GetRepositoryOwner() != ""
+		subSet := rule.GetSub() != ""
+		enterpriseSet := rule.GetEnterprise() != ""
+		enterpriseIDSet := rule.GetEnterpriseId() != ""
+		if !subSet && !ownerSet && !repoSet && !enterpriseSet && !enterpriseIDSet {
+			return trace.BadParameter(`allow rule for github must include at least one of "repository", "repository_owner", "sub", "enterprise" or "enterprise_id"`)
+		}
+	}
+
+	return nil
+}
+
 // validates per join method token configurations
 func validateJoinMethod(token *joiningv1.ScopedToken) error {
 	switch types.JoinMethod(token.GetSpec().GetJoinMethod()) {
@@ -373,6 +410,10 @@ func validateJoinMethod(token *joiningv1.ScopedToken) error {
 		// Bound keypair tokens are always valid
 	case types.JoinMethodGenericOIDC:
 		return trace.Wrap(validateGenericOIDC(token.GetSpec().GetGenericOidc()), "generic_oidc join method")
+	case types.JoinMethodGitHub:
+		if err := validateGithub(token.GetSpec().GetGithub(), TokenUsageMode(token.GetSpec().GetUsageMode())); err != nil {
+			return trace.Wrap(err, "github join method")
+		}
 	default:
 		return trace.BadParameter("join method %q does not support scoping", token.GetSpec().GetJoinMethod())
 	}
@@ -1002,6 +1043,33 @@ func (t *Token) GetGenericOIDC() (*types.ProvisionTokenSpecV2GenericOIDC, error)
 		MustMatchFields: globalMatchers,
 		AllowAny:        allow,
 	}, nil
+}
+
+func (t *Token) GetGithub() *types.ProvisionTokenSpecV2GitHub {
+	spec := t.scoped.GetSpec().GetGithub()
+
+	allow := make([]*types.ProvisionTokenSpecV2GitHub_Rule, len(spec.GetAllow()))
+	for i, rule := range spec.GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2GitHub_Rule{
+			Sub:             rule.GetSub(),
+			Repository:      rule.GetRepository(),
+			RepositoryOwner: rule.GetRepositoryOwner(),
+			Workflow:        rule.GetWorkflow(),
+			Environment:     rule.GetEnvironment(),
+			Actor:           rule.GetActor(),
+			Ref:             rule.GetRef(),
+			RefType:         rule.GetRefType(),
+			Enterprise:      rule.GetEnterprise(),
+			EnterpriseID:    rule.GetEnterpriseId(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2GitHub{
+		EnterpriseServerHost: spec.GetEnterpriseServerHost(),
+		EnterpriseSlug:       spec.GetEnterpriseSlug(),
+		StaticJWKS:           spec.GetStaticJwks(),
+		Allow:                allow,
+	}
 }
 
 // GetScoped returns the inner scoped token wrapped by this [provision.Token].

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -1148,6 +1148,142 @@ func TestValidateScopedToken(t *testing.T) {
 			},
 		},
 		{
+			name: "valid github token with EnterpriseServerHost",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetJoinMethod(string(types.JoinMethodGitHub))
+
+				tok.GetSpec().SetGithub(joiningv1.Github_builder{
+					EnterpriseServerHost: "example.com",
+					EnterpriseSlug:       "",
+					Allow: []*joiningv1.Github_Rule{
+						joiningv1.Github_Rule_builder{
+							Sub: "foo",
+						}.Build(),
+					},
+				}.Build())
+			},
+		},
+		{
+			name: "valid github token with EnterpriseSlug",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetJoinMethod(string(types.JoinMethodGitHub))
+
+				tok.GetSpec().SetGithub(joiningv1.Github_builder{
+					EnterpriseServerHost: "",
+					EnterpriseSlug:       "exampleorg",
+					Allow: []*joiningv1.Github_Rule{
+						joiningv1.Github_Rule_builder{
+							Sub: "foo",
+						}.Build(),
+					},
+				}.Build())
+			},
+		},
+		{
+			name: "github token with single use mode",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetJoinMethod(string(types.JoinMethodGitHub))
+				tok.GetSpec().SetUsageMode(string(joining.TokenUsageModeSingle))
+				tok.GetSpec().SetGithub(joiningv1.Github_builder{
+					Allow: []*joiningv1.Github_Rule{
+						joiningv1.Github_Rule_builder{
+							Sub: "foo",
+						}.Build(),
+					},
+				}.Build())
+			},
+			expectedStrongErr: `usage mode "single_use" is not supported for github join method`,
+			expectedWeakErr:   `usage mode "single_use" is not supported for github join method`,
+		},
+		{
+			name: "github token with EnterpriseSlug and EnterpriseServerHost set",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetJoinMethod(string(types.JoinMethodGitHub))
+
+				tok.GetSpec().SetGithub(joiningv1.Github_builder{
+					EnterpriseServerHost: "example.com",
+					EnterpriseSlug:       "exampleorg",
+					Allow: []*joiningv1.Github_Rule{
+						joiningv1.Github_Rule_builder{
+							Sub: "foo",
+						}.Build(),
+					},
+				}.Build())
+			},
+			expectedStrongErr: "'github.enterprise_server_host' and 'github.enterprise_slug' cannot both be set",
+			expectedWeakErr:   "'github.enterprise_server_host' and 'github.enterprise_slug' cannot both be set",
+		},
+		{
+			name: "github token with EnterpriseServerHost with a path",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetJoinMethod(string(types.JoinMethodGitHub))
+
+				tok.GetSpec().SetGithub(joiningv1.Github_builder{
+					EnterpriseServerHost: "example.com/v1",
+					Allow: []*joiningv1.Github_Rule{
+						joiningv1.Github_Rule_builder{
+							Sub: "foo",
+						}.Build(),
+					},
+				}.Build())
+			},
+			expectedStrongErr: "github.enterprise_server_host' should not contain the scheme or path",
+			expectedWeakErr:   "github.enterprise_server_host' should not contain the scheme or path",
+		},
+		{
+			name: "github token with EnterpriseServerHost with a scheme",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetJoinMethod(string(types.JoinMethodGitHub))
+
+				tok.GetSpec().SetGithub(joiningv1.Github_builder{
+					EnterpriseServerHost: "https://example.com",
+					Allow: []*joiningv1.Github_Rule{
+						joiningv1.Github_Rule_builder{
+							Sub: "foo",
+						}.Build(),
+					},
+				}.Build())
+			},
+			expectedStrongErr: "github.enterprise_server_host' should not contain the scheme or path",
+			expectedWeakErr:   "github.enterprise_server_host' should not contain the scheme or path",
+		},
+		{
+			name: "github token with no rules",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetJoinMethod(string(types.JoinMethodGitHub))
+
+				tok.GetSpec().SetGithub(joiningv1.Github_builder{
+					Allow: []*joiningv1.Github_Rule{},
+				}.Build())
+			},
+			expectedStrongErr: "the github join method requires at least one token allow rule",
+			expectedWeakErr:   "the github join method requires at least one token allow rule",
+		},
+		{
+			name: "github token with empty rules",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetJoinMethod(string(types.JoinMethodGitHub))
+
+				tok.GetSpec().SetGithub(joiningv1.Github_builder{
+					Allow: []*joiningv1.Github_Rule{
+						joiningv1.Github_Rule_builder{}.Build(),
+						joiningv1.Github_Rule_builder{}.Build(),
+					},
+				}.Build())
+			},
+			expectedStrongErr: "allow rule for github must include at least one of",
+			expectedWeakErr:   "allow rule for github must include at least one of",
+		},
+		{
+			name: "github token with no github config",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.GetSpec().SetJoinMethod(string(types.JoinMethodGitHub))
+				// deliberately not calling SetGithub()
+			},
+			expectedStrongErr: "github configuration must be defined",
+			expectedWeakErr:   "github configuration must be defined",
+		},
+		{
 			name: "non-bot token with bot",
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.Bot = "/aa/bb::foo"
@@ -1307,6 +1443,42 @@ func TestScopedTokenAzureRoundTrip(t *testing.T) {
 			},
 		},
 	}, token.GetAzure())
+}
+
+func TestScopedTokenGithubRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	githubConfig := types.ProvisionTokenSpecV2GitHub{
+		EnterpriseServerHost: "example.com",
+		Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+			{
+				Sub:             "foo",
+				Repository:      "bar",
+				RepositoryOwner: "myself",
+			},
+		},
+	}
+
+	scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(types.ProvisionTokenSpecV2{
+		JoinMethod: types.JoinMethodGitHub,
+		Roles:      []types.SystemRole{types.RoleNode},
+		GitHub:     &githubConfig,
+	}, joiningv1.ScopedToken_builder{
+		Scope: "/test",
+		Metadata: headerv1.Metadata_builder{
+			Name: "test-token",
+		}.Build(),
+		Spec: joiningv1.ScopedTokenSpec_builder{
+			AssignedScope: "/test",
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	token, err := joining.NewToken(scopedToken)
+	require.NoError(t, err)
+
+	require.Equal(t, &githubConfig, token.GetGithub())
 }
 
 func TestNewTokenGetBot(t *testing.T) {


### PR DESCRIPTION

Changelog: Added support for the GitHub Actions join method with scoped join tokens, including scoped Bot

Backport of https://github.com/gravitational/teleport/pull/68939


## Manual Test Plan
### Test Environment

local, running a local GHA

### Test Cases
- [x] Unscoped bots can still join, rejoin, and recover using the github join method
- [x] Scoped bots can join, rejoin, and recover using github joining
