### PR TITLE
tbot: include init containers (sidecars) in Kubernetes workload attestation

### DIFF
--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
@@ -194,15 +194,23 @@ func (a *KubernetesAttestor) tryGetPodAndContainerStatus(ctx context.Context, po
 		return nil, nil, trace.NotFound("pod %q not found", podID)
 	}
 
-	var containerStatus *v1.ContainerStatus
+	// Look in the main containers of the Pod.
 	for _, status := range pod.Status.ContainerStatuses {
 		// Kubelet returns the container ID prefixed by `<type>://`.
 		if _, id, _ := strings.Cut(status.ContainerID, "://"); id == containerID {
-			containerStatus = &status
-			break
+			return pod, &status, nil
 		}
 	}
-	return pod, containerStatus, nil
+
+	// Look in the init containers of the Pod (sidecars).
+	for _, status := range pod.Status.InitContainerStatuses {
+		// Kubelet returns the container ID prefixed by `<type>://`.
+		if _, id, _ := strings.Cut(status.ContainerID, "://"); id == containerID {
+			return pod, &status, nil
+		}
+	}
+
+	return pod, nil, nil
 }
 
 // kubeletClient is a HTTP client for the Kubelet API

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
@@ -29,7 +29,9 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
@@ -47,8 +49,6 @@ import (
 
 func TestKubernetesAttestor_Attest(t *testing.T) {
 	t.Parallel()
-	log := logtest.NewLogger()
-	ctx := context.Background()
 
 	mockToken := "FOOBARBUZZ"
 	mockPID := 1234
@@ -56,109 +56,172 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 	mockPodID := "61c266b0-6f75-4490-8d92-3c9ae4d02787"
 	mockContainerID := "9da25af0b548c8c60aa60f77f299ba727bf72d58248bd7528eb5390ffcce555a"
 
-	// Setup mock Kubelet Secure API
-	var requests int
-	mockKubeletAPI := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path != "/pods" {
-			http.NotFound(w, req)
-			return
-		}
+	testCases := map[string]struct {
+		containerStatusFunc     func(callCount int) []v1.ContainerStatus
+		initContainerStatusFunc func(callCount int) []v1.ContainerStatus
+		wantRequests            int
+	}{
+		"main container": {
+			wantRequests: 2,
+			containerStatusFunc: func(callCount int) []v1.ContainerStatus {
+				// Don't return the container status in the first response, to simulate
+				// the kubelet API's eventual consistency.
+				var containerStatuses []v1.ContainerStatus
+				switch {
+				case callCount == 1:
+					containerStatuses = append(containerStatuses, v1.ContainerStatus{
+						ContainerID: "docker://totally-wrong-container-id",
+					})
+				case callCount > 1:
+					containerStatuses = append(containerStatuses, v1.ContainerStatus{
+						ContainerID: "docker://" + mockContainerID,
+						Name:        "container-1",
+						Image:       "my.registry.io/my-app:v1",
+						ImageID:     "docker-pullable://my.registry.io/my-app@sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					})
+				}
 
-		// Don't return the container status in the first response, to simulate
-		// the kubelet API's eventual consistency.
-		var containerStatuses []v1.ContainerStatus
-		switch {
-		case requests == 1:
-			containerStatuses = append(containerStatuses, v1.ContainerStatus{
-				ContainerID: "docker://totally-wrong-container-id",
-			})
-		case requests > 1:
-			containerStatuses = append(containerStatuses, v1.ContainerStatus{
-				ContainerID: "docker://" + mockContainerID,
-				Name:        "container-1",
-				Image:       "my.registry.io/my-app:v1",
-				ImageID:     "docker-pullable://my.registry.io/my-app@sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
-			})
-		}
-		requests++
-
-		out := v1.PodList{
-			Items: []v1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "my-pod",
-						Namespace: "default",
-						UID:       types.UID(mockPodID),
-						Labels: map[string]string{
-							"my-label": "my-label-value",
-						},
-					},
-					Spec: v1.PodSpec{
-						ServiceAccountName: "my-service-account",
-					},
-					Status: v1.PodStatus{
-						ContainerStatuses: containerStatuses,
-					},
-				},
+				return containerStatuses
 			},
-		}
-		w.WriteHeader(200)
-		assert.NoError(t, json.NewEncoder(w).Encode(out))
-	}))
-	t.Cleanup(mockKubeletAPI.Close)
-	kubeletAddr := mockKubeletAPI.Listener.Addr().String()
-	host, port, err := net.SplitHostPort(kubeletAddr)
-	require.NoError(t, err)
-	portInt, err := strconv.Atoi(port)
-	require.NoError(t, err)
 
-	// Setup mock filesystem
-	tmpDir := t.TempDir()
-	tokenPath := filepath.Join(tmpDir, "token")
-	require.NoError(t, os.WriteFile(tokenPath, []byte(mockToken), 0644))
-	procPath := filepath.Join(tmpDir, "proc")
-	procPIDPath := filepath.Join(procPath, strconv.Itoa(mockPID))
-	pidMountInfoPath := filepath.Join(procPIDPath, "mountinfo")
-	require.NoError(t, os.MkdirAll(procPIDPath, 0755))
-	require.NoError(t, utils.CopyFile(
-		filepath.Join("container", "testdata", "mountfile", "k8s-real-gcp-v1.29.5-gke.1091002"),
-		pidMountInfoPath,
-		0755),
-	)
-
-	// Setup Attestor for mocks
-	attestor := NewKubernetesAttestor(KubernetesAttestorConfig{
-		Enabled: true,
-		Kubelet: KubeletClientConfig{
-			TokenPath:  tokenPath,
-			SkipVerify: true,
-			SecurePort: portInt,
+			initContainerStatusFunc: func(_ int) []v1.ContainerStatus {
+				return []v1.ContainerStatus{
+					{
+						ContainerID: "docker://1231455ksasdffgdk923klsklsdghkld0235wehlsdgjsd3i50sekfgort0235ui",
+						Name:        "another-container-1",
+						Image:       "my.registry.io/my-other-app:v1",
+						ImageID:     "docker-pullable://my.registry.io/my-other-app:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					},
+				}
+			},
 		},
-	}, log)
-	attestor.rootPath = tmpDir
-	attestor.clock = clockwork.NewRealClock()
-	attestor.kubeletClient.getEnv = func(s string) string {
-		env := map[string]string{
-			"TELEPORT_NODE_NAME": host,
-		}
-		return env[s]
+
+		"init container": {
+			wantRequests: 1,
+			containerStatusFunc: func(_ int) []v1.ContainerStatus {
+				return []v1.ContainerStatus{
+					{
+						ContainerID: "docker://1231455ksasdffgdk923klsklsdghkld0235wehlsdgjsd3i50sekfgort0235ui",
+						Name:        "another-container-1",
+						Image:       "my.registry.io/my-other-app:v1",
+						ImageID:     "docker-pullable://my.registry.io/my-other-app:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					},
+				}
+			},
+
+			initContainerStatusFunc: func(_ int) []v1.ContainerStatus {
+				return []v1.ContainerStatus{
+					{
+						ContainerID: "docker://" + mockContainerID,
+						Name:        "container-1",
+						Image:       "my.registry.io/my-app:v1",
+						ImageID:     "docker-pullable://my.registry.io/my-app@sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					},
+				}
+			},
+		},
 	}
 
-	att, err := attestor.Attest(ctx, mockPID)
-	assert.NoError(t, err)
-	assert.Empty(t, cmp.Diff(workloadidentityv1pb.WorkloadAttrsKubernetes_builder{
-		Attested:       true,
-		ServiceAccount: "my-service-account",
-		Namespace:      "default",
-		PodName:        "my-pod",
-		PodUid:         mockPodID,
-		Labels: map[string]string{
-			"my-label": "my-label-value",
-		},
-		Container: workloadidentityv1pb.WorkloadAttrsKubernetesContainer_builder{
-			Name:        "container-1",
-			Image:       "my.registry.io/my-app:v1",
-			ImageDigest: "sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
-		}.Build(),
-	}.Build(), att, protocmp.Transform()))
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			log := logtest.NewLogger()
+
+			// Setup mock Kubelet Secure API
+			var requests atomic.Int32
+			mockKubeletAPI := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.URL.Path != "/pods" {
+					http.NotFound(w, req)
+					return
+				}
+
+				requests.Add(1)
+				out := v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "my-pod",
+								Namespace: "default",
+								UID:       types.UID(mockPodID),
+								Labels: map[string]string{
+									"my-label": "my-label-value",
+								},
+							},
+							Spec: v1.PodSpec{
+								ServiceAccountName: "my-service-account",
+							},
+							Status: v1.PodStatus{
+								ContainerStatuses:     tc.containerStatusFunc(int(requests.Load())),
+								InitContainerStatuses: tc.initContainerStatusFunc(int(requests.Load())),
+							},
+						},
+					},
+				}
+				w.WriteHeader(200)
+				assert.NoError(t, json.NewEncoder(w).Encode(out))
+			}))
+			t.Cleanup(mockKubeletAPI.Close)
+			kubeletAddr := mockKubeletAPI.Listener.Addr().String()
+			host, port, err := net.SplitHostPort(kubeletAddr)
+			require.NoError(t, err)
+			portInt, err := strconv.Atoi(port)
+			require.NoError(t, err)
+
+			// Setup mock filesystem
+			tmpDir := t.TempDir()
+			tokenPath := filepath.Join(tmpDir, "token")
+			require.NoError(t, os.WriteFile(tokenPath, []byte(mockToken), 0o644))
+			procPath := filepath.Join(tmpDir, "proc")
+			procPIDPath := filepath.Join(procPath, strconv.Itoa(mockPID))
+			pidMountInfoPath := filepath.Join(procPIDPath, "mountinfo")
+			require.NoError(t, os.MkdirAll(procPIDPath, 0o755))
+			require.NoError(t, utils.CopyFile(
+				filepath.Join("container", "testdata", "mountfile", "k8s-real-gcp-v1.29.5-gke.1091002"),
+				pidMountInfoPath,
+				0o755),
+			)
+
+			// Setup Attestor for mocks
+			attestor := NewKubernetesAttestor(KubernetesAttestorConfig{
+				Enabled: true,
+				Kubelet: KubeletClientConfig{
+					TokenPath:  tokenPath,
+					SkipVerify: true,
+					SecurePort: portInt,
+				},
+			}, log)
+			attestor.rootPath = tmpDir
+			attestor.clock = clockwork.NewRealClock()
+			attestor.kubeletClient.getEnv = func(s string) string {
+				env := map[string]string{
+					"TELEPORT_NODE_NAME": host,
+				}
+				return env[s]
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+
+			att, err := attestor.Attest(ctx, mockPID)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(workloadidentityv1pb.WorkloadAttrsKubernetes_builder{
+				Attested:       true,
+				ServiceAccount: "my-service-account",
+				Namespace:      "default",
+				PodName:        "my-pod",
+				PodUid:         mockPodID,
+				Labels: map[string]string{
+					"my-label": "my-label-value",
+				},
+				Container: workloadidentityv1pb.WorkloadAttrsKubernetesContainer_builder{
+					Name:        "container-1",
+					Image:       "my.registry.io/my-app:v1",
+					ImageDigest: "sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+				}.Build(),
+			}.Build(), att, protocmp.Transform()))
+			require.EqualValues(t, tc.wantRequests, requests.Load())
+			require.NoError(t, ctx.Err())
+		})
+	}
 }

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
@@ -200,7 +200,7 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 				return env[s]
 			}
 
-			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
 
 			att, err := attestor.Attest(ctx, mockPID)
@@ -221,7 +221,6 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 				}.Build(),
 			}.Build(), att, protocmp.Transform()))
 			require.EqualValues(t, tc.wantRequests, requests.Load())
-			require.NoError(t, ctx.Err())
 		})
 	}
 }


### PR DESCRIPTION
<!-- Provide a descriptive entry for the changelog of the next release. -->

Closes https://github.com/gravitational/customer-sensitive-requests/issues/687

Changelog: Fixed tbot Kubernetes attestor not finding native sidecar containers

Previous to this change, when trying to attest a Kubernetes Pod Container, `tbot` would look only at the `pod.Status.ContainerStatuses` of the given Pod. That excluded "native sidecars" which are in-fact init containers.

This change also adds `pod.Status.InitContainerStatuses` to the search path, which enables sidecars to be attested too.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

local

### Test Cases
- [x] create a pod with a native sidecar and validate that it gets the full attestation/identity.

```
...
spec:
  spiffe:
    id: "/k8s/{{ workload.kubernetes.namespace }}/{{ workload.kubernetes.pod_name }}/{{ workload.kubernetes.container.name }}"
...
```

```
# tbot spiffe-inspect --path "unix:///run/tbot/sockets/workload.sock"
...
# JWT SVIDs                                                                                                                            
- spiffe://teleport-local/k8s/default/sidecar-test-pod/spiffe-client
...
```
