### PR TITLE
Add spiffe-tls to supported CA overrides and create mapper func.

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -792,7 +792,7 @@ Flags:
 |---|---|---|
 |`--[no-]disabled`|`false`|If true creates a disabled override|
 |`--[no-]force`|`false`|If true attempts to force creation, ignoring select state validation|
-|`--type`|*no default*|CA type (db-client, windows)|
+|`--type`|*no default*|CA type (db-client, spiffe-tls, windows)|
 
 Arguments:
 
@@ -819,7 +819,7 @@ Flags:
 |`--out`|*no default*|If set writes CSRs to files using --out as the path prefix|
 |`--public-key`|*no default*|Public key hash of CA certificate to be targeted|
 |`--subject`|*no default*|Customized certificate subject. Example: "O=MyClusterName,OU=MyOrgUnit,CN=MyCommonName"|
-|`--type`|*no default*|CA type (db-client, windows)|
+|`--type`|*no default*|CA type (db-client, spiffe-tls, windows)|
 
 ## tctl auth crl
 
@@ -855,7 +855,7 @@ Flags:
 |---|---|---|
 |`--[no-]force`|`false`|If true attempts to force deletion. May be used to delete live overrides.|
 |`--public-key`|*no default*|Public key hash of the certificate override to be targeted|
-|`--type`|*no default*|CA type (db-client, windows)|
+|`--type`|*no default*|CA type (db-client, spiffe-tls, windows)|
 
 ## tctl auth export
 
@@ -986,7 +986,7 @@ Flags:
 |`--set-cert`|*no default*|CA override certificate file in PEM form|
 |`--set-chain`|*no default*|CA override trust chain files in PEM form|
 |`--set-disabled`|*no default* (one of: `true`, `false`)|If true disables the override, if false enables it|
-|`--type`|*no default*|CA type (db-client, windows)|
+|`--type`|*no default*|CA type (db-client, spiffe-tls, windows)|
 
 ## tctl autoupdate agents mark-done
 

--- a/lib/subca/parsed.go
+++ b/lib/subca/parsed.go
@@ -37,16 +37,32 @@ func SupportedCATypes() []string {
 	return slices.Clone(allowedCAOverrideSubKinds)
 }
 
+// SPIFFECAOverrideSubKind is the sub_kind for SPIFFE CA overrides.
+// The SPIFFE CA has both X.509 (TLS) and JWT signing components, and this
+// sub_kind targets the TLS signing component.
+const SPIFFECAOverrideSubKind = "spiffe-tls"
+
 var (
 	allowedCAOverrideSubKinds = []string{
 		string(types.DatabaseClientCA),
 		string(types.WindowsCA),
+		SPIFFECAOverrideSubKind,
 	}
 
 	// Public keys are printed as HEX(SHA256(...)), therefore it's a hex string
 	// with exactly 64 characters. See PublicKeyHash.
 	certificateOverridePublicKeyRE = regexp.MustCompile(`^[0-9A-Fa-f]{64}$`)
 )
+
+// SubKindToCertAuthType maps a CA override sub_kind to its CertAuthType.
+func SubKindToCertAuthType(subKind string) types.CertAuthType {
+	switch subKind {
+	case SPIFFECAOverrideSubKind:
+		return types.SPIFFECA
+	default:
+		return types.CertAuthType(subKind)
+	}
+}
 
 // ParsedCertAuthorityOverride is a CertAuthorityOverride with a
 // ParsedCertificateOverride list.

--- a/lib/subca/parsed.go
+++ b/lib/subca/parsed.go
@@ -45,8 +45,8 @@ const SPIFFECAOverrideSubKind = "spiffe-tls"
 var (
 	allowedCAOverrideSubKinds = []string{
 		string(types.DatabaseClientCA),
-		string(types.WindowsCA),
 		SPIFFECAOverrideSubKind,
+		string(types.WindowsCA),
 	}
 
 	// Public keys are printed as HEX(SHA256(...)), therefore it's a hex string

--- a/lib/subca/parsed_test.go
+++ b/lib/subca/parsed_test.go
@@ -525,3 +525,21 @@ func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
 		}
 	})
 }
+
+func TestSubKindToCertAuthType(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		subKind string
+		want    types.CertAuthType
+	}{
+		{subKind: string(types.DatabaseClientCA), want: types.DatabaseClientCA},
+		{subKind: string(types.WindowsCA), want: types.WindowsCA},
+		{subKind: subca.SPIFFECAOverrideSubKind, want: types.SPIFFECA},
+	} {
+		t.Run(tt.subKind, func(t *testing.T) {
+			got := subca.SubKindToCertAuthType(tt.subKind)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/lib/subca/parsed_test.go
+++ b/lib/subca/parsed_test.go
@@ -529,17 +529,18 @@ func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
 func TestSubKindToCertAuthType(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range []struct {
-		subKind string
-		want    types.CertAuthType
-	}{
-		{subKind: string(types.DatabaseClientCA), want: types.DatabaseClientCA},
-		{subKind: string(types.WindowsCA), want: types.WindowsCA},
-		{subKind: subca.SPIFFECAOverrideSubKind, want: types.SPIFFECA},
-	} {
-		t.Run(tt.subKind, func(t *testing.T) {
-			got := subca.SubKindToCertAuthType(tt.subKind)
-			assert.Equal(t, tt.want, got)
-		})
+	want := map[string]types.CertAuthType{
+		string(types.DatabaseClientCA): types.DatabaseClientCA,
+		subca.SPIFFECAOverrideSubKind:  types.SPIFFECA,
+		string(types.WindowsCA):        types.WindowsCA,
 	}
+
+	for _, subKind := range subca.SupportedCATypes() {
+		expected, ok := want[subKind]
+		assert.True(t, ok, "missing test case for %s", subKind)
+		assert.Equal(t, expected, subca.SubKindToCertAuthType(subKind))
+	}
+
+	// Ensure types.SPIFFECA ("spiffe") passes through unmodified.
+	assert.Equal(t, types.SPIFFECA, subca.SubKindToCertAuthType(string(types.SPIFFECA)))
 }

--- a/lib/subca/parsed_test.go
+++ b/lib/subca/parsed_test.go
@@ -529,15 +529,15 @@ func TestValidateAndParseCAOverride_ParsedResource(t *testing.T) {
 func TestSubKindToCertAuthType(t *testing.T) {
 	t.Parallel()
 
-	want := map[string]types.CertAuthType{
-		string(types.DatabaseClientCA): types.DatabaseClientCA,
+	specialsMap := map[string]types.CertAuthType{
 		subca.SPIFFECAOverrideSubKind:  types.SPIFFECA,
-		string(types.WindowsCA):        types.WindowsCA,
 	}
 
 	for _, subKind := range subca.SupportedCATypes() {
-		expected, ok := want[subKind]
-		assert.True(t, ok, "missing test case for %s", subKind)
+		expected := types.CertAuthType(subKind)
+		if val, ok := specialsMap[subKind]; ok {
+			expected = val
+		}
 		assert.Equal(t, expected, subca.SubKindToCertAuthType(subKind))
 	}
 

--- a/lib/subca/parsed_test.go
+++ b/lib/subca/parsed_test.go
@@ -530,7 +530,7 @@ func TestSubKindToCertAuthType(t *testing.T) {
 	t.Parallel()
 
 	specialsMap := map[string]types.CertAuthType{
-		subca.SPIFFECAOverrideSubKind:  types.SPIFFECA,
+		subca.SPIFFECAOverrideSubKind: types.SPIFFECA,
 	}
 
 	for _, subKind := range subca.SupportedCATypes() {

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -307,8 +307,9 @@ func TestMakeCATypeNames(t *testing.T) {
 	want := []string{
 		"db-client",
 		"windows",
+		"spiffe-tls",
 	}
-	assert.Equal(t, want, got.Names, ""+
+	assert.ElementsMatch(t, want, got.Names, ""+
 		"CAType names mismatch. "+
 		"This is likely because a new entry was added to subca.SupportedCATypes(). "+
 		"Verify the newly added name and, if working as intended, add it to want list above.",

--- a/tool/tctl/common/subca/subca_command_test.go
+++ b/tool/tctl/common/subca/subca_command_test.go
@@ -306,10 +306,10 @@ func TestMakeCATypeNames(t *testing.T) {
 	got := subca.MakeCATypeNames()
 	want := []string{
 		"db-client",
-		"windows",
 		"spiffe-tls",
+		"windows",
 	}
-	assert.ElementsMatch(t, want, got.Names, ""+
+	assert.Equal(t, want, got.Names, ""+
 		"CAType names mismatch. "+
 		"This is likely because a new entry was added to subca.SupportedCATypes(). "+
 		"Verify the newly added name and, if working as intended, add it to want list above.",


### PR DESCRIPTION
Part of https://github.com/gravitational/core/issues/103.

Defines the [spiffe-tls](https://github.com/gravitational/teleport/blob/master/rfd/0237-sub-ca-support.md#spiffe-issuer-overrides) CA override sub-kind and a mapper func that maps the sub-kind to the `types.CertAuthType`. Important: SPIFFE CA is a special case and unlike the others that are pre-existing, hence why the mapper func is necessary. The mapper func will be used later and this change is setting it up in advance.