### PR TITLE
[v17] Fix `IdentityFileWatch` halting due to context cancellation

### DIFF
--- a/integrations/access/common/app.go
+++ b/integrations/access/common/app.go
@@ -103,7 +103,13 @@ func (a *BaseApp) checkTeleportVersion(ctx context.Context) (proto.PingResponse,
 
 // initTeleport creates a Teleport client and validates Teleport connectivity.
 func (a *BaseApp) initTeleport(ctx context.Context, conf PluginConfiguration) (clusterName, webProxyAddr string, err error) {
-	clt, err := conf.GetTeleportClient(ctx)
+	// Preserve the parent context without deadline for the client and its
+	// goroutines (IdentityFileWatcher) which will outlive init.
+	clientCtx := ctx
+	ctx, cancel := context.WithTimeout(ctx, initTimeout)
+	defer cancel()
+
+	clt, err := conf.GetTeleportClient(clientCtx)
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}
@@ -173,15 +179,19 @@ func (a *BaseApp) run(ctx context.Context) error {
 }
 
 func (a *BaseApp) init(ctx context.Context) error {
+	// Preserve the parent context without deadline for the client and its
+	// goroutines (IdentityFileWatcher) which will outlive init.
+	clientCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
+
 	log := logger.Get(ctx)
 
 	if a.Clock == nil {
 		a.Clock = clockwork.NewRealClock()
 	}
 
-	clusterName, webProxyAddr, err := a.initTeleport(ctx, a.Conf)
+	clusterName, webProxyAddr, err := a.initTeleport(clientCtx, a.Conf)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/integrations/access/email/app.go
+++ b/integrations/access/email/app.go
@@ -150,11 +150,15 @@ func (a *App) run(ctx context.Context) error {
 // init inits plugin
 func (a *App) init(ctx context.Context) error {
 	log := logger.Get(ctx)
+
+	// Preserve the parent context without deadline for the client and its
+	// goroutines (IdentityFileWatcher) which will outlive init.
+	clientCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
 
 	var err error
-	if a.apiClient, err = a.conf.GetTeleportClient(ctx); err != nil {
+	if a.apiClient, err = a.conf.GetTeleportClient(clientCtx); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/integrations/access/jira/app.go
+++ b/integrations/access/jira/app.go
@@ -179,13 +179,16 @@ func (a *App) run(ctx context.Context) error {
 }
 
 func (a *App) init(ctx context.Context) error {
+	// Preserve the parent context without deadline for the client and its
+	// goroutines (IdentityFileWatcher) which will outlive init.
+	clientCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
 	log := logger.Get(ctx)
 
 	var err error
 	if a.teleport == nil {
-		if a.teleport, err = common.GetTeleportClient(ctx, a.conf.Teleport); err != nil {
+		if a.teleport, err = common.GetTeleportClient(clientCtx, a.conf.Teleport); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/integrations/access/msteams/app.go
+++ b/integrations/access/msteams/app.go
@@ -113,6 +113,9 @@ func (a *App) WaitReady(ctx context.Context) (bool, error) {
 
 // init initializes the application
 func (a *App) init(ctx context.Context) error {
+	// Preserve the parent context without deadline for the client and its
+	// goroutines (IdentityFileWatcher) which will outlive init.
+	clientCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
 
@@ -120,7 +123,7 @@ func (a *App) init(ctx context.Context) error {
 		a.apiClient = a.conf.Client
 	} else {
 		var err error
-		a.apiClient, err = common.GetTeleportClient(ctx, a.conf.Teleport)
+		a.apiClient, err = common.GetTeleportClient(clientCtx, a.conf.Teleport)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/integrations/access/opsgenie/app.go
+++ b/integrations/access/opsgenie/app.go
@@ -158,11 +158,14 @@ func (a *App) run(ctx context.Context) error {
 }
 
 func (a *App) init(ctx context.Context) error {
+	// Preserve the parent context without deadline for the client and its
+	// goroutines (IdentityFileWatcher) which will outlive init.
+	clientCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
 
 	var err error
-	a.teleport, err = a.conf.GetTeleportClient(ctx)
+	a.teleport, err = a.conf.GetTeleportClient(clientCtx)
 	if err != nil {
 		return trace.Wrap(err, "getting teleport client")
 	}

--- a/integrations/access/pagerduty/app.go
+++ b/integrations/access/pagerduty/app.go
@@ -157,6 +157,9 @@ func (a *App) run(ctx context.Context) error {
 }
 
 func (a *App) init(ctx context.Context) error {
+	// Preserve the parent context without deadline for the client and its
+	// goroutines (IdentityFileWatcher) which will outlive init.
+	clientCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
 	log := logger.Get(ctx)
@@ -167,7 +170,7 @@ func (a *App) init(ctx context.Context) error {
 	)
 
 	if a.teleport == nil {
-		if a.teleport, err = common.GetTeleportClient(ctx, a.conf.Teleport); err != nil {
+		if a.teleport, err = common.GetTeleportClient(clientCtx, a.conf.Teleport); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/integrations/access/servicenow/app.go
+++ b/integrations/access/servicenow/app.go
@@ -164,12 +164,15 @@ func (a *App) run(ctx context.Context) error {
 }
 
 func (a *App) init(ctx context.Context) error {
+	// Preserve the parent context without deadline for the client and its
+	// goroutines (IdentityFileWatcher) which will outlive init.
+	clientCtx := ctx
 	ctx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
 	log := logger.Get(ctx)
 
 	var err error
-	a.teleport, err = a.conf.GetTeleportClient(ctx)
+	a.teleport, err = a.conf.GetTeleportClient(clientCtx)
 	if err != nil {
 		return trace.Wrap(err, "getting teleport client")
 	}

--- a/integrations/lib/config.go
+++ b/integrations/lib/config.go
@@ -132,12 +132,15 @@ func NewIdentityFileWatcher(ctx context.Context, path string, interval time.Dura
 		for {
 			select {
 			case <-ctx.Done():
+				log.Debug("Stopping identity file watcher", "error", ctx.Err())
 				return
 			case <-timer.C:
 			}
 
 			if err := dynamicCred.Reload(); err != nil {
 				log.WithError(err).Error("Failed to reload identity file from disk.")
+			} else if expiry, ok := dynamicCred.Expiry(); ok {
+				log.Debug("Reloaded identity file from disk", "path", path, "expires", expiry)
 			}
 			timer.Reset(interval)
 		}
@@ -182,9 +185,12 @@ func (cfg TeleportConfig) NewClient(ctx context.Context) (*client.Client, error)
 		log.Info("At least one non-expired credential has been found, continuing startup")
 	}
 
+	dialCtx, cancel := context.WithTimeout(ctx, initTimeout)
+	defer cancel()
+
 	bk := grpcbackoff.DefaultConfig
 	bk.MaxDelay = grpcBackoffMaxDelay
-	clt, err := client.New(ctx, client.Config{
+	clt, err := client.New(dialCtx, client.Config{
 		Addrs:       []string{addr},
 		Credentials: creds,
 		DialOpts: []grpc.DialOption{


### PR DESCRIPTION
Backport #69198 to branch/v17

changelog: Fixed an issue where the access plugins would silently fail to reload credentials refreshed by `tbot` and exit as soon as its current connection is disrupted.

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Slack plugin reloads credentials every `refresh_identity_interval` (now denoted by a debug log)
- [x] When the plugin's connection to Auth is disrupted and it's original credentials are expired, it successfully reconnects with refreshed credentials