### PR TITLE
tbot: restrict initContainers to native sidecars only

### DIFF
--- a/api/gen/proto/go/teleport/workloadidentity/v1/attrs_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/attrs_protohybrid.pb.go
@@ -37,6 +37,57 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Type maps to specific container types from Kubernetes.
+type WorkloadAttrsKubernetesContainer_Type int32
+
+const (
+	WorkloadAttrsKubernetesContainer_TYPE_UNSPECIFIED WorkloadAttrsKubernetesContainer_Type = 0
+	// TYPE_REGULAR is used for the main containers of a Pod.
+	WorkloadAttrsKubernetesContainer_TYPE_REGULAR WorkloadAttrsKubernetesContainer_Type = 1
+	// TYPE_INIT is used for the init containers of a Pod.
+	WorkloadAttrsKubernetesContainer_TYPE_INIT WorkloadAttrsKubernetesContainer_Type = 2
+	// TYPE_EPHEMERAL is reserved for ephemeral containers, not currently supported.
+	WorkloadAttrsKubernetesContainer_TYPE_EPHEMERAL WorkloadAttrsKubernetesContainer_Type = 3
+)
+
+// Enum value maps for WorkloadAttrsKubernetesContainer_Type.
+var (
+	WorkloadAttrsKubernetesContainer_Type_name = map[int32]string{
+		0: "TYPE_UNSPECIFIED",
+		1: "TYPE_REGULAR",
+		2: "TYPE_INIT",
+		3: "TYPE_EPHEMERAL",
+	}
+	WorkloadAttrsKubernetesContainer_Type_value = map[string]int32{
+		"TYPE_UNSPECIFIED": 0,
+		"TYPE_REGULAR":     1,
+		"TYPE_INIT":        2,
+		"TYPE_EPHEMERAL":   3,
+	}
+)
+
+func (x WorkloadAttrsKubernetesContainer_Type) Enum() *WorkloadAttrsKubernetesContainer_Type {
+	p := new(WorkloadAttrsKubernetesContainer_Type)
+	*p = x
+	return p
+}
+
+func (x WorkloadAttrsKubernetesContainer_Type) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (WorkloadAttrsKubernetesContainer_Type) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_workloadidentity_v1_attrs_proto_enumTypes[0].Descriptor()
+}
+
+func (WorkloadAttrsKubernetesContainer_Type) Type() protoreflect.EnumType {
+	return &file_teleport_workloadidentity_v1_attrs_proto_enumTypes[0]
+}
+
+func (x WorkloadAttrsKubernetesContainer_Type) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
 // Attributes sourced from the Kubernetes workload attestor.
 type WorkloadAttrsKubernetes struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -212,7 +263,9 @@ type WorkloadAttrsKubernetesContainer struct {
 	// The name of the image the container is running.
 	Image string `protobuf:"bytes,2,opt,name=image,proto3" json:"image,omitempty"`
 	// The exact image digest the container is running.
-	ImageDigest   string `protobuf:"bytes,3,opt,name=image_digest,json=imageDigest,proto3" json:"image_digest,omitempty"`
+	ImageDigest string `protobuf:"bytes,3,opt,name=image_digest,json=imageDigest,proto3" json:"image_digest,omitempty"`
+	// The type of the container.
+	Type          WorkloadAttrsKubernetesContainer_Type `protobuf:"varint,4,opt,name=type,proto3,enum=teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer_Type" json:"type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -263,6 +316,13 @@ func (x *WorkloadAttrsKubernetesContainer) GetImageDigest() string {
 	return ""
 }
 
+func (x *WorkloadAttrsKubernetesContainer) GetType() WorkloadAttrsKubernetesContainer_Type {
+	if x != nil {
+		return x.Type
+	}
+	return WorkloadAttrsKubernetesContainer_TYPE_UNSPECIFIED
+}
+
 func (x *WorkloadAttrsKubernetesContainer) SetName(v string) {
 	x.Name = v
 }
@@ -275,6 +335,10 @@ func (x *WorkloadAttrsKubernetesContainer) SetImageDigest(v string) {
 	x.ImageDigest = v
 }
 
+func (x *WorkloadAttrsKubernetesContainer) SetType(v WorkloadAttrsKubernetesContainer_Type) {
+	x.Type = v
+}
+
 type WorkloadAttrsKubernetesContainer_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -284,6 +348,8 @@ type WorkloadAttrsKubernetesContainer_builder struct {
 	Image string
 	// The exact image digest the container is running.
 	ImageDigest string
+	// The type of the container.
+	Type WorkloadAttrsKubernetesContainer_Type
 }
 
 func (b0 WorkloadAttrsKubernetesContainer_builder) Build() *WorkloadAttrsKubernetesContainer {
@@ -293,6 +359,7 @@ func (b0 WorkloadAttrsKubernetesContainer_builder) Build() *WorkloadAttrsKuberne
 	x.Name = b.Name
 	x.Image = b.Image
 	x.ImageDigest = b.ImageDigest
+	x.Type = b.Type
 	return m0
 }
 
@@ -1584,11 +1651,17 @@ const file_teleport_workloadidentity_v1_attrs_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\f\n" +
 	"\n" +
-	"_container\"o\n" +
+	"_container\"\x9b\x02\n" +
 	" WorkloadAttrsKubernetesContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05image\x18\x02 \x01(\tR\x05image\x12!\n" +
-	"\fimage_digest\x18\x03 \x01(\tR\vimageDigest\"\xd1\x01\n" +
+	"\fimage_digest\x18\x03 \x01(\tR\vimageDigest\x12W\n" +
+	"\x04type\x18\x04 \x01(\x0e2C.teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer.TypeR\x04type\"Q\n" +
+	"\x04Type\x12\x14\n" +
+	"\x10TYPE_UNSPECIFIED\x10\x00\x12\x10\n" +
+	"\fTYPE_REGULAR\x10\x01\x12\r\n" +
+	"\tTYPE_INIT\x10\x02\x12\x12\n" +
+	"\x0eTYPE_EPHEMERAL\x10\x03\"\xd1\x01\n" +
 	"\x11WorkloadAttrsUnix\x12\x1a\n" +
 	"\battested\x18\x01 \x01(\bR\battested\x12\x10\n" +
 	"\x03pid\x18\x02 \x01(\x05R\x03pid\x12\x10\n" +
@@ -1659,56 +1732,59 @@ const file_teleport_workloadidentity_v1_attrs_proto_rawDesc = "" +
 	"\x04user\x18\x02 \x01(\v2'.teleport.workloadidentity.v1.UserAttrsR\x04user\x12;\n" +
 	"\x04join\x18\x03 \x01(\v2'.teleport.workloadidentity.v1.JoinAttrsR\x04joinBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
 
+var file_teleport_workloadidentity_v1_attrs_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_teleport_workloadidentity_v1_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_teleport_workloadidentity_v1_attrs_proto_goTypes = []any{
-	(*WorkloadAttrsKubernetes)(nil),          // 0: teleport.workloadidentity.v1.WorkloadAttrsKubernetes
-	(*WorkloadAttrsKubernetesContainer)(nil), // 1: teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer
-	(*WorkloadAttrsUnix)(nil),                // 2: teleport.workloadidentity.v1.WorkloadAttrsUnix
-	(*WorkloadAttrsPodman)(nil),              // 3: teleport.workloadidentity.v1.WorkloadAttrsPodman
-	(*WorkloadAttrsPodmanContainer)(nil),     // 4: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer
-	(*WorkloadAttrsPodmanPod)(nil),           // 5: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod
-	(*WorkloadAttrsDocker)(nil),              // 6: teleport.workloadidentity.v1.WorkloadAttrsDocker
-	(*WorkloadAttrsDockerContainer)(nil),     // 7: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer
-	(*WorkloadAttrsSystemd)(nil),             // 8: teleport.workloadidentity.v1.WorkloadAttrsSystemd
-	(*WorkloadAttrsSigstore)(nil),            // 9: teleport.workloadidentity.v1.WorkloadAttrsSigstore
-	(*WorkloadAttrs)(nil),                    // 10: teleport.workloadidentity.v1.WorkloadAttrs
-	(*UserAttrs)(nil),                        // 11: teleport.workloadidentity.v1.UserAttrs
-	(*Attrs)(nil),                            // 12: teleport.workloadidentity.v1.Attrs
-	nil,                                      // 13: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.LabelsEntry
-	nil,                                      // 14: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.LabelsEntry
-	nil,                                      // 15: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.LabelsEntry
-	nil,                                      // 16: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.LabelsEntry
-	nil,                                      // 17: teleport.workloadidentity.v1.UserAttrs.LabelsEntry
-	(*SigstoreVerificationPayload)(nil),      // 18: teleport.workloadidentity.v1.SigstoreVerificationPayload
-	(*v1.Trait)(nil),                         // 19: teleport.trait.v1.Trait
-	(*JoinAttrs)(nil),                        // 20: teleport.workloadidentity.v1.JoinAttrs
+	(WorkloadAttrsKubernetesContainer_Type)(0), // 0: teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer.Type
+	(*WorkloadAttrsKubernetes)(nil),            // 1: teleport.workloadidentity.v1.WorkloadAttrsKubernetes
+	(*WorkloadAttrsKubernetesContainer)(nil),   // 2: teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer
+	(*WorkloadAttrsUnix)(nil),                  // 3: teleport.workloadidentity.v1.WorkloadAttrsUnix
+	(*WorkloadAttrsPodman)(nil),                // 4: teleport.workloadidentity.v1.WorkloadAttrsPodman
+	(*WorkloadAttrsPodmanContainer)(nil),       // 5: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer
+	(*WorkloadAttrsPodmanPod)(nil),             // 6: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod
+	(*WorkloadAttrsDocker)(nil),                // 7: teleport.workloadidentity.v1.WorkloadAttrsDocker
+	(*WorkloadAttrsDockerContainer)(nil),       // 8: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer
+	(*WorkloadAttrsSystemd)(nil),               // 9: teleport.workloadidentity.v1.WorkloadAttrsSystemd
+	(*WorkloadAttrsSigstore)(nil),              // 10: teleport.workloadidentity.v1.WorkloadAttrsSigstore
+	(*WorkloadAttrs)(nil),                      // 11: teleport.workloadidentity.v1.WorkloadAttrs
+	(*UserAttrs)(nil),                          // 12: teleport.workloadidentity.v1.UserAttrs
+	(*Attrs)(nil),                              // 13: teleport.workloadidentity.v1.Attrs
+	nil,                                        // 14: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.LabelsEntry
+	nil,                                        // 15: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.LabelsEntry
+	nil,                                        // 16: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.LabelsEntry
+	nil,                                        // 17: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.LabelsEntry
+	nil,                                        // 18: teleport.workloadidentity.v1.UserAttrs.LabelsEntry
+	(*SigstoreVerificationPayload)(nil),        // 19: teleport.workloadidentity.v1.SigstoreVerificationPayload
+	(*v1.Trait)(nil),                           // 20: teleport.trait.v1.Trait
+	(*JoinAttrs)(nil),                          // 21: teleport.workloadidentity.v1.JoinAttrs
 }
 var file_teleport_workloadidentity_v1_attrs_proto_depIdxs = []int32{
-	13, // 0: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetes.LabelsEntry
-	1,  // 1: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer
-	4,  // 2: teleport.workloadidentity.v1.WorkloadAttrsPodman.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer
-	5,  // 3: teleport.workloadidentity.v1.WorkloadAttrsPodman.pod:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanPod
-	14, // 4: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.LabelsEntry
-	15, // 5: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.LabelsEntry
-	7,  // 6: teleport.workloadidentity.v1.WorkloadAttrsDocker.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDockerContainer
-	16, // 7: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.LabelsEntry
-	18, // 8: teleport.workloadidentity.v1.WorkloadAttrsSigstore.payloads:type_name -> teleport.workloadidentity.v1.SigstoreVerificationPayload
-	2,  // 9: teleport.workloadidentity.v1.WorkloadAttrs.unix:type_name -> teleport.workloadidentity.v1.WorkloadAttrsUnix
-	0,  // 10: teleport.workloadidentity.v1.WorkloadAttrs.kubernetes:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetes
-	3,  // 11: teleport.workloadidentity.v1.WorkloadAttrs.podman:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodman
-	6,  // 12: teleport.workloadidentity.v1.WorkloadAttrs.docker:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDocker
-	8,  // 13: teleport.workloadidentity.v1.WorkloadAttrs.systemd:type_name -> teleport.workloadidentity.v1.WorkloadAttrsSystemd
-	9,  // 14: teleport.workloadidentity.v1.WorkloadAttrs.sigstore:type_name -> teleport.workloadidentity.v1.WorkloadAttrsSigstore
-	17, // 15: teleport.workloadidentity.v1.UserAttrs.labels:type_name -> teleport.workloadidentity.v1.UserAttrs.LabelsEntry
-	19, // 16: teleport.workloadidentity.v1.UserAttrs.traits:type_name -> teleport.trait.v1.Trait
-	10, // 17: teleport.workloadidentity.v1.Attrs.workload:type_name -> teleport.workloadidentity.v1.WorkloadAttrs
-	11, // 18: teleport.workloadidentity.v1.Attrs.user:type_name -> teleport.workloadidentity.v1.UserAttrs
-	20, // 19: teleport.workloadidentity.v1.Attrs.join:type_name -> teleport.workloadidentity.v1.JoinAttrs
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	14, // 0: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetes.LabelsEntry
+	2,  // 1: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer
+	0,  // 2: teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer.type:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer.Type
+	5,  // 3: teleport.workloadidentity.v1.WorkloadAttrsPodman.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer
+	6,  // 4: teleport.workloadidentity.v1.WorkloadAttrsPodman.pod:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanPod
+	15, // 5: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.LabelsEntry
+	16, // 6: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.LabelsEntry
+	8,  // 7: teleport.workloadidentity.v1.WorkloadAttrsDocker.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDockerContainer
+	17, // 8: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.LabelsEntry
+	19, // 9: teleport.workloadidentity.v1.WorkloadAttrsSigstore.payloads:type_name -> teleport.workloadidentity.v1.SigstoreVerificationPayload
+	3,  // 10: teleport.workloadidentity.v1.WorkloadAttrs.unix:type_name -> teleport.workloadidentity.v1.WorkloadAttrsUnix
+	1,  // 11: teleport.workloadidentity.v1.WorkloadAttrs.kubernetes:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetes
+	4,  // 12: teleport.workloadidentity.v1.WorkloadAttrs.podman:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodman
+	7,  // 13: teleport.workloadidentity.v1.WorkloadAttrs.docker:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDocker
+	9,  // 14: teleport.workloadidentity.v1.WorkloadAttrs.systemd:type_name -> teleport.workloadidentity.v1.WorkloadAttrsSystemd
+	10, // 15: teleport.workloadidentity.v1.WorkloadAttrs.sigstore:type_name -> teleport.workloadidentity.v1.WorkloadAttrsSigstore
+	18, // 16: teleport.workloadidentity.v1.UserAttrs.labels:type_name -> teleport.workloadidentity.v1.UserAttrs.LabelsEntry
+	20, // 17: teleport.workloadidentity.v1.UserAttrs.traits:type_name -> teleport.trait.v1.Trait
+	11, // 18: teleport.workloadidentity.v1.Attrs.workload:type_name -> teleport.workloadidentity.v1.WorkloadAttrs
+	12, // 19: teleport.workloadidentity.v1.Attrs.user:type_name -> teleport.workloadidentity.v1.UserAttrs
+	21, // 20: teleport.workloadidentity.v1.Attrs.join:type_name -> teleport.workloadidentity.v1.JoinAttrs
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_teleport_workloadidentity_v1_attrs_proto_init() }
@@ -1726,13 +1802,14 @@ func file_teleport_workloadidentity_v1_attrs_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_workloadidentity_v1_attrs_proto_rawDesc), len(file_teleport_workloadidentity_v1_attrs_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_teleport_workloadidentity_v1_attrs_proto_goTypes,
 		DependencyIndexes: file_teleport_workloadidentity_v1_attrs_proto_depIdxs,
+		EnumInfos:         file_teleport_workloadidentity_v1_attrs_proto_enumTypes,
 		MessageInfos:      file_teleport_workloadidentity_v1_attrs_proto_msgTypes,
 	}.Build()
 	File_teleport_workloadidentity_v1_attrs_proto = out.File

--- a/api/gen/proto/go/teleport/workloadidentity/v1/attrs_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/attrs_protoopaque.pb.go
@@ -37,6 +37,57 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Type maps to specific container types from Kubernetes.
+type WorkloadAttrsKubernetesContainer_Type int32
+
+const (
+	WorkloadAttrsKubernetesContainer_TYPE_UNSPECIFIED WorkloadAttrsKubernetesContainer_Type = 0
+	// TYPE_REGULAR is used for the main containers of a Pod.
+	WorkloadAttrsKubernetesContainer_TYPE_REGULAR WorkloadAttrsKubernetesContainer_Type = 1
+	// TYPE_INIT is used for the init containers of a Pod.
+	WorkloadAttrsKubernetesContainer_TYPE_INIT WorkloadAttrsKubernetesContainer_Type = 2
+	// TYPE_EPHEMERAL is reserved for ephemeral containers, not currently supported.
+	WorkloadAttrsKubernetesContainer_TYPE_EPHEMERAL WorkloadAttrsKubernetesContainer_Type = 3
+)
+
+// Enum value maps for WorkloadAttrsKubernetesContainer_Type.
+var (
+	WorkloadAttrsKubernetesContainer_Type_name = map[int32]string{
+		0: "TYPE_UNSPECIFIED",
+		1: "TYPE_REGULAR",
+		2: "TYPE_INIT",
+		3: "TYPE_EPHEMERAL",
+	}
+	WorkloadAttrsKubernetesContainer_Type_value = map[string]int32{
+		"TYPE_UNSPECIFIED": 0,
+		"TYPE_REGULAR":     1,
+		"TYPE_INIT":        2,
+		"TYPE_EPHEMERAL":   3,
+	}
+)
+
+func (x WorkloadAttrsKubernetesContainer_Type) Enum() *WorkloadAttrsKubernetesContainer_Type {
+	p := new(WorkloadAttrsKubernetesContainer_Type)
+	*p = x
+	return p
+}
+
+func (x WorkloadAttrsKubernetesContainer_Type) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (WorkloadAttrsKubernetesContainer_Type) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_workloadidentity_v1_attrs_proto_enumTypes[0].Descriptor()
+}
+
+func (WorkloadAttrsKubernetesContainer_Type) Type() protoreflect.EnumType {
+	return &file_teleport_workloadidentity_v1_attrs_proto_enumTypes[0]
+}
+
+func (x WorkloadAttrsKubernetesContainer_Type) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
 // Attributes sourced from the Kubernetes workload attestor.
 type WorkloadAttrsKubernetes struct {
 	state                     protoimpl.MessageState            `protogen:"opaque.v1"`
@@ -199,10 +250,11 @@ func (b0 WorkloadAttrsKubernetes_builder) Build() *WorkloadAttrsKubernetes {
 
 // Attributes of the container sourced from the Kubernetes workload attestation.
 type WorkloadAttrsKubernetesContainer struct {
-	state                  protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_Name        string                 `protobuf:"bytes,1,opt,name=name,proto3"`
-	xxx_hidden_Image       string                 `protobuf:"bytes,2,opt,name=image,proto3"`
-	xxx_hidden_ImageDigest string                 `protobuf:"bytes,3,opt,name=image_digest,json=imageDigest,proto3"`
+	state                  protoimpl.MessageState                `protogen:"opaque.v1"`
+	xxx_hidden_Name        string                                `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_Image       string                                `protobuf:"bytes,2,opt,name=image,proto3"`
+	xxx_hidden_ImageDigest string                                `protobuf:"bytes,3,opt,name=image_digest,json=imageDigest,proto3"`
+	xxx_hidden_Type        WorkloadAttrsKubernetesContainer_Type `protobuf:"varint,4,opt,name=type,proto3,enum=teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer_Type"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -253,6 +305,13 @@ func (x *WorkloadAttrsKubernetesContainer) GetImageDigest() string {
 	return ""
 }
 
+func (x *WorkloadAttrsKubernetesContainer) GetType() WorkloadAttrsKubernetesContainer_Type {
+	if x != nil {
+		return x.xxx_hidden_Type
+	}
+	return WorkloadAttrsKubernetesContainer_TYPE_UNSPECIFIED
+}
+
 func (x *WorkloadAttrsKubernetesContainer) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
@@ -265,6 +324,10 @@ func (x *WorkloadAttrsKubernetesContainer) SetImageDigest(v string) {
 	x.xxx_hidden_ImageDigest = v
 }
 
+func (x *WorkloadAttrsKubernetesContainer) SetType(v WorkloadAttrsKubernetesContainer_Type) {
+	x.xxx_hidden_Type = v
+}
+
 type WorkloadAttrsKubernetesContainer_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -274,6 +337,8 @@ type WorkloadAttrsKubernetesContainer_builder struct {
 	Image string
 	// The exact image digest the container is running.
 	ImageDigest string
+	// The type of the container.
+	Type WorkloadAttrsKubernetesContainer_Type
 }
 
 func (b0 WorkloadAttrsKubernetesContainer_builder) Build() *WorkloadAttrsKubernetesContainer {
@@ -283,6 +348,7 @@ func (b0 WorkloadAttrsKubernetesContainer_builder) Build() *WorkloadAttrsKuberne
 	x.xxx_hidden_Name = b.Name
 	x.xxx_hidden_Image = b.Image
 	x.xxx_hidden_ImageDigest = b.ImageDigest
+	x.xxx_hidden_Type = b.Type
 	return m0
 }
 
@@ -1555,11 +1621,17 @@ const file_teleport_workloadidentity_v1_attrs_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\f\n" +
 	"\n" +
-	"_container\"o\n" +
+	"_container\"\x9b\x02\n" +
 	" WorkloadAttrsKubernetesContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05image\x18\x02 \x01(\tR\x05image\x12!\n" +
-	"\fimage_digest\x18\x03 \x01(\tR\vimageDigest\"\xd1\x01\n" +
+	"\fimage_digest\x18\x03 \x01(\tR\vimageDigest\x12W\n" +
+	"\x04type\x18\x04 \x01(\x0e2C.teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer.TypeR\x04type\"Q\n" +
+	"\x04Type\x12\x14\n" +
+	"\x10TYPE_UNSPECIFIED\x10\x00\x12\x10\n" +
+	"\fTYPE_REGULAR\x10\x01\x12\r\n" +
+	"\tTYPE_INIT\x10\x02\x12\x12\n" +
+	"\x0eTYPE_EPHEMERAL\x10\x03\"\xd1\x01\n" +
 	"\x11WorkloadAttrsUnix\x12\x1a\n" +
 	"\battested\x18\x01 \x01(\bR\battested\x12\x10\n" +
 	"\x03pid\x18\x02 \x01(\x05R\x03pid\x12\x10\n" +
@@ -1630,56 +1702,59 @@ const file_teleport_workloadidentity_v1_attrs_proto_rawDesc = "" +
 	"\x04user\x18\x02 \x01(\v2'.teleport.workloadidentity.v1.UserAttrsR\x04user\x12;\n" +
 	"\x04join\x18\x03 \x01(\v2'.teleport.workloadidentity.v1.JoinAttrsR\x04joinBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
 
+var file_teleport_workloadidentity_v1_attrs_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_teleport_workloadidentity_v1_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_teleport_workloadidentity_v1_attrs_proto_goTypes = []any{
-	(*WorkloadAttrsKubernetes)(nil),          // 0: teleport.workloadidentity.v1.WorkloadAttrsKubernetes
-	(*WorkloadAttrsKubernetesContainer)(nil), // 1: teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer
-	(*WorkloadAttrsUnix)(nil),                // 2: teleport.workloadidentity.v1.WorkloadAttrsUnix
-	(*WorkloadAttrsPodman)(nil),              // 3: teleport.workloadidentity.v1.WorkloadAttrsPodman
-	(*WorkloadAttrsPodmanContainer)(nil),     // 4: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer
-	(*WorkloadAttrsPodmanPod)(nil),           // 5: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod
-	(*WorkloadAttrsDocker)(nil),              // 6: teleport.workloadidentity.v1.WorkloadAttrsDocker
-	(*WorkloadAttrsDockerContainer)(nil),     // 7: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer
-	(*WorkloadAttrsSystemd)(nil),             // 8: teleport.workloadidentity.v1.WorkloadAttrsSystemd
-	(*WorkloadAttrsSigstore)(nil),            // 9: teleport.workloadidentity.v1.WorkloadAttrsSigstore
-	(*WorkloadAttrs)(nil),                    // 10: teleport.workloadidentity.v1.WorkloadAttrs
-	(*UserAttrs)(nil),                        // 11: teleport.workloadidentity.v1.UserAttrs
-	(*Attrs)(nil),                            // 12: teleport.workloadidentity.v1.Attrs
-	nil,                                      // 13: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.LabelsEntry
-	nil,                                      // 14: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.LabelsEntry
-	nil,                                      // 15: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.LabelsEntry
-	nil,                                      // 16: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.LabelsEntry
-	nil,                                      // 17: teleport.workloadidentity.v1.UserAttrs.LabelsEntry
-	(*SigstoreVerificationPayload)(nil),      // 18: teleport.workloadidentity.v1.SigstoreVerificationPayload
-	(*v1.Trait)(nil),                         // 19: teleport.trait.v1.Trait
-	(*JoinAttrs)(nil),                        // 20: teleport.workloadidentity.v1.JoinAttrs
+	(WorkloadAttrsKubernetesContainer_Type)(0), // 0: teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer.Type
+	(*WorkloadAttrsKubernetes)(nil),            // 1: teleport.workloadidentity.v1.WorkloadAttrsKubernetes
+	(*WorkloadAttrsKubernetesContainer)(nil),   // 2: teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer
+	(*WorkloadAttrsUnix)(nil),                  // 3: teleport.workloadidentity.v1.WorkloadAttrsUnix
+	(*WorkloadAttrsPodman)(nil),                // 4: teleport.workloadidentity.v1.WorkloadAttrsPodman
+	(*WorkloadAttrsPodmanContainer)(nil),       // 5: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer
+	(*WorkloadAttrsPodmanPod)(nil),             // 6: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod
+	(*WorkloadAttrsDocker)(nil),                // 7: teleport.workloadidentity.v1.WorkloadAttrsDocker
+	(*WorkloadAttrsDockerContainer)(nil),       // 8: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer
+	(*WorkloadAttrsSystemd)(nil),               // 9: teleport.workloadidentity.v1.WorkloadAttrsSystemd
+	(*WorkloadAttrsSigstore)(nil),              // 10: teleport.workloadidentity.v1.WorkloadAttrsSigstore
+	(*WorkloadAttrs)(nil),                      // 11: teleport.workloadidentity.v1.WorkloadAttrs
+	(*UserAttrs)(nil),                          // 12: teleport.workloadidentity.v1.UserAttrs
+	(*Attrs)(nil),                              // 13: teleport.workloadidentity.v1.Attrs
+	nil,                                        // 14: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.LabelsEntry
+	nil,                                        // 15: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.LabelsEntry
+	nil,                                        // 16: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.LabelsEntry
+	nil,                                        // 17: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.LabelsEntry
+	nil,                                        // 18: teleport.workloadidentity.v1.UserAttrs.LabelsEntry
+	(*SigstoreVerificationPayload)(nil),        // 19: teleport.workloadidentity.v1.SigstoreVerificationPayload
+	(*v1.Trait)(nil),                           // 20: teleport.trait.v1.Trait
+	(*JoinAttrs)(nil),                          // 21: teleport.workloadidentity.v1.JoinAttrs
 }
 var file_teleport_workloadidentity_v1_attrs_proto_depIdxs = []int32{
-	13, // 0: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetes.LabelsEntry
-	1,  // 1: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer
-	4,  // 2: teleport.workloadidentity.v1.WorkloadAttrsPodman.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer
-	5,  // 3: teleport.workloadidentity.v1.WorkloadAttrsPodman.pod:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanPod
-	14, // 4: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.LabelsEntry
-	15, // 5: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.LabelsEntry
-	7,  // 6: teleport.workloadidentity.v1.WorkloadAttrsDocker.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDockerContainer
-	16, // 7: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.LabelsEntry
-	18, // 8: teleport.workloadidentity.v1.WorkloadAttrsSigstore.payloads:type_name -> teleport.workloadidentity.v1.SigstoreVerificationPayload
-	2,  // 9: teleport.workloadidentity.v1.WorkloadAttrs.unix:type_name -> teleport.workloadidentity.v1.WorkloadAttrsUnix
-	0,  // 10: teleport.workloadidentity.v1.WorkloadAttrs.kubernetes:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetes
-	3,  // 11: teleport.workloadidentity.v1.WorkloadAttrs.podman:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodman
-	6,  // 12: teleport.workloadidentity.v1.WorkloadAttrs.docker:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDocker
-	8,  // 13: teleport.workloadidentity.v1.WorkloadAttrs.systemd:type_name -> teleport.workloadidentity.v1.WorkloadAttrsSystemd
-	9,  // 14: teleport.workloadidentity.v1.WorkloadAttrs.sigstore:type_name -> teleport.workloadidentity.v1.WorkloadAttrsSigstore
-	17, // 15: teleport.workloadidentity.v1.UserAttrs.labels:type_name -> teleport.workloadidentity.v1.UserAttrs.LabelsEntry
-	19, // 16: teleport.workloadidentity.v1.UserAttrs.traits:type_name -> teleport.trait.v1.Trait
-	10, // 17: teleport.workloadidentity.v1.Attrs.workload:type_name -> teleport.workloadidentity.v1.WorkloadAttrs
-	11, // 18: teleport.workloadidentity.v1.Attrs.user:type_name -> teleport.workloadidentity.v1.UserAttrs
-	20, // 19: teleport.workloadidentity.v1.Attrs.join:type_name -> teleport.workloadidentity.v1.JoinAttrs
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	14, // 0: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetes.LabelsEntry
+	2,  // 1: teleport.workloadidentity.v1.WorkloadAttrsKubernetes.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer
+	0,  // 2: teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer.type:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetesContainer.Type
+	5,  // 3: teleport.workloadidentity.v1.WorkloadAttrsPodman.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer
+	6,  // 4: teleport.workloadidentity.v1.WorkloadAttrsPodman.pod:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanPod
+	15, // 5: teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanContainer.LabelsEntry
+	16, // 6: teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodmanPod.LabelsEntry
+	8,  // 7: teleport.workloadidentity.v1.WorkloadAttrsDocker.container:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDockerContainer
+	17, // 8: teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.labels:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDockerContainer.LabelsEntry
+	19, // 9: teleport.workloadidentity.v1.WorkloadAttrsSigstore.payloads:type_name -> teleport.workloadidentity.v1.SigstoreVerificationPayload
+	3,  // 10: teleport.workloadidentity.v1.WorkloadAttrs.unix:type_name -> teleport.workloadidentity.v1.WorkloadAttrsUnix
+	1,  // 11: teleport.workloadidentity.v1.WorkloadAttrs.kubernetes:type_name -> teleport.workloadidentity.v1.WorkloadAttrsKubernetes
+	4,  // 12: teleport.workloadidentity.v1.WorkloadAttrs.podman:type_name -> teleport.workloadidentity.v1.WorkloadAttrsPodman
+	7,  // 13: teleport.workloadidentity.v1.WorkloadAttrs.docker:type_name -> teleport.workloadidentity.v1.WorkloadAttrsDocker
+	9,  // 14: teleport.workloadidentity.v1.WorkloadAttrs.systemd:type_name -> teleport.workloadidentity.v1.WorkloadAttrsSystemd
+	10, // 15: teleport.workloadidentity.v1.WorkloadAttrs.sigstore:type_name -> teleport.workloadidentity.v1.WorkloadAttrsSigstore
+	18, // 16: teleport.workloadidentity.v1.UserAttrs.labels:type_name -> teleport.workloadidentity.v1.UserAttrs.LabelsEntry
+	20, // 17: teleport.workloadidentity.v1.UserAttrs.traits:type_name -> teleport.trait.v1.Trait
+	11, // 18: teleport.workloadidentity.v1.Attrs.workload:type_name -> teleport.workloadidentity.v1.WorkloadAttrs
+	12, // 19: teleport.workloadidentity.v1.Attrs.user:type_name -> teleport.workloadidentity.v1.UserAttrs
+	21, // 20: teleport.workloadidentity.v1.Attrs.join:type_name -> teleport.workloadidentity.v1.JoinAttrs
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_teleport_workloadidentity_v1_attrs_proto_init() }
@@ -1697,13 +1772,14 @@ func file_teleport_workloadidentity_v1_attrs_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_workloadidentity_v1_attrs_proto_rawDesc), len(file_teleport_workloadidentity_v1_attrs_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_teleport_workloadidentity_v1_attrs_proto_goTypes,
 		DependencyIndexes: file_teleport_workloadidentity_v1_attrs_proto_depIdxs,
+		EnumInfos:         file_teleport_workloadidentity_v1_attrs_proto_enumTypes,
 		MessageInfos:      file_teleport_workloadidentity_v1_attrs_proto_msgTypes,
 	}.Build()
 	File_teleport_workloadidentity_v1_attrs_proto = out.File

--- a/api/proto/teleport/workloadidentity/v1/attrs.proto
+++ b/api/proto/teleport/workloadidentity/v1/attrs.proto
@@ -48,6 +48,19 @@ message WorkloadAttrsKubernetesContainer {
   string image = 2;
   // The exact image digest the container is running.
   string image_digest = 3;
+  // The type of the container.
+  Type type = 4;
+
+  // Type maps to specific container types from Kubernetes.
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    // TYPE_REGULAR is used for the main containers of a Pod.
+    TYPE_REGULAR = 1;
+    // TYPE_INIT is used for the init containers of a Pod.
+    TYPE_INIT = 2;
+    // TYPE_EPHEMERAL is reserved for ephemeral containers, not currently supported.
+    TYPE_EPHEMERAL = 3;
+  }
 }
 
 // Attributes sourced from the Unix workload attestor.

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
@@ -74,6 +74,12 @@ type KubernetesAttestor struct {
 	clock    clockwork.Clock
 }
 
+// containerStatus wraps a Kubernetes v1.ContainerStatus together with its type.
+type containerStatus struct {
+	Status v1.ContainerStatus
+	Type   workloadidentityv1pb.WorkloadAttrsKubernetesContainer_Type
+}
+
 // NewKubernetesAttestor creates a new KubernetesAttestor.
 func NewKubernetesAttestor(cfg KubernetesAttestorConfig, log *slog.Logger) *KubernetesAttestor {
 	kubeletClient := newKubeletClient(cfg.Kubelet)
@@ -109,9 +115,10 @@ func (a *KubernetesAttestor) Attest(ctx context.Context, pid int) (*workloadiden
 	var ctr *workloadidentityv1pb.WorkloadAttrsKubernetesContainer
 	if containerStatus != nil {
 		ctr = workloadidentityv1pb.WorkloadAttrsKubernetesContainer_builder{
-			Name:        containerStatus.Name,
-			Image:       containerStatus.Image,
-			ImageDigest: imageDigestRegex.FindString(containerStatus.ImageID),
+			Name:        containerStatus.Status.Name,
+			Image:       containerStatus.Status.Image,
+			ImageDigest: imageDigestRegex.FindString(containerStatus.Status.ImageID),
+			Type:        containerStatus.Type,
 		}.Build()
 	}
 
@@ -128,7 +135,7 @@ func (a *KubernetesAttestor) Attest(ctx context.Context, pid int) (*workloadiden
 	return att, nil
 }
 
-func (a *KubernetesAttestor) getPodAndContainerStatus(ctx context.Context, podID, containerID string) (*v1.Pod, *v1.ContainerStatus, error) {
+func (a *KubernetesAttestor) getPodAndContainerStatus(ctx context.Context, podID, containerID string) (*v1.Pod, *containerStatus, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
@@ -145,7 +152,7 @@ func (a *KubernetesAttestor) getPodAndContainerStatus(ctx context.Context, podID
 
 	var (
 		pod             *v1.Pod
-		containerStatus *v1.ContainerStatus
+		containerStatus *containerStatus
 	)
 LOOP:
 	for {
@@ -177,7 +184,7 @@ LOOP:
 	return nil, nil, err
 }
 
-func (a *KubernetesAttestor) tryGetPodAndContainerStatus(ctx context.Context, podID, containerID string) (*v1.Pod, *v1.ContainerStatus, error) {
+func (a *KubernetesAttestor) tryGetPodAndContainerStatus(ctx context.Context, podID, containerID string) (*v1.Pod, *containerStatus, error) {
 	pods, err := a.kubeletClient.ListAllPods(ctx)
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "listing all pods")
@@ -198,7 +205,7 @@ func (a *KubernetesAttestor) tryGetPodAndContainerStatus(ctx context.Context, po
 	for _, status := range pod.Status.ContainerStatuses {
 		// Kubelet returns the container ID prefixed by `<type>://`.
 		if _, id, _ := strings.Cut(status.ContainerID, "://"); id == containerID {
-			return pod, &status, nil
+			return pod, &containerStatus{Status: status, Type: workloadidentityv1pb.WorkloadAttrsKubernetesContainer_TYPE_REGULAR}, nil
 		}
 	}
 
@@ -206,7 +213,7 @@ func (a *KubernetesAttestor) tryGetPodAndContainerStatus(ctx context.Context, po
 	for _, status := range pod.Status.InitContainerStatuses {
 		// Kubelet returns the container ID prefixed by `<type>://`.
 		if _, id, _ := strings.Cut(status.ContainerID, "://"); id == containerID {
-			return pod, &status, nil
+			return pod, &containerStatus{Status: status, Type: workloadidentityv1pb.WorkloadAttrsKubernetesContainer_TYPE_INIT}, nil
 		}
 	}
 

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix.go
@@ -213,11 +213,32 @@ func (a *KubernetesAttestor) tryGetPodAndContainerStatus(ctx context.Context, po
 	for _, status := range pod.Status.InitContainerStatuses {
 		// Kubelet returns the container ID prefixed by `<type>://`.
 		if _, id, _ := strings.Cut(status.ContainerID, "://"); id == containerID {
+			// Accept only native sidecars (RestartPolicy == Always)
+			if !isNativeSidecarContainer(pod, status.Name) {
+				return nil, nil, trace.AccessDenied("container %q is not a native sidecar", status.Name)
+			}
+
 			return pod, &containerStatus{Status: status, Type: workloadidentityv1pb.WorkloadAttrsKubernetesContainer_TYPE_INIT}, nil
 		}
 	}
 
 	return pod, nil, nil
+}
+
+// getInitContainerSpec returns the Spec of the container in the Pod based on its name.
+func isNativeSidecarContainer(pod *v1.Pod, name string) bool {
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == name {
+			// Native containers have RestartPolicy == Always.
+			if c.RestartPolicy != nil && *c.RestartPolicy == v1.ContainerRestartPolicyAlways {
+				return true
+			}
+
+			break
+		}
+	}
+
+	return false
 }
 
 // kubeletClient is a HTTP client for the Kubelet API

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
@@ -56,11 +56,18 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 	mockPodID := "61c266b0-6f75-4490-8d92-3c9ae4d02787"
 	mockContainerID := "9da25af0b548c8c60aa60f77f299ba727bf72d58248bd7528eb5390ffcce555a"
 
+	restartPolicy := func(s v1.ContainerRestartPolicy) *v1.ContainerRestartPolicy {
+		return &s
+	}
+
 	testCases := map[string]struct {
 		containerStatusFunc     func(callCount int) []v1.ContainerStatus
 		initContainerStatusFunc func(callCount int) []v1.ContainerStatus
-		wantRequests            int
-		wantType                workloadidentityv1pb.WorkloadAttrsKubernetesContainer_Type
+		initContainerSpecsFunc  func(callCount int) []v1.Container
+
+		wantRequests int
+		wantType     workloadidentityv1pb.WorkloadAttrsKubernetesContainer_Type
+		wantError    string
 	}{
 		"regular container": {
 			wantRequests: 2,
@@ -96,9 +103,18 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 					},
 				}
 			},
+
+			initContainerSpecsFunc: func(_ int) []v1.Container {
+				return []v1.Container{
+					{
+						Name:          "another-container-1",
+						RestartPolicy: restartPolicy(v1.ContainerRestartPolicyAlways),
+					},
+				}
+			},
 		},
 
-		"init container": {
+		"init container: native sidecar": {
 			wantRequests: 1,
 			wantType:     workloadidentityv1pb.WorkloadAttrsKubernetesContainer_TYPE_INIT,
 			containerStatusFunc: func(_ int) []v1.ContainerStatus {
@@ -119,6 +135,87 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 						Name:        "container-1",
 						Image:       "my.registry.io/my-app:v1",
 						ImageID:     "docker-pullable://my.registry.io/my-app@sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					},
+				}
+			},
+
+			initContainerSpecsFunc: func(_ int) []v1.Container {
+				return []v1.Container{
+					{
+						Name:          "container-1",
+						RestartPolicy: restartPolicy(v1.ContainerRestartPolicyAlways),
+					},
+				}
+			},
+		},
+
+		"init container: not a native sidecar": {
+			wantRequests: 1,
+			wantType:     workloadidentityv1pb.WorkloadAttrsKubernetesContainer_TYPE_INIT,
+			wantError:    `"container-1" is not a native sidecar`,
+			containerStatusFunc: func(_ int) []v1.ContainerStatus {
+				return []v1.ContainerStatus{
+					{
+						ContainerID: "docker://1231455ksasdffgdk923klsklsdghkld0235wehlsdgjsd3i50sekfgort0235ui",
+						Name:        "another-container-1",
+						Image:       "my.registry.io/my-other-app:v1",
+						ImageID:     "docker-pullable://my.registry.io/my-other-app:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					},
+				}
+			},
+
+			initContainerStatusFunc: func(_ int) []v1.ContainerStatus {
+				return []v1.ContainerStatus{
+					{
+						ContainerID: "docker://" + mockContainerID,
+						Name:        "container-1",
+						Image:       "my.registry.io/my-app:v1",
+						ImageID:     "docker-pullable://my.registry.io/my-app@sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					},
+				}
+			},
+
+			initContainerSpecsFunc: func(_ int) []v1.Container {
+				return []v1.Container{
+					{
+						Name:          "container-1",
+						RestartPolicy: restartPolicy(v1.ContainerRestartPolicyOnFailure),
+					},
+				}
+			},
+		},
+
+		"init container: spec not found": {
+			wantRequests: 1,
+			wantType:     workloadidentityv1pb.WorkloadAttrsKubernetesContainer_TYPE_INIT,
+			wantError:    `"container-1" is not a native sidecar`,
+			containerStatusFunc: func(_ int) []v1.ContainerStatus {
+				return []v1.ContainerStatus{
+					{
+						ContainerID: "docker://1231455ksasdffgdk923klsklsdghkld0235wehlsdgjsd3i50sekfgort0235ui",
+						Name:        "another-container-1",
+						Image:       "my.registry.io/my-other-app:v1",
+						ImageID:     "docker-pullable://my.registry.io/my-other-app:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					},
+				}
+			},
+
+			initContainerStatusFunc: func(_ int) []v1.ContainerStatus {
+				return []v1.ContainerStatus{
+					{
+						ContainerID: "docker://" + mockContainerID,
+						Name:        "container-1",
+						Image:       "my.registry.io/my-app:v1",
+						ImageID:     "docker-pullable://my.registry.io/my-app@sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					},
+				}
+			},
+
+			initContainerSpecsFunc: func(_ int) []v1.Container {
+				return []v1.Container{
+					{
+						Name:          "container-2",
+						RestartPolicy: restartPolicy(v1.ContainerRestartPolicyAlways),
 					},
 				}
 			},
@@ -153,6 +250,7 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 							},
 							Spec: v1.PodSpec{
 								ServiceAccountName: "my-service-account",
+								InitContainers:     tc.initContainerSpecsFunc(int(requests.Load())),
 							},
 							Status: v1.PodStatus{
 								ContainerStatuses:     tc.containerStatusFunc(int(requests.Load())),
@@ -207,6 +305,12 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 			defer cancel()
 
 			att, err := attestor.Attest(ctx, mockPID)
+			if tc.wantError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantError)
+				return
+			}
+
 			require.NoError(t, err)
 			require.Empty(t, cmp.Diff(workloadidentityv1pb.WorkloadAttrsKubernetes_builder{
 				Attested:       true,

--- a/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
+++ b/lib/tbot/workloadidentity/workloadattest/kubernetes_unix_test.go
@@ -60,9 +60,11 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 		containerStatusFunc     func(callCount int) []v1.ContainerStatus
 		initContainerStatusFunc func(callCount int) []v1.ContainerStatus
 		wantRequests            int
+		wantType                workloadidentityv1pb.WorkloadAttrsKubernetesContainer_Type
 	}{
-		"main container": {
+		"regular container": {
 			wantRequests: 2,
+			wantType:     workloadidentityv1pb.WorkloadAttrsKubernetesContainer_TYPE_REGULAR,
 			containerStatusFunc: func(callCount int) []v1.ContainerStatus {
 				// Don't return the container status in the first response, to simulate
 				// the kubelet API's eventual consistency.
@@ -98,6 +100,7 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 
 		"init container": {
 			wantRequests: 1,
+			wantType:     workloadidentityv1pb.WorkloadAttrsKubernetesContainer_TYPE_INIT,
 			containerStatusFunc: func(_ int) []v1.ContainerStatus {
 				return []v1.ContainerStatus{
 					{
@@ -218,6 +221,7 @@ func TestKubernetesAttestor_Attest(t *testing.T) {
 					Name:        "container-1",
 					Image:       "my.registry.io/my-app:v1",
 					ImageDigest: "sha256:84c998f7610b356a5eed24f801c01b273cf3e83f081f25c9b16aa8136c2cafb1",
+					Type:        tc.wantType,
 				}.Build(),
 			}.Build(), att, protocmp.Transform()))
 			require.EqualValues(t, tc.wantRequests, requests.Load())


### PR DESCRIPTION
This is a fork from https://github.com/gravitational/teleport/pull/69276 for discussion.

It restrict the the Pod's container attestation when looking at `Init Containers`. With this change, only "native sidecars" would be considered (those with `RestartPolicy == Always`).

This was flagged by codex here: https://github.com/gravitational/teleport/pull/69276#discussion_r3704408211
