### PR TITLE
Update Terraform modules

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -3,6 +3,10 @@ title: Reference for the teleport-discovery-aws Terraform module
 sidebar_label: teleport-discovery-aws
 description: This page describes the teleport-discovery-aws Terraform module.
 page_type: reference
+tags:
+ - infrastructure-as-code
+ - reference
+ - platform-wide
 ---
 
 {/*

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/teleport-discovery-azure.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-azure/teleport-discovery-azure.mdx
@@ -3,6 +3,10 @@ title: Reference for the teleport-discovery-azure Terraform module
 sidebar_label: teleport-discovery-azure
 description: This page describes the teleport-discovery-azure Terraform module.
 page_type: reference
+tags:
+ - infrastructure-as-code
+ - reference
+ - platform-wide
 ---
 
 {/*

--- a/integrations/terraform-modules/gen/docs.sh
+++ b/integrations/terraform-modules/gen/docs.sh
@@ -99,6 +99,10 @@ title: Reference for the ${module_name} Terraform module
 sidebar_label: ${module_name}
 description: This page describes the ${module_name} Terraform module.
 page_type: reference
+tags:
+ - infrastructure-as-code
+ - reference
+ - platform-wide
 ---
 
 {/*

--- a/integrations/terraform-modules/teleport/container-service/aws/README.md
+++ b/integrations/terraform-modules/teleport/container-service/aws/README.md
@@ -115,5 +115,6 @@ No modules.
 | ecs\_task\_role\_arn | The ARN of the task IAM role for the Teleport agent ECS task. |
 | ecs\_task\_role\_name | The name of the task IAM role for the Teleport agent ECS task. |
 | security\_group\_id | Security group ID created for the Teleport agent ECS service. |
+| teleport\_config | Teleport configuration used by the ECS task. |
 | teleport\_provision\_token\_allow\_aws\_arn | A value that can be used with a Teleport IAM join token to allow the ECS cluster to join the Teleport cluster using its IAM credentials. |
 <!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/container-service/aws/README.md
+++ b/integrations/terraform-modules/teleport/container-service/aws/README.md
@@ -69,13 +69,13 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | apply\_aws\_tags | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
-| assign\_public\_ip | Whether to assign public IP addresses to Teleport agent ECS tasks. If this is set to true, then var.ecs\_service\_subnets must be public subnets (route to an internet gateway). Otherwise, var.ecs\_service\_subnets must be private subnets (route to a NAT gateway). | `bool` | `false` | no |
+| assign\_public\_ip | Whether to assign public IP addresses to Teleport ECS tasks. If this is set to true, then var.ecs\_service\_subnets must be public subnets (route to an internet gateway). Otherwise, var.ecs\_service\_subnets must be private subnets (route to a NAT gateway). | `bool` | `false` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
-| create\_security\_group | Whether to create a security group for the Teleport agent ECS tasks. | `bool` | `true` | no |
+| create\_security\_group | Whether to create a security group for the Teleport ECS tasks. | `bool` | `true` | no |
 | ecs\_cluster\_name | Name of the ECS cluster. | `string` | `"teleport"` | no |
 | ecs\_cluster\_use\_name\_prefix | Determines whether `var.ecs_cluster_name` is used as a prefix of the ECS cluster name. | `bool` | `true` | no |
-| ecs\_service\_name | Name of the ECS service. | `string` | `"teleport-service"` | no |
-| ecs\_service\_subnets | Subnet IDs where the Teleport agent will be deployed. If var.assign\_public\_ip is true, then all of these subnets must be public subnets (route to an internet gateway). If var.assign\_public\_ip is false, then all of these subnets must be private subnets (route to a NAT gateway). | `list(string)` | n/a | yes |
+| ecs\_service\_name | Name of the ECS service. | `string` | `"teleport"` | no |
+| ecs\_service\_subnets | Subnet IDs where Teleport will be deployed. If var.assign\_public\_ip is true, then all of these subnets must be public subnets (route to an internet gateway). If var.assign\_public\_ip is false, then all of these subnets must be private subnets (route to a NAT gateway). | `list(string)` | n/a | yes |
 | ecs\_task\_cloudwatch\_log\_group\_kms\_key\_id | KMS key ID or ARN used to encrypt the ECS task CloudWatch log group. When null, CloudWatch Logs uses its default encryption key. | `string` | `null` | no |
 | ecs\_task\_cloudwatch\_log\_group\_name | Name for the ECS task CloudWatch log group. | `string` | `"ecs-teleport"` | no |
 | ecs\_task\_cloudwatch\_log\_group\_region | AWS region for the ECS task CloudWatch log group. Defaults to the AWS provider region. | `string` | `null` | no |
@@ -83,7 +83,7 @@ No modules.
 | ecs\_task\_cloudwatch\_log\_group\_skip\_destroy | Whether to preserve the ECS task CloudWatch log group when destroying module resources. Set to true if you do not wish the log group (and any logs it may contain) to be deleted at destroy time, and instead just remove the log group from the Terraform state. | `bool` | `false` | no |
 | ecs\_task\_cloudwatch\_log\_group\_use\_name\_prefix | Determines whether `var.ecs_task_cloudwatch_log_group_name` is used as a prefix of the ECS task CloudWatch log group name. | `bool` | `true` | no |
 | ecs\_task\_cpu | Number of cpu units used by the ECS task. | `number` | `2048` | no |
-| ecs\_task\_definition\_name | Name of the ECS task. | `string` | `"teleport-agent"` | no |
+| ecs\_task\_definition\_name | Name of the ECS task. | `string` | `"teleport"` | no |
 | ecs\_task\_definition\_use\_name\_prefix | Determines whether `var.ecs_task_definition_name` is used as a prefix of the ECS task definition name. | `bool` | `true` | no |
 | ecs\_task\_desired\_count | Desired number of Teleport ECS tasks to run. | `number` | `2` | no |
 | ecs\_task\_force\_new\_deployment | Set to true to force the ECS service to redeploy tasks without configuration changes. | `bool` | `false` | no |
@@ -91,13 +91,13 @@ No modules.
 | ecs\_task\_role\_inline\_policy | Optional JSON policy document to merge into the inline policy attached to the ECS task IAM role. | `string` | `null` | no |
 | ecs\_task\_role\_self\_assumption\_allowed | Whether the ECS task IAM role can assume itself. | `bool` | `true` | no |
 | environment\_vars | Environment variables to set on the Teleport ECS container. | `map(string)` | `{}` | no |
-| managed\_updates\_enabled | Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module. | `bool` | `true` | no |
+| managed\_updates\_enabled | Whether to resolve the Teleport version from the configured Managed Updates endpoint when applying this module. | `bool` | `true` | no |
 | managed\_updates\_group | Update group to query through the v2 Managed Updates endpoint. | `string` | `"default"` | no |
-| security\_group\_ids | Additional security group IDs to attach to the Teleport agent ECS tasks. | `list(string)` | `[]` | no |
+| security\_group\_ids | Additional security group IDs to attach to the Teleport ECS tasks. | `list(string)` | `[]` | no |
 | teleport\_config | Teleport configuration. Write the configuration using native Terraform syntax. Warning: sensitive data, such as static join tokens, is visible to anyone who can read the task definition. | `any` | n/a | yes |
 | teleport\_container\_image | Container image used for Teleport ECS tasks. | `string` | `"public.ecr.aws/gravitational/teleport-ent-distroless"` | no |
 | teleport\_version | The version of Teleport to deploy. Generally, the version of Teleport should be controlled by using the appropriate version of this module. This variable is intended for development usage. | `string` | `"19.0.0-prealpha.2"` | no |
-| vpc\_id | VPC ID where the Teleport agent will be deployed. | `string` | n/a | yes |
+| vpc\_id | VPC ID where Teleport will be deployed. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/integrations/terraform-modules/teleport/container-service/aws/README.md
+++ b/integrations/terraform-modules/teleport/container-service/aws/README.md
@@ -91,7 +91,7 @@ No modules.
 | ecs\_task\_role\_inline\_policy | Optional JSON policy document to merge into the inline policy attached to the ECS task IAM role. | `string` | `null` | no |
 | ecs\_task\_role\_self\_assumption\_allowed | Whether the ECS task IAM role can assume itself. | `bool` | `true` | no |
 | environment\_vars | Environment variables to set on the Teleport ECS container. | `map(string)` | `{}` | no |
-| managed\_updates\_enabled | Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module. | `bool` | `false` | no |
+| managed\_updates\_enabled | Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module. | `bool` | `true` | no |
 | managed\_updates\_group | Update group to query through the v2 Managed Updates endpoint. | `string` | `"default"` | no |
 | security\_group\_ids | Additional security group IDs to attach to the Teleport agent ECS tasks. | `list(string)` | `[]` | no |
 | teleport\_config | Teleport configuration. Write the configuration using native Terraform syntax. Warning: sensitive data, such as static join tokens, is visible to anyone who can read the task definition. | `any` | n/a | yes |

--- a/integrations/terraform-modules/teleport/container-service/aws/aws_task_execution_role.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/aws_task_execution_role.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "ecs_execution_trust" {
       test = "ArnLike"
       values = [
         format(
-          "arn:%s:ecs:%s:%s:*",
+          "arn:%v:ecs:%v:%v:*",
           one(data.aws_partition.this[*].partition),
           one(data.aws_region.this[*].region),
           one(data.aws_caller_identity.this[*].account_id),

--- a/integrations/terraform-modules/teleport/container-service/aws/aws_task_role.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/aws_task_role.tf
@@ -13,7 +13,7 @@ locals {
     one(random_string.name_suffix[*].result),
   )
   ecs_task_role_arn = format(
-    "arn:%s:iam::%s:role/%s",
+    "arn:%v:iam::%v:role/%v",
     one(data.aws_partition.this[*].partition),
     one(data.aws_caller_identity.this[*].account_id),
     local.ecs_task_role_name,
@@ -76,7 +76,7 @@ data "aws_iam_policy_document" "ecs_task_trust" {
       test = "ArnLike"
       values = [
         format(
-          "arn:%s:ecs:%s:%s:*",
+          "arn:%v:ecs:%v:%v:*",
           one(data.aws_partition.this[*].partition),
           one(data.aws_region.this[*].region),
           one(data.aws_caller_identity.this[*].account_id),
@@ -107,7 +107,7 @@ data "aws_iam_policy_document" "ecs_task_trust" {
 
       principals {
         identifiers = [format(
-          "arn:%s:iam::%s:root",
+          "arn:%v:iam::%v:root",
           one(data.aws_partition.this[*].partition),
           one(data.aws_caller_identity.this[*].account_id),
         )]

--- a/integrations/terraform-modules/teleport/container-service/aws/data.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/data.tf
@@ -20,7 +20,7 @@ data "http" "managed_updates" {
   count = var.create && var.managed_updates_enabled ? 1 : 0
 
   url = format(
-    "https://%s/webapi/find?group=%s",
+    "https://%v/webapi/find?group=%v",
     local.managed_updates_proxy_addr,
     urlencode(coalesce(var.managed_updates_group, "default")),
   )

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/README.md
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/README.md
@@ -37,7 +37,7 @@ This example deploys the Teleport Database Service to AWS ECS and joins it to an
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| teleport\_proxy\_addr | The address of the Teleport proxy service in host:port form. | `string` | n/a | yes |
+| teleport\_proxy\_addr | The address of the Teleport Proxy Service in host:port form. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/docs_description
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/docs_description
@@ -1,1 +1,1 @@
-Deploy Teleport Database Service to ECS
+Deploy Teleport Database Service to ECS.

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/main.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/main.tf
@@ -27,7 +27,6 @@ module "teleport_database_service" {
   ecs_service_name       = "${local.namespace}-svc"
   ecs_service_subnets    = module.vpc.public_subnets
   ecs_task_desired_count = 1
-  ecs_task_name          = "${local.namespace}-task"
   environment_vars       = { EXAMPLE_VAR = "EXAMPLE_VALUE" }
   vpc_id                 = module.vpc.vpc_id
 

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/variables.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/variables.tf
@@ -1,4 +1,4 @@
 variable "teleport_proxy_addr" {
-  description = "The address of the Teleport proxy service in host:port form."
+  description = "The address of the Teleport Proxy Service in host:port form."
   type        = string
 }

--- a/integrations/terraform-modules/teleport/container-service/aws/outputs.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/outputs.tf
@@ -65,7 +65,7 @@ EOF
   value = (
     var.create
     ? format(
-      "arn:%s:sts::%s:assumed-role/%s/*",
+      "arn:%v:sts::%v:assumed-role/%v/*",
       one(data.aws_partition.this[*].partition),
       one(data.aws_caller_identity.this[*].account_id),
       one(aws_iam_role.ecs_task[*].name),

--- a/integrations/terraform-modules/teleport/container-service/aws/outputs.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/outputs.tf
@@ -73,3 +73,8 @@ EOF
     : null
   )
 }
+
+output "teleport_config" {
+  description = "Teleport configuration used by the ECS task."
+  value       = var.create ? var.teleport_config : null
+}

--- a/integrations/terraform-modules/teleport/container-service/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/variables.tf
@@ -32,7 +32,7 @@ variable "apply_aws_tags" {
 }
 
 variable "managed_updates_enabled" {
-  default     = false
+  default     = true
   description = "Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module."
   type        = bool
 }

--- a/integrations/terraform-modules/teleport/container-service/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/variables.tf
@@ -4,7 +4,7 @@
 
 variable "ecs_service_subnets" {
   description = <<EOF
-Subnet IDs where the Teleport agent will be deployed.
+Subnet IDs where Teleport will be deployed.
 If var.assign_public_ip is true, then all of these subnets must be public subnets (route to an internet gateway).
 If var.assign_public_ip is false, then all of these subnets must be private subnets (route to a NAT gateway).
 EOF
@@ -12,7 +12,7 @@ EOF
 }
 
 variable "vpc_id" {
-  description = "VPC ID where the Teleport agent will be deployed."
+  description = "VPC ID where Teleport will be deployed."
   type        = string
 }
 
@@ -33,7 +33,7 @@ variable "apply_aws_tags" {
 
 variable "managed_updates_enabled" {
   default     = true
-  description = "Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module."
+  description = "Whether to resolve the Teleport version from the configured Managed Updates endpoint when applying this module."
   type        = bool
 }
 
@@ -46,7 +46,7 @@ variable "managed_updates_group" {
 variable "assign_public_ip" {
   default     = false
   description = <<EOF
-Whether to assign public IP addresses to Teleport agent ECS tasks.
+Whether to assign public IP addresses to Teleport ECS tasks.
 If this is set to true, then var.ecs_service_subnets must be public subnets (route to an internet gateway).
 Otherwise, var.ecs_service_subnets must be private subnets (route to a NAT gateway).
 EOF
@@ -61,7 +61,7 @@ variable "create" {
 
 variable "create_security_group" {
   default     = true
-  description = "Whether to create a security group for the Teleport agent ECS tasks."
+  description = "Whether to create a security group for the Teleport ECS tasks."
   type        = bool
 }
 
@@ -78,7 +78,7 @@ variable "ecs_cluster_use_name_prefix" {
 }
 
 variable "ecs_service_name" {
-  default     = "teleport-service"
+  default     = "teleport"
   description = "Name of the ECS service."
   type        = string
 }
@@ -131,7 +131,7 @@ variable "ecs_task_cpu" {
 }
 
 variable "ecs_task_definition_name" {
-  default     = "teleport-agent"
+  default     = "teleport"
   description = "Name of the ECS task."
   type        = string
 }
@@ -181,7 +181,7 @@ variable "environment_vars" {
 
 variable "security_group_ids" {
   default     = []
-  description = "Additional security group IDs to attach to the Teleport agent ECS tasks."
+  description = "Additional security group IDs to attach to the Teleport ECS tasks."
   type        = list(string)
 }
 

--- a/integrations/terraform-modules/teleport/db-agent/aws/README.md
+++ b/integrations/terraform-modules/teleport/db-agent/aws/README.md
@@ -55,6 +55,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| allow\_database\_modification | Whether to add RDS permissions that allow the Teleport Database agent to modify database configuration. | `bool` | `false` | no |
 | apply\_aws\_tags | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
 | assign\_public\_ip | Whether to assign public IP addresses to Teleport db agent ECS tasks. If this is set to true, then var.ecs\_service\_subnets must be public subnets (route to an internet gateway). Otherwise, var.ecs\_service\_subnets must be private subnets (route to a NAT gateway). | `bool` | `false` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |

--- a/integrations/terraform-modules/teleport/db-agent/aws/README.md
+++ b/integrations/terraform-modules/teleport/db-agent/aws/README.md
@@ -107,6 +107,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | ecs\_task\_role\_arn | The ARN of the task IAM role for the Teleport db agent ECS task. |
 | ecs\_task\_role\_name | The name of the task IAM role for the Teleport db agent ECS task. |
 | security\_group\_id | Security group ID created for the Teleport db agent ECS service. |
+| teleport\_config | Teleport configuration used by the db agent ECS task. |
 | teleport\_provision\_token\_allow\_aws\_arn | A value that can be used with a Teleport IAM join token to allow the ECS cluster to join the Teleport cluster using its IAM credentials. |
 | teleport\_provision\_token\_name | Name of the Teleport provision token that allows the db agent to join the cluster using AWS IAM credentials. |
 <!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/db-agent/aws/README.md
+++ b/integrations/terraform-modules/teleport/db-agent/aws/README.md
@@ -55,17 +55,17 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| allow\_database\_modification | Whether to add RDS permissions that allow the Teleport Database agent to modify database configuration. | `bool` | `false` | no |
+| allow\_database\_modification | Whether to add RDS permissions that allow the Teleport Database Service to modify database configuration. | `bool` | `false` | no |
 | apply\_aws\_tags | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
-| assign\_public\_ip | Whether to assign public IP addresses to Teleport db agent ECS tasks. If this is set to true, then var.ecs\_service\_subnets must be public subnets (route to an internet gateway). Otherwise, var.ecs\_service\_subnets must be private subnets (route to a NAT gateway). | `bool` | `false` | no |
+| assign\_public\_ip | Whether to assign public IP addresses to Teleport ECS tasks. If this is set to true, then var.ecs\_service\_subnets must be public subnets (route to an internet gateway). Otherwise, var.ecs\_service\_subnets must be private subnets (route to a NAT gateway). | `bool` | `false` | no |
 | create | Toggle creation of all resources. | `bool` | `true` | no |
-| create\_security\_group | Whether to create a security group for the Teleport db agent ECS tasks. | `bool` | `true` | no |
+| create\_security\_group | Whether to create a security group for the Teleport ECS tasks. | `bool` | `true` | no |
 | database\_service\_resources | Override the db\_service resource matchers. When null, a default matcher is used that matches databases in the same account, region, and VPC. | ```list(object({ labels = map(list(string)) aws = optional(object({ assume_role_arn = optional(string, "") external_id = optional(string, "") })) }))``` | `null` | no |
 | database\_types\_for\_default\_iam\_policy | Database types for which default IAM policy statements will be added to the ECS task role's inline policy. Currently, only `rds` is supported. Statements in the default IAM policy can be overridden by a statement with a matching SID in var.ecs\_task\_role\_inline\_policy. | `list(string)` | `[]` | no |
 | ecs\_cluster\_name | Name of the ECS cluster. | `string` | `"teleport-db-services"` | no |
 | ecs\_cluster\_use\_name\_prefix | Determines whether `var.ecs_cluster_name` is used as a prefix of the ECS cluster name. | `bool` | `true` | no |
 | ecs\_service\_name | Name of the ECS service. | `string` | `"teleport-db-service"` | no |
-| ecs\_service\_subnets | Subnet IDs where the Teleport db agent will be deployed. If var.assign\_public\_ip is true, then all of these subnets must be public subnets (route to an internet gateway). If var.assign\_public\_ip is false, then all of these subnets must be private subnets (route to a NAT gateway). | `list(string)` | n/a | yes |
+| ecs\_service\_subnets | Subnet IDs where Teleport will be deployed. If var.assign\_public\_ip is true, then all of these subnets must be public subnets (route to an internet gateway). If var.assign\_public\_ip is false, then all of these subnets must be private subnets (route to a NAT gateway). | `list(string)` | n/a | yes |
 | ecs\_task\_cloudwatch\_log\_group\_kms\_key\_id | KMS key ID or ARN used to encrypt the ECS task CloudWatch log group. When null, CloudWatch Logs uses its default encryption key. | `string` | `null` | no |
 | ecs\_task\_cloudwatch\_log\_group\_name | Name for the ECS task CloudWatch log group. | `string` | `"ecs-teleport"` | no |
 | ecs\_task\_cloudwatch\_log\_group\_region | AWS region for the ECS task CloudWatch log group. Defaults to the AWS provider region. | `string` | `null` | no |
@@ -75,40 +75,40 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | ecs\_task\_cpu | Number of CPU units used by the ECS task. | `number` | `2048` | no |
 | ecs\_task\_definition\_name | Name of the ECS task. | `string` | `"teleport-db-agent"` | no |
 | ecs\_task\_definition\_use\_name\_prefix | Determines whether `var.ecs_task_definition_name` is used as a prefix of the ECS task definition name. | `bool` | `true` | no |
-| ecs\_task\_desired\_count | Desired number of Teleport db agent ECS tasks to run. | `number` | `2` | no |
+| ecs\_task\_desired\_count | Desired number of Teleport ECS tasks to run. | `number` | `2` | no |
 | ecs\_task\_force\_new\_deployment | Set to true to force the ECS service to redeploy tasks without configuration changes. | `bool` | `false` | no |
 | ecs\_task\_memory | Amount (in MiB) of memory used by the ECS task. | `number` | `4096` | no |
 | ecs\_task\_role\_inline\_policy | Optional JSON policy document to merge into the inline policy attached to the ECS task IAM role. | `string` | `null` | no |
-| environment\_vars | Environment variables to set on the Teleport db agent ECS container. | `map(string)` | `{}` | no |
+| environment\_vars | Environment variables to set on the Teleport ECS container. | `map(string)` | `{}` | no |
 | join\_params | Override the Teleport join parameters. When null, the module creates an IAM join token automatically. Set this to use a pre-existing token or a different join method. | ```object({ token_name = string method = string })``` | `null` | no |
-| log\_level | Teleport agent log level. | `string` | `"INFO"` | no |
+| log\_level | Teleport log level. | `string` | `"INFO"` | no |
 | managed\_updates\_enabled | Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module. | `bool` | `true` | no |
 | managed\_updates\_group | Update group to query through the v2 Managed Updates endpoint. | `string` | `"default"` | no |
-| security\_group\_ids | Additional security group IDs to attach to the Teleport db agent ECS tasks. | `list(string)` | `[]` | no |
-| teleport\_container\_image | Container image used for the Teleport db agent ECS tasks. | `string` | `"public.ecr.aws/gravitational/teleport-ent-distroless"` | no |
+| security\_group\_ids | Additional security group IDs to attach to the Teleport ECS tasks. | `list(string)` | `[]` | no |
+| teleport\_container\_image | Container image used for the Teleport ECS tasks. | `string` | `"public.ecr.aws/gravitational/teleport-ent-distroless"` | no |
 | teleport\_provision\_token\_name | Name for the Teleport provision token resource. | `string` | `"iam-db-agent"` | no |
 | teleport\_provision\_token\_use\_name\_prefix | Determines whether the name of the Teleport provision token is used as a prefix. | `bool` | `true` | no |
 | teleport\_proxy\_public\_addr | Teleport cluster proxy public address `host:port`. | `string` | n/a | yes |
 | teleport\_version | The version of Teleport to deploy. Generally, the version of Teleport should be controlled by using the appropriate version of this module. This variable is intended for development usage. | `string` | `"19.0.0-prealpha.2"` | no |
-| vpc\_id | VPC ID where the Teleport db agent will be deployed. | `string` | n/a | yes |
+| vpc\_id | VPC ID where Teleport will be deployed. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 | ---- | ----------- |
-| ecs\_cluster\_arn | ARN of the ECS cluster for the Teleport db agent ECS service. |
-| ecs\_cluster\_name | Name of the ECS cluster for the Teleport db agent ECS service. |
-| ecs\_execution\_role\_arn | The ARN of the execution IAM role for the Teleport db agent ECS task. |
-| ecs\_execution\_role\_name | The name of the execution IAM role for the Teleport db agent ECS task. |
-| ecs\_service\_arn | ARN of the Teleport db agent ECS service. |
-| ecs\_service\_name | Name of the Teleport db agent ECS service. |
-| ecs\_task\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group for the Teleport db agent ECS task. |
-| ecs\_task\_cloudwatch\_log\_group\_name | Name of the CloudWatch log group for the Teleport db agent ECS task. |
-| ecs\_task\_definition\_arn | ARN of the Teleport db agent ECS task definition. |
-| ecs\_task\_role\_arn | The ARN of the task IAM role for the Teleport db agent ECS task. |
-| ecs\_task\_role\_name | The name of the task IAM role for the Teleport db agent ECS task. |
-| security\_group\_id | Security group ID created for the Teleport db agent ECS service. |
-| teleport\_config | Teleport configuration used by the db agent ECS task. |
+| ecs\_cluster\_arn | ARN of the ECS cluster for the Teleport ECS service. |
+| ecs\_cluster\_name | Name of the ECS cluster for the Teleport ECS service. |
+| ecs\_execution\_role\_arn | The ARN of the execution IAM role for the Teleport ECS task. |
+| ecs\_execution\_role\_name | The name of the execution IAM role for the Teleport ECS task. |
+| ecs\_service\_arn | ARN of the Teleport ECS service. |
+| ecs\_service\_name | Name of the Teleport ECS service. |
+| ecs\_task\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group for the Teleport ECS task. |
+| ecs\_task\_cloudwatch\_log\_group\_name | Name of the CloudWatch log group for the Teleport ECS task. |
+| ecs\_task\_definition\_arn | ARN of the Teleport ECS task definition. |
+| ecs\_task\_role\_arn | The ARN of the task IAM role for the Teleport ECS task. |
+| ecs\_task\_role\_name | The name of the task IAM role for the Teleport ECS task. |
+| security\_group\_id | Security group ID created for the Teleport ECS service. |
+| teleport\_config | Teleport configuration used by the ECS task. |
 | teleport\_provision\_token\_allow\_aws\_arn | A value that can be used with a Teleport IAM join token to allow the ECS cluster to join the Teleport cluster using its IAM credentials. |
-| teleport\_provision\_token\_name | Name of the Teleport provision token that allows the db agent to join the cluster using AWS IAM credentials. |
+| teleport\_provision\_token\_name | Name of the Teleport provision token that allows the to join the cluster using AWS IAM credentials. |
 <!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/db-agent/aws/README.md
+++ b/integrations/terraform-modules/teleport/db-agent/aws/README.md
@@ -86,7 +86,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | managed\_updates\_group | Update group to query through the v2 Managed Updates endpoint. | `string` | `"default"` | no |
 | security\_group\_ids | Additional security group IDs to attach to the Teleport db agent ECS tasks. | `list(string)` | `[]` | no |
 | teleport\_container\_image | Container image used for the Teleport db agent ECS tasks. | `string` | `"public.ecr.aws/gravitational/teleport-ent-distroless"` | no |
-| teleport\_provision\_token\_name | Name for the Teleport provision token resource. | `string` | `"db-agent"` | no |
+| teleport\_provision\_token\_name | Name for the Teleport provision token resource. | `string` | `"iam-db-agent"` | no |
 | teleport\_provision\_token\_use\_name\_prefix | Determines whether the name of the Teleport provision token is used as a prefix. | `bool` | `true` | no |
 | teleport\_proxy\_public\_addr | Teleport cluster proxy public address `host:port`. | `string` | n/a | yes |
 | teleport\_version | The version of Teleport to deploy. Generally, the version of Teleport should be controlled by using the appropriate version of this module. This variable is intended for development usage. | `string` | `"19.0.0-prealpha.2"` | no |

--- a/integrations/terraform-modules/teleport/db-agent/aws/README.md
+++ b/integrations/terraform-modules/teleport/db-agent/aws/README.md
@@ -81,7 +81,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | environment\_vars | Environment variables to set on the Teleport db agent ECS container. | `map(string)` | `{}` | no |
 | join\_params | Override the Teleport join parameters. When null, the module creates an IAM join token automatically. Set this to use a pre-existing token or a different join method. | ```object({ token_name = string method = string })``` | `null` | no |
 | log\_level | Teleport agent log level. | `string` | `"INFO"` | no |
-| managed\_updates\_enabled | Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module. | `bool` | `false` | no |
+| managed\_updates\_enabled | Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module. | `bool` | `true` | no |
 | managed\_updates\_group | Update group to query through the v2 Managed Updates endpoint. | `string` | `"default"` | no |
 | security\_group\_ids | Additional security group IDs to attach to the Teleport db agent ECS tasks. | `list(string)` | `[]` | no |
 | teleport\_container\_image | Container image used for the Teleport db agent ECS tasks. | `string` | `"public.ecr.aws/gravitational/teleport-ent-distroless"` | no |

--- a/integrations/terraform-modules/teleport/db-agent/aws/data.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/data.tf
@@ -26,7 +26,10 @@ data "aws_iam_policy_document" "ecs_task_inline_policy" {
   )
 
   dynamic "statement" {
-    for_each = contains(var.database_types_for_default_iam_policy, "rds") ? [true] : []
+    for_each = (
+      contains(var.database_types_for_default_iam_policy, "rds") &&
+      var.allow_database_modification
+    ) ? [true] : []
 
     content {
       sid = "RDSAutoEnableIAMAuth"

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/main.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/main.tf
@@ -24,6 +24,7 @@ module "teleport_db_agent" {
   vpc_id                     = module.vpc.vpc_id
 
   ecs_task_role_inline_policy           = data.aws_iam_policy_document.example_statement_override.json
+  allow_database_modification           = true
   database_types_for_default_iam_policy = ["rds"]
 }
 

--- a/integrations/terraform-modules/teleport/db-agent/aws/outputs.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/outputs.tf
@@ -65,7 +65,7 @@ output "teleport_provision_token_allow_aws_arn" {
 
 output "teleport_provision_token_name" {
   description = "Name of the Teleport provision token that allows the db agent to join the cluster using AWS IAM credentials."
-  value       = nonsensitive(try(teleport_provision_token.agent_aws_iam[0].metadata.name, null))
+  value       = try(nonsensitive(teleport_provision_token.agent_aws_iam[0].metadata.name), null)
 }
 
 output "teleport_config" {

--- a/integrations/terraform-modules/teleport/db-agent/aws/outputs.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/outputs.tf
@@ -1,60 +1,60 @@
 output "ecs_cluster_name" {
-  description = "Name of the ECS cluster for the Teleport db agent ECS service."
+  description = "Name of the ECS cluster for the Teleport ECS service."
   value       = module.teleport_db_service.ecs_cluster_name
 }
 
 output "ecs_cluster_arn" {
-  description = "ARN of the ECS cluster for the Teleport db agent ECS service."
+  description = "ARN of the ECS cluster for the Teleport ECS service."
   value       = module.teleport_db_service.ecs_cluster_arn
 }
 
 output "ecs_service_name" {
-  description = "Name of the Teleport db agent ECS service."
+  description = "Name of the Teleport ECS service."
   value       = module.teleport_db_service.ecs_service_name
 }
 
 output "ecs_service_arn" {
-  description = "ARN of the Teleport db agent ECS service."
+  description = "ARN of the Teleport ECS service."
   value       = module.teleport_db_service.ecs_service_arn
 }
 
 output "ecs_task_definition_arn" {
-  description = "ARN of the Teleport db agent ECS task definition."
+  description = "ARN of the Teleport ECS task definition."
   value       = module.teleport_db_service.ecs_task_definition_arn
 }
 
 output "ecs_task_cloudwatch_log_group_name" {
-  description = "Name of the CloudWatch log group for the Teleport db agent ECS task."
+  description = "Name of the CloudWatch log group for the Teleport ECS task."
   value       = module.teleport_db_service.ecs_task_cloudwatch_log_group_name
 }
 
 output "ecs_task_cloudwatch_log_group_arn" {
-  description = "ARN of the CloudWatch log group for the Teleport db agent ECS task."
+  description = "ARN of the CloudWatch log group for the Teleport ECS task."
   value       = module.teleport_db_service.ecs_task_cloudwatch_log_group_arn
 }
 
 output "security_group_id" {
-  description = "Security group ID created for the Teleport db agent ECS service."
+  description = "Security group ID created for the Teleport ECS service."
   value       = module.teleport_db_service.security_group_id
 }
 
 output "ecs_execution_role_arn" {
-  description = "The ARN of the execution IAM role for the Teleport db agent ECS task."
+  description = "The ARN of the execution IAM role for the Teleport ECS task."
   value       = module.teleport_db_service.ecs_execution_role_arn
 }
 
 output "ecs_execution_role_name" {
-  description = "The name of the execution IAM role for the Teleport db agent ECS task."
+  description = "The name of the execution IAM role for the Teleport ECS task."
   value       = module.teleport_db_service.ecs_execution_role_name
 }
 
 output "ecs_task_role_arn" {
-  description = "The ARN of the task IAM role for the Teleport db agent ECS task."
+  description = "The ARN of the task IAM role for the Teleport ECS task."
   value       = module.teleport_db_service.ecs_task_role_arn
 }
 
 output "ecs_task_role_name" {
-  description = "The name of the task IAM role for the Teleport db agent ECS task."
+  description = "The name of the task IAM role for the Teleport ECS task."
   value       = module.teleport_db_service.ecs_task_role_name
 }
 
@@ -64,11 +64,11 @@ output "teleport_provision_token_allow_aws_arn" {
 }
 
 output "teleport_provision_token_name" {
-  description = "Name of the Teleport provision token that allows the db agent to join the cluster using AWS IAM credentials."
+  description = "Name of the Teleport provision token that allows the to join the cluster using AWS IAM credentials."
   value       = try(nonsensitive(teleport_provision_token.agent_aws_iam[0].metadata.name), null)
 }
 
 output "teleport_config" {
-  description = "Teleport configuration used by the db agent ECS task."
+  description = "Teleport configuration used by the ECS task."
   value       = module.teleport_db_service.teleport_config
 }

--- a/integrations/terraform-modules/teleport/db-agent/aws/outputs.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/outputs.tf
@@ -67,3 +67,8 @@ output "teleport_provision_token_name" {
   description = "Name of the Teleport provision token that allows the db agent to join the cluster using AWS IAM credentials."
   value       = nonsensitive(try(teleport_provision_token.agent_aws_iam[0].metadata.name, null))
 }
+
+output "teleport_config" {
+  description = "Teleport configuration used by the db agent ECS task."
+  value       = module.teleport_db_service.teleport_config
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/teleport_provision_token.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/teleport_provision_token.tf
@@ -1,7 +1,10 @@
 locals {
   teleport_provision_token_name = (
     var.teleport_provision_token_use_name_prefix
-    ? "${var.teleport_provision_token_name}-${one(random_id.teleport_provision_token_suffix[*].hex)}"
+    ? format("%v-%v",
+      var.teleport_provision_token_name,
+      one(random_id.teleport_provision_token_suffix[*].hex),
+    )
     : var.teleport_provision_token_name
   )
 }

--- a/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
@@ -249,7 +249,7 @@ variable "teleport_container_image" {
 }
 
 variable "teleport_provision_token_name" {
-  default     = "db-agent"
+  default     = "iam-db-agent"
   description = "Name for the Teleport provision token resource."
   type        = string
   nullable    = false

--- a/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
@@ -36,6 +36,12 @@ variable "vpc_id" {
 # Optional variables
 ################################################################################
 
+variable "allow_database_modification" {
+  default     = false
+  description = "Whether to add RDS permissions that allow the Teleport Database agent to modify database configuration."
+  type        = bool
+}
+
 variable "apply_aws_tags" {
   default     = {}
   description = "Additional AWS tags to apply to all created AWS resources."

--- a/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
@@ -43,7 +43,7 @@ variable "apply_aws_tags" {
 }
 
 variable "managed_updates_enabled" {
-  default     = false
+  default     = true
   description = "Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module."
   type        = bool
 }

--- a/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
@@ -4,7 +4,7 @@
 
 variable "ecs_service_subnets" {
   description = <<EOF
-Subnet IDs where the Teleport db agent will be deployed.
+Subnet IDs where Teleport will be deployed.
 If var.assign_public_ip is true, then all of these subnets must be public subnets (route to an internet gateway).
 If var.assign_public_ip is false, then all of these subnets must be private subnets (route to a NAT gateway).
 EOF
@@ -28,7 +28,7 @@ variable "teleport_proxy_public_addr" {
 }
 
 variable "vpc_id" {
-  description = "VPC ID where the Teleport db agent will be deployed."
+  description = "VPC ID where Teleport will be deployed."
   type        = string
 }
 
@@ -38,7 +38,7 @@ variable "vpc_id" {
 
 variable "allow_database_modification" {
   default     = false
-  description = "Whether to add RDS permissions that allow the Teleport Database agent to modify database configuration."
+  description = "Whether to add RDS permissions that allow the Teleport Database Service to modify database configuration."
   type        = bool
 }
 
@@ -63,7 +63,7 @@ variable "managed_updates_group" {
 variable "assign_public_ip" {
   default     = false
   description = <<EOF
-Whether to assign public IP addresses to Teleport db agent ECS tasks.
+Whether to assign public IP addresses to Teleport ECS tasks.
 If this is set to true, then var.ecs_service_subnets must be public subnets (route to an internet gateway).
 Otherwise, var.ecs_service_subnets must be private subnets (route to a NAT gateway).
 EOF
@@ -78,7 +78,7 @@ variable "create" {
 
 variable "create_security_group" {
   default     = true
-  description = "Whether to create a security group for the Teleport db agent ECS tasks."
+  description = "Whether to create a security group for the Teleport ECS tasks."
   type        = bool
 }
 
@@ -170,7 +170,7 @@ variable "ecs_task_definition_use_name_prefix" {
 
 variable "ecs_task_desired_count" {
   default     = 2
-  description = "Desired number of Teleport db agent ECS tasks to run."
+  description = "Desired number of Teleport ECS tasks to run."
   type        = number
 }
 
@@ -195,7 +195,7 @@ variable "ecs_task_role_inline_policy" {
 
 variable "environment_vars" {
   default     = {}
-  description = "Environment variables to set on the Teleport db agent ECS container."
+  description = "Environment variables to set on the Teleport ECS container."
   type        = map(string)
 }
 
@@ -232,19 +232,19 @@ variable "database_service_resources" {
 
 variable "log_level" {
   default     = "INFO"
-  description = "Teleport agent log level."
+  description = "Teleport log level."
   type        = string
 }
 
 variable "security_group_ids" {
   default     = []
-  description = "Additional security group IDs to attach to the Teleport db agent ECS tasks."
+  description = "Additional security group IDs to attach to the Teleport ECS tasks."
   type        = list(string)
 }
 
 variable "teleport_container_image" {
   default     = "public.ecr.aws/gravitational/teleport-ent-distroless"
-  description = "Container image used for the Teleport db agent ECS tasks."
+  description = "Container image used for the Teleport ECS tasks."
   type        = string
 }
 

--- a/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
@@ -60,7 +60,6 @@ variable "managed_updates_group" {
   type        = string
 }
 
-
 variable "assign_public_ip" {
   default     = false
   description = <<EOF

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
@@ -70,6 +70,9 @@ locals {
   ]
 
   rds_actions = [
+    "ec2:DescribeSecurityGroups",
+    "ec2:DescribeSubnets",
+    "ec2:DescribeVpcs",
     "rds:DescribeDBClusters",
     "rds:DescribeDBInstances",
   ]

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
@@ -3,12 +3,6 @@
 ################################################################################
 
 locals {
-  teleport_discovery_config_name = (
-    var.teleport_discovery_config_use_name_prefix
-    ? "${var.teleport_discovery_config_name}-${local.teleport_resource_name_suffix}"
-    : var.teleport_discovery_config_name
-  )
-
   legacy_aws_matchers = length(var.match_aws_resource_types) == 0 ? [] : [
     {
       types                = var.match_aws_resource_types
@@ -161,7 +155,11 @@ resource "teleport_discovery_config" "aws" {
     metadata = {
       description = "Configure Teleport to discover AWS resources."
       labels      = local.apply_teleport_resource_labels
-      name        = local.teleport_discovery_config_name
+      name = (
+        var.teleport_discovery_config_use_name_prefix
+        ? "${var.teleport_discovery_config_name}-${local.teleport_resource_name_suffix}"
+        : var.teleport_discovery_config_name
+      )
     }
   }
 


### PR DESCRIPTION
Part of https://github.com/gravitational/core/issues/183
- https://github.com/gravitational/core/issues/183

While writing the Terraform database discovery docs guide and testing, I found various things that could be improved with the modules.
These modules aren't publicly published yet, hence no change log.

## Manual Test Plan
### Test Environment
- cloud staging tenant
- AWS dev account

### Test Cases
- [x] apply the terraform modules
  - [x] with and without managed updates enabled
  - [x] with an output for the module
  - [x] with and without RDS modify permissions enabled
  - [x] with create=false, no errors are produced from null values in expressions
  - [x] without token name provided, the default used is "iam-db-agent-<random suffix>"
  - [x] verify the discovery module attaches permissions for listing VPCs, subnets, and security groups
  - [x] verify that token name output is not sensitive