### PR TITLE
[v18] Fix missing prerequisite for Teleport user in CA Override doc.

### DIFF
--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -57,10 +57,37 @@ The `cert_authority_override` resource targets a CA with the following fields:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise (v18.9.0 or higher)"!)
 
+- A Teleport user with a role that has access to the `cert_authority_override`
+  resource. The preset `editor` role does not have this access. To grant it, add
+  the following rule to your role:
+
+  ```yaml
+  kind: role
+  version: v8
+  metadata:
+    name: <Var name="role-name" />
+  spec:
+    allow:
+      rules:
+        - resources:
+            - cert_authority_override
+          verbs:
+            - read
+            - list
+            - create
+            - update
+            - delete
+  ```
+
+  Assign the `<Var name="role-name" />` role to the user who will manage CA
+  overrides.
+
 - Only the following CAs are currently supported: `db_client` and `windows`.
+
 - All Auth Service instances and related services, such as Windows Desktop
   Service and Database Service instances, must be upgraded to the same CA
   override-aware Teleport version.
+
 - For safety, back up your cluster state before starting and retain downstream
   trust to the self-signed CA certificates until the upgrade is fully verified.
 

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -83,9 +83,11 @@ The `cert_authority_override` resource targets a CA with the following fields:
   CA overrides.
 
 - Only the following CAs are currently supported: `db_client` and `windows`.
+
 - All Auth Service instances and related services, such as Windows Desktop
   Service and Database Service instances, must be upgraded to the same CA
   override-aware Teleport version.
+
 - For safety, back up your cluster state before starting and retain downstream
   trust to the self-signed CA certificates until the upgrade is fully verified.
 

--- a/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-overrides.mdx
@@ -65,29 +65,27 @@ The `cert_authority_override` resource targets a CA with the following fields:
   kind: role
   version: v8
   metadata:
-    name: <Var name="role-name" />
+    name: <Var name="ca-override-admin" />
   spec:
     allow:
       rules:
         - resources:
             - cert_authority_override
           verbs:
-            - read
-            - list
             - create
-            - update
             - delete
+            - list
+            - read
+            - update
   ```
 
-  Assign the `<Var name="role-name" />` role to the user who will manage CA
-  overrides.
+  Assign the `<Var name="ca-override-admin" />` role to the user who will manage
+  CA overrides.
 
 - Only the following CAs are currently supported: `db_client` and `windows`.
-
 - All Auth Service instances and related services, such as Windows Desktop
   Service and Database Service instances, must be upgraded to the same CA
   override-aware Teleport version.
-
 - For safety, back up your cluster state before starting and retain downstream
   trust to the self-signed CA certificates until the upgrade is fully verified.
 


### PR DESCRIPTION
Backport #69206 to branch/v18

We should be able to be merge right away since it doesn't depend on any new features to be backported to v18.