### PR TITLE
Udpate tsh ls output to display the SQN

### DIFF
--- a/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
@@ -1,7 +1,7 @@
-Scope         Node Name            Node ID              Address    Labels              
-------------- -------------------- -------------------- ---------- ------------------- 
-              unscoped-direct-name unscoped-direct-uuid 1.2.3.4:22 key=val             
-/staging/west scoped-direct-name   scoped-direct-uuid   1.2.3.4:44 key1=val1,key2=val2 
-              unscoped-tunnel-name unscoped-tunnel-uuid ⟵ Tunnel                       
-/staging/west scoped-tunnel-name   scoped-tunnel-uuid   ⟵ Tunnel                       
+SSH Server ID                     Hostname             Address    Labels              
+--------------------------------- -------------------- ---------- ------------------- 
+unscoped-direct-uuid              unscoped-direct-name 1.2.3.4:22 key=val             
+/staging/west::scoped-direct-uuid scoped-direct-name   1.2.3.4:44 key1=val1,key2=val2 
+unscoped-tunnel-uuid              unscoped-tunnel-name ⟵ Tunnel                       
+/staging/west::scoped-tunnel-uuid scoped-tunnel-name   ⟵ Tunnel                       
 

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
@@ -1,7 +1,7 @@
-Scope         Node Name            Node ID              Address    Labels              
-------------- -------------------- -------------------- ---------- ------------------- 
-              unscoped-direct-name unscoped-direct-uuid 1.2.3.4:22 key=val             
-/staging/west scoped-direct-name   scoped-direct-uuid   1.2.3.4:44 key1=val1,key2=val2 
-              unscoped-tunnel-name unscoped-tunnel-uuid ⟵ Tunnel                       
-/staging/west scoped-tunnel-name   scoped-tunnel-uuid   ⟵ Tunnel                       
+Node Name                         Node ID              Address    Labels              
+--------------------------------- -------------------- ---------- ------------------- 
+unscoped-direct-name              unscoped-direct-uuid 1.2.3.4:22 key=val             
+/staging/west::scoped-direct-name scoped-direct-uuid   1.2.3.4:44 key1=val1,key2=val2 
+unscoped-tunnel-name              unscoped-tunnel-uuid ⟵ Tunnel                       
+/staging/west::scoped-tunnel-name scoped-tunnel-uuid   ⟵ Tunnel                       
 

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
@@ -1,5 +1,5 @@
-Scope         Node Name          Address    Labels              
-------------- ------------------ ---------- ------------------- 
-/staging/west scoped-direct-name 1.2.3.4:44 key1=val1,key2=val2 
-/staging/west scoped-tunnel-name ⟵ Tunnel                       
+SSH Server ID            Hostname           Address    Labels              
+------------------------ ------------------ ---------- ------------------- 
+/staging/west::scoped... scoped-direct-name 1.2.3.4:44 key1=val1,key2=val2 
+/staging/west::scoped... scoped-tunnel-name ⟵ Tunnel                       
 

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
@@ -1,5 +1,5 @@
-Scope         Node Name          Address    Labels              
-------------- ------------------ ---------- ------------------- 
-/staging/west scoped-direct-name 1.2.3.4:44 key1=val1,key2=val2 
-/staging/west scoped-tunnel-name ⟵ Tunnel                       
+Node Name                           Address    Labels              
+----------------------------------- ---------- ------------------- 
+/staging/west::scoped-direct-nam... 1.2.3.4:44 key1=val1,key2=val2 
+/staging/west::scoped-tunnel-nam... ⟵ Tunnel                       
 

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_unscoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_unscoped.golden
@@ -1,4 +1,4 @@
-Node Name            Address    Labels  
+Hostname             Address    Labels  
 -------------------- ---------- ------- 
 unscoped-direct-name 1.2.3.4:22 key=val 
 unscoped-tunnel-name ⟵ Tunnel           

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
@@ -1,5 +1,5 @@
-Scope         Node Name          Node ID            Address    Labels              
-------------- ------------------ ------------------ ---------- ------------------- 
-/staging/west scoped-direct-name scoped-direct-uuid 1.2.3.4:44 key1=val1,key2=val2 
-/staging/west scoped-tunnel-name scoped-tunnel-uuid ⟵ Tunnel                       
+Node Name                         Node ID            Address    Labels              
+--------------------------------- ------------------ ---------- ------------------- 
+/staging/west::scoped-direct-name scoped-direct-uuid 1.2.3.4:44 key1=val1,key2=val2 
+/staging/west::scoped-tunnel-name scoped-tunnel-uuid ⟵ Tunnel                       
 

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
@@ -1,5 +1,5 @@
-Scope         Node Name          Node ID            Address    Labels              
-------------- ------------------ ------------------ ---------- ------------------- 
-/staging/west scoped-direct-name scoped-direct-uuid 1.2.3.4:44 key1=val1,key2=val2 
-/staging/west scoped-tunnel-name scoped-tunnel-uuid ⟵ Tunnel                       
+SSH Server ID                     Hostname           Address    Labels              
+--------------------------------- ------------------ ---------- ------------------- 
+/staging/west::scoped-direct-uuid scoped-direct-name 1.2.3.4:44 key1=val1,key2=val2 
+/staging/west::scoped-tunnel-uuid scoped-tunnel-name ⟵ Tunnel                       
 

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_unscoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_unscoped.golden
@@ -1,5 +1,5 @@
-Node Name            Node ID              Address    Labels  
+SSH Server ID        Hostname             Address    Labels  
 -------------------- -------------------- ---------- ------- 
-unscoped-direct-name unscoped-direct-uuid 1.2.3.4:22 key=val 
-unscoped-tunnel-name unscoped-tunnel-uuid ⟵ Tunnel           
+unscoped-direct-uuid unscoped-direct-name 1.2.3.4:22 key=val 
+unscoped-tunnel-uuid unscoped-tunnel-name ⟵ Tunnel           
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4892,6 +4892,25 @@ func makeClientForProxy(cf *CLIConf, proxy string) (*client.TeleportClient, erro
 	return tc, nil
 }
 
+// dropScopeFromSSHHost strips the scope from any hosts provided
+// to tsh ssh as an SQN, i.e. tsh ssh user@/foo/bar::baz uptime.
+// This improves the UX for scoped users while Teleport transitions
+// to honoring SQNs everywhere.
+//
+// TODO(scopes): Remove this once SQN SSH routing is supported.
+func dropScopeFromSSHHost(host string) (string, error) {
+	if !scopes.MaybeSQN(host) {
+		return host, nil
+	}
+
+	qualifiedName, err := scopes.ParseQualifiedName(host)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return qualifiedName.Name, nil
+}
+
 func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, error) {
 	if cf.TracingProvider == nil {
 		cf.TracingProvider = tracing.NoopProvider()
@@ -4918,6 +4937,10 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 			hostLogin = strings.Join(parts[:partsLength-1], "@")
 			hostUser = parts[partsLength-1]
 		}
+		hostUser, err = dropScopeFromSSHHost(hostUser)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		// see if remote host is specified as a set of labels
 		if strings.Contains(hostUser, "=") {
 			labels, err = parse.LabelSelectorSpec(hostUser)
@@ -4939,6 +4962,10 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 				hostUser = hostname
 			} else {
 				hostUser = userHost
+			}
+			hostUser, err = dropScopeFromSSHHost(hostUser)
+			if err != nil {
+				return nil, trace.Wrap(err)
 			}
 			break
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3240,32 +3240,16 @@ func listNodesAllClusters(cf *CLIConf) error {
 }
 
 func printNodesWithClusters(nodes []nodeListing, verbose bool, output io.Writer) error {
-	var rows [][]string
-	var withScope bool
+	rows := make([][]string, 0, len(nodes))
 	for _, n := range nodes {
-		if n.Node.GetScope() != "" {
-			withScope = true
-			break
-		}
-	}
-
-	for _, n := range nodes {
-		rows = append(rows, getNodeRow(n.Proxy, n.Cluster, n.Node, withScope, verbose))
+		rows = append(rows, getNodeRow(n.Proxy, n.Cluster, n.Node, verbose))
 	}
 
 	var t asciitable.Table
 	if verbose {
-		if withScope {
-			t = asciitable.MakeTable([]string{"Scope", "Proxy", "Cluster", "Node Name", "Node ID", "Address", "Labels"}, rows...)
-		} else {
-			t = asciitable.MakeTable([]string{"Proxy", "Cluster", "Node Name", "Node ID", "Address", "Labels"}, rows...)
-		}
+		t = asciitable.MakeTable([]string{"Proxy", "Cluster", "Node Name", "Node ID", "Address", "Labels"}, rows...)
 	} else {
-		if withScope {
-			t = asciitable.MakeTableWithTruncatedColumn([]string{"Scope", "Proxy", "Cluster", "Node Name", "Address", "Labels"}, rows, "Labels")
-		} else {
-			t = asciitable.MakeTableWithTruncatedColumn([]string{"Proxy", "Cluster", "Node Name", "Address", "Labels"}, rows, "Labels")
-		}
+		t = asciitable.MakeTableWithTruncatedColumn([]string{"Proxy", "Cluster", "Node Name", "Address", "Labels"}, rows, "Labels")
 	}
 	if _, err := fmt.Fprintln(output, t.AsBuffer().String()); err != nil {
 		return trace.Wrap(err)
@@ -3472,7 +3456,7 @@ func serializeNodes(nodes []types.Server, format string) (string, error) {
 	return string(out), trace.Wrap(err)
 }
 
-func getNodeRow(proxy, cluster string, node types.Server, withScope bool, verbose bool) []string {
+func getNodeRow(proxy, cluster string, node types.Server, verbose bool) []string {
 	// Reusable function to get addr or tunnel for each node
 	getAddr := func(n types.Server) string {
 		switch {
@@ -3486,54 +3470,35 @@ func getNodeRow(proxy, cluster string, node types.Server, withScope bool, verbos
 	}
 
 	row := make([]string, 0)
-
-	if withScope {
-		row = append(row, node.GetScope())
-	}
-
 	if proxy != "" && cluster != "" {
 		row = append(row, proxy, cluster)
 	}
 
 	labels := common.FormatLabels(node.GetAllLabels(), verbose)
+	name := scopes.QualifiedName{Scope: node.GetScope(), Name: node.GetHostname()}.String()
 	if verbose {
-		row = append(row, node.GetHostname(), node.GetName(), getAddr(node), labels)
+		row = append(row, name, node.GetName(), getAddr(node), labels)
 	} else {
-		row = append(row, node.GetHostname(), getAddr(node), labels)
+		row = append(row, name, getAddr(node), labels)
 	}
 	return row
 }
 
 func printNodesAsText[T types.Server](output io.Writer, nodes []T, verbose bool) error {
-	var rows [][]string
-	var withScope bool
+	rows := make([][]string, 0, len(nodes))
 	for _, n := range nodes {
-		if n.GetScope() != "" {
-			withScope = true
-			break
-		}
-	}
-	for _, n := range nodes {
-		rows = append(rows, getNodeRow("", "", n, withScope, verbose))
+		rows = append(rows, getNodeRow("", "", n, verbose))
 	}
 	var t asciitable.Table
 	switch verbose {
 	// In verbose mode, print everything on a single line and include the Node
 	// ID (UUID). Useful for machines that need to parse the output of "tsh ls".
 	case true:
-		if withScope {
-			t = asciitable.MakeTable([]string{"Scope", "Node Name", "Node ID", "Address", "Labels"}, rows...)
-		} else {
-			t = asciitable.MakeTable([]string{"Node Name", "Node ID", "Address", "Labels"}, rows...)
-		}
+		t = asciitable.MakeTable([]string{"Node Name", "Node ID", "Address", "Labels"}, rows...)
 	// In normal mode chunk the labels and print two per line and allow multiple
 	// lines per node.
 	case false:
-		if withScope {
-			t = asciitable.MakeTableWithTruncatedColumn([]string{"Scope", "Node Name", "Address", "Labels"}, rows, "Labels")
-		} else {
-			t = asciitable.MakeTableWithTruncatedColumn([]string{"Node Name", "Address", "Labels"}, rows, "Labels")
-		}
+		t = asciitable.MakeTableWithTruncatedColumn([]string{"Node Name", "Address", "Labels"}, rows, "Labels")
 	}
 	if _, err := fmt.Fprintln(output, t.AsBuffer().String()); err != nil {
 		return trace.Wrap(err)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3240,31 +3240,21 @@ func listNodesAllClusters(cf *CLIConf) error {
 }
 
 func printNodesWithClusters(nodes []nodeListing, verbose bool, output io.Writer) error {
-	var rows [][]string
-	var withScope bool
-	for _, n := range nodes {
-		if n.Node.GetScope() != "" {
-			withScope = true
-			break
-		}
-	}
+	withScope := slices.ContainsFunc(nodes, func(n nodeListing) bool { return n.Node.GetScope() != "" })
 
+	rows := make([][]string, 0, len(nodes))
 	for _, n := range nodes {
 		rows = append(rows, getNodeRow(n.Proxy, n.Cluster, n.Node, withScope, verbose))
 	}
 
 	var t asciitable.Table
 	if verbose {
-		if withScope {
-			t = asciitable.MakeTable([]string{"Scope", "Proxy", "Cluster", "Node Name", "Node ID", "Address", "Labels"}, rows...)
-		} else {
-			t = asciitable.MakeTable([]string{"Proxy", "Cluster", "Node Name", "Node ID", "Address", "Labels"}, rows...)
-		}
+		t = asciitable.MakeTable([]string{"SSH Server ID", "Proxy", "Cluster", "Hostname", "Address", "Labels"}, rows...)
 	} else {
 		if withScope {
-			t = asciitable.MakeTableWithTruncatedColumn([]string{"Scope", "Proxy", "Cluster", "Node Name", "Address", "Labels"}, rows, "Labels")
+			t = asciitable.MakeTableWithTruncatedColumn([]string{"SSH Server ID", "Proxy", "Cluster", "Hostname", "Address", "Labels"}, rows, "Labels")
 		} else {
-			t = asciitable.MakeTableWithTruncatedColumn([]string{"Proxy", "Cluster", "Node Name", "Address", "Labels"}, rows, "Labels")
+			t = asciitable.MakeTableWithTruncatedColumn([]string{"Proxy", "Cluster", "Hostname", "Address", "Labels"}, rows, "Labels")
 		}
 	}
 	if _, err := fmt.Fprintln(output, t.AsBuffer().String()); err != nil {
@@ -3472,7 +3462,7 @@ func serializeNodes(nodes []types.Server, format string) (string, error) {
 	return string(out), trace.Wrap(err)
 }
 
-func getNodeRow(proxy, cluster string, node types.Server, withScope bool, verbose bool) []string {
+func getNodeRow(proxy, cluster string, node types.Server, withScope, verbose bool) []string {
 	// Reusable function to get addr or tunnel for each node
 	getAddr := func(n types.Server) string {
 		switch {
@@ -3487,17 +3477,14 @@ func getNodeRow(proxy, cluster string, node types.Server, withScope bool, verbos
 
 	row := make([]string, 0)
 
-	if withScope {
-		row = append(row, node.GetScope())
-	}
-
+	name := scopes.QualifiedName{Scope: node.GetScope(), Name: node.GetName()}.String()
 	if proxy != "" && cluster != "" {
 		row = append(row, proxy, cluster)
 	}
 
 	labels := common.FormatLabels(node.GetAllLabels(), verbose)
-	if verbose {
-		row = append(row, node.GetHostname(), node.GetName(), getAddr(node), labels)
+	if verbose || withScope {
+		row = append(row, name, node.GetHostname(), getAddr(node), labels)
 	} else {
 		row = append(row, node.GetHostname(), getAddr(node), labels)
 	}
@@ -3505,34 +3492,26 @@ func getNodeRow(proxy, cluster string, node types.Server, withScope bool, verbos
 }
 
 func printNodesAsText[T types.Server](output io.Writer, nodes []T, verbose bool) error {
-	var rows [][]string
-	var withScope bool
-	for _, n := range nodes {
-		if n.GetScope() != "" {
-			withScope = true
-			break
-		}
-	}
+	withScope := slices.ContainsFunc(nodes, func(s T) bool { return s.GetScope() != "" })
+
+	rows := make([][]string, 0, len(nodes))
 	for _, n := range nodes {
 		rows = append(rows, getNodeRow("", "", n, withScope, verbose))
 	}
+
 	var t asciitable.Table
 	switch verbose {
 	// In verbose mode, print everything on a single line and include the Node
 	// ID (UUID). Useful for machines that need to parse the output of "tsh ls".
 	case true:
-		if withScope {
-			t = asciitable.MakeTable([]string{"Scope", "Node Name", "Node ID", "Address", "Labels"}, rows...)
-		} else {
-			t = asciitable.MakeTable([]string{"Node Name", "Node ID", "Address", "Labels"}, rows...)
-		}
+		t = asciitable.MakeTable([]string{"SSH Server ID", "Hostname", "Address", "Labels"}, rows...)
 	// In normal mode chunk the labels and print two per line and allow multiple
 	// lines per node.
 	case false:
 		if withScope {
-			t = asciitable.MakeTableWithTruncatedColumn([]string{"Scope", "Node Name", "Address", "Labels"}, rows, "Labels")
+			t = asciitable.MakeTableWithTruncatedColumn([]string{"SSH Server ID", "Hostname", "Address", "Labels"}, rows, "Labels")
 		} else {
-			t = asciitable.MakeTableWithTruncatedColumn([]string{"Node Name", "Address", "Labels"}, rows, "Labels")
+			t = asciitable.MakeTableWithTruncatedColumn([]string{"Hostname", "Address", "Labels"}, rows, "Labels")
 		}
 	}
 	if _, err := fmt.Fprintln(output, t.AsBuffer().String()); err != nil {

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1329,6 +1329,53 @@ func TestPrintNodesAsText(t *testing.T) {
 	}
 }
 
+func TestDropScopeFromSSHHost(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		host    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "bare hostname",
+			host: "node.example.com",
+			want: "node.example.com",
+		},
+		{
+			name: "scoped hostname",
+			host: "/foo/bar::baz",
+			want: "baz",
+		},
+		{
+			name: "scoped mixed-case hostname",
+			host: "/foo/bar::Baz.example.com",
+			want: "Baz.example.com",
+		},
+		{
+			name: "IPv6 address",
+			host: "[::1]",
+			want: "[::1]",
+		},
+		{
+			name:    "invalid scoped hostname",
+			host:    "/foo/bar::",
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := dropScopeFromSSHHost(tt.host)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestMakeClient(t *testing.T) {
 	t.Parallel()
 
@@ -1426,6 +1473,13 @@ func TestMakeClient(t *testing.T) {
 	require.Equal(t,
 		map[string]string{"A": "B", "C": "D"},
 		tc.ExtraProxyHeaders)
+
+	// specific configuration with scoped hostname copied from tsh ls.
+	conf.UserHost = "root@/foo/bar::baz"
+	tc, err = makeClient(&conf)
+	require.NoError(t, err)
+	require.Equal(t, "root", tc.Config.HostLogin)
+	require.Equal(t, "baz", tc.Config.Host)
 
 	_, proxy := makeTestServers(t)
 


### PR DESCRIPTION
Removes the scope column in favor of displaying the SQN in the Node Name column.

Before:

```console
$ tsh ls
Scope          Node Name   Address    Labels
-------------- ----------- ---------- -----------------------------------
/example/basic tunnel-node ⟵ Tunnel   arch=,env=test,os=mac

$ tsh ls -v
Scope          Node Name   Node ID                              Address    Labels
-------------- ----------- ------------------------------------ ---------- --------------------------
/example/basic tunnel-node 48e6d07d-6f64-472f-93b1-1d4dd991b4a1 ⟵ Tunnel   arch=arm64,env=test,os=mac

```

After:

```console
$ tsh ls
SSH Server ID                                Hostname    Address    Labels
-------------------------------------------- ----------- ---------- -----------------------------------
/examples/foo::ea237e28-01af-493e-a7fa-a3... tunnel-node ⟵ Tunnel   arch=,env=test,os=mac

$ tsh ls -v
SSH Server ID                                       Hostname    Address    Labels
--------------------------------------------------- ----------- ---------- -----------------------------------
/examples/foo::ea237e28-01af-493e-a7fa-a3c71b14ffcb tunnel-node ⟵ Tunnel   arch=,env=test,,os=mac

```


## Manual Test Plan
### Test Environment

Locally build tsh against scopes-q2.cloud.gravitational.io

### Test Cases
- [x] tsh ls no longer has a scope column
- [x] tsh ls emits the SQN in the Node Name column
