### PR TITLE
[v18] Connect: Fix shadows in unified resources view

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -412,39 +412,25 @@ const CardOuterContainer = styled(Box)<{
   shouldDisplayWarning: boolean;
   showHoverState: boolean;
 }>`
-  border-radius: ${props => props.theme.radii[3]}px;
+  border-radius: ${({ theme }) => theme.radii[3]}px;
+  transition: all 150ms;
 
-  ${props =>
-    props.showAllLabels &&
+  ${({ showAllLabels, shouldDisplayWarning }) =>
+    showAllLabels &&
     css`
       position: absolute;
       left: 0;
       // The padding is required to show the WarningRightEdgeBadgeIcon
-      right: ${props.shouldDisplayWarning ? '28px' : 0};
+      right: ${shouldDisplayWarning ? '28px' : 0};
       z-index: 1;
     `}
-  transition: all 150ms;
 
-  ${p =>
-    (p.showHoverState || p.showAllLabels) &&
+  ${({ showHoverState, showAllLabels, theme }) =>
+    (showHoverState || showAllLabels) &&
     css`
-      // Using double ampersand because of https://github.com/styled-components/styled-components/issues/3678.
-      ${CardContainer}:hover && {
-        background-color: ${props => props.theme.colors.levels.surface};
-
-        // We use a pseudo element for the shadow with position: absolute in order to prevent
-        // the shadow from increasing the size of the layout and causing scrollbar flicker.
-        &:after {
-          box-shadow: ${props => props.theme.boxShadow[3]};
-          border-radius: ${props => props.theme.radii[3]}px;
-          content: '';
-          position: absolute;
-          top: 0;
-          left: 0;
-          z-index: -1;
-          width: 100%;
-          height: 100%;
-        }
+      ${CardContainer}:hover & {
+        background-color: ${theme.colors.levels.surface};
+        box-shadow: ${theme.boxShadow[3]};
       }
     `}
 `;

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -360,6 +360,8 @@ const RowContainer = styled(Box)<{
   &:hover {
     background-color: ${props =>
       props.showHoverState ? props.theme.colors.levels.surface : 'transparent'};
+    box-shadow: ${({ showHoverState, theme }) =>
+      showHoverState ? theme.boxShadow[3] : 'none'};
 
     ${p =>
       p.shouldDisplayWarning &&
@@ -371,23 +373,6 @@ const RowContainer = styled(Box)<{
           action: 'hover',
           viewType: 'list',
         })};
-      `}
-
-    ${p =>
-      p.showHoverState &&
-      css`
-        // We use a pseudo element for the shadow with position: absolute in order to prevent
-        // the shadow from increasing the size of the layout and causing scrollbar flicker.
-        &:after {
-          box-shadow: ${props => props.theme.boxShadow[3]};
-          content: '';
-          position: absolute;
-          top: 0;
-          left: 0;
-          z-index: -1;
-          width: 100%;
-          height: 100%;
-        }
       `}
   }
 `;


### PR DESCRIPTION
Backport #69224 to branch/v18

Although we don't have the new design system in v18 yet, this change ensures the shadows will render correctly.

## Manual Test Plan
### Test Environment
Local builds.

### Test Cases
- [x] The shadows look the same (compared to the current v18) in Chrome, Firefox, Safari, and Connect. 