### PR TITLE
[v17] Restrict forced termination to moderators

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -290,8 +290,9 @@ type ServerContext struct {
 	// session is created.
 	sessionID rsession.ID
 
-	// session holds the active session (if there's an active one).
-	session *session
+	// party holds the active party (if there's an active one). This party should have
+	// already passed basic authz checks (e.g. joining permissions).
+	party *party
 
 	// closers is a list of io.Closer that will be called when session closes
 	// this is handy as sometimes client closes session, in this case resources
@@ -567,10 +568,10 @@ func (c *ServerContext) ID() int {
 func (c *ServerContext) SessionID() rsession.ID {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	if c.session == nil {
-		return c.sessionID
+	if c.party != nil {
+		return c.party.s.id
 	}
-	return c.session.id
+	return c.sessionID
 }
 
 // GetServer returns the underlying server which this context was created in.
@@ -623,11 +624,10 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 		return trace.BadParameter("invalid session ID")
 	}
 
-	// update ctx with the session if it exists
+	// update ctx with the session ID if a matching session exists
 	if sess, found := reg.findSession(*id); found {
 		c.sessionID = *id
-		c.session = sess
-		c.Logger.Debugf("Will join session %v for SSH connection %v.", c.session.id, c.ServerConn.RemoteAddr())
+		c.Logger.Debugf("Will join session %v for SSH connection %v.", sess.id, c.ServerConn.RemoteAddr())
 	} else {
 		// TODO(capnspacehook): DELETE IN 17.0.0 - by then all supported
 		// clients should only set TELEPORT_SESSION when they want to
@@ -707,14 +707,21 @@ func (c *ServerContext) getEnvLocked(key string) (string, bool) {
 	return c.Parent().GetEnv(key)
 }
 
-// setSession sets the context's session
-func (c *ServerContext) setSession(sess *session, ch ssh.Channel) {
+// setParty sets the context's party to an active session.
+func (c *ServerContext) setParty(p *party) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.session = sess
+	if c.party != nil {
+		return trace.BadParameter("already party to another session")
+	}
+	c.party = p
+	c.closers = append(c.closers, p)
+	return nil
+}
 
-	// inform the client of the session ID that is being used in a new
-	// goroutine to reduce latency
+// sendCurrentSessionID informs the client of the session ID that is being used
+// in a new goroutine to reduce latency.
+func (c *ServerContext) sendCurrentSessionID(ch ssh.Channel, sess *session) {
 	go func() {
 		c.Logger.Debug("Sending current session ID.")
 		_, err := ch.SendRequest(teleport.CurrentSessionIDRequest, false, []byte(sess.ID()))
@@ -724,11 +731,20 @@ func (c *ServerContext) setSession(sess *session, ch ssh.Channel) {
 	}()
 }
 
-// getSession returns the context's session
-func (c *ServerContext) getSession() *session {
+// getParty returns the context's party to an active session, if there is one.
+func (c *ServerContext) getParty() *party {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.session
+	return c.party
+}
+
+// getSession returns the session the context's party belongs to, if there is
+// an active party. Callers that don't need the party itself should prefer this.
+func (c *ServerContext) getSession() *session {
+	if p := c.getParty(); p != nil {
+		return p.s
+	}
+	return nil
 }
 
 func (c *ServerContext) SetAllowFileCopying(allow bool) {

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -290,8 +290,9 @@ type ServerContext struct {
 	// session is created.
 	sessionID rsession.ID
 
-	// session holds the active session (if there's an active one).
-	session *session
+	// party holds the active party (if there's an active one). This party should have
+	// already passed basic authz checks (e.g. joining permissions).
+	party *party
 
 	// closers is a list of io.Closer that will be called when session closes
 	// this is handy as sometimes client closes session, in this case resources
@@ -565,12 +566,10 @@ func (c *ServerContext) ID() int {
 
 // SessionID returns the ID of the session in the context.
 func (c *ServerContext) SessionID() rsession.ID {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.session == nil {
-		return c.sessionID
+	if session := c.getSession(); session != nil {
+		return session.id
 	}
-	return c.session.id
+	return c.sessionID
 }
 
 // GetServer returns the underlying server which this context was created in.
@@ -623,11 +622,10 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 		return trace.BadParameter("invalid session ID")
 	}
 
-	// update ctx with the session if it exists
+	// update ctx with the session ID if a matching session exists
 	if sess, found := reg.findSession(*id); found {
 		c.sessionID = *id
-		c.session = sess
-		c.Logger.Debugf("Will join session %v for SSH connection %v.", c.session.id, c.ServerConn.RemoteAddr())
+		c.Logger.Debugf("Will join session %v for SSH connection %v.", sess.id, c.ServerConn.RemoteAddr())
 	} else {
 		// TODO(capnspacehook): DELETE IN 17.0.0 - by then all supported
 		// clients should only set TELEPORT_SESSION when they want to
@@ -707,14 +705,21 @@ func (c *ServerContext) getEnvLocked(key string) (string, bool) {
 	return c.Parent().GetEnv(key)
 }
 
-// setSession sets the context's session
-func (c *ServerContext) setSession(sess *session, ch ssh.Channel) {
+// setParty sets the context's party to an active session.
+func (c *ServerContext) setParty(p *party) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.session = sess
+	if c.party != nil {
+		return trace.BadParameter("already party to another session")
+	}
+	c.party = p
+	c.closers = append(c.closers, p)
+	return nil
+}
 
-	// inform the client of the session ID that is being used in a new
-	// goroutine to reduce latency
+// sendCurrentSessionID informs the client of the session ID that is being used
+// in a new goroutine to reduce latency.
+func (c *ServerContext) sendCurrentSessionID(ch ssh.Channel, sess *session) {
 	go func() {
 		c.Logger.Debug("Sending current session ID.")
 		_, err := ch.SendRequest(teleport.CurrentSessionIDRequest, false, []byte(sess.ID()))
@@ -724,11 +729,20 @@ func (c *ServerContext) setSession(sess *session, ch ssh.Channel) {
 	}()
 }
 
-// getSession returns the context's session
-func (c *ServerContext) getSession() *session {
+// getParty returns the context's party to an active session, if there is one.
+func (c *ServerContext) getParty() *party {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.session
+	return c.party
+}
+
+// getSession returns the session the context's party belongs to, if there is
+// an active party. Callers that don't need the party itself should prefer this.
+func (c *ServerContext) getSession() *session {
+	if p := c.getParty(); p != nil {
+		return p.s
+	}
+	return nil
 }
 
 func (c *ServerContext) SetAllowFileCopying(allow bool) {

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -400,7 +400,7 @@ func (e *remoteExec) PID() int {
 // emitExecAuditEvent emits either an SCP or exec event based on the
 // command run.
 //
-// Note: to ensure that the event is recorded ctx.session must be used
+// Note: to ensure that the event is recorded ctx.getSession() must be used
 // instead of ctx.srv.
 func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 	// Create common fields for event.
@@ -465,7 +465,7 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 				scpEvent.Code = events.SCPDownloadCode
 			}
 		}
-		if err := ctx.session.emitAuditEvent(ctx.srv.Context(), scpEvent); err != nil {
+		if err := ctx.getSession().emitAuditEvent(ctx.srv.Context(), scpEvent); err != nil {
 			log.WithError(err).Warn("Failed to emit scp event.")
 		}
 	} else {
@@ -485,7 +485,7 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 		} else {
 			execEvent.Code = events.ExecCode
 		}
-		if err := ctx.session.emitAuditEvent(ctx.srv.Context(), execEvent); err != nil {
+		if err := ctx.getSession().emitAuditEvent(ctx.srv.Context(), execEvent); err != nil {
 			log.WithError(err).Warn("Failed to emit exec event.")
 		}
 	}

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -80,7 +80,7 @@ func TestOSCommandPrep(t *testing.T) {
 		"SSH_CLIENT=10.0.0.5 4817 3022",
 		"SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022",
 		"TERM=xterm",
-		fmt.Sprintf("SSH_TTY=%v", scx.session.term.TTYName()),
+		fmt.Sprintf("SSH_TTY=%v", scx.party.s.term.TTYName()),
 		"SSH_SESSION_ID=xxx",
 		"SSH_TELEPORT_HOST_UUID=testID",
 		"SSH_TELEPORT_CLUSTER_NAME=localhost",

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/modules"
@@ -61,7 +62,7 @@ func TestEmitExecAuditEvent(t *testing.T) {
 	srv := newMockServer(t)
 	scx := newExecServerContext(t, srv)
 
-	rec, ok := scx.session.recorder.(*mockRecorder)
+	rec, ok := scx.party.s.recorder.(*mockRecorder)
 	require.True(t, ok)
 
 	scx.GetServer().TargetMetadata()
@@ -146,16 +147,24 @@ func newExecServerContext(t *testing.T, srv Server) *ServerContext {
 	term.SetTermType("xterm")
 
 	rec := &mockRecorder{done: false}
-	scx.session = &session{
+	s := &session{
 		id:       "xxx",
 		term:     term,
 		emitter:  rec,
 		recorder: rec,
+		scx:      scx,
+		registry: &SessionRegistry{
+			SessionRegistryConfig: SessionRegistryConfig{
+				Srv: srv,
+			},
+		},
 	}
+	scx.party = newParty(s, types.SessionPeerMode, nil, scx)
+
 	err = scx.SetSSHRequest(&ssh.Request{Type: sshutils.ExecRequest})
 	require.NoError(t, err)
 
-	t.Cleanup(func() { require.NoError(t, scx.session.term.Close()) })
+	t.Cleanup(func() { require.NoError(t, scx.party.s.term.Close()) })
 
 	return scx
 }

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -361,9 +361,8 @@ func (s *SessionRegistry) UpsertHostUser(identityContext IdentityContext, obtain
 }
 
 // OpenSession either joins an existing active session or starts a new session.
-func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *ServerContext) error {
-	session := scx.getSession()
-	if session != nil && !session.isStopped() {
+func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *ServerContext) (err error) {
+	if session, found := s.findSession(scx.SessionID()); found && !session.isStopped() {
 		scx.Infof("Joining existing session %v.", session.id)
 		mode := types.SessionParticipantMode(scx.env[teleport.EnvSSHJoinMode])
 		if mode == "" {
@@ -399,14 +398,27 @@ func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	scx.setSession(sess, ch)
+
+	// Make sure to close the session when returning an error
+	defer func() {
+		if err != nil {
+			sess.Close()
+		}
+	}()
+
 	s.addSession(sess)
 	scx.Infof("Creating (interactive) session %v.", sid)
+
+	if err := p.ctx.setParty(p); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Inform the client of the session ID that is being used.
+	scx.sendCurrentSessionID(ch, sess)
 
 	// Start an interactive session (TTY attached). Close the session if an error
 	// occurs, otherwise it will be closed by the callee.
 	if err := sess.startInteractive(ctx, scx, p); err != nil {
-		sess.Close()
 		return trace.Wrap(err)
 	}
 	return nil
@@ -458,9 +470,12 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 		return errCannotStartUnattendedSession
 	}
 
-	// Start a non-interactive session (TTY attached). Close the session if an error
-	// occurs, otherwise it will be closed by the callee.
-	scx.setSession(sess, channel)
+	if err := p.ctx.setParty(p); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Inform the client of the session ID that is being used.
+	scx.sendCurrentSessionID(channel, sess)
 
 	err = sess.startExec(ctx, channel, scx, p)
 	if err != nil {
@@ -470,13 +485,7 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 	return nil
 }
 
-func (s *SessionRegistry) ForceTerminate(ctx *ServerContext) error {
-	sess := ctx.getSession()
-	if sess == nil {
-		s.logger.DebugContext(s.Srv.Context(), "Unable to terminate session, no session found in context.")
-		return nil
-	}
-
+func (s *SessionRegistry) ForceTerminate(sess *session) error {
 	sess.BroadcastMessage("Forcefully terminating session...")
 
 	// Stop session, it will be cleaned up in the background to ensure
@@ -493,7 +502,7 @@ func (s *SessionRegistry) GetTerminalSize(sessionID string) (*term.Winsize, erro
 
 	sess := s.sessions[rsession.ID(sessionID)]
 	if sess == nil {
-		return nil, trace.NotFound("No session found in context.")
+		return nil, trace.NotFound("session not found")
 	}
 
 	return sess.term.GetWinSize()
@@ -783,6 +792,7 @@ type session struct {
 
 	initiator string
 
+	// scx is the host context for the session.
 	scx *ServerContext
 
 	presenceEnabled bool
@@ -881,7 +891,7 @@ func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *Se
 
 	go func() {
 		if _, open := <-sess.io.TerminateNotifier(); open {
-			err := sess.registry.ForceTerminate(sess.scx)
+			err := sess.registry.ForceTerminate(sess)
 			if err != nil {
 				sess.logger.ErrorContext(sess.serverCtx, "Failed to terminate session.", "error", err)
 			}
@@ -1721,7 +1731,7 @@ func (s *session) removePartyUnderLock(p *party) error {
 	if !canRun {
 		if policyOptions.OnLeaveAction == types.OnSessionLeaveTerminate {
 			// Force termination in goroutine to avoid deadlock
-			go s.registry.ForceTerminate(s.scx)
+			go s.registry.ForceTerminate(s)
 			return nil
 		}
 
@@ -2019,7 +2029,6 @@ func (s *session) addParty(p *party, mode types.SessionParticipantMode) error {
 	// Adds participant to in-memory map of party members.
 	s.parties[p.id] = p
 	s.participants[p.id] = p
-	p.ctx.AddCloser(p)
 
 	// Write last chunk (so the newly joined parties won't stare at a blank screen).
 	if _, err := p.Write(s.io.GetRecentHistory()); err != nil {
@@ -2110,6 +2119,10 @@ func (s *session) join(ch ssh.Channel, scx *ServerContext, mode types.SessionPar
 
 	// create a new "party" (connected client) and launch/join the session.
 	p := newParty(s, mode, ch, scx)
+	if err := p.ctx.setParty(p); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if err := s.addParty(p, mode); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -504,7 +504,7 @@ func TestSessionRegistrySetupFailureCleanup(t *testing.T) {
 
 			err = tt.openSession(t.Context(), reg, channel, scx)
 			require.Error(t, err)
-			require.Nil(t, scx.session)
+			require.Nil(t, scx.party)
 
 			if tt.errAssertion != nil {
 				tt.errAssertion(t, err)
@@ -604,18 +604,18 @@ func TestInteractiveSession(t *testing.T) {
 		io.ReadAll(sshChanOpen)
 	}()
 	require.NoError(t, reg.OpenSession(context.Background(), sshChanOpen, scx))
-	require.NotNil(t, scx.session)
+	require.NotNil(t, scx.party)
 
 	// Simulate changing window size to capture an additional event.
 	require.NoError(t, reg.NotifyWinChange(context.Background(), rsession.TerminalParams{W: 100, H: 100}, scx))
 
 	// Stopping the session should trigger the session
 	// to end and cleanup in the background
-	scx.session.Stop()
+	scx.party.s.Stop()
 
 	// Wait for the session to be removed from the registry.
 	require.Eventually(t, func() bool {
-		_, found := reg.findSession(scx.session.id)
+		_, found := reg.findSession(scx.party.s.id)
 		return !found
 	}, time.Second*15, time.Millisecond*500)
 
@@ -689,11 +689,11 @@ func TestNonInteractiveSession(t *testing.T) {
 			io.ReadAll(sshChanOpen)
 		}()
 		require.NoError(t, reg.OpenExecSession(context.Background(), sshChanOpen, scx))
-		require.NotNil(t, scx.session)
+		require.NotNil(t, scx.party)
 
 		// Wait for the command execution to complete and the session to be terminated.
 		require.Eventually(t, func() bool {
-			_, found := reg.findSession(scx.session.id)
+			_, found := reg.findSession(scx.party.s.id)
 			return !found
 		}, time.Second*15, time.Millisecond*500)
 
@@ -752,11 +752,11 @@ func TestNonInteractiveSession(t *testing.T) {
 			io.ReadAll(sshChanOpen)
 		}()
 		require.NoError(t, reg.OpenExecSession(context.Background(), sshChanOpen, scx))
-		require.NotNil(t, scx.session)
+		require.NotNil(t, scx.party)
 
 		// Wait for the command execution to complete and the session to be terminated.
 		require.Eventually(t, func() bool {
-			_, found := reg.findSession(scx.session.id)
+			_, found := reg.findSession(scx.party.s.id)
 			return !found
 		}, time.Second*15, time.Millisecond*500)
 
@@ -925,8 +925,8 @@ func TestParties(t *testing.T) {
 
 func testJoinSession(t *testing.T, reg *SessionRegistry, sess *session) {
 	scx := newTestServerContext(t, reg.Srv, nil)
+	scx.sessionID = sess.id
 	sshChanOpen := newMockSSHChannel()
-	scx.setSession(sess, sshChanOpen)
 
 	// Open a new session
 	go func() {
@@ -1039,8 +1039,8 @@ func testOpenSession(t *testing.T, reg *SessionRegistry, roleSet services.RoleSe
 	err := reg.OpenSession(context.Background(), sshChanOpen, scx)
 	require.NoError(t, err)
 
-	require.NotNil(t, scx.session)
-	return scx.session, sshChanOpen
+	require.NotNil(t, scx.party)
+	return scx.party.s, sshChanOpen
 }
 
 type mockRecorder struct {
@@ -1374,13 +1374,13 @@ func TestCloseProxySession(t *testing.T) {
 
 	err = reg.OpenSession(context.Background(), sshChanOpen, scx)
 	require.NoError(t, err)
-	require.NotNil(t, scx.session)
+	require.NotNil(t, scx.party)
 
 	// After the session is open, we force a close coming from the server. Do
 	// this inside a goroutine to avoid being blocked.
 	closeChan := make(chan error)
 	go func() {
-		closeChan <- scx.session.Close()
+		closeChan <- scx.party.s.Close()
 	}()
 
 	select {
@@ -1421,13 +1421,13 @@ func TestCloseRemoteSession(t *testing.T) {
 
 	err := reg.OpenSession(context.Background(), sshChanOpen, scx)
 	require.NoError(t, err)
-	require.NotNil(t, scx.session)
+	require.NotNil(t, scx.party)
 
 	// After the session is open, we force a close coming from the server. Do
 	// this inside a goroutine to avoid being blocked.
 	closeChan := make(chan error)
 	go func() {
-		closeChan <- scx.session.Close()
+		closeChan <- scx.party.s.Close()
 	}()
 
 	select {
@@ -1922,4 +1922,59 @@ func (f *fakeSudoersBackend) RemoveSudoers(name string) error {
 
 	delete(f.sudoers, name)
 	return f.err
+}
+
+func TestHandleForceTerminate(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockServer(t)
+	reg, err := NewSessionRegistry(SessionRegistryConfig{
+		Srv:                   srv,
+		SessionTrackerService: srv.auth,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { reg.Close() })
+
+	termHandlers := &TermHandlers{SessionRegistry: reg}
+
+	tests := []struct {
+		name         string
+		joinMode     types.SessionParticipantMode
+		accessDenied bool
+	}{
+		{
+			name:         "empty join mode denied",
+			accessDenied: true,
+		},
+		{
+			name:         "peer denied",
+			joinMode:     types.SessionPeerMode,
+			accessDenied: true,
+		},
+		{
+			name:         "observer denied",
+			joinMode:     types.SessionObserverMode,
+			accessDenied: true,
+		},
+		{
+			name:     "moderator allowed",
+			joinMode: types.SessionModeratorMode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostSess, _ := testOpenSession(t, reg, nil)
+			t.Cleanup(hostSess.Stop)
+
+			hostSess.scx.party.mode = tt.joinMode
+
+			err := termHandlers.HandleForceTerminate(nil, nil, hostSess.scx)
+			if tt.accessDenied {
+				require.True(t, trace.IsAccessDenied(err), "expected AccessDenied, got %v", err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	tracingssh "github.com/gravitational/teleport/api/observability/tracing/ssh"
+	"github.com/gravitational/teleport/api/types"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
 )
@@ -190,8 +191,18 @@ func (t *TermHandlers) HandleWinChange(ctx context.Context, ch ssh.Channel, req 
 	return nil
 }
 
-func (t *TermHandlers) HandleForceTerminate(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
-	err := t.SessionRegistry.ForceTerminate(ctx)
+func (t *TermHandlers) HandleForceTerminate(_ ssh.Channel, _ *ssh.Request, ctx *ServerContext) error {
+	p := ctx.getParty()
+	if p == nil {
+		t.SessionRegistry.logger.DebugContext(t.SessionRegistry.Srv.Context(), "Unable to terminate session, not party to a session.")
+		return nil
+	}
+
+	if p.mode != types.SessionModeratorMode {
+		return trace.AccessDenied("only moderators can force terminate a session")
+	}
+
+	err := t.SessionRegistry.ForceTerminate(p.s)
 	return trace.Wrap(err)
 }
 


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/67394 to branch/v17

Changelog: Restrict forced termination to moderators.

## Manual Test Plan
### Test Environment

### Test Cases
- [x] moderator can still terminate session
  - [x] from WebUI
  - [x] from `tsh join` 