### PR TITLE
[v18] Add Terraform ECS module example

### DIFF
--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/README.md
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/README.md
@@ -1,0 +1,47 @@
+## Deploy Teleport Database Service to ECS
+
+This example deploys the Teleport Database Service to AWS ECS and joins it to an example Teleport cluster using an IAM join token.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| terraform | >= 1.5.7 |
+| aws | ~> 6.0 |
+| http | ~> 3.0 |
+| teleport | ~> 18.5 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| aws | ~> 6.0 |
+| teleport | ~> 18.5 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| teleport\_database\_service | ../.. | n/a |
+| vpc | terraform-aws-modules/vpc/aws | 6.6.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| teleport_provision_token.iam | resource |
+| [aws_availability_zones.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| teleport\_proxy\_addr | The address of the Teleport proxy service in host:port form. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| teleport\_database\_service | n/a |
+<!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/data.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/data.tf
@@ -1,0 +1,1 @@
+data "aws_availability_zones" "this" {}

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/docs_description
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/docs_description
@@ -1,0 +1,1 @@
+Deploy Teleport Database Service to ECS

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/docs_title
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/docs_title
@@ -1,0 +1,1 @@
+Teleport Database Service Example

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/main.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/main.tf
@@ -1,0 +1,84 @@
+locals {
+  namespace = "example"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "6.6.0"
+
+  azs  = slice(data.aws_availability_zones.this.names, 0, 3)
+  cidr = "10.0.0.0/16"
+  name = "${local.namespace}-vpc"
+
+  public_subnets  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnets = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+}
+
+module "teleport_database_service" {
+  source = "../.."
+
+  # Enable managed updates
+  managed_updates_enabled = true
+  managed_updates_group   = "default"
+
+  apply_aws_tags         = { "example" = "true" }
+  assign_public_ip       = true # must be true when using public subnets
+  ecs_cluster_name       = "${local.namespace}-cluster"
+  ecs_service_name       = "${local.namespace}-svc"
+  ecs_service_subnets    = module.vpc.public_subnets
+  ecs_task_desired_count = 1
+  ecs_task_name          = "${local.namespace}-task"
+  environment_vars       = { EXAMPLE_VAR = "EXAMPLE_VALUE" }
+  vpc_id                 = module.vpc.vpc_id
+
+  teleport_config = {
+    version = "v3"
+    teleport = {
+      join_params = {
+        token_name = "${local.namespace}-iam"
+        method     = "iam"
+      }
+      proxy_server = var.teleport_proxy_addr
+      log = {
+        severity = "DEBUG"
+      }
+    }
+    auth_service = {
+      enabled = "no"
+    }
+    proxy_service = {
+      enabled = "no"
+    }
+    ssh_service = {
+      enabled = "no"
+    }
+    discovery_service = {
+      enabled = "no"
+    }
+    db_service = {
+      enabled = "yes"
+      resources = [
+        {
+          labels = {
+            "env" = "example"
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource "teleport_provision_token" "iam" {
+  metadata = {
+    name        = "${local.namespace}-iam"
+    description = "Allow the Teleport ECS agent to join the cluster using AWS IAM credentials."
+  }
+  spec = {
+    allow = [{
+      aws_arn = module.teleport_database_service.teleport_provision_token_allow_aws_arn
+    }]
+    join_method = "iam"
+    roles       = ["Db"]
+  }
+  version = "v2"
+}

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/outputs.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/outputs.tf
@@ -1,0 +1,3 @@
+output "teleport_database_service" {
+  value = module.teleport_database_service
+}

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/providers.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/providers.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  region = "us-east-1"
+
+  default_tags {
+    tags = {
+      env = "example"
+    }
+  }
+}
+
+provider "teleport" {
+  addr         = var.teleport_proxy_addr
+  profile_name = replace(var.teleport_proxy_addr, "/:[0-9]+.*/", "")
+}

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/variables.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/variables.tf
@@ -1,0 +1,4 @@
+variable "teleport_proxy_addr" {
+  description = "The address of the Teleport proxy service in host:port form."
+  type        = string
+}

--- a/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/versions.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/examples/db-service/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.0"
+    }
+    teleport = {
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
+      version = "~> 18.5"
+    }
+  }
+}


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/68915 to branch/v18
- https://github.com/gravitational/teleport/pull/68915 

Part of https://github.com/gravitational/core/issues/183
- https://github.com/gravitational/core/issues/183

## Manual Test Plan
### Test Environment
- aws dev account
- cloud staging tenant

### Test Cases
- [X] run `terraform apply` with `teleport_proxy_addr` set and verify that the ECS-hosted Teleport Database Service instance is created and joins the Teleport cluster.

