### PR TITLE
Make Linux desktop requestable

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -4870,6 +4870,8 @@ func GetEnrichedResourcePage(ctx context.Context, clt GetResourcesClient, req *p
 				resource = respResource.GetWindowsDesktop()
 			case types.KindWindowsDesktopService:
 				resource = respResource.GetWindowsDesktopService()
+			case types.KindLinuxDesktop:
+				resource = proto.UnpackLinuxDesktop(respResource.GetLinuxDesktop())
 			case types.KindKubernetesCluster:
 				resource = respResource.GetKubeCluster()
 			case types.KindKubeServer:
@@ -4937,6 +4939,8 @@ func GetResourcePage[T types.ResourceWithLabels](ctx context.Context, clt GetRes
 				resource = respResource.GetWindowsDesktop()
 			case types.KindWindowsDesktopService:
 				resource = respResource.GetWindowsDesktopService()
+			case types.KindLinuxDesktop:
+				resource = proto.UnpackLinuxDesktop(respResource.GetLinuxDesktop())
 			case types.KindKubernetesCluster:
 				resource = respResource.GetKubeCluster()
 			case types.KindKubeServer:

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1599,6 +1599,7 @@ var RequestableResourceKinds = []string{
 	KindDatabase,
 	KindApp,
 	KindWindowsDesktop,
+	KindLinuxDesktop,
 	KindUserGroup,
 	KindSAMLIdPServiceProvider,
 	KindIdentityCenterAccount,

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2401,6 +2401,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 		types.KindAppServer,
 		types.KindKubeServer,
 		types.KindWindowsDesktop,
+		types.KindLinuxDesktop,
 		types.KindWindowsDesktopService,
 		types.KindUserGroup,
 		types.KindSAMLIdPServiceProvider,

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -27,6 +27,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
@@ -1814,6 +1815,23 @@ func (c *Cache) listResources(ctx context.Context, req authproto.ListResourcesRe
 			filter,
 			func(d types.WindowsDesktopService) types.ResourceWithLabels {
 				return d.Clone()
+			},
+		)
+		return resp, trace.Wrap(err)
+	case types.KindLinuxDesktop:
+		resp, err := buildListResourcesResponse(
+			func(yield func(types.ResourceWithLabels) bool) {
+				for desktop := range c.collections.linuxDesktops.store.resources(linuxDesktopNameIndex, req.StartKey, "") {
+					if !yield(types.Resource153ToResourceWithLabels(desktop)) {
+						return
+					}
+				}
+			},
+			limit,
+			filter,
+			func(r types.ResourceWithLabels) types.ResourceWithLabels {
+				unwrapper := r.(types.Resource153UnwrapperT[*linuxdesktopv1.LinuxDesktop])
+				return types.Resource153ToResourceWithLabels(proto.CloneOf(unwrapper.UnwrapT()))
 			},
 		)
 		return resp, trace.Wrap(err)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -27,7 +27,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
@@ -40,6 +39,7 @@ import (
 	authproto "github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	identitycenterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/identitycenter/v1"
+	linuxdesktopv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/linuxdesktop/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	apitracing "github.com/gravitational/teleport/api/observability/tracing"

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
@@ -761,7 +761,7 @@ describe('LinuxDesktopAccessSection', () => {
       kind: 'linux_desktop',
       labels: [{ name: 'os', value: 'ubuntu' }],
       logins: [
-        expect.objectContaining({ value: '{{internal.logins}}' }),
+        expect.objectContaining({ value: '{{internal.linux_desktop_logins}}' }),
         expect.objectContaining({ label: 'alice', value: 'alice' }),
       ],
       hideValidationErrors: true,

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/standardmodel.ts
@@ -735,7 +735,7 @@ export function newResourceAccess(
       return {
         kind: 'linux_desktop',
         labels: [],
-        logins: [stringToOption('{{internal.logins}}')],
+        logins: [stringToOption('{{internal.linux_desktop_logins}}')],
         hideValidationErrors: true,
       };
     case 'git_server':


### PR DESCRIPTION
This PR allows users to request access to Linux desktops


<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local cluster

### Test Cases
- [x] Linux desktop shows up in list of requestable resources
- [x] User can request access to Linux desktop resource
- [x] Approved request access grants access to Linux desktop
