### PR TITLE
[v18] Add ECS database agent Terraform module

### DIFF
--- a/integrations/terraform-modules/gen/update-version.sh
+++ b/integrations/terraform-modules/gen/update-version.sh
@@ -28,7 +28,13 @@ if [[ -z "${VERSION}" ]]; then
 fi
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-cat > "${script_dir}"/../teleport/container-service/aws/teleport_version_variable.tf <<EOF
+modules=(
+    "teleport/container-service/aws"
+    "teleport/db-agent/aws"
+)
+
+for module in "${modules[@]}"; do
+    cat > "${script_dir}/../${module}/teleport_version_variable.tf" <<EOF
 variable "teleport_version" {
   default     = "${VERSION}"
   description = <<EOD
@@ -39,3 +45,4 @@ EOD
   type        = string
 }
 EOF
+done

--- a/integrations/terraform-modules/teleport/container-service/aws/README.md
+++ b/integrations/terraform-modules/teleport/container-service/aws/README.md
@@ -25,6 +25,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | terraform | >= 1.5.7 |
 | aws | >= 6.0 |
 | http | >= 3.0 |
+| random | >= 3.0 |
 
 ## Providers
 
@@ -32,6 +33,7 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 | ---- | ------- |
 | aws | >= 6.0 |
 | http | >= 3.0 |
+| random | >= 3.0 |
 
 ## Modules
 
@@ -51,9 +53,11 @@ No modules.
 | [aws_iam_role_policy.ecs_task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_security_group.teleport_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.allow_all_outbound_from_teleport_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [random_string.name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.ecs_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_execution_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecs_task_inline_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecs_task_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -69,18 +73,23 @@ No modules.
 | create | Toggle creation of all resources. | `bool` | `true` | no |
 | create\_security\_group | Whether to create a security group for the Teleport agent ECS tasks. | `bool` | `true` | no |
 | ecs\_cluster\_name | Name of the ECS cluster. | `string` | `"teleport"` | no |
+| ecs\_cluster\_use\_name\_prefix | Determines whether `var.ecs_cluster_name` is used as a prefix of the ECS cluster name. | `bool` | `true` | no |
 | ecs\_service\_name | Name of the ECS service. | `string` | `"teleport-service"` | no |
 | ecs\_service\_subnets | Subnet IDs where the Teleport agent will be deployed. If var.assign\_public\_ip is true, then all of these subnets must be public subnets (route to an internet gateway). If var.assign\_public\_ip is false, then all of these subnets must be private subnets (route to a NAT gateway). | `list(string)` | n/a | yes |
+| ecs\_task\_cloudwatch\_log\_group\_kms\_key\_id | KMS key ID or ARN used to encrypt the ECS task CloudWatch log group. When null, CloudWatch Logs uses its default encryption key. | `string` | `null` | no |
 | ecs\_task\_cloudwatch\_log\_group\_name | Name for the ECS task CloudWatch log group. | `string` | `"ecs-teleport"` | no |
 | ecs\_task\_cloudwatch\_log\_group\_region | AWS region for the ECS task CloudWatch log group. Defaults to the AWS provider region. | `string` | `null` | no |
 | ecs\_task\_cloudwatch\_log\_group\_retention\_days | Number of days to retain logs in the ECS task CloudWatch log group. | `number` | `30` | no |
 | ecs\_task\_cloudwatch\_log\_group\_skip\_destroy | Whether to preserve the ECS task CloudWatch log group when destroying module resources. Set to true if you do not wish the log group (and any logs it may contain) to be deleted at destroy time, and instead just remove the log group from the Terraform state. | `bool` | `false` | no |
-| ecs\_task\_cpu | Number of cpu units used by the ECS task. | `string` | `"2048"` | no |
+| ecs\_task\_cloudwatch\_log\_group\_use\_name\_prefix | Determines whether `var.ecs_task_cloudwatch_log_group_name` is used as a prefix of the ECS task CloudWatch log group name. | `bool` | `true` | no |
+| ecs\_task\_cpu | Number of cpu units used by the ECS task. | `number` | `2048` | no |
+| ecs\_task\_definition\_name | Name of the ECS task. | `string` | `"teleport-agent"` | no |
+| ecs\_task\_definition\_use\_name\_prefix | Determines whether `var.ecs_task_definition_name` is used as a prefix of the ECS task definition name. | `bool` | `true` | no |
 | ecs\_task\_desired\_count | Desired number of Teleport ECS tasks to run. | `number` | `2` | no |
 | ecs\_task\_force\_new\_deployment | Set to true to force the ECS service to redeploy tasks without configuration changes. | `bool` | `false` | no |
-| ecs\_task\_memory | Amount (in MiB) of memory used by the ECS task. | `string` | `"4096"` | no |
-| ecs\_task\_name | Name of the ECS task. | `string` | `"teleport-agent"` | no |
-| ecs\_task\_role\_inline\_policy | Optional JSON policy document to attach inline to the ECS task IAM role. | `string` | `null` | no |
+| ecs\_task\_memory | Amount (in MiB) of memory used by the ECS task. | `number` | `4096` | no |
+| ecs\_task\_role\_inline\_policy | Optional JSON policy document to merge into the inline policy attached to the ECS task IAM role. | `string` | `null` | no |
+| ecs\_task\_role\_self\_assumption\_allowed | Whether the ECS task IAM role can assume itself. | `bool` | `true` | no |
 | environment\_vars | Environment variables to set on the Teleport ECS container. | `map(string)` | `{}` | no |
 | managed\_updates\_enabled | Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module. | `bool` | `false` | no |
 | managed\_updates\_group | Update group to query through the v2 Managed Updates endpoint. | `string` | `"default"` | no |
@@ -94,8 +103,15 @@ No modules.
 
 | Name | Description |
 | ---- | ----------- |
+| ecs\_cluster\_arn | ARN of the ECS cluster for the Teleport ECS service. |
+| ecs\_cluster\_name | Name of the ECS cluster for the Teleport ECS service. |
 | ecs\_execution\_role\_arn | The ARN of the execution IAM role for the Teleport ECS task. |
 | ecs\_execution\_role\_name | The name of the execution IAM role for the Teleport ECS task. |
+| ecs\_service\_arn | ARN of the Teleport ECS service. |
+| ecs\_service\_name | Name of the Teleport ECS service. |
+| ecs\_task\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group for the Teleport ECS task. |
+| ecs\_task\_cloudwatch\_log\_group\_name | Name of the CloudWatch log group for the Teleport ECS task. |
+| ecs\_task\_definition\_arn | ARN of the Teleport ECS task definition. |
 | ecs\_task\_role\_arn | The ARN of the task IAM role for the Teleport agent ECS task. |
 | ecs\_task\_role\_name | The name of the task IAM role for the Teleport agent ECS task. |
 | security\_group\_id | Security group ID created for the Teleport agent ECS service. |

--- a/integrations/terraform-modules/teleport/container-service/aws/aws_cloudwatch_log_group.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/aws_cloudwatch_log_group.tf
@@ -1,11 +1,19 @@
 resource "aws_cloudwatch_log_group" "this" {
   count = var.create ? 1 : 0
 
-  name = var.ecs_task_cloudwatch_log_group_name
+  name = (
+    var.ecs_task_cloudwatch_log_group_use_name_prefix
+    ? format("%v-%v",
+      var.ecs_task_cloudwatch_log_group_name,
+      one(random_string.name_suffix[*].result),
+    )
+    : var.ecs_task_cloudwatch_log_group_name
+  )
   region = coalesce(
     var.ecs_task_cloudwatch_log_group_region,
-    one(data.aws_region.this[*].name),
+    one(data.aws_region.this[*].region),
   )
+  kms_key_id        = var.ecs_task_cloudwatch_log_group_kms_key_id
   retention_in_days = var.ecs_task_cloudwatch_log_group_retention_days
   skip_destroy      = var.ecs_task_cloudwatch_log_group_skip_destroy
   tags              = var.apply_aws_tags

--- a/integrations/terraform-modules/teleport/container-service/aws/aws_ecs_cluster.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/aws_ecs_cluster.tf
@@ -5,6 +5,13 @@
 resource "aws_ecs_cluster" "teleport_agent" {
   count = var.create ? 1 : 0
 
-  name = var.ecs_cluster_name
+  name = (
+    var.ecs_cluster_use_name_prefix
+    ? format("%v-%v",
+      var.ecs_cluster_name,
+      one(random_string.name_suffix[*].result),
+    )
+    : var.ecs_cluster_name
+  )
   tags = var.apply_aws_tags
 }

--- a/integrations/terraform-modules/teleport/container-service/aws/aws_ecs_task_definition.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/aws_ecs_task_definition.tf
@@ -51,17 +51,27 @@ resource "aws_ecs_task_definition" "teleport_agent" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          "awslogs-group"         = one(aws_cloudwatch_log_group.this[*].name)
-          "awslogs-region"        = one(aws_cloudwatch_log_group.this[*].region)
-          "awslogs-stream-prefix" = "${var.ecs_cluster_name}-${var.ecs_service_name}"
+          "awslogs-group"  = one(aws_cloudwatch_log_group.this[*].name)
+          "awslogs-region" = one(aws_cloudwatch_log_group.this[*].region)
+          "awslogs-stream-prefix" = format("%v-%v",
+            one(aws_ecs_cluster.teleport_agent[*].name),
+            var.ecs_service_name,
+          )
         }
       }
       name = "teleport"
     }
   ])
-  cpu                      = var.ecs_task_cpu
-  execution_role_arn       = one(aws_iam_role.ecs_execution[*].arn)
-  family                   = var.ecs_task_name
+  cpu                = var.ecs_task_cpu
+  execution_role_arn = one(aws_iam_role.ecs_execution[*].arn)
+  family = (
+    var.ecs_task_definition_use_name_prefix
+    ? format("%v-%v",
+      var.ecs_task_definition_name,
+      one(random_string.name_suffix[*].result),
+    )
+    : var.ecs_task_definition_name
+  )
   memory                   = var.ecs_task_memory
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]

--- a/integrations/terraform-modules/teleport/container-service/aws/aws_task_execution_role.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/aws_task_execution_role.tf
@@ -7,8 +7,12 @@ resource "aws_iam_role" "ecs_execution" {
 
   assume_role_policy = one(data.aws_iam_policy_document.ecs_execution_trust[*].json)
   description        = "Execution role used by the Teleport ECS agent task."
-  name_prefix        = "${var.ecs_cluster_name}-exec"
-  tags               = var.apply_aws_tags
+  name = format("%v-%v-exec-%v",
+    one(aws_ecs_cluster.teleport_agent[*].name),
+    one(data.aws_region.this[*].region),
+    one(random_string.name_suffix[*].result),
+  )
+  tags = var.apply_aws_tags
 }
 
 data "aws_iam_policy_document" "ecs_execution_trust" {
@@ -31,7 +35,7 @@ data "aws_iam_policy_document" "ecs_execution_trust" {
         format(
           "arn:%s:ecs:%s:%s:*",
           one(data.aws_partition.this[*].partition),
-          one(data.aws_region.this[*].name),
+          one(data.aws_region.this[*].region),
           one(data.aws_caller_identity.this[*].account_id),
         ),
       ]

--- a/integrations/terraform-modules/teleport/container-service/aws/aws_task_role.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/aws_task_role.tf
@@ -2,27 +2,66 @@
 # Task role
 ################################################################################
 
+locals {
+  enable_ecs_task_inline_policy = var.create && (
+    var.ecs_task_role_self_assumption_allowed ||
+    var.ecs_task_role_inline_policy != null
+  )
+  ecs_task_role_name = format("%v-%v-task-%v",
+    one(aws_ecs_cluster.teleport_agent[*].name),
+    one(data.aws_region.this[*].region),
+    one(random_string.name_suffix[*].result),
+  )
+  ecs_task_role_arn = format(
+    "arn:%s:iam::%s:role/%s",
+    one(data.aws_partition.this[*].partition),
+    one(data.aws_caller_identity.this[*].account_id),
+    local.ecs_task_role_name,
+  )
+}
+
 resource "aws_iam_role" "ecs_task" {
   count = var.create ? 1 : 0
 
   assume_role_policy = one(data.aws_iam_policy_document.ecs_task_trust[*].json)
   description        = "Task role used by the Teleport ECS agent task."
-  name_prefix        = "${var.ecs_cluster_name}-task"
+  name               = local.ecs_task_role_name
   tags               = var.apply_aws_tags
 }
 
 resource "aws_iam_role_policy" "ecs_task" {
-  count = var.create && var.ecs_task_role_inline_policy != null ? 1 : 0
+  count = local.enable_ecs_task_inline_policy ? 1 : 0
 
   name   = "ecs-task"
-  policy = var.ecs_task_role_inline_policy
+  policy = one(data.aws_iam_policy_document.ecs_task_inline_policy[*].json)
   role   = one(aws_iam_role.ecs_task[*].id)
+}
+
+data "aws_iam_policy_document" "ecs_task_inline_policy" {
+  count = local.enable_ecs_task_inline_policy ? 1 : 0
+
+  source_policy_documents = (
+    var.ecs_task_role_inline_policy == null
+    ? []
+    : [var.ecs_task_role_inline_policy]
+  )
+
+  dynamic "statement" {
+    for_each = var.ecs_task_role_self_assumption_allowed ? [true] : []
+
+    content {
+      actions   = ["sts:AssumeRole"]
+      effect    = "Allow"
+      resources = [local.ecs_task_role_arn]
+    }
+  }
 }
 
 data "aws_iam_policy_document" "ecs_task_trust" {
   count = var.create ? 1 : 0
 
   statement {
+    sid     = "TrustECS"
     actions = ["sts:AssumeRole"]
 
     effect = "Allow"
@@ -39,7 +78,7 @@ data "aws_iam_policy_document" "ecs_task_trust" {
         format(
           "arn:%s:ecs:%s:%s:*",
           one(data.aws_partition.this[*].partition),
-          one(data.aws_region.this[*].name),
+          one(data.aws_region.this[*].region),
           one(data.aws_caller_identity.this[*].account_id),
         ),
       ]
@@ -49,6 +88,31 @@ data "aws_iam_policy_document" "ecs_task_trust" {
     principals {
       identifiers = ["ecs-tasks.amazonaws.com"]
       type        = "Service"
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.ecs_task_role_self_assumption_allowed ? [true] : []
+
+    content {
+      sid     = "TrustSelf"
+      actions = ["sts:AssumeRole"]
+      effect  = "Allow"
+
+      condition {
+        test     = "ArnEquals"
+        values   = [local.ecs_task_role_arn]
+        variable = "aws:PrincipalArn"
+      }
+
+      principals {
+        identifiers = [format(
+          "arn:%s:iam::%s:root",
+          one(data.aws_partition.this[*].partition),
+          one(data.aws_caller_identity.this[*].account_id),
+        )]
+        type = "AWS"
+      }
     }
   }
 }

--- a/integrations/terraform-modules/teleport/container-service/aws/outputs.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/outputs.tf
@@ -1,3 +1,38 @@
+output "ecs_cluster_name" {
+  description = "Name of the ECS cluster for the Teleport ECS service."
+  value       = one(aws_ecs_cluster.teleport_agent[*].name)
+}
+
+output "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster for the Teleport ECS service."
+  value       = one(aws_ecs_cluster.teleport_agent[*].arn)
+}
+
+output "ecs_service_name" {
+  description = "Name of the Teleport ECS service."
+  value       = one(aws_ecs_service.teleport_agent[*].name)
+}
+
+output "ecs_service_arn" {
+  description = "ARN of the Teleport ECS service."
+  value       = one(aws_ecs_service.teleport_agent[*].id)
+}
+
+output "ecs_task_definition_arn" {
+  description = "ARN of the Teleport ECS task definition."
+  value       = one(aws_ecs_task_definition.teleport_agent[*].arn)
+}
+
+output "ecs_task_cloudwatch_log_group_name" {
+  description = "Name of the CloudWatch log group for the Teleport ECS task."
+  value       = one(aws_cloudwatch_log_group.this[*].name)
+}
+
+output "ecs_task_cloudwatch_log_group_arn" {
+  description = "ARN of the CloudWatch log group for the Teleport ECS task."
+  value       = one(aws_cloudwatch_log_group.this[*].arn)
+}
+
 output "security_group_id" {
   description = "Security group ID created for the Teleport agent ECS service."
   value       = one(aws_security_group.teleport_agent[*].id)

--- a/integrations/terraform-modules/teleport/container-service/aws/random.tf
+++ b/integrations/terraform-modules/teleport/container-service/aws/random.tf
@@ -1,0 +1,9 @@
+resource "random_string" "name_suffix" {
+  count = var.create ? 1 : 0
+
+  length  = 4
+  lower   = true
+  numeric = true
+  special = false
+  upper   = false
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/LICENSE
+++ b/integrations/terraform-modules/teleport/db-agent/aws/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/integrations/terraform-modules/teleport/db-agent/aws/README.md
+++ b/integrations/terraform-modules/teleport/db-agent/aws/README.md
@@ -1,0 +1,112 @@
+# AWS Database Agent Terraform module
+
+This Terraform module deploys a Teleport Database Service agent to Amazon ECS. It creates the ECS resources, IAM task role, and optional security group required for the agent to join a Teleport cluster using AWS IAM.
+
+## Prerequisites
+<!-- lint ignore absolute-docs-links -->
+- [Configure Teleport Terraform Provider](https://goteleport.com/docs/configuration/terraform-provider/)
+- [Configure AWS Terraform provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
+
+## Examples
+
+Refer to the [examples](./examples) for example usage of this module.
+
+## How to get help
+
+If you're having trouble, check out our [GitHub Discussions](https://github.com/gravitational/teleport/discussions).
+
+For bugs related to this code, please [open an issue](https://github.com/gravitational/teleport/issues/new/choose).
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| terraform | >= 1.5.7 |
+| aws | >= 6.0 |
+| random | >= 3.0 |
+| teleport | >= 18.8.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| aws | >= 6.0 |
+| random | >= 3.0 |
+| teleport | >= 18.8.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| teleport\_db\_service | ../../container-service/aws | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [random_id.teleport_provision_token_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| teleport_provision_token.agent_aws_iam | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.ecs_task_inline_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| apply\_aws\_tags | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
+| assign\_public\_ip | Whether to assign public IP addresses to Teleport db agent ECS tasks. If this is set to true, then var.ecs\_service\_subnets must be public subnets (route to an internet gateway). Otherwise, var.ecs\_service\_subnets must be private subnets (route to a NAT gateway). | `bool` | `false` | no |
+| create | Toggle creation of all resources. | `bool` | `true` | no |
+| create\_security\_group | Whether to create a security group for the Teleport db agent ECS tasks. | `bool` | `true` | no |
+| database\_service\_resources | Override the db\_service resource matchers. When null, a default matcher is used that matches databases in the same account, region, and VPC. | ```list(object({ labels = map(list(string)) aws = optional(object({ assume_role_arn = optional(string, "") external_id = optional(string, "") })) }))``` | `null` | no |
+| database\_types\_for\_default\_iam\_policy | Database types for which default IAM policy statements will be added to the ECS task role's inline policy. Currently, only `rds` is supported. Statements in the default IAM policy can be overridden by a statement with a matching SID in var.ecs\_task\_role\_inline\_policy. | `list(string)` | `[]` | no |
+| ecs\_cluster\_name | Name of the ECS cluster. | `string` | `"teleport-db-services"` | no |
+| ecs\_cluster\_use\_name\_prefix | Determines whether `var.ecs_cluster_name` is used as a prefix of the ECS cluster name. | `bool` | `true` | no |
+| ecs\_service\_name | Name of the ECS service. | `string` | `"teleport-db-service"` | no |
+| ecs\_service\_subnets | Subnet IDs where the Teleport db agent will be deployed. If var.assign\_public\_ip is true, then all of these subnets must be public subnets (route to an internet gateway). If var.assign\_public\_ip is false, then all of these subnets must be private subnets (route to a NAT gateway). | `list(string)` | n/a | yes |
+| ecs\_task\_cloudwatch\_log\_group\_kms\_key\_id | KMS key ID or ARN used to encrypt the ECS task CloudWatch log group. When null, CloudWatch Logs uses its default encryption key. | `string` | `null` | no |
+| ecs\_task\_cloudwatch\_log\_group\_name | Name for the ECS task CloudWatch log group. | `string` | `"ecs-teleport"` | no |
+| ecs\_task\_cloudwatch\_log\_group\_region | AWS region for the ECS task CloudWatch log group. Defaults to the AWS provider region. | `string` | `null` | no |
+| ecs\_task\_cloudwatch\_log\_group\_retention\_days | Number of days to retain logs in the ECS task CloudWatch log group. | `number` | `30` | no |
+| ecs\_task\_cloudwatch\_log\_group\_skip\_destroy | Whether to preserve the ECS task CloudWatch log group when destroying module resources. Set to true if you do not wish the log group (and any logs it may contain) to be deleted at destroy time, and instead just remove the log group from the Terraform state. | `bool` | `false` | no |
+| ecs\_task\_cloudwatch\_log\_group\_use\_name\_prefix | Determines whether `var.ecs_task_cloudwatch_log_group_name` is used as a prefix of the ECS task CloudWatch log group name. | `bool` | `true` | no |
+| ecs\_task\_cpu | Number of CPU units used by the ECS task. | `number` | `2048` | no |
+| ecs\_task\_definition\_name | Name of the ECS task. | `string` | `"teleport-db-agent"` | no |
+| ecs\_task\_definition\_use\_name\_prefix | Determines whether `var.ecs_task_definition_name` is used as a prefix of the ECS task definition name. | `bool` | `true` | no |
+| ecs\_task\_desired\_count | Desired number of Teleport db agent ECS tasks to run. | `number` | `2` | no |
+| ecs\_task\_force\_new\_deployment | Set to true to force the ECS service to redeploy tasks without configuration changes. | `bool` | `false` | no |
+| ecs\_task\_memory | Amount (in MiB) of memory used by the ECS task. | `number` | `4096` | no |
+| ecs\_task\_role\_inline\_policy | Optional JSON policy document to merge into the inline policy attached to the ECS task IAM role. | `string` | `null` | no |
+| environment\_vars | Environment variables to set on the Teleport db agent ECS container. | `map(string)` | `{}` | no |
+| join\_params | Override the Teleport join parameters. When null, the module creates an IAM join token automatically. Set this to use a pre-existing token or a different join method. | ```object({ token_name = string method = string })``` | `null` | no |
+| log\_level | Teleport agent log level. | `string` | `"INFO"` | no |
+| managed\_updates\_enabled | Whether to resolve the Teleport container version from the configured Managed Updates endpoint when applying this module. | `bool` | `false` | no |
+| managed\_updates\_group | Update group to query through the v2 Managed Updates endpoint. | `string` | `"default"` | no |
+| security\_group\_ids | Additional security group IDs to attach to the Teleport db agent ECS tasks. | `list(string)` | `[]` | no |
+| teleport\_container\_image | Container image used for the Teleport db agent ECS tasks. | `string` | `"public.ecr.aws/gravitational/teleport-ent-distroless"` | no |
+| teleport\_provision\_token\_name | Name for the Teleport provision token resource. | `string` | `"db-agent"` | no |
+| teleport\_provision\_token\_use\_name\_prefix | Determines whether the name of the Teleport provision token is used as a prefix. | `bool` | `true` | no |
+| teleport\_proxy\_public\_addr | Teleport cluster proxy public address `host:port`. | `string` | n/a | yes |
+| teleport\_version | The version of Teleport to deploy. Generally, the version of Teleport should be controlled by using the appropriate version of this module. This variable is intended for development usage. | `string` | `"18.10.0"` | no |
+| vpc\_id | VPC ID where the Teleport db agent will be deployed. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| ecs\_cluster\_arn | ARN of the ECS cluster for the Teleport db agent ECS service. |
+| ecs\_cluster\_name | Name of the ECS cluster for the Teleport db agent ECS service. |
+| ecs\_execution\_role\_arn | The ARN of the execution IAM role for the Teleport db agent ECS task. |
+| ecs\_execution\_role\_name | The name of the execution IAM role for the Teleport db agent ECS task. |
+| ecs\_service\_arn | ARN of the Teleport db agent ECS service. |
+| ecs\_service\_name | Name of the Teleport db agent ECS service. |
+| ecs\_task\_cloudwatch\_log\_group\_arn | ARN of the CloudWatch log group for the Teleport db agent ECS task. |
+| ecs\_task\_cloudwatch\_log\_group\_name | Name of the CloudWatch log group for the Teleport db agent ECS task. |
+| ecs\_task\_definition\_arn | ARN of the Teleport db agent ECS task definition. |
+| ecs\_task\_role\_arn | The ARN of the task IAM role for the Teleport db agent ECS task. |
+| ecs\_task\_role\_name | The name of the task IAM role for the Teleport db agent ECS task. |
+| security\_group\_id | Security group ID created for the Teleport db agent ECS service. |
+| teleport\_provision\_token\_allow\_aws\_arn | A value that can be used with a Teleport IAM join token to allow the ECS cluster to join the Teleport cluster using its IAM credentials. |
+| teleport\_provision\_token\_name | Name of the Teleport provision token that allows the db agent to join the cluster using AWS IAM credentials. |
+<!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/db-agent/aws/data.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/data.tf
@@ -1,0 +1,68 @@
+data "aws_caller_identity" "this" {
+  count = var.create ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = var.teleport_proxy_public_addr != ""
+      error_message = "The Teleport proxy public address must not be empty when create is true."
+    }
+  }
+}
+
+data "aws_region" "this" {
+  count = var.create ? 1 : 0
+}
+
+data "aws_iam_policy_document" "ecs_task_inline_policy" {
+  count = var.create && (
+    var.ecs_task_role_inline_policy != null ||
+    contains(var.database_types_for_default_iam_policy, "rds")
+  ) ? 1 : 0
+
+  override_policy_documents = (
+    var.ecs_task_role_inline_policy == null
+    ? []
+    : [var.ecs_task_role_inline_policy]
+  )
+
+  dynamic "statement" {
+    for_each = contains(var.database_types_for_default_iam_policy, "rds") ? [true] : []
+
+    content {
+      sid = "RDSAutoEnableIAMAuth"
+
+      actions = [
+        "rds:ModifyDBCluster",
+        "rds:ModifyDBInstance",
+      ]
+      effect    = "Allow"
+      resources = ["*"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = contains(var.database_types_for_default_iam_policy, "rds") ? [true] : []
+
+    content {
+      sid       = "RDSConnect"
+      actions   = ["rds-db:connect"]
+      effect    = "Allow"
+      resources = ["*"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = contains(var.database_types_for_default_iam_policy, "rds") ? [true] : []
+
+    content {
+      sid = "RDSFetchMetadata"
+
+      actions = [
+        "rds:DescribeDBClusters",
+        "rds:DescribeDBInstances",
+      ]
+      effect    = "Allow"
+      resources = ["*"]
+    }
+  }
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/README.md
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/README.md
@@ -1,0 +1,53 @@
+# Simple AWS Database Agent
+
+This example deploys a Teleport Database Service agent to Amazon ECS in a new VPC. It uses public subnets and requires the address of an existing Teleport proxy.
+
+```shell
+terraform init
+terraform apply -var='teleport_proxy_addr=teleport.example.com:443'
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| terraform | >= 1.5.7 |
+| aws | ~> 6.0 |
+| random | ~> 3.0 |
+| teleport | ~> 18.8 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| aws | ~> 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| teleport\_db\_agent | ../.. | n/a |
+| vpc | terraform-aws-modules/vpc/aws | 6.6.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_availability_zones.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.example_statement_override](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| teleport\_proxy\_addr | The address of the Teleport proxy service in host:port form. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| teleport\_db\_agent | n/a |
+<!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/data.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/data.tf
@@ -1,0 +1,5 @@
+data "aws_availability_zones" "this" {}
+
+data "aws_caller_identity" "this" {}
+
+data "aws_region" "this" {}

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/docs_description
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/docs_description
@@ -1,0 +1,1 @@
+Deploy a Teleport Database Service agent to Amazon ECS in a new VPC.

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/docs_title
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/docs_title
@@ -1,0 +1,1 @@
+Simple AWS Database Agent

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/main.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/main.tf
@@ -1,0 +1,46 @@
+locals {
+  namespace = "example"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "6.6.0"
+
+  azs  = slice(data.aws_availability_zones.this.names, 0, 3)
+  cidr = "10.0.0.0/16"
+  name = "${local.namespace}-vpc"
+
+  public_subnets  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnets = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+}
+
+module "teleport_db_agent" {
+  source = "../.."
+
+  assign_public_ip           = true # Required when using public subnets.
+  ecs_service_subnets        = module.vpc.public_subnets
+  managed_updates_enabled    = true
+  teleport_proxy_public_addr = var.teleport_proxy_addr
+  vpc_id                     = module.vpc.vpc_id
+
+  ecs_task_role_inline_policy           = data.aws_iam_policy_document.example_statement_override.json
+  database_types_for_default_iam_policy = ["rds"]
+}
+
+data "aws_iam_policy_document" "example_statement_override" {
+  statement {
+    # matches the SID of a statement in default IAM policy for "rds" database
+    # and overrides it
+    sid    = "RDSAutoEnableIAMAuth"
+    effect = "Allow"
+
+    actions = [
+      "rds:ModifyDBCluster",
+      "rds:ModifyDBInstance",
+    ]
+    resources = [
+      # restrict the default modify IAM permissions to specific databases instead of "*"
+      "arn:aws:rds:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:db:example"
+    ]
+  }
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/outputs.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/outputs.tf
@@ -1,0 +1,3 @@
+output "teleport_db_agent" {
+  value = module.teleport_db_agent
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/providers.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/providers.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      env = "example"
+    }
+  }
+}
+
+provider "teleport" {
+  addr         = var.teleport_proxy_addr
+  profile_name = replace(var.teleport_proxy_addr, "/:[0-9]+.*/", "")
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/variables.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/variables.tf
@@ -1,0 +1,4 @@
+variable "teleport_proxy_addr" {
+  description = "The address of the Teleport proxy service in host:port form."
+  type        = string
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/versions.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/examples/simple/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = "~> 3.0"
     }
-    http = {
-      source  = "hashicorp/http"
-      version = ">= 3.0"
+    teleport = {
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
+      version = "~> 18.8"
     }
   }
 }

--- a/integrations/terraform-modules/teleport/db-agent/aws/main.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/main.tf
@@ -1,0 +1,82 @@
+module "teleport_db_service" {
+  # TODO(gavin): change this to the published module version
+  # source  = "terraform.releases.teleport.dev/teleport/container-service/aws"
+  source = "../../container-service/aws"
+
+  apply_aws_tags                                = var.apply_aws_tags
+  assign_public_ip                              = var.assign_public_ip
+  create                                        = var.create
+  create_security_group                         = var.create_security_group
+  ecs_cluster_name                              = var.ecs_cluster_name
+  ecs_cluster_use_name_prefix                   = var.ecs_cluster_use_name_prefix
+  ecs_service_name                              = var.ecs_service_name
+  ecs_service_subnets                           = var.ecs_service_subnets
+  ecs_task_cloudwatch_log_group_name            = var.ecs_task_cloudwatch_log_group_name
+  ecs_task_cloudwatch_log_group_use_name_prefix = var.ecs_task_cloudwatch_log_group_use_name_prefix
+  ecs_task_cloudwatch_log_group_region          = var.ecs_task_cloudwatch_log_group_region
+  ecs_task_cloudwatch_log_group_kms_key_id      = var.ecs_task_cloudwatch_log_group_kms_key_id
+  ecs_task_cloudwatch_log_group_retention_days  = var.ecs_task_cloudwatch_log_group_retention_days
+  ecs_task_cloudwatch_log_group_skip_destroy    = var.ecs_task_cloudwatch_log_group_skip_destroy
+  ecs_task_cpu                                  = var.ecs_task_cpu
+  ecs_task_definition_name                      = var.ecs_task_definition_name
+  ecs_task_definition_use_name_prefix           = var.ecs_task_definition_use_name_prefix
+  ecs_task_desired_count                        = var.ecs_task_desired_count
+  ecs_task_force_new_deployment                 = var.ecs_task_force_new_deployment
+  ecs_task_memory                               = var.ecs_task_memory
+  ecs_task_role_inline_policy                   = one(data.aws_iam_policy_document.ecs_task_inline_policy[*].json)
+  environment_vars                              = var.environment_vars
+  managed_updates_enabled                       = var.managed_updates_enabled
+  managed_updates_group                         = var.managed_updates_group
+  security_group_ids                            = var.security_group_ids
+  teleport_container_image                      = var.teleport_container_image
+  teleport_version                              = var.teleport_version
+  vpc_id                                        = var.vpc_id
+
+  teleport_config = {
+    version = "v3"
+    teleport = {
+      nodename     = "" # setting nodename to an empty string ensures that it's picked up from the host's hostname
+      proxy_server = var.teleport_proxy_public_addr
+      join_params = (
+        var.join_params != null
+        ? var.join_params
+        : var.create
+        ? {
+          token_name = local.teleport_provision_token_name
+          method     = "iam"
+        }
+        : null
+      )
+      log = {
+        output   = "stderr"
+        severity = var.log_level
+      }
+    }
+    auth_service = {
+      enabled = false
+    }
+    proxy_service = {
+      enabled = false
+    }
+    ssh_service = {
+      enabled = false
+    }
+    db_service = {
+      enabled = true
+      resources = (
+        var.database_service_resources != null
+        ? var.database_service_resources
+        : [{
+          aws = {
+            assume_role_arn = module.teleport_db_service.ecs_task_role_arn
+          }
+          labels = {
+            "account-id" = data.aws_caller_identity.this[*].account_id
+            "region"     = data.aws_region.this[*].region
+            "vpc-id"     = [var.vpc_id]
+          }
+        }]
+      )
+    }
+  }
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/outputs.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/outputs.tf
@@ -1,0 +1,69 @@
+output "ecs_cluster_name" {
+  description = "Name of the ECS cluster for the Teleport db agent ECS service."
+  value       = module.teleport_db_service.ecs_cluster_name
+}
+
+output "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster for the Teleport db agent ECS service."
+  value       = module.teleport_db_service.ecs_cluster_arn
+}
+
+output "ecs_service_name" {
+  description = "Name of the Teleport db agent ECS service."
+  value       = module.teleport_db_service.ecs_service_name
+}
+
+output "ecs_service_arn" {
+  description = "ARN of the Teleport db agent ECS service."
+  value       = module.teleport_db_service.ecs_service_arn
+}
+
+output "ecs_task_definition_arn" {
+  description = "ARN of the Teleport db agent ECS task definition."
+  value       = module.teleport_db_service.ecs_task_definition_arn
+}
+
+output "ecs_task_cloudwatch_log_group_name" {
+  description = "Name of the CloudWatch log group for the Teleport db agent ECS task."
+  value       = module.teleport_db_service.ecs_task_cloudwatch_log_group_name
+}
+
+output "ecs_task_cloudwatch_log_group_arn" {
+  description = "ARN of the CloudWatch log group for the Teleport db agent ECS task."
+  value       = module.teleport_db_service.ecs_task_cloudwatch_log_group_arn
+}
+
+output "security_group_id" {
+  description = "Security group ID created for the Teleport db agent ECS service."
+  value       = module.teleport_db_service.security_group_id
+}
+
+output "ecs_execution_role_arn" {
+  description = "The ARN of the execution IAM role for the Teleport db agent ECS task."
+  value       = module.teleport_db_service.ecs_execution_role_arn
+}
+
+output "ecs_execution_role_name" {
+  description = "The name of the execution IAM role for the Teleport db agent ECS task."
+  value       = module.teleport_db_service.ecs_execution_role_name
+}
+
+output "ecs_task_role_arn" {
+  description = "The ARN of the task IAM role for the Teleport db agent ECS task."
+  value       = module.teleport_db_service.ecs_task_role_arn
+}
+
+output "ecs_task_role_name" {
+  description = "The name of the task IAM role for the Teleport db agent ECS task."
+  value       = module.teleport_db_service.ecs_task_role_name
+}
+
+output "teleport_provision_token_allow_aws_arn" {
+  description = "A value that can be used with a Teleport IAM join token to allow the ECS cluster to join the Teleport cluster using its IAM credentials."
+  value       = module.teleport_db_service.teleport_provision_token_allow_aws_arn
+}
+
+output "teleport_provision_token_name" {
+  description = "Name of the Teleport provision token that allows the db agent to join the cluster using AWS IAM credentials."
+  value       = nonsensitive(try(teleport_provision_token.agent_aws_iam[0].metadata.name, null))
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/teleport_provision_token.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/teleport_provision_token.tf
@@ -1,0 +1,31 @@
+locals {
+  teleport_provision_token_name = (
+    var.teleport_provision_token_use_name_prefix
+    ? "${var.teleport_provision_token_name}-${one(random_id.teleport_provision_token_suffix[*].hex)}"
+    : var.teleport_provision_token_name
+  )
+}
+
+resource "random_id" "teleport_provision_token_suffix" {
+  count = var.create && var.join_params == null && var.teleport_provision_token_use_name_prefix ? 1 : 0
+
+  byte_length = 4
+}
+
+resource "teleport_provision_token" "agent_aws_iam" {
+  count = var.create && var.join_params == null ? 1 : 0
+
+  metadata = {
+    name        = local.teleport_provision_token_name
+    description = "Allow Teleport db agent to join the cluster using AWS IAM credentials."
+  }
+  spec = {
+    allow = [{
+      aws_account = try(data.aws_caller_identity.this[0].account_id, "")
+      aws_arn     = module.teleport_db_service.teleport_provision_token_allow_aws_arn
+    }]
+    join_method = "iam"
+    roles       = ["Db"]
+  }
+  version = "v2"
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/teleport_version_variable.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/teleport_version_variable.tf
@@ -1,0 +1,9 @@
+variable "teleport_version" {
+  default     = "18.10.0"
+  description = <<EOD
+The version of Teleport to deploy.
+Generally, the version of Teleport should be controlled by using the appropriate version of this module.
+This variable is intended for development usage.
+EOD
+  type        = string
+}

--- a/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/variables.tf
@@ -4,21 +4,32 @@
 
 variable "ecs_service_subnets" {
   description = <<EOF
-Subnet IDs where the Teleport agent will be deployed.
+Subnet IDs where the Teleport db agent will be deployed.
 If var.assign_public_ip is true, then all of these subnets must be public subnets (route to an internet gateway).
 If var.assign_public_ip is false, then all of these subnets must be private subnets (route to a NAT gateway).
 EOF
   type        = list(string)
 }
 
-variable "vpc_id" {
-  description = "VPC ID where the Teleport agent will be deployed."
+variable "teleport_proxy_public_addr" {
+  description = "Teleport cluster proxy public address `host:port`."
   type        = string
+  nullable    = false
+
+  validation {
+    condition     = !strcontains(var.teleport_proxy_public_addr, "://")
+    error_message = "Must not contain a URL scheme."
+  }
+
+  validation {
+    condition     = var.teleport_proxy_public_addr == "" || strcontains(var.teleport_proxy_public_addr, ":")
+    error_message = "The address must be in the form `host:port`."
+  }
 }
 
-variable "teleport_config" {
-  description = "Teleport configuration. Write the configuration using native Terraform syntax. Warning: sensitive data, such as static join tokens, is visible to anyone who can read the task definition."
-  type        = any
+variable "vpc_id" {
+  description = "VPC ID where the Teleport db agent will be deployed."
+  type        = string
 }
 
 ################################################################################
@@ -43,10 +54,11 @@ variable "managed_updates_group" {
   type        = string
 }
 
+
 variable "assign_public_ip" {
   default     = false
   description = <<EOF
-Whether to assign public IP addresses to Teleport agent ECS tasks.
+Whether to assign public IP addresses to Teleport db agent ECS tasks.
 If this is set to true, then var.ecs_service_subnets must be public subnets (route to an internet gateway).
 Otherwise, var.ecs_service_subnets must be private subnets (route to a NAT gateway).
 EOF
@@ -61,12 +73,21 @@ variable "create" {
 
 variable "create_security_group" {
   default     = true
-  description = "Whether to create a security group for the Teleport agent ECS tasks."
+  description = "Whether to create a security group for the Teleport db agent ECS tasks."
   type        = bool
 }
 
+variable "join_params" {
+  default     = null
+  description = "Override the Teleport join parameters. When null, the module creates an IAM join token automatically. Set this to use a pre-existing token or a different join method."
+  type = object({
+    token_name = string
+    method     = string
+  })
+}
+
 variable "ecs_cluster_name" {
-  default     = "teleport"
+  default     = "teleport-db-services"
   description = "Name of the ECS cluster."
   type        = string
 }
@@ -78,7 +99,7 @@ variable "ecs_cluster_use_name_prefix" {
 }
 
 variable "ecs_service_name" {
-  default     = "teleport-service"
+  default     = "teleport-db-service"
   description = "Name of the ECS service."
   type        = string
 }
@@ -126,12 +147,12 @@ EOF
 
 variable "ecs_task_cpu" {
   default     = 2048
-  description = "Number of cpu units used by the ECS task."
+  description = "Number of CPU units used by the ECS task."
   type        = number
 }
 
 variable "ecs_task_definition_name" {
-  default     = "teleport-agent"
+  default     = "teleport-db-agent"
   description = "Name of the ECS task."
   type        = string
 }
@@ -144,7 +165,7 @@ variable "ecs_task_definition_use_name_prefix" {
 
 variable "ecs_task_desired_count" {
   default     = 2
-  description = "Desired number of Teleport ECS tasks to run."
+  description = "Desired number of Teleport db agent ECS tasks to run."
   type        = number
 }
 
@@ -167,26 +188,71 @@ variable "ecs_task_role_inline_policy" {
   type        = string
 }
 
-variable "ecs_task_role_self_assumption_allowed" {
-  default     = true
-  description = "Whether the ECS task IAM role can assume itself."
-  type        = bool
-}
-
 variable "environment_vars" {
   default     = {}
-  description = "Environment variables to set on the Teleport ECS container."
+  description = "Environment variables to set on the Teleport db agent ECS container."
   type        = map(string)
+}
+
+variable "database_types_for_default_iam_policy" {
+  default     = []
+  description = <<EOF
+Database types for which default IAM policy statements will be added to the ECS task role's inline policy.
+Currently, only `rds` is supported.
+Statements in the default IAM policy can be overridden by a statement with a matching SID in var.ecs_task_role_inline_policy.
+EOF
+  nullable    = false
+  type        = list(string)
+
+  validation {
+    condition = alltrue([
+      for database_type in var.database_types_for_default_iam_policy
+      : database_type == "rds"
+    ])
+    error_message = "Supported database types are: rds."
+  }
+}
+
+variable "database_service_resources" {
+  default     = null
+  description = "Override the db_service resource matchers. When null, a default matcher is used that matches databases in the same account, region, and VPC."
+  type = list(object({
+    labels = map(list(string))
+    aws = optional(object({
+      assume_role_arn = optional(string, "")
+      external_id     = optional(string, "")
+    }))
+  }))
+}
+
+variable "log_level" {
+  default     = "INFO"
+  description = "Teleport agent log level."
+  type        = string
 }
 
 variable "security_group_ids" {
   default     = []
-  description = "Additional security group IDs to attach to the Teleport agent ECS tasks."
+  description = "Additional security group IDs to attach to the Teleport db agent ECS tasks."
   type        = list(string)
 }
 
 variable "teleport_container_image" {
   default     = "public.ecr.aws/gravitational/teleport-ent-distroless"
-  description = "Container image used for Teleport ECS tasks."
+  description = "Container image used for the Teleport db agent ECS tasks."
   type        = string
+}
+
+variable "teleport_provision_token_name" {
+  default     = "db-agent"
+  description = "Name for the Teleport provision token resource."
+  type        = string
+  nullable    = false
+}
+
+variable "teleport_provision_token_use_name_prefix" {
+  default     = true
+  description = "Determines whether the name of the Teleport provision token is used as a prefix."
+  type        = bool
+  nullable    = false
 }

--- a/integrations/terraform-modules/teleport/db-agent/aws/versions.tf
+++ b/integrations/terraform-modules/teleport/db-agent/aws/versions.tf
@@ -10,9 +10,9 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.0"
     }
-    http = {
-      source  = "hashicorp/http"
-      version = ">= 3.0"
+    teleport = {
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
+      version = ">= 18.8.0"
     }
   }
 }


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/68960 to branch/v18.
- https://github.com/gravitational/teleport/pull/68960

Part of https://github.com/gravitational/core/issues/183
- https://github.com/gravitational/core/issues/183

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- staging cloud tenant on v19

### Test Cases
- [X] running the example creates a Teleport db agent that joins the cluster
