### PR TITLE
Cluster-scope resource constraint matcher correlation

### DIFF
--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -235,6 +235,12 @@ type AccessResourcesGetter interface {
 	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
 	ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
 
+	// GetClusterName returns the name of the cluster the getter reads from.
+	// The getter lists resources from that cluster whatever cluster a
+	// requested resource ID names. Callers correlating IDs back to those
+	// resources need the name (see services.BuildResourceConstraintMatchers).
+	GetClusterName(ctx context.Context) (types.ClusterName, error)
+
 	GetAccessList(context.Context, string) (*accesslist.AccessList, error)
 	GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, error)
 

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1795,7 +1795,7 @@ func (m *RequestValidator) getRequestableRoles(ctx context.Context, identity tls
 	constraintMatchers := make([][]RoleMatcher, 0, len(underlyingResources))
 	for _, resource := range underlyingResources {
 		if err := accessChecker.CheckAccess(resource, AccessState{MFAVerified: true}); err == nil {
-			matchers, err := BuildResourceConstraintMatchers(resourceAccessIDs, resource)
+			matchers, err := BuildResourceConstraintMatchers(resourceAccessIDs, resource, cluster.GetClusterName())
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/services/resource_constraints.go
+++ b/lib/services/resource_constraints.go
@@ -118,22 +118,32 @@ func buildStringConstraintTransform(
 
 // BuildResourceConstraintMatchers returns RoleMatchers derived from any
 // ResourceConstraints requested for the given resource, correlating the
-// resource against resourceAccessIDs by kind and name. Entries without
-// constraints contribute no matchers, so resource kinds that cannot carry
-// constraints are unaffected.
+// resource against resourceAccessIDs by kind, name, and cluster. Entries
+// without constraints contribute no matchers, so resource kinds that cannot
+// carry constraints are unaffected.
 //
 // Correlating by kind and name mirrors how requested resources are looked up
-// from their IDs (see [accessrequest.GetResourcesByResourceIDs]); callers are
-// expected to pass resources and resourceAccessIDs scoped to the same cluster.
+// from their IDs (see [accessrequest.GetResourcesByResourceIDs]). That lookup
+// reads from the local cluster whatever cluster an ID names. An entry scoped
+// to a foreign cluster can therefore correlate to a same-named local
+// resource, and the cluster check keeps its constraints from applying there.
+//
+// An entry with no ClusterName counts as local. An empty localCluster skips
+// the check and keeps every entry. That is looser than enforcement-side
+// correlation, and it means a caller that cannot resolve the local cluster
+// name never silently drops constraints.
 //
 // TODO(kiosion): When constraints extend for Kubernetes support, kube sub-resource
 // IDs need name-only correlation against the kube_cluster resource, like
 // getKubeResourcesFromResourceIDs
-func BuildResourceConstraintMatchers(resourceAccessIDs []types.ResourceAccessID, resource types.Resource) ([]RoleMatcher, error) {
+func BuildResourceConstraintMatchers(resourceAccessIDs []types.ResourceAccessID, resource types.Resource, localCluster string) ([]RoleMatcher, error) {
 	var matchers []RoleMatcher
 	for _, raid := range resourceAccessIDs {
 		rid := raid.GetResourceID()
 		if rid.Name != resource.GetName() || rid.Kind != resource.GetKind() {
+			continue
+		}
+		if localCluster != "" && rid.ClusterName != "" && rid.ClusterName != localCluster {
 			continue
 		}
 		rm, err := MatcherFromConstraints(raid.GetConstraints())

--- a/lib/services/resource_constraints_test.go
+++ b/lib/services/resource_constraints_test.go
@@ -228,7 +228,7 @@ func TestBuildResourceConstraintMatchers(t *testing.T) {
 				Id:          types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "node-1"},
 				Constraints: sshConstraints,
 			},
-		}, node)
+		}, node, "cluster")
 		require.NoError(t, err)
 		require.Len(t, matchers, 1)
 
@@ -244,7 +244,7 @@ func TestBuildResourceConstraintMatchers(t *testing.T) {
 	t.Run("entries without constraints yield no matchers", func(t *testing.T) {
 		matchers, err := BuildResourceConstraintMatchers([]types.ResourceAccessID{
 			{Id: types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "node-1"}},
-		}, node)
+		}, node, "cluster")
 		require.NoError(t, err)
 		require.Empty(t, matchers)
 	})
@@ -259,7 +259,7 @@ func TestBuildResourceConstraintMatchers(t *testing.T) {
 				Id:          types.ResourceID{ClusterName: "cluster", Kind: types.KindApp, Name: "node-1"},
 				Constraints: sshConstraints,
 			},
-		}, node)
+		}, node, "cluster")
 		require.NoError(t, err)
 		require.Empty(t, matchers)
 	})
@@ -274,8 +274,70 @@ func TestBuildResourceConstraintMatchers(t *testing.T) {
 					},
 				},
 			},
-		}, node)
+		}, node, "cluster")
 		require.Error(t, err)
+	})
+
+	t.Run("foreign-cluster entries for a same-named resource yield no matchers", func(t *testing.T) {
+		matchers, err := BuildResourceConstraintMatchers([]types.ResourceAccessID{
+			{
+				Id:          types.ResourceID{ClusterName: "leaf", Kind: types.KindNode, Name: "node-1"},
+				Constraints: sshConstraints,
+			},
+		}, node, "cluster")
+		require.NoError(t, err)
+		require.Empty(t, matchers)
+	})
+
+	t.Run("cross-cluster same-named pair only contributes the local entry", func(t *testing.T) {
+		rootConstraints := &types.ResourceConstraints{
+			Details: &types.ResourceConstraints_Ssh{
+				Ssh: &types.SSHResourceConstraints{Logins: []string{"root"}},
+			},
+		}
+		matchers, err := BuildResourceConstraintMatchers([]types.ResourceAccessID{
+			{
+				Id:          types.ResourceID{ClusterName: "leaf", Kind: types.KindNode, Name: "node-1"},
+				Constraints: rootConstraints,
+			},
+			{
+				Id:          types.ResourceID{ClusterName: "cluster", Kind: types.KindNode, Name: "node-1"},
+				Constraints: sshConstraints,
+			},
+		}, node, "cluster")
+		require.NoError(t, err)
+		require.Len(t, matchers, 1)
+
+		// Only the local entry's login matches. The foreign entry's does not.
+		ok, err := matchers[0].Match(roleAllowingSSHLogins("ubuntu"), types.Allow)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		ok, err = matchers[0].Match(roleAllowingSSHLogins("root"), types.Allow)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("entries without a cluster name are treated as local", func(t *testing.T) {
+		matchers, err := BuildResourceConstraintMatchers([]types.ResourceAccessID{
+			{
+				Id:          types.ResourceID{Kind: types.KindNode, Name: "node-1"},
+				Constraints: sshConstraints,
+			},
+		}, node, "cluster")
+		require.NoError(t, err)
+		require.Len(t, matchers, 1)
+	})
+
+	t.Run("unknown local cluster keeps all entries", func(t *testing.T) {
+		matchers, err := BuildResourceConstraintMatchers([]types.ResourceAccessID{
+			{
+				Id:          types.ResourceID{ClusterName: "leaf", Kind: types.KindNode, Name: "node-1"},
+				Constraints: sshConstraints,
+			},
+		}, node, "")
+		require.NoError(t, err)
+		require.Len(t, matchers, 1)
 	})
 }
 


### PR DESCRIPTION
## Context
`BuildResourceConstraintMatchers` correlates a resolved resource with the requested resource IDs carrying constraints for it, only matching on kind and name currently. The lookup that produced those resources also currently ignores the cluster on ID names. `accessrequest.GetResourcesByResourceIDs` buckets IDs by kind and lists by name against whatever cluster the client reads from. On a root cluster a request for `/leaf/node/node-01` resolves to the root's own `node-01` (if one exists), and the leaf entry's constraints applied there.

## Changes
Correlation now takes the local cluster name and skips entries scoped elsewhere. `modules.AccessResourcesGetter` gains `GetClusterName` because the enterprise callers only hold the getter.

## Related
- Requires/required by gravitational/teleport.e#9339

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
