### PR TITLE
Remove deprecated code

### DIFF
--- a/api/mfa/ceremony.go
+++ b/api/mfa/ceremony.go
@@ -160,13 +160,6 @@ func PerformAdminActionMFACeremony(ctx context.Context, mfaCeremony CeremonyFn, 
 		},
 	}
 
-	// Remove MFA resp from context if set. This way, the mfa required
-	// check will return true as long as MFA for admin actions is enabled,
-	// even if the current context has a reusable MFA. v18 server will
-	// return this requirement as expected.
-	// TODO(Joerger): DELETE IN v19.0.0
-	ceremonyCtx := ContextWithMFAResponse(ctx, nil)
-
-	resp, err := mfaCeremony(ceremonyCtx, challengeRequest, WithPromptReasonAdminAction())
+	resp, err := mfaCeremony(ctx, challengeRequest, WithPromptReasonAdminAction())
 	return resp, trace.Wrap(err)
 }

--- a/api/utils/keys/hardwarekey/hardwarekey.go
+++ b/api/utils/keys/hardwarekey/hardwarekey.go
@@ -35,10 +35,6 @@ type Service interface {
 	// Sign performs a cryptographic signature using the specified hardware
 	// private key and provided signature parameters.
 	Sign(ctx context.Context, ref *PrivateKeyRef, keyInfo ContextualKeyInfo, rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error)
-	// TODO(Joerger): DELETE IN v19.0.0
-	// GetFullKeyRef gets the full [PrivateKeyRef] for an existing hardware private
-	// key in the given slot of the hardware key with the given serial number.
-	GetFullKeyRef(serialNumber uint32, slotKey PIVSlotKey) (*PrivateKeyRef, error)
 }
 
 // Signer is a hardware key implementation of [crypto.Signer].
@@ -152,14 +148,6 @@ func decodeKeyRef(encodedKeyRef []byte, s Service) (*PrivateKeyRef, error) {
 
 	// Ensure that all required fields are decoded.
 	if err := ref.Validate(); err != nil {
-		// If some fields are missing, this is likely an old login key with only
-		// the serial number and slot. Fetch missing data from the hardware key.
-		// This data will be saved to the login key on next login
-		// TODO(Joerger): DELETE IN v19.0.0
-		if ref.SerialNumber != 0 && ref.SlotKey != 0 {
-			return s.GetFullKeyRef(ref.SerialNumber, ref.SlotKey)
-		}
-
 		return nil, trace.Wrap(err)
 	}
 

--- a/api/utils/keys/hardwarekey/hardwarekey_test.go
+++ b/api/utils/keys/hardwarekey/hardwarekey_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/sha512"
-	"encoding/json"
 	"fmt"
 	"io"
 	"testing"
@@ -59,29 +58,6 @@ func TestPrivateKey_EncodeDecode(t *testing.T) {
 	require.NoError(t, err)
 
 	decodedSigner, err := hardwarekey.DecodeSigner(encoded, s, contextualKeyInfo)
-	require.NoError(t, err)
-	require.Equal(t, hwSigner, decodedSigner)
-}
-
-// Old client logins would only have encoded the serial number and slot key.
-// TODO(Joerger): DELETE IN v19.0.0
-func TestPrivateKey_DecodePartialKeyRef(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	s := hardwarekey.NewMockHardwareKeyService(nil /*prompt*/)
-	hwSigner, err := s.NewPrivateKey(ctx, hardwarekey.PrivateKeyConfig{
-		Policy: hardwarekey.PromptPolicyNone,
-	})
-	require.NoError(t, err)
-
-	partialKeyRefJSON, err := json.Marshal(&hardwarekey.PrivateKeyRef{
-		SerialNumber: hwSigner.Ref.SerialNumber,
-		SlotKey:      hwSigner.Ref.SlotKey,
-	})
-	require.NoError(t, err)
-
-	decodedSigner, err := hardwarekey.DecodeSigner(partialKeyRefJSON, s, hardwarekey.ContextualKeyInfo{})
 	require.NoError(t, err)
 	require.Equal(t, hwSigner, decodedSigner)
 }

--- a/api/utils/keys/hardwarekey/service_mock.go
+++ b/api/utils/keys/hardwarekey/service_mock.go
@@ -210,22 +210,6 @@ func (s *MockHardwareKeyService) AddUnknownAgentKey(ref *PrivateKeyRef) {
 	}] = true
 }
 
-// TODO(Joerger): DELETE IN v19.0.0
-func (s *MockHardwareKeyService) GetFullKeyRef(serialNumber uint32, slotKey PIVSlotKey) (*PrivateKeyRef, error) {
-	s.fakeHardwarePrivateKeysMux.Lock()
-	defer s.fakeHardwarePrivateKeysMux.Unlock()
-
-	priv, ok := s.fakeHardwarePrivateKeys[hardwareKeySlot{
-		serialNumber: serialNumber,
-		slot:         slotKey,
-	}]
-	if !ok {
-		return nil, trace.NotFound("key not found in slot 0x%x", slotKey)
-	}
-
-	return priv.ref, nil
-}
-
 func (s *MockHardwareKeyService) MockTouch() {
 	s.mockTouch <- struct{}{}
 }

--- a/api/utils/keys/hardwarekeyagent/service.go
+++ b/api/utils/keys/hardwarekeyagent/service.go
@@ -157,8 +157,3 @@ func (s *Service) agentSign(ctx context.Context, ref *hardwarekey.PrivateKeyRef,
 
 	return resp.Signature, nil
 }
-
-// TODO(Joerger): DELETE IN v19.0.0
-func (s *Service) GetFullKeyRef(serialNumber uint32, slotKey hardwarekey.PIVSlotKey) (*hardwarekey.PrivateKeyRef, error) {
-	return s.fallbackService.GetFullKeyRef(serialNumber, slotKey)
-}

--- a/api/utils/keys/piv/service.go
+++ b/api/utils/keys/piv/service.go
@@ -250,39 +250,6 @@ type baseKeyRef struct {
 	slotKey      hardwarekey.PIVSlotKey
 }
 
-// GetFullKeyRef gets the full [PrivateKeyRef] for an existing hardware private
-// key in the given slot of the hardware key with the given serial number.
-//
-// Used for backwards compatibility with old logins.
-// TODO(Joerger): DELETE IN v19.0.0
-func (s *YubiKeyService) GetFullKeyRef(serialNumber uint32, slotKey hardwarekey.PIVSlotKey) (*hardwarekey.PrivateKeyRef, error) {
-	keyRefsMux.Lock()
-	defer keyRefsMux.Unlock()
-
-	baseRef := baseKeyRef{serialNumber: serialNumber, slotKey: slotKey}
-	if ref, ok := keyRefs[baseRef]; ok && ref != nil {
-		return ref, nil
-	}
-
-	y, err := s.getYubiKey(serialNumber)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	pivSlot, err := parsePIVSlot(slotKey)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	ref, err := y.getKeyRef(pivSlot, 0 /*PIN is not cached for out-of-date client keys*/)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	keyRefs[baseRef] = ref
-	return ref, nil
-}
-
 // Get the given YubiKey with the serial number. If the provided serialNumber is "0",
 // return the first YubiKey found in the smart card list.
 func (s *YubiKeyService) getYubiKey(serialNumber uint32) (*YubiKey, error) {

--- a/api/utils/keys/piv/service_unavailable.go
+++ b/api/utils/keys/piv/service_unavailable.go
@@ -45,8 +45,4 @@ func (s *unavailableYubiKeyPIVService) Sign(_ context.Context, _ *hardwarekey.Pr
 	return nil, trace.Wrap(errPIVUnavailable)
 }
 
-func (s *unavailableYubiKeyPIVService) GetFullKeyRef(serialNumber uint32, slotKey hardwarekey.PIVSlotKey) (*hardwarekey.PrivateKeyRef, error) {
-	return nil, trace.Wrap(errPIVUnavailable)
-}
-
 func (s *unavailableYubiKeyPIVService) SetPrompt(_ hardwarekey.Prompt) {}

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -238,9 +238,6 @@ type HeadlessRequest struct {
 	Action string `json:"action"`
 	// MFAResponse is an MFA response used to authenticate the headless request.
 	MFAResponse *MFAChallengeResponse `json:"mfaResponse"`
-	// WebauthnAssertionResponse is a signed WebAuthn credential assertion.
-	// TODO(Joerger): DELETE IN v19.0.0, new clients send mfaResponse
-	WebauthnAssertionResponse *wantypes.CredentialAssertionResponse `json:"webauthnAssertionResponse,omitempty"`
 }
 
 // SSHLogin contains common SSH login parameters.

--- a/lib/srv/desktop/tdp/protocol/legacy/proto.go
+++ b/lib/srv/desktop/tdp/protocol/legacy/proto.go
@@ -732,7 +732,9 @@ func (m MFA) Encode() ([]byte, error) {
 	} else if m.MFAAuthenticateResponse != nil {
 		switch t := m.MFAAuthenticateResponse.Response.(type) {
 		case *authproto.MFAAuthenticateResponse_Webauthn:
-			buff, err = json.Marshal(wantypes.CredentialAssertionResponseFromProto(m.MFAAuthenticateResponse.GetWebauthn()))
+			buff, err = json.Marshal(mfatypes.MFAChallengeResponse{
+				WebauthnResponse: wantypes.CredentialAssertionResponseFromProto(m.MFAAuthenticateResponse.GetWebauthn()),
+			})
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/tbot/services/identity/key_agent_service.go
+++ b/lib/tbot/services/identity/key_agent_service.go
@@ -303,8 +303,3 @@ func (*hardwareKeyService) NewPrivateKey(context.Context, hardwarekey.PrivateKey
 	// Hardware Key Agent during login.
 	return nil, trace.NotImplemented("generating new private keys is not supported")
 }
-
-func (*hardwareKeyService) GetFullKeyRef(uint32, hardwarekey.PIVSlotKey) (*hardwarekey.PrivateKeyRef, error) {
-	// This method is marked for deletion in v19.
-	return nil, trace.NotImplemented("GetFullKeyRef is not implemented")
-}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5846,7 +5846,7 @@ func TestCreatePrivilegeToken(t *testing.T) {
 
 	endpoint := pack.clt.Endpoint("webapi", "users", "privilege", "token")
 	re, err := pack.clt.PostJSON(context.Background(), endpoint, &privilegeTokenRequest{
-		SecondFactorToken: totpCode,
+		ExistingMFAResponse: &client.MFAChallengeResponse{TOTPCode: totpCode},
 	})
 	require.NoError(t, err)
 
@@ -5882,7 +5882,7 @@ func TestAddMFADevice(t *testing.T) {
 	// Obtain a privilege token.
 	endpoint := pack.clt.Endpoint("webapi", "users", "privilege", "token")
 	re, err := pack.clt.PostJSON(ctx, endpoint, &privilegeTokenRequest{
-		SecondFactorToken: totpCode,
+		ExistingMFAResponse: &client.MFAChallengeResponse{TOTPCode: totpCode},
 	})
 	require.NoError(t, err)
 	var privilegeToken string
@@ -5977,7 +5977,7 @@ func TestDeleteMFA(t *testing.T) {
 	// Obtain a privilege token.
 	endpoint := pack.clt.Endpoint("webapi", "users", "privilege", "token")
 	re, err := pack.clt.PostJSON(ctx, endpoint, &privilegeTokenRequest{
-		SecondFactorToken: totpCode,
+		ExistingMFAResponse: &client.MFAChallengeResponse{TOTPCode: totpCode},
 	})
 	require.NoError(t, err)
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2712,7 +2712,9 @@ func TestTerminalRequireSessionMFA(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				webauthnResBytes, err := json.Marshal(wantypes.CredentialAssertionResponseFromProto(res.GetWebauthn()))
+				webauthnResBytes, err := json.Marshal(client.MFAChallengeResponse{
+					WebauthnResponse: wantypes.CredentialAssertionResponseFromProto(res.GetWebauthn()),
+				})
 				require.NoError(t, err)
 
 				envelope := &terminal.Envelope{
@@ -5846,7 +5848,7 @@ func TestCreatePrivilegeToken(t *testing.T) {
 
 	endpoint := pack.clt.Endpoint("webapi", "users", "privilege", "token")
 	re, err := pack.clt.PostJSON(context.Background(), endpoint, &privilegeTokenRequest{
-		SecondFactorToken: totpCode,
+		ExistingMFAResponse: &client.MFAChallengeResponse{TOTPCode: totpCode},
 	})
 	require.NoError(t, err)
 
@@ -5882,7 +5884,7 @@ func TestAddMFADevice(t *testing.T) {
 	// Obtain a privilege token.
 	endpoint := pack.clt.Endpoint("webapi", "users", "privilege", "token")
 	re, err := pack.clt.PostJSON(ctx, endpoint, &privilegeTokenRequest{
-		SecondFactorToken: totpCode,
+		ExistingMFAResponse: &client.MFAChallengeResponse{TOTPCode: totpCode},
 	})
 	require.NoError(t, err)
 	var privilegeToken string
@@ -5977,7 +5979,7 @@ func TestDeleteMFA(t *testing.T) {
 	// Obtain a privilege token.
 	endpoint := pack.clt.Endpoint("webapi", "users", "privilege", "token")
 	re, err := pack.clt.PostJSON(ctx, endpoint, &privilegeTokenRequest{
-		SecondFactorToken: totpCode,
+		ExistingMFAResponse: &client.MFAChallengeResponse{TOTPCode: totpCode},
 	})
 	require.NoError(t, err)
 

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -120,9 +120,6 @@ type CreateAppSessionRequest struct {
 	AWSRole string `json:"arn,omitempty"`
 	// MFAResponse is an optional MFA response used to create an MFA verified app session.
 	MFAResponse client.MFAChallengeResponse `json:"mfaResponse"`
-	// TODO(Joerger): DELETE IN v19.0.0
-	// Backwards compatible version of MFAResponse
-	MFAResponseJSON string `json:"mfa_response"`
 }
 
 // CreateAppSessionResponse is a response to POST /v1/webapi/sessions/app
@@ -164,14 +161,6 @@ func (h *Handler) createAppSession(w http.ResponseWriter, r *http.Request, p htt
 	mfaResponse, err := req.MFAResponse.GetOptionalMFAResponseProtoReq()
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	// Fallback to backwards compatible mfa response.
-	if mfaResponse == nil && req.MFAResponseJSON != "" {
-		mfaResponse, err = client.ParseMFAChallengeResponse([]byte(req.MFAResponseJSON))
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 	}
 
 	// Get an auth client connected with the user's identity.

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -829,7 +829,9 @@ func performMFACeremonyWS(t *testing.T, ws *websocket.Conn, pack *authPack) {
 	})
 	require.NoError(t, err)
 
-	webauthnResBytes, err := json.Marshal(wantypes.CredentialAssertionResponseFromProto(res.GetWebauthn()))
+	webauthnResBytes, err := json.Marshal(client.MFAChallengeResponse{
+		WebauthnResponse: wantypes.CredentialAssertionResponseFromProto(res.GetWebauthn()),
+	})
 	require.NoError(t, err)
 
 	envelopeBytes, err := proto.Marshal(&terminal.Envelope{

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -84,12 +84,6 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 		moderatedSessionID:    query.Get("moderatedSessionId"),
 	}
 
-	// Check for old query parameter, uses the same data structure.
-	// TODO(Joerger): DELETE IN v19.0.0
-	if req.mfaResponse == "" {
-		req.mfaResponse = query.Get("webauthn")
-	}
-
 	var mfaResponse *proto.MFAAuthenticateResponse
 	if req.mfaResponse != "" {
 		var err error

--- a/lib/web/headless.go
+++ b/lib/web/headless.go
@@ -65,12 +65,6 @@ func (h *Handler) putHeadlessState(_ http.ResponseWriter, r *http.Request, param
 		return nil, trace.Wrap(err)
 	}
 
-	if req.MFAResponse == nil && req.WebauthnAssertionResponse != nil {
-		req.MFAResponse = &client.MFAChallengeResponse{
-			WebauthnResponse: req.WebauthnAssertionResponse,
-		}
-	}
-
 	// MFAResponse is required only when accepting a request.
 	mfaResp, err := req.MFAResponse.GetOptionalMFAResponseProtoReq()
 	if err != nil {

--- a/lib/web/mfajson/mfajson.go
+++ b/lib/web/mfajson/mfajson.go
@@ -24,29 +24,16 @@ import (
 	"github.com/gravitational/trace"
 
 	authproto "github.com/gravitational/teleport/api/client/proto"
-	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client/mfatypes"
 )
-
-// TODO(Joerger): DELETE IN v19.0.0 and use mfatypes.MFAChallengeResponse instead.
-// Before v17, the WebUI sends a flattened webauthn response instead of a full
-// MFA challenge response. Newer WebUI versions v17+ will send both for
-// backwards compatibility.
-type challengeResponse struct {
-	mfatypes.MFAChallengeResponse
-	*wantypes.CredentialAssertionResponse
-}
 
 // Decode parses a JSON-encoded MFA authentication response.
 // Only webauthn (type="n") is currently supported.
 func Decode(b []byte, typ string) (*authproto.MFAAuthenticateResponse, error) {
-	var resp challengeResponse
+	var resp mfatypes.MFAChallengeResponse
 	if err := json.Unmarshal(b, &resp); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	// Move flattened webauthn response into resp.
-	resp.MFAChallengeResponse.WebauthnAssertionResponse = resp.CredentialAssertionResponse
 
 	protoResp, err := resp.GetOptionalMFAResponseProtoReq()
 	if err != nil {

--- a/lib/web/users.go
+++ b/lib/web/users.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
-	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -318,12 +317,6 @@ func deleteUser(r *http.Request, params httprouter.Params, m userAPIGetter, user
 }
 
 type privilegeTokenRequest struct {
-	// TODO(Joerger): DELETE IN v19.0.0 in favor of ExistingMFAResponse
-	// SecondFactorToken is the totp code.
-	SecondFactorToken string `json:"secondFactorToken"`
-	// TODO(Joerger): DELETE IN v19.0.0 in favor of ExistingMFAResponse
-	// WebauthnResponse is the response from authenticators.
-	WebauthnResponse *wantypes.CredentialAssertionResponse `json:"webauthnAssertionResponse"`
 	// ExistingMFAResponse is an MFA challenge response from an existing device.
 	// Not required if the user has no existing devices.
 	ExistingMFAResponse *client.MFAChallengeResponse `json:"existingMfaResponse"`
@@ -336,25 +329,9 @@ func (h *Handler) createPrivilegeTokenHandle(w http.ResponseWriter, r *http.Requ
 		return nil, trace.Wrap(err)
 	}
 
-	protoReq := &proto.CreatePrivilegeTokenRequest{}
-
-	switch {
-	case req.SecondFactorToken != "":
-		protoReq.ExistingMFAResponse = &proto.MFAAuthenticateResponse{Response: &proto.MFAAuthenticateResponse_TOTP{
-			TOTP: &proto.TOTPResponse{Code: req.SecondFactorToken},
-		}}
-	case req.WebauthnResponse != nil:
-		protoReq.ExistingMFAResponse = &proto.MFAAuthenticateResponse{Response: &proto.MFAAuthenticateResponse_Webauthn{
-			Webauthn: wantypes.CredentialAssertionResponseToProto(req.WebauthnResponse),
-		}}
-	case req.ExistingMFAResponse != nil:
-		var err error
-		protoReq.ExistingMFAResponse, err = req.ExistingMFAResponse.GetOptionalMFAResponseProtoReq()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	default:
-		// Can be empty, which means user did not have a second factor registered.
+	mfaResp, err := req.ExistingMFAResponse.GetOptionalMFAResponseProtoReq()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	clt, err := ctx.GetClient()
@@ -362,7 +339,7 @@ func (h *Handler) createPrivilegeTokenHandle(w http.ResponseWriter, r *http.Requ
 		return nil, trace.Wrap(err)
 	}
 
-	token, err := clt.CreatePrivilegeToken(r.Context(), protoReq)
+	token, err := clt.CreatePrivilegeToken(r.Context(), &proto.CreatePrivilegeTokenRequest{ExistingMFAResponse: mfaResp})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -1481,7 +1481,7 @@ const cfg = {
   },
 
   getScpUrl({ mfaResponse, ...params }: UrlScpParams) {
-    let path = generateFullPath(cfg.api.scp, {
+    const path = generateFullPath(cfg.api.scp, {
       ...params,
     });
 
@@ -1491,13 +1491,6 @@ const cfg = {
     // non-required MFA will mean this param is undefined and generatePath doesn't like undefined
     // or optional params. So we append it ourselves here. Its ok to be undefined when sent to the server
     // as the existence of this param is what will issue certs
-
-    // TODO(Joerger): DELETE IN v19.0.0
-    // We include webauthn for backwards compatibility.
-    path = `${path}&webauthn=${JSON.stringify({
-      webauthnAssertionResponse: mfaResponse.webauthn_response,
-    })}`;
-
     return `${path}&mfaResponse=${JSON.stringify(mfaResponse)}`;
   },
 

--- a/web/packages/teleport/src/services/api/api.test.ts
+++ b/web/packages/teleport/src/services/api/api.test.ts
@@ -123,7 +123,6 @@ describe('api.fetch', () => {
         ...getAuthHeaders(),
         [MFA_HEADER]: JSON.stringify({
           ...mfaResp,
-          webauthnAssertionResponse: mfaResp.webauthn_response,
         }),
       },
     });
@@ -144,7 +143,6 @@ describe('api.fetch', () => {
         ...getAuthHeaders(),
         [MFA_HEADER]: JSON.stringify({
           ...mfaResp,
-          webauthnAssertionResponse: mfaResp.webauthn_response,
         }),
       },
     });

--- a/web/packages/teleport/src/services/api/api.ts
+++ b/web/packages/teleport/src/services/api/api.ts
@@ -402,9 +402,6 @@ const api = {
     if (mfaResponse) {
       options.headers[MFA_HEADER] = JSON.stringify({
         ...mfaResponse,
-        // TODO(Joerger): DELETE IN v19.0.0.
-        // We include webauthnAssertionResponse for backwards compatibility.
-        webauthnAssertionResponse: mfaResponse.webauthn_response,
       });
     }
 

--- a/web/packages/teleport/src/services/apps/apps.ts
+++ b/web/packages/teleport/src/services/apps/apps.ts
@@ -44,18 +44,7 @@ const service = {
   },
 
   async createAppSession(params: CreateAppSessionParams) {
-    const createAppSession = {
-      ...params,
-      // TODO(Joerger): DELETE IN v19.0.0.
-      // We include a string version of the MFA response for backwards compatibility.
-      mfa_response: params.mfaResponse
-        ? JSON.stringify({
-            webauthnAssertionResponse: params.mfaResponse.webauthn_response,
-          })
-        : null,
-    };
-
-    return api.post(cfg.api.appSession, createAppSession).then(json => ({
+    return api.post(cfg.api.appSession, params).then(json => ({
       fqdn: json.fqdn as string,
       cookieValue: json.cookie_value as string,
       subjectCookieValue: json.subject_cookie_value as string,

--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -250,8 +250,6 @@ const auth = {
       const request = {
         action: 'accept',
         mfaResponse: res,
-        // TODO(Joerger): DELETE IN v19.0.0, new clients send mfaResponse.
-        webauthnAssertionResponse: res.webauthn_response,
       };
 
       return api.put(cfg.getHeadlessSsoPath(transactionId), request);
@@ -359,10 +357,6 @@ const auth = {
   createPrivilegeToken(existingMfaResponse?: MfaChallengeResponse) {
     return api.post(cfg.api.createPrivilegeTokenPath, {
       existingMfaResponse,
-      // TODO(Joerger): DELETE IN v19.0.0
-      // Also provide totp/webauthn response in backwards compatible format.
-      secondFactorToken: existingMfaResponse?.totp_code,
-      webauthnAssertionResponse: existingMfaResponse?.webauthn_response,
     });
   },
 


### PR DESCRIPTION
Addresses my `DELETE IN v19.0.0` TODOs. 

## Manual Test Plan
Short list of manual tests as most of this is covered by the main test plan, which will be run before the v19 release.

### Test Environment
### Test Cases
- [x] Sanity check each feature works:
  - [x] WebUI 
    - [x] accept headless login
    - [x] change password w/ mfa 
    - [x] file transfer
    - [x] app session
  - [x] Hardware Key Support
    - [x] same-version
    - [x] v19 client -> v18 auth
    - [x] v18 client -> v19 auth 
  - [x] Admin MFA
    - [x] same-version
    - [x] v19 client -> v18 auth
    - [x] v18 client -> v19 auth 