### PR TITLE
Allow local proxy with a PIV MFA device

### DIFF
--- a/lib/client/local_proxy_middleware.go
+++ b/lib/client/local_proxy_middleware.go
@@ -508,13 +508,7 @@ func generateSelfSignedCAFromCert(cert tls.Certificate, caPath string) (tls.Cert
 		return tls.Certificate{}, trace.ConvertSystemError(err)
 	}
 
-	keyPem, err := keys.MarshalPrivateKey(signer)
-	if err != nil {
-		return tls.Certificate{}, trace.Wrap(err)
-	}
-
-	caCert, err := tls.X509KeyPair(certPem, keyPem)
-	return caCert, trace.Wrap(err)
+	return keys.TLSCertificateForSigner(signer, certPem)
 }
 
 // getTLSCertExpireTime returns the certificate NotAfter time.

--- a/lib/client/local_proxy_middleware_test.go
+++ b/lib/client/local_proxy_middleware_test.go
@@ -18,6 +18,7 @@ package client_test
 
 import (
 	"context"
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -29,6 +30,8 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -78,46 +81,83 @@ func TestCertChecker(t *testing.T) {
 }
 
 func TestLocalCertGenerator(t *testing.T) {
-	ctx := context.Background()
-	clock := clockwork.NewFakeClock()
-	certIssuer := newMockCertIssuer(t, clock)
-	certChecker := client.NewCertChecker(certIssuer, clock)
-	caPath := filepath.Join(t.TempDir(), "localca.pem")
+	for _, tt := range []struct {
+		name      string
+		newSigner func(context.Context) (crypto.Signer, error)
+	}{
+		{
+			name: "software key",
+			newSigner: func(context.Context) (crypto.Signer, error) {
+				return cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+			},
+		},
+		{
+			name: "PIV key",
+			newSigner: func(ctx context.Context) (crypto.Signer, error) {
+				hwks := hardwarekey.NewMockHardwareKeyService(nil /*prompt*/)
+				return hwks.NewPrivateKey(ctx, hardwarekey.PrivateKeyConfig{})
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			clock := clockwork.NewFakeClock()
+			certIssuer := newMockCertIssuer(t, clock)
+			certIssuer.newSigner = tt.newSigner
+			certChecker := client.NewCertChecker(certIssuer, clock)
+			caPath := filepath.Join(t.TempDir(), "localca.pem")
 
-	localCertGenerator, err := client.NewLocalCertGenerator(ctx, certChecker, caPath)
-	require.NoError(t, err)
+			localCertGenerator, err := client.NewLocalCertGenerator(ctx, certChecker, caPath)
+			require.NoError(t, err)
 
-	// The cert generator should return the local CA cert for SNIs "localhost" or empty (plain ip).
-	caCert, err := localCertGenerator.GetCertificate(&tls.ClientHelloInfo{
-		ServerName: "localhost",
-	})
-	require.NoError(t, err)
-	require.Equal(t, []string{"localhost"}, caCert.Leaf.DNSNames)
+			// The cert generator should return the local CA cert for SNIs "localhost" or empty (plain ip).
+			caCert, err := localCertGenerator.GetCertificate(&tls.ClientHelloInfo{
+				ServerName: "localhost",
+			})
+			require.NoError(t, err)
+			require.Equal(t, []string{"localhost"}, caCert.Leaf.DNSNames)
 
-	cert, err := localCertGenerator.GetCertificate(&tls.ClientHelloInfo{
-		ServerName: "",
-	})
-	require.NoError(t, err)
-	require.Equal(t, caCert, cert)
+			cert, err := localCertGenerator.GetCertificate(&tls.ClientHelloInfo{
+				ServerName: "",
+			})
+			require.NoError(t, err)
+			require.Equal(t, caCert, cert)
 
-	// The cert generator should issue new certs from the local CA for other SNIs.
-	exampleCert, err := localCertGenerator.GetCertificate(&tls.ClientHelloInfo{
-		ServerName: "example.com",
-	})
-	require.NoError(t, err)
-	require.Equal(t, []string{"example.com"}, exampleCert.Leaf.DNSNames)
+			// The cert generator should issue new certs from the local CA for other SNIs.
+			exampleCert, err := localCertGenerator.GetCertificate(&tls.ClientHelloInfo{
+				ServerName: "example.com",
+			})
+			require.NoError(t, err)
+			require.Equal(t, []string{"example.com"}, exampleCert.Leaf.DNSNames)
+
+			// Verify that the generated certificate is actually trusted by the local
+			// CA.
+			roots := x509.NewCertPool()
+			roots.AddCert(caCert.Leaf)
+			_, err = exampleCert.Leaf.Verify(x509.VerifyOptions{
+				Roots:       roots,
+				DNSName:     "example.com",
+				CurrentTime: caCert.Leaf.NotBefore,
+			})
+			require.NoError(t, err)
+		})
+	}
 }
 
 type mockCertIssuer struct {
-	ca       *tlsca.CertAuthority
-	clock    clockwork.Clock
-	checkErr error
-	issueErr error
+	ca        *tlsca.CertAuthority
+	clock     clockwork.Clock
+	checkErr  error
+	issueErr  error
+	newSigner func(context.Context) (crypto.Signer, error)
 }
 
 func newMockCertIssuer(t *testing.T, clock clockwork.Clock) *mockCertIssuer {
 	certIssuer := &mockCertIssuer{
 		clock: clock,
+		newSigner: func(context.Context) (crypto.Signer, error) {
+			return cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+		},
 	}
 
 	certIssuer.initCA(t)
@@ -152,13 +192,13 @@ func (c *mockCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error)
 		return tls.Certificate{}, trace.Wrap(c.issueErr)
 	}
 
-	priv, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	signer, err := c.newSigner(ctx)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}
 
 	certPem, err := c.ca.GenerateCertificate(tlsca.CertificateRequest{
-		PublicKey: priv.Public(),
+		PublicKey: signer.Public(),
 		Subject: pkix.Name{
 			CommonName:   "user",
 			Organization: []string{"teleport"},
@@ -169,7 +209,7 @@ func (c *mockCertIssuer) IssueCert(ctx context.Context) (tls.Certificate, error)
 		return tls.Certificate{}, trace.Wrap(err)
 	}
 
-	tlsCert, err := tls.X509KeyPair(certPem, priv.PrivateKeyPEM())
+	tlsCert, err := keys.TLSCertificateForSigner(signer, certPem)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}


### PR DESCRIPTION
Previously, the self-signed CA certificate was generated using a marshaled private key from the user's certificate. If this certificate is backed by a PIV device, it means it's using a Teleport-specific PEM block that is a reference to the MFA device, and not a real key material (as the actual key material is securely stored on a hardware device and not extractable).

With this change, instead of supplying the key material, a signer is supplied instead that knows how to deal with a hardware device.

Fixes https://github.com/gravitational/teleport/issues/69199




<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog:


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
