### PR TITLE
add scoped verb transition shim

### DIFF
--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -17,6 +17,21 @@ package access
 
 import "github.com/gravitational/teleport/api/types"
 
+// Verb is an alias that allows current teleport code to import a scopedaccess.Verb type
+// compatible with the current ScopedAccessChecker.CheckAccessToRules signature. A future commit
+// will switch this over to being a proper enum type, but we need this intermediate state to
+// avoid breaking CI.
+type Verb = string
+
+const (
+	Create  Verb = types.VerbCreate
+	Read    Verb = types.VerbReadNoSecrets
+	Update  Verb = types.VerbUpdate
+	Delete  Verb = types.VerbDelete
+	List    Verb = types.VerbList
+	Secrets Verb = types.VerbRead
+)
+
 // isAllowedScopedVerb returns true if the given verb is allowed for the given scoped resource kind. Scoped roles are not sane
 // for use with all resource kind/verb combinations, so we restrict the allowed combinations here.
 func isAllowedScopedRule(kind string, verb string) bool {


### PR DESCRIPTION
Adds type alias and constants to `lib/scopes/access` which mirror the new verb type and verb constants introduced in https://github.com/gravitational/teleport/pull/69232.  These are designed to allow scoped access checks in `e` to be updated to use the new syntax before we actually merge https://github.com/gravitational/teleport/pull/69232.  Without this, we'd temporarily break `e` when merging it.

Note that these new constants map `types.VerbReadNoSecrets` to `scopedaccess.Read` and `types.VerbRead` to `scopedaccess.Secrets`.  This is an intentional remapping, and consistent with the deeper remapping done in https://github.com/gravitational/teleport/pull/69232.  Intermediate and final behavior remain correct.