### PR TITLE
[v18] Scope namespace bot instances (#68390, #68391, #69126)

### DIFF
--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
@@ -44,7 +44,11 @@ type GetBotInstanceRequest struct {
 	// The name of the bot associated with the instance.
 	BotName string `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
 	// The unique identifier of the bot instance to retrieve.
-	InstanceId    string `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	InstanceId string `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope      string `protobuf:"bytes,3,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -88,12 +92,23 @@ func (x *GetBotInstanceRequest) GetInstanceId() string {
 	return ""
 }
 
+func (x *GetBotInstanceRequest) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *GetBotInstanceRequest) SetBotName(v string) {
 	x.BotName = v
 }
 
 func (x *GetBotInstanceRequest) SetInstanceId(v string) {
 	x.InstanceId = v
+}
+
+func (x *GetBotInstanceRequest) SetBotScope(v string) {
+	x.BotScope = v
 }
 
 type GetBotInstanceRequest_builder struct {
@@ -103,6 +118,10 @@ type GetBotInstanceRequest_builder struct {
 	BotName string
 	// The unique identifier of the bot instance to retrieve.
 	InstanceId string
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope string
 }
 
 func (b0 GetBotInstanceRequest_builder) Build() *GetBotInstanceRequest {
@@ -111,6 +130,7 @@ func (b0 GetBotInstanceRequest_builder) Build() *GetBotInstanceRequest {
 	_, _ = b, x
 	x.BotName = b.BotName
 	x.InstanceId = b.InstanceId
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -488,7 +508,11 @@ type DeleteBotInstanceRequest struct {
 	// The name of the BotInstance to delete.
 	BotName string `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
 	// The unique identifier of the bot instance to delete.
-	InstanceId    string `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	InstanceId string `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope      string `protobuf:"bytes,3,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -532,12 +556,23 @@ func (x *DeleteBotInstanceRequest) GetInstanceId() string {
 	return ""
 }
 
+func (x *DeleteBotInstanceRequest) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *DeleteBotInstanceRequest) SetBotName(v string) {
 	x.BotName = v
 }
 
 func (x *DeleteBotInstanceRequest) SetInstanceId(v string) {
 	x.InstanceId = v
+}
+
+func (x *DeleteBotInstanceRequest) SetBotScope(v string) {
+	x.BotScope = v
 }
 
 type DeleteBotInstanceRequest_builder struct {
@@ -547,6 +582,10 @@ type DeleteBotInstanceRequest_builder struct {
 	BotName string
 	// The unique identifier of the bot instance to delete.
 	InstanceId string
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope string
 }
 
 func (b0 DeleteBotInstanceRequest_builder) Build() *DeleteBotInstanceRequest {
@@ -555,6 +594,7 @@ func (b0 DeleteBotInstanceRequest_builder) Build() *DeleteBotInstanceRequest {
 	_, _ = b, x
 	x.BotName = b.BotName
 	x.InstanceId = b.InstanceId
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -699,7 +739,14 @@ type ListBotInstancesV2Request_Filters struct {
 	// match against supported fields.
 	SearchTerm string `protobuf:"bytes,2,opt,name=search_term,json=searchTerm,proto3" json:"search_term,omitempty"`
 	// A Teleport predicate language query used to filter the results.
-	Query         string `protobuf:"bytes,3,opt,name=query,proto3" json:"query,omitempty"`
+	Query string `protobuf:"bytes,3,opt,name=query,proto3" json:"query,omitempty"`
+	// The scope of the bot to list BotInstances for. Only valid alongside a
+	// non-empty bot_name, which it qualifies to uniquely identify a scoped bot
+	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
+	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
+	// selects the unscoped bot with that name. This is not a standalone scope
+	// filter for listing all of a scope's instances.
+	BotScope      string `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -750,6 +797,13 @@ func (x *ListBotInstancesV2Request_Filters) GetQuery() string {
 	return ""
 }
 
+func (x *ListBotInstancesV2Request_Filters) GetBotScope() string {
+	if x != nil {
+		return x.BotScope
+	}
+	return ""
+}
+
 func (x *ListBotInstancesV2Request_Filters) SetBotName(v string) {
 	x.BotName = v
 }
@@ -760,6 +814,10 @@ func (x *ListBotInstancesV2Request_Filters) SetSearchTerm(v string) {
 
 func (x *ListBotInstancesV2Request_Filters) SetQuery(v string) {
 	x.Query = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) SetBotScope(v string) {
+	x.BotScope = v
 }
 
 type ListBotInstancesV2Request_Filters_builder struct {
@@ -773,6 +831,13 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	SearchTerm string
 	// A Teleport predicate language query used to filter the results.
 	Query string
+	// The scope of the bot to list BotInstances for. Only valid alongside a
+	// non-empty bot_name, which it qualifies to uniquely identify a scoped bot
+	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
+	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
+	// selects the unscoped bot with that name. This is not a standalone scope
+	// filter for listing all of a scope's instances.
+	BotScope string
 }
 
 func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2Request_Filters {
@@ -782,6 +847,7 @@ func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2R
 	x.BotName = b.BotName
 	x.SearchTerm = b.SearchTerm
 	x.Query = b.Query
+	x.BotScope = b.BotScope
 	return m0
 }
 
@@ -789,18 +855,19 @@ var File_teleport_machineid_v1_bot_instance_service_proto protoreflect.FileDescr
 
 const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
-	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"S\n" +
+	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"p\n" +
 	"\x15GetBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
-	"instanceId\"\xce\x01\n" +
+	"instanceId\x12\x1b\n" +
+	"\tbot_scope\x18\x03 \x01(\tR\bbotScope\"\xce\x01\n" +
 	"\x17ListBotInstancesRequest\x12&\n" +
 	"\x0ffilter_bot_name\x18\x01 \x01(\tR\rfilterBotName\x12\x1b\n" +
 	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\x12,\n" +
 	"\x12filter_search_term\x18\x04 \x01(\tR\x10filterSearchTerm\x12!\n" +
-	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xc2\x02\n" +
+	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xdf\x02\n" +
 	"\x19ListBotInstancesV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -808,19 +875,21 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"sort_field\x18\x03 \x01(\tR\tsortField\x12\x1b\n" +
 	"\tsort_desc\x18\x04 \x01(\bR\bsortDesc\x12P\n" +
-	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1a[\n" +
+	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1ax\n" +
 	"\aFilters\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vsearch_term\x18\x02 \x01(\tR\n" +
 	"searchTerm\x12\x14\n" +
-	"\x05query\x18\x03 \x01(\tR\x05query\"\x8b\x01\n" +
+	"\x05query\x18\x03 \x01(\tR\x05query\x12\x1b\n" +
+	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"\x8b\x01\n" +
 	"\x18ListBotInstancesResponse\x12G\n" +
 	"\rbot_instances\x18\x01 \x03(\v2\".teleport.machineid.v1.BotInstanceR\fbotInstances\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"V\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"s\n" +
 	"\x18DeleteBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
-	"instanceId\"\xc1\x01\n" +
+	"instanceId\x12\x1b\n" +
+	"\tbot_scope\x18\x03 \x01(\tR\bbotScope\"\xc1\x01\n" +
 	"\x16SubmitHeartbeatRequest\x12O\n" +
 	"\theartbeat\x18\x01 \x01(\v21.teleport.machineid.v1.BotInstanceStatusHeartbeatR\theartbeat\x12V\n" +
 	"\x0eservice_health\x18\x02 \x03(\v2/.teleport.machineid.v1.BotInstanceServiceHealthR\rserviceHealth\"\x19\n" +

--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protohybrid.pb.go
@@ -23,6 +23,7 @@
 package machineidv1
 
 import (
+	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -745,8 +746,16 @@ type ListBotInstancesV2Request_Filters struct {
 	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
 	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
 	// selects the unscoped bot with that name. This is not a standalone scope
-	// filter for listing all of a scope's instances.
-	BotScope      string `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	// filter for listing all of a scope's instances - use scope_filter for that.
+	BotScope string `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3" json:"bot_scope,omitempty"`
+	// scope_filter selects BotInstances by the scope of their owning bot.
+	// Defaults to one of EXACT or UNSCOPED depending on whether the caller is a
+	// scoped or unscoped identity. Exhaustive user-facing views (e.g. `tctl get`)
+	// should specify mode ALL.
+	//
+	// Mutually exclusive with bot_name, which already constrains the result to a
+	// single bot in a single scope; setting both is an error.
+	ScopeFilter   *v1.Filter `protobuf:"bytes,5,opt,name=scope_filter,json=scopeFilter,proto3" json:"scope_filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -804,6 +813,13 @@ func (x *ListBotInstancesV2Request_Filters) GetBotScope() string {
 	return ""
 }
 
+func (x *ListBotInstancesV2Request_Filters) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListBotInstancesV2Request_Filters) SetBotName(v string) {
 	x.BotName = v
 }
@@ -818,6 +834,21 @@ func (x *ListBotInstancesV2Request_Filters) SetQuery(v string) {
 
 func (x *ListBotInstancesV2Request_Filters) SetBotScope(v string) {
 	x.BotScope = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) SetScopeFilter(v *v1.Filter) {
+	x.ScopeFilter = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.ScopeFilter != nil
+}
+
+func (x *ListBotInstancesV2Request_Filters) ClearScopeFilter() {
+	x.ScopeFilter = nil
 }
 
 type ListBotInstancesV2Request_Filters_builder struct {
@@ -836,8 +867,16 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
 	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
 	// selects the unscoped bot with that name. This is not a standalone scope
-	// filter for listing all of a scope's instances.
+	// filter for listing all of a scope's instances - use scope_filter for that.
 	BotScope string
+	// scope_filter selects BotInstances by the scope of their owning bot.
+	// Defaults to one of EXACT or UNSCOPED depending on whether the caller is a
+	// scoped or unscoped identity. Exhaustive user-facing views (e.g. `tctl get`)
+	// should specify mode ALL.
+	//
+	// Mutually exclusive with bot_name, which already constrains the result to a
+	// single bot in a single scope; setting both is an error.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2Request_Filters {
@@ -848,6 +887,7 @@ func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2R
 	x.SearchTerm = b.SearchTerm
 	x.Query = b.Query
 	x.BotScope = b.BotScope
+	x.ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -855,7 +895,7 @@ var File_teleport_machineid_v1_bot_instance_service_proto protoreflect.FileDescr
 
 const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
-	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"p\n" +
+	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"p\n" +
 	"\x15GetBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
@@ -867,7 +907,7 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\x12,\n" +
 	"\x12filter_search_term\x18\x04 \x01(\tR\x10filterSearchTerm\x12!\n" +
-	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xdf\x02\n" +
+	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\x9f\x03\n" +
 	"\x19ListBotInstancesV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -875,13 +915,14 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"sort_field\x18\x03 \x01(\tR\tsortField\x12\x1b\n" +
 	"\tsort_desc\x18\x04 \x01(\bR\bsortDesc\x12P\n" +
-	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1ax\n" +
+	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1a\xb7\x01\n" +
 	"\aFilters\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vsearch_term\x18\x02 \x01(\tR\n" +
 	"searchTerm\x12\x14\n" +
 	"\x05query\x18\x03 \x01(\tR\x05query\x12\x1b\n" +
-	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"\x8b\x01\n" +
+	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\x12=\n" +
+	"\fscope_filter\x18\x05 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"\x8b\x01\n" +
 	"\x18ListBotInstancesResponse\x12G\n" +
 	"\rbot_instances\x18\x01 \x03(\v2\".teleport.machineid.v1.BotInstanceR\fbotInstances\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"s\n" +
@@ -915,7 +956,8 @@ var file_teleport_machineid_v1_bot_instance_service_proto_goTypes = []any{
 	(*BotInstance)(nil),                       // 9: teleport.machineid.v1.BotInstance
 	(*BotInstanceStatusHeartbeat)(nil),        // 10: teleport.machineid.v1.BotInstanceStatusHeartbeat
 	(*BotInstanceServiceHealth)(nil),          // 11: teleport.machineid.v1.BotInstanceServiceHealth
-	(*emptypb.Empty)(nil),                     // 12: google.protobuf.Empty
+	(*v1.Filter)(nil),                         // 12: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),                     // 13: google.protobuf.Empty
 }
 var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
 	8,  // 0: teleport.machineid.v1.ListBotInstancesRequest.sort:type_name -> types.SortBy
@@ -923,21 +965,22 @@ var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
 	9,  // 2: teleport.machineid.v1.ListBotInstancesResponse.bot_instances:type_name -> teleport.machineid.v1.BotInstance
 	10, // 3: teleport.machineid.v1.SubmitHeartbeatRequest.heartbeat:type_name -> teleport.machineid.v1.BotInstanceStatusHeartbeat
 	11, // 4: teleport.machineid.v1.SubmitHeartbeatRequest.service_health:type_name -> teleport.machineid.v1.BotInstanceServiceHealth
-	0,  // 5: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
-	1,  // 6: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
-	2,  // 7: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
-	4,  // 8: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
-	5,  // 9: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
-	9,  // 10: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
-	3,  // 11: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	3,  // 12: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	12, // 13: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
-	6,  // 14: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
-	10, // [10:15] is the sub-list for method output_type
-	5,  // [5:10] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	12, // 5: teleport.machineid.v1.ListBotInstancesV2Request.Filters.scope_filter:type_name -> teleport.scopes.v1.Filter
+	0,  // 6: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
+	1,  // 7: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
+	2,  // 8: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
+	4,  // 9: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
+	5,  // 10: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
+	9,  // 11: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
+	3,  // 12: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	3,  // 13: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	13, // 14: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
+	6,  // 15: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
+	11, // [11:16] is the sub-list for method output_type
+	6,  // [6:11] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_teleport_machineid_v1_bot_instance_service_proto_init() }

--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
@@ -43,6 +43,7 @@ type GetBotInstanceRequest struct {
 	state                 protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_BotName    string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
 	xxx_hidden_InstanceId string                 `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3"`
+	xxx_hidden_BotScope   string                 `protobuf:"bytes,3,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -86,12 +87,23 @@ func (x *GetBotInstanceRequest) GetInstanceId() string {
 	return ""
 }
 
+func (x *GetBotInstanceRequest) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *GetBotInstanceRequest) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
 }
 
 func (x *GetBotInstanceRequest) SetInstanceId(v string) {
 	x.xxx_hidden_InstanceId = v
+}
+
+func (x *GetBotInstanceRequest) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
 }
 
 type GetBotInstanceRequest_builder struct {
@@ -101,6 +113,10 @@ type GetBotInstanceRequest_builder struct {
 	BotName string
 	// The unique identifier of the bot instance to retrieve.
 	InstanceId string
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope string
 }
 
 func (b0 GetBotInstanceRequest_builder) Build() *GetBotInstanceRequest {
@@ -109,6 +125,7 @@ func (b0 GetBotInstanceRequest_builder) Build() *GetBotInstanceRequest {
 	_, _ = b, x
 	x.xxx_hidden_BotName = b.BotName
 	x.xxx_hidden_InstanceId = b.InstanceId
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -467,6 +484,7 @@ type DeleteBotInstanceRequest struct {
 	state                 protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_BotName    string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
 	xxx_hidden_InstanceId string                 `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3"`
+	xxx_hidden_BotScope   string                 `protobuf:"bytes,3,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -510,12 +528,23 @@ func (x *DeleteBotInstanceRequest) GetInstanceId() string {
 	return ""
 }
 
+func (x *DeleteBotInstanceRequest) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *DeleteBotInstanceRequest) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
 }
 
 func (x *DeleteBotInstanceRequest) SetInstanceId(v string) {
 	x.xxx_hidden_InstanceId = v
+}
+
+func (x *DeleteBotInstanceRequest) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
 }
 
 type DeleteBotInstanceRequest_builder struct {
@@ -525,6 +554,10 @@ type DeleteBotInstanceRequest_builder struct {
 	BotName string
 	// The unique identifier of the bot instance to delete.
 	InstanceId string
+	// The scope of the bot associated with the instance. Combined with bot_name
+	// to uniquely identify a scoped bot. Leave empty if the associated bot is
+	// unscoped.
+	BotScope string
 }
 
 func (b0 DeleteBotInstanceRequest_builder) Build() *DeleteBotInstanceRequest {
@@ -533,6 +566,7 @@ func (b0 DeleteBotInstanceRequest_builder) Build() *DeleteBotInstanceRequest {
 	_, _ = b, x
 	x.xxx_hidden_BotName = b.BotName
 	x.xxx_hidden_InstanceId = b.InstanceId
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -673,6 +707,7 @@ type ListBotInstancesV2Request_Filters struct {
 	xxx_hidden_BotName    string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
 	xxx_hidden_SearchTerm string                 `protobuf:"bytes,2,opt,name=search_term,json=searchTerm,proto3"`
 	xxx_hidden_Query      string                 `protobuf:"bytes,3,opt,name=query,proto3"`
+	xxx_hidden_BotScope   string                 `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -723,6 +758,13 @@ func (x *ListBotInstancesV2Request_Filters) GetQuery() string {
 	return ""
 }
 
+func (x *ListBotInstancesV2Request_Filters) GetBotScope() string {
+	if x != nil {
+		return x.xxx_hidden_BotScope
+	}
+	return ""
+}
+
 func (x *ListBotInstancesV2Request_Filters) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
 }
@@ -733,6 +775,10 @@ func (x *ListBotInstancesV2Request_Filters) SetSearchTerm(v string) {
 
 func (x *ListBotInstancesV2Request_Filters) SetQuery(v string) {
 	x.xxx_hidden_Query = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) SetBotScope(v string) {
+	x.xxx_hidden_BotScope = v
 }
 
 type ListBotInstancesV2Request_Filters_builder struct {
@@ -746,6 +792,13 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	SearchTerm string
 	// A Teleport predicate language query used to filter the results.
 	Query string
+	// The scope of the bot to list BotInstances for. Only valid alongside a
+	// non-empty bot_name, which it qualifies to uniquely identify a scoped bot
+	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
+	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
+	// selects the unscoped bot with that name. This is not a standalone scope
+	// filter for listing all of a scope's instances.
+	BotScope string
 }
 
 func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2Request_Filters {
@@ -755,6 +808,7 @@ func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2R
 	x.xxx_hidden_BotName = b.BotName
 	x.xxx_hidden_SearchTerm = b.SearchTerm
 	x.xxx_hidden_Query = b.Query
+	x.xxx_hidden_BotScope = b.BotScope
 	return m0
 }
 
@@ -762,18 +816,19 @@ var File_teleport_machineid_v1_bot_instance_service_proto protoreflect.FileDescr
 
 const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
-	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"S\n" +
+	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"p\n" +
 	"\x15GetBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
-	"instanceId\"\xce\x01\n" +
+	"instanceId\x12\x1b\n" +
+	"\tbot_scope\x18\x03 \x01(\tR\bbotScope\"\xce\x01\n" +
 	"\x17ListBotInstancesRequest\x12&\n" +
 	"\x0ffilter_bot_name\x18\x01 \x01(\tR\rfilterBotName\x12\x1b\n" +
 	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\x12,\n" +
 	"\x12filter_search_term\x18\x04 \x01(\tR\x10filterSearchTerm\x12!\n" +
-	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xc2\x02\n" +
+	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xdf\x02\n" +
 	"\x19ListBotInstancesV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -781,19 +836,21 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"sort_field\x18\x03 \x01(\tR\tsortField\x12\x1b\n" +
 	"\tsort_desc\x18\x04 \x01(\bR\bsortDesc\x12P\n" +
-	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1a[\n" +
+	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1ax\n" +
 	"\aFilters\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vsearch_term\x18\x02 \x01(\tR\n" +
 	"searchTerm\x12\x14\n" +
-	"\x05query\x18\x03 \x01(\tR\x05query\"\x8b\x01\n" +
+	"\x05query\x18\x03 \x01(\tR\x05query\x12\x1b\n" +
+	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"\x8b\x01\n" +
 	"\x18ListBotInstancesResponse\x12G\n" +
 	"\rbot_instances\x18\x01 \x03(\v2\".teleport.machineid.v1.BotInstanceR\fbotInstances\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"V\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"s\n" +
 	"\x18DeleteBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
-	"instanceId\"\xc1\x01\n" +
+	"instanceId\x12\x1b\n" +
+	"\tbot_scope\x18\x03 \x01(\tR\bbotScope\"\xc1\x01\n" +
 	"\x16SubmitHeartbeatRequest\x12O\n" +
 	"\theartbeat\x18\x01 \x01(\v21.teleport.machineid.v1.BotInstanceStatusHeartbeatR\theartbeat\x12V\n" +
 	"\x0eservice_health\x18\x02 \x03(\v2/.teleport.machineid.v1.BotInstanceServiceHealthR\rserviceHealth\"\x19\n" +

--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service_protoopaque.pb.go
@@ -23,6 +23,7 @@
 package machineidv1
 
 import (
+	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -703,13 +704,14 @@ func (b0 SubmitHeartbeatResponse_builder) Build() *SubmitHeartbeatResponse {
 
 // Filters contains fields to be used to filter the results.
 type ListBotInstancesV2Request_Filters struct {
-	state                 protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_BotName    string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
-	xxx_hidden_SearchTerm string                 `protobuf:"bytes,2,opt,name=search_term,json=searchTerm,proto3"`
-	xxx_hidden_Query      string                 `protobuf:"bytes,3,opt,name=query,proto3"`
-	xxx_hidden_BotScope   string                 `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_BotName     string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
+	xxx_hidden_SearchTerm  string                 `protobuf:"bytes,2,opt,name=search_term,json=searchTerm,proto3"`
+	xxx_hidden_Query       string                 `protobuf:"bytes,3,opt,name=query,proto3"`
+	xxx_hidden_BotScope    string                 `protobuf:"bytes,4,opt,name=bot_scope,json=botScope,proto3"`
+	xxx_hidden_ScopeFilter *v1.Filter             `protobuf:"bytes,5,opt,name=scope_filter,json=scopeFilter,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *ListBotInstancesV2Request_Filters) Reset() {
@@ -765,6 +767,13 @@ func (x *ListBotInstancesV2Request_Filters) GetBotScope() string {
 	return ""
 }
 
+func (x *ListBotInstancesV2Request_Filters) GetScopeFilter() *v1.Filter {
+	if x != nil {
+		return x.xxx_hidden_ScopeFilter
+	}
+	return nil
+}
+
 func (x *ListBotInstancesV2Request_Filters) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
 }
@@ -779,6 +788,21 @@ func (x *ListBotInstancesV2Request_Filters) SetQuery(v string) {
 
 func (x *ListBotInstancesV2Request_Filters) SetBotScope(v string) {
 	x.xxx_hidden_BotScope = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) SetScopeFilter(v *v1.Filter) {
+	x.xxx_hidden_ScopeFilter = v
+}
+
+func (x *ListBotInstancesV2Request_Filters) HasScopeFilter() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ScopeFilter != nil
+}
+
+func (x *ListBotInstancesV2Request_Filters) ClearScopeFilter() {
+	x.xxx_hidden_ScopeFilter = nil
 }
 
 type ListBotInstancesV2Request_Filters_builder struct {
@@ -797,8 +821,16 @@ type ListBotInstancesV2Request_Filters_builder struct {
 	// (a scoped bot is identified by the pair (scope, name)); setting bot_scope
 	// without bot_name is an error. An empty bot_scope with a non-empty bot_name
 	// selects the unscoped bot with that name. This is not a standalone scope
-	// filter for listing all of a scope's instances.
+	// filter for listing all of a scope's instances - use scope_filter for that.
 	BotScope string
+	// scope_filter selects BotInstances by the scope of their owning bot.
+	// Defaults to one of EXACT or UNSCOPED depending on whether the caller is a
+	// scoped or unscoped identity. Exhaustive user-facing views (e.g. `tctl get`)
+	// should specify mode ALL.
+	//
+	// Mutually exclusive with bot_name, which already constrains the result to a
+	// single bot in a single scope; setting both is an error.
+	ScopeFilter *v1.Filter
 }
 
 func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2Request_Filters {
@@ -809,6 +841,7 @@ func (b0 ListBotInstancesV2Request_Filters_builder) Build() *ListBotInstancesV2R
 	x.xxx_hidden_SearchTerm = b.SearchTerm
 	x.xxx_hidden_Query = b.Query
 	x.xxx_hidden_BotScope = b.BotScope
+	x.xxx_hidden_ScopeFilter = b.ScopeFilter
 	return m0
 }
 
@@ -816,7 +849,7 @@ var File_teleport_machineid_v1_bot_instance_service_proto protoreflect.FileDescr
 
 const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
-	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\"p\n" +
+	"0teleport/machineid/v1/bot_instance_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"p\n" +
 	"\x15GetBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
@@ -828,7 +861,7 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"page_token\x18\x03 \x01(\tR\tpageToken\x12,\n" +
 	"\x12filter_search_term\x18\x04 \x01(\tR\x10filterSearchTerm\x12!\n" +
-	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\xdf\x02\n" +
+	"\x04sort\x18\x05 \x01(\v2\r.types.SortByR\x04sort\"\x9f\x03\n" +
 	"\x19ListBotInstancesV2Request\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -836,13 +869,14 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\n" +
 	"sort_field\x18\x03 \x01(\tR\tsortField\x12\x1b\n" +
 	"\tsort_desc\x18\x04 \x01(\bR\bsortDesc\x12P\n" +
-	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1ax\n" +
+	"\x06filter\x18\x05 \x01(\v28.teleport.machineid.v1.ListBotInstancesV2Request.FiltersR\x06filter\x1a\xb7\x01\n" +
 	"\aFilters\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vsearch_term\x18\x02 \x01(\tR\n" +
 	"searchTerm\x12\x14\n" +
 	"\x05query\x18\x03 \x01(\tR\x05query\x12\x1b\n" +
-	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\"\x8b\x01\n" +
+	"\tbot_scope\x18\x04 \x01(\tR\bbotScope\x12=\n" +
+	"\fscope_filter\x18\x05 \x01(\v2\x1a.teleport.scopes.v1.FilterR\vscopeFilter\"\x8b\x01\n" +
 	"\x18ListBotInstancesResponse\x12G\n" +
 	"\rbot_instances\x18\x01 \x03(\v2\".teleport.machineid.v1.BotInstanceR\fbotInstances\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"s\n" +
@@ -876,7 +910,8 @@ var file_teleport_machineid_v1_bot_instance_service_proto_goTypes = []any{
 	(*BotInstance)(nil),                       // 9: teleport.machineid.v1.BotInstance
 	(*BotInstanceStatusHeartbeat)(nil),        // 10: teleport.machineid.v1.BotInstanceStatusHeartbeat
 	(*BotInstanceServiceHealth)(nil),          // 11: teleport.machineid.v1.BotInstanceServiceHealth
-	(*emptypb.Empty)(nil),                     // 12: google.protobuf.Empty
+	(*v1.Filter)(nil),                         // 12: teleport.scopes.v1.Filter
+	(*emptypb.Empty)(nil),                     // 13: google.protobuf.Empty
 }
 var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
 	8,  // 0: teleport.machineid.v1.ListBotInstancesRequest.sort:type_name -> types.SortBy
@@ -884,21 +919,22 @@ var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
 	9,  // 2: teleport.machineid.v1.ListBotInstancesResponse.bot_instances:type_name -> teleport.machineid.v1.BotInstance
 	10, // 3: teleport.machineid.v1.SubmitHeartbeatRequest.heartbeat:type_name -> teleport.machineid.v1.BotInstanceStatusHeartbeat
 	11, // 4: teleport.machineid.v1.SubmitHeartbeatRequest.service_health:type_name -> teleport.machineid.v1.BotInstanceServiceHealth
-	0,  // 5: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
-	1,  // 6: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
-	2,  // 7: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
-	4,  // 8: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
-	5,  // 9: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
-	9,  // 10: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
-	3,  // 11: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	3,  // 12: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	12, // 13: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
-	6,  // 14: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
-	10, // [10:15] is the sub-list for method output_type
-	5,  // [5:10] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	12, // 5: teleport.machineid.v1.ListBotInstancesV2Request.Filters.scope_filter:type_name -> teleport.scopes.v1.Filter
+	0,  // 6: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
+	1,  // 7: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
+	2,  // 8: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
+	4,  // 9: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
+	5,  // 10: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
+	9,  // 11: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
+	3,  // 12: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	3,  // 13: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	13, // 14: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
+	6,  // 15: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
+	11, // [11:16] is the sub-list for method output_type
+	6,  // [6:11] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_teleport_machineid_v1_bot_instance_service_proto_init() }

--- a/api/proto/teleport/machineid/v1/bot_instance_service.proto
+++ b/api/proto/teleport/machineid/v1/bot_instance_service.proto
@@ -28,6 +28,10 @@ message GetBotInstanceRequest {
   string bot_name = 1;
   // The unique identifier of the bot instance to retrieve.
   string instance_id = 2;
+  // The scope of the bot associated with the instance. Combined with bot_name
+  // to uniquely identify a scoped bot. Leave empty if the associated bot is
+  // unscoped.
+  string bot_scope = 3;
 }
 
 // Request for ListBotInstances.
@@ -80,6 +84,13 @@ message ListBotInstancesV2Request {
     string search_term = 2;
     // A Teleport predicate language query used to filter the results.
     string query = 3;
+    // The scope of the bot to list BotInstances for. Only valid alongside a
+    // non-empty bot_name, which it qualifies to uniquely identify a scoped bot
+    // (a scoped bot is identified by the pair (scope, name)); setting bot_scope
+    // without bot_name is an error. An empty bot_scope with a non-empty bot_name
+    // selects the unscoped bot with that name. This is not a standalone scope
+    // filter for listing all of a scope's instances.
+    string bot_scope = 4;
   }
 }
 
@@ -98,6 +109,10 @@ message DeleteBotInstanceRequest {
   string bot_name = 1;
   // The unique identifier of the bot instance to delete.
   string instance_id = 2;
+  // The scope of the bot associated with the instance. Combined with bot_name
+  // to uniquely identify a scoped bot. Leave empty if the associated bot is
+  // unscoped.
+  string bot_scope = 3;
 }
 
 // The request for SubmitHeartbeat.

--- a/api/proto/teleport/machineid/v1/bot_instance_service.proto
+++ b/api/proto/teleport/machineid/v1/bot_instance_service.proto
@@ -19,6 +19,7 @@ package teleport.machineid.v1;
 import "google/protobuf/empty.proto";
 import "teleport/legacy/types/types.proto";
 import "teleport/machineid/v1/bot_instance.proto";
+import "teleport/scopes/v1/scopes.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1;machineidv1";
 
@@ -89,8 +90,16 @@ message ListBotInstancesV2Request {
     // (a scoped bot is identified by the pair (scope, name)); setting bot_scope
     // without bot_name is an error. An empty bot_scope with a non-empty bot_name
     // selects the unscoped bot with that name. This is not a standalone scope
-    // filter for listing all of a scope's instances.
+    // filter for listing all of a scope's instances - use scope_filter for that.
     string bot_scope = 4;
+    // scope_filter selects BotInstances by the scope of their owning bot.
+    // Defaults to one of EXACT or UNSCOPED depending on whether the caller is a
+    // scoped or unscoped identity. Exhaustive user-facing views (e.g. `tctl get`)
+    // should specify mode ALL.
+    //
+    // Mutually exclusive with bot_name, which already constrains the result to a
+    // single bot in a single scope; setting both is an error.
+    teleport.scopes.v1.Filter scope_filter = 5;
   }
 }
 

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1169,7 +1169,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|name|*no default* (optional)|The name of the bot from which to list instances. If unset, lists instances from all bots.|
+|name|*no default* (optional)|The name of the bot from which to list instances. For a scoped bot, provide a scope-qualified name of the form \[scope\]::\[name\]. If unset, lists instances from all bots.|
 
 ## tctl bots instances show
 
@@ -1185,7 +1185,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|id|*no default* (required)|The full ID of the bot instance, in the form of \[bot name\]/\[uuid\]|
+|id|*no default* (required)|The full ID of the bot instance, in the form of \[bot name\]/\[uuid\]. For an instance of a scoped bot, prefix the ID with the bot's scope: \[scope\]::\[bot name\]/\[uuid\].|
 
 ## tctl bots ls
 

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1168,7 +1168,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|name|*no default* (optional)|The name of the bot from which to list instances. If unset, lists instances from all bots.|
+|name|*no default* (optional)|The name of the bot from which to list instances. For a scoped bot, provide a scope-qualified name of the form \[scope\]::\[name\]. If unset, lists instances from all bots.|
 
 ## tctl bots instances show
 
@@ -1184,7 +1184,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|id|*no default* (required)|The full ID of the bot instance, in the form of \[bot name\]/\[uuid\]|
+|id|*no default* (required)|The full ID of the bot instance, in the form of \[bot name\]/\[uuid\]. For an instance of a scoped bot, prefix the ID with the bot's scope: \[scope\]::\[bot name\]/\[uuid\].|
 
 ## tctl bots ls
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1281,6 +1281,7 @@ func supportedScopedWatchKind(kind string) bool {
 	case types.KindAccessList,
 		types.KindAccessListMember,
 		types.KindAccessListReview,
+		types.KindBotInstance,
 		scopedaccess.KindScopedRole,
 		scopedaccess.KindScopedRoleAssignment,
 		types.KindKubernetesCluster,

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1281,6 +1281,7 @@ func supportedScopedWatchKind(kind string) bool {
 	case types.KindAccessList,
 		types.KindAccessListMember,
 		types.KindAccessListReview,
+		types.KindBotInstance,
 		scopedaccess.KindScopedRole,
 		scopedaccess.KindScopedRoleAssignment,
 		types.KindKubernetesCluster:

--- a/lib/auth/auth_with_roles_watch_authz_test.go
+++ b/lib/auth/auth_with_roles_watch_authz_test.go
@@ -197,6 +197,38 @@ func TestScopedWatchKindAuthz(t *testing.T) {
 			assertErr: requireAccessDenied,
 		},
 		{
+			// bot_instance is namespaced and carries its scope on delete events, so it is
+			// whitelisted for scope-targeting watch filters.
+			name:      "bot_instance default resolves to EXACT at pin",
+			kind:      types.KindBotInstance,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
+			wantScope: pinScope,
+		},
+		{
+			name:      "bot_instance DESCENDANTS at pin",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_DESCENDANTS, pinScope),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_DESCENDANTS,
+			wantScope: pinScope,
+		},
+		{
+			name:      "bot_instance ALL rewritten to DESCENDANTS at pin",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_DESCENDANTS,
+			wantScope: pinScope,
+		},
+		{
+			name:      "bot_instance EXACT at orthogonal scope denied by pin enforcement",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/bar"),
+			assertErr: requireAccessDenied,
+		},
+		{
 			// scoped-kind-whitelist: this test case and associated behaviore can be removed once all scoped
 			// kinds are namespaced.
 			name:      "non-namespaced kind EXACT denied by whitelist",
@@ -395,6 +427,20 @@ func TestUnscopedWatchKindAuthz(t *testing.T) {
 		{
 			name:      "scoped_role EXACT allowed for unscoped caller",
 			kind:      scopedaccess.KindScopedRole,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
+		},
+		{
+			name:      "bot_instance defaults to UNSCOPED for unscoped caller",
+			kind:      types.KindBotInstance,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_UNSCOPED,
+		},
+		{
+			name:      "bot_instance EXACT allowed for unscoped caller",
+			kind:      types.KindBotInstance,
 			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
 			assertErr: require.NoError,
 			wantMode:  scopesv1.Mode_MODE_EXACT,

--- a/lib/auth/auth_with_roles_watch_authz_test.go
+++ b/lib/auth/auth_with_roles_watch_authz_test.go
@@ -197,11 +197,29 @@ func TestScopedWatchKindAuthz(t *testing.T) {
 			assertErr: requireAccessDenied,
 		},
 		{
+			// bot_instance is namespaced and carries its scope on delete events, so it is
+			// whitelisted for scope-targeting watch filters.
+			name:      "bot_instance default resolves to EXACT at pin",
+			kind:      types.KindBotInstance,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
+			wantScope: pinScope,
+		},
+		{
 			name:      "workload_identity default resolves to EXACT at pin",
 			kind:      types.KindWorkloadIdentity,
 			filter:    nil,
 			assertErr: require.NoError,
 			wantMode:  scopesv1.Mode_MODE_EXACT,
+			wantScope: pinScope,
+		},
+		{
+			name:      "bot_instance DESCENDANTS at pin",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_DESCENDANTS, pinScope),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_DESCENDANTS,
 			wantScope: pinScope,
 		},
 		{
@@ -213,12 +231,26 @@ func TestScopedWatchKindAuthz(t *testing.T) {
 			wantScope: pinScope,
 		},
 		{
+			name:      "bot_instance ALL rewritten to DESCENDANTS at pin",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_DESCENDANTS,
+			wantScope: pinScope,
+		},
+		{
 			name:      "workload_identity ALL rewritten to DESCENDANTS at pin",
 			kind:      types.KindWorkloadIdentity,
 			filter:    filter(scopesv1.Mode_MODE_ALL, ""),
 			assertErr: require.NoError,
 			wantMode:  scopesv1.Mode_MODE_DESCENDANTS,
 			wantScope: pinScope,
+		},
+		{
+			name:      "bot_instance EXACT at orthogonal scope denied by pin enforcement",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/bar"),
+			assertErr: requireAccessDenied,
 		},
 		{
 			name:      "workload_identity EXACT at orthogonal scope denied by pin enforcement",
@@ -430,11 +462,25 @@ func TestUnscopedWatchKindAuthz(t *testing.T) {
 			wantMode:  scopesv1.Mode_MODE_EXACT,
 		},
 		{
+			name:      "bot_instance defaults to UNSCOPED for unscoped caller",
+			kind:      types.KindBotInstance,
+			filter:    nil,
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_UNSCOPED,
+		},
+		{
 			name:      "workload_identity defaults to UNSCOPED for unscoped caller",
 			kind:      types.KindWorkloadIdentity,
 			filter:    nil,
 			assertErr: require.NoError,
 			wantMode:  scopesv1.Mode_MODE_UNSCOPED,
+		},
+		{
+			name:      "bot_instance EXACT allowed for unscoped caller",
+			kind:      types.KindBotInstance,
+			filter:    filter(scopesv1.Mode_MODE_EXACT, "/foo"),
+			assertErr: require.NoError,
+			wantMode:  scopesv1.Mode_MODE_EXACT,
 		},
 		{
 			name:      "workload_identity EXACT allowed for unscoped caller",

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1547,8 +1547,10 @@ type Cache interface {
 	// ListRelayServers returns a paginated list of relay server heartbeats.
 	ListRelayServers(ctx context.Context, pageSize int, pageToken string) (_ []*presencev1.RelayServer, nextPageToken string, _ error)
 
-	// GetBotInstance returns the specified BotInstance resource.
-	GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error)
+	// GetBotInstance returns the specified BotInstance resource. A bot is
+	// identified by the request's (bot_scope, bot_name); bot_scope is empty
+	// for instances of unscoped bots.
+	GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error)
 
 	// ListBotInstances returns a page of BotInstance resources.
 	ListBotInstances(ctx context.Context, pageSize int, lastToken string, options *services.ListBotInstancesRequestOptions) ([]*machineidv1.BotInstance, string, error)

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1546,8 +1546,10 @@ type Cache interface {
 	// ListRelayServers returns a paginated list of relay server heartbeats.
 	ListRelayServers(ctx context.Context, pageSize int, pageToken string) (_ []*presencev1.RelayServer, nextPageToken string, _ error)
 
-	// GetBotInstance returns the specified BotInstance resource.
-	GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error)
+	// GetBotInstance returns the specified BotInstance resource. A bot is
+	// identified by the request's (bot_scope, bot_name); bot_scope is empty
+	// for instances of unscoped bots.
+	GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error)
 
 	// ListBotInstances returns a page of BotInstance resources.
 	ListBotInstances(ctx context.Context, pageSize int, lastToken string, options *services.ListBotInstancesRequestOptions) ([]*machineidv1.BotInstance, string, error)

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -661,7 +661,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		PrimaryCache:       c,
 		Events:             p.AuthServer.Services,
 		Inventory:          p.AuthServer.Services,
-		BotInstanceBackend: p.AuthServer.Services,
+		BotInstanceBackend: p.AuthServer.Services.BotInstance,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -329,7 +330,11 @@ func (a *Server) updateBotInstance(
 	var instanceGeneration int32
 	instanceNotFound := false
 	if botInstanceID != "" {
-		existingInstance, err := a.BotInstance.GetBotInstance(ctx, botName, botInstanceID)
+		existingInstance, err := a.BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{
+			BotScope:   scope,
+			BotName:    botName,
+			InstanceId: botInstanceID,
+		}.Build())
 		if trace.IsNotFound(err) {
 			instanceNotFound = true
 		} else if err != nil {
@@ -489,32 +494,36 @@ func (a *Server) updateBotInstance(
 		}
 	}
 
-	_, err := a.BotInstance.PatchBotInstance(ctx, botName, botInstanceID, func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
-		if bi.Status == nil {
-			bi.Status = &machineidv1pb.BotInstanceStatus{}
-		}
+	_, err := a.BotInstance.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Scope: scope, Name: botName},
+		InstanceID: botInstanceID,
+		UpdateFn: func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
+			if bi.Status == nil {
+				bi.Status = &machineidv1pb.BotInstanceStatus{}
+			}
 
-		// Update the record's expiration timestamp based on the request TTL
-		// plus an expiry margin.
-		bi.Metadata.Expires = timestamppb.New(a.GetClock().Now().Add(req.TTL + machineidv1.ExpiryMargin))
+			// Update the record's expiration timestamp based on the request TTL
+			// plus an expiry margin.
+			bi.Metadata.Expires = timestamppb.New(a.GetClock().Now().Add(req.TTL + machineidv1.ExpiryMargin))
 
-		// If we're at or above the limit, remove enough of the front elements
-		// to make room for the new one at the end.
-		if len(bi.Status.LatestAuthentications) >= machineidv1.AuthenticationHistoryLimit {
-			toRemove := len(bi.Status.LatestAuthentications) - machineidv1.AuthenticationHistoryLimit + 1
-			bi.Status.LatestAuthentications = bi.Status.LatestAuthentications[toRemove:]
-		}
+			// If we're at or above the limit, remove enough of the front elements
+			// to make room for the new one at the end.
+			if len(bi.Status.LatestAuthentications) >= machineidv1.AuthenticationHistoryLimit {
+				toRemove := len(bi.Status.LatestAuthentications) - machineidv1.AuthenticationHistoryLimit + 1
+				bi.Status.LatestAuthentications = bi.Status.LatestAuthentications[toRemove:]
+			}
 
-		// An initial auth record should have been added during initial join,
-		// but if not, add it now.
-		if bi.Status.InitialAuthentication == nil {
-			log.WarnContext(ctx, "bot instance is missing its initial authentication record, a new one will be added")
-			bi.Status.InitialAuthentication = authRecord
-		}
+			// An initial auth record should have been added during initial join,
+			// but if not, add it now.
+			if bi.Status.InitialAuthentication == nil {
+				log.WarnContext(ctx, "bot instance is missing its initial authentication record, a new one will be added")
+				bi.Status.InitialAuthentication = authRecord
+			}
 
-		bi.Status.LatestAuthentications = append(bi.Status.LatestAuthentications, authRecord)
+			bi.Status.LatestAuthentications = append(bi.Status.LatestAuthentications, authRecord)
 
-		return bi, nil
+			return bi, nil
+		},
 	})
 
 	return trace.Wrap(err)

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -329,7 +330,11 @@ func (a *Server) updateBotInstance(
 	var instanceGeneration int32
 	instanceNotFound := false
 	if botInstanceID != "" {
-		existingInstance, err := a.BotInstance.GetBotInstance(ctx, botName, botInstanceID)
+		existingInstance, err := a.BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{
+			BotScope:   scope,
+			BotName:    botName,
+			InstanceId: botInstanceID,
+		}.Build())
 		if trace.IsNotFound(err) {
 			instanceNotFound = true
 		} else if err != nil {
@@ -496,32 +501,36 @@ func (a *Server) updateBotInstance(
 		}
 	}
 
-	_, err := a.BotInstance.PatchBotInstance(ctx, botName, botInstanceID, func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
-		if bi.Status == nil {
-			bi.Status = &machineidv1pb.BotInstanceStatus{}
-		}
+	_, err := a.BotInstance.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Scope: scope, Name: botName},
+		InstanceID: botInstanceID,
+		UpdateFn: func(bi *machineidv1pb.BotInstance) (*machineidv1pb.BotInstance, error) {
+			if bi.Status == nil {
+				bi.Status = &machineidv1pb.BotInstanceStatus{}
+			}
 
-		// Update the record's expiration timestamp based on the request TTL
-		// plus an expiry margin.
-		bi.Metadata.Expires = timestamppb.New(a.GetClock().Now().Add(req.TTL + machineidv1.ExpiryMargin))
+			// Update the record's expiration timestamp based on the request TTL
+			// plus an expiry margin.
+			bi.Metadata.Expires = timestamppb.New(a.GetClock().Now().Add(req.TTL + machineidv1.ExpiryMargin))
 
-		// If we're at or above the limit, remove enough of the front elements
-		// to make room for the new one at the end.
-		if len(bi.Status.LatestAuthentications) >= machineidv1.AuthenticationHistoryLimit {
-			toRemove := len(bi.Status.LatestAuthentications) - machineidv1.AuthenticationHistoryLimit + 1
-			bi.Status.LatestAuthentications = bi.Status.LatestAuthentications[toRemove:]
-		}
+			// If we're at or above the limit, remove enough of the front elements
+			// to make room for the new one at the end.
+			if len(bi.Status.LatestAuthentications) >= machineidv1.AuthenticationHistoryLimit {
+				toRemove := len(bi.Status.LatestAuthentications) - machineidv1.AuthenticationHistoryLimit + 1
+				bi.Status.LatestAuthentications = bi.Status.LatestAuthentications[toRemove:]
+			}
 
-		// An initial auth record should have been added during initial join,
-		// but if not, add it now.
-		if bi.Status.InitialAuthentication == nil {
-			log.WarnContext(ctx, "bot instance is missing its initial authentication record, a new one will be added")
-			bi.Status.InitialAuthentication = authRecord
-		}
+			// An initial auth record should have been added during initial join,
+			// but if not, add it now.
+			if bi.Status.InitialAuthentication == nil {
+				log.WarnContext(ctx, "bot instance is missing its initial authentication record, a new one will be added")
+				bi.Status.InitialAuthentication = authRecord
+			}
 
-		bi.Status.LatestAuthentications = append(bi.Status.LatestAuthentications, authRecord)
+			bi.Status.LatestAuthentications = append(bi.Status.LatestAuthentications, authRecord)
 
-		return bi, nil
+			return bi, nil
+		},
 	})
 
 	return trace.Wrap(err)

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -185,7 +185,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 	// Renew the cert a bunch of times.
 	for i := 0; i < 10; i++ {
 		// Ensure the state of the bot instance before renewal is sane.
-		bi, err := srv.Auth().BotInstance.GetBotInstance(ctx, initialIdent.BotName, initialIdent.BotInstanceID)
+		bi, err := srv.Auth().BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "", BotName: initialIdent.BotName, InstanceId: initialIdent.BotInstanceID}.Build())
 		require.NoError(t, err)
 
 		// There should always be at least 1 entry as the initial join is
@@ -221,7 +221,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 		require.Equal(t, uint64(i+2), renewedIdent.Generation)
 
 		// Ensure the bot instance after renewal is sane.
-		bi, err = srv.Auth().BotInstance.GetBotInstance(ctx, initialIdent.BotName, initialIdent.BotInstanceID)
+		bi, err = srv.Auth().BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "", BotName: initialIdent.BotName, InstanceId: initialIdent.BotInstanceID}.Build())
 		require.NoError(t, err)
 
 		require.Len(t, bi.Status.LatestAuthentications, min(i+2, machineidv1.AuthenticationHistoryLimit))
@@ -432,7 +432,7 @@ func TestRegisterBotInstance(t *testing.T) {
 	require.NotEmpty(t, ident.BotInstanceID)
 
 	// The instance ID should match a bot instance record.
-	botInstance, err := srv.Auth().BotInstance.GetBotInstance(ctx, ident.BotName, ident.BotInstanceID)
+	botInstance, err := srv.Auth().BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "", BotName: ident.BotName, InstanceId: ident.BotInstanceID}.Build())
 	require.NoError(t, err)
 
 	require.Equal(t, ident.BotName, botInstance.GetSpec().BotName)
@@ -1056,7 +1056,10 @@ func TestRegisterBot_BotInstanceRejoin(t *testing.T) {
 	// Simulate the instance record disappearing (expired, deleted, or backend
 	// rollback): the rejoin should be issued a fresh instance, not denied, and
 	// must not lock the join token.
-	require.NoError(t, a.BotInstance.DeleteBotInstance(ctx, botName, initialK8sInstanceID))
+	require.NoError(t, a.BotInstance.DeleteBotInstance(ctx, machineidv1pb.DeleteBotInstanceRequest_builder{
+		BotName:    botName,
+		InstanceId: initialK8sInstanceID,
+	}.Build()))
 
 	freshK8sResult, err := registerHelper(ctx, k8sToken, addr, func(p *joinclient.JoinParams) {
 		p.KubernetesReadFileFunc = k8sReadFileFunc

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -185,7 +185,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 	// Renew the cert a bunch of times.
 	for i := 0; i < 10; i++ {
 		// Ensure the state of the bot instance before renewal is sane.
-		bi, err := srv.Auth().BotInstance.GetBotInstance(ctx, initialIdent.BotName, initialIdent.BotInstanceID)
+		bi, err := srv.Auth().BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "", BotName: initialIdent.BotName, InstanceId: initialIdent.BotInstanceID}.Build())
 		require.NoError(t, err)
 
 		// There should always be at least 1 entry as the initial join is
@@ -221,7 +221,7 @@ func TestRegisterBotCertificateGenerationCheck(t *testing.T) {
 		require.Equal(t, uint64(i+2), renewedIdent.Generation)
 
 		// Ensure the bot instance after renewal is sane.
-		bi, err = srv.Auth().BotInstance.GetBotInstance(ctx, initialIdent.BotName, initialIdent.BotInstanceID)
+		bi, err = srv.Auth().BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "", BotName: initialIdent.BotName, InstanceId: initialIdent.BotInstanceID}.Build())
 		require.NoError(t, err)
 
 		require.Len(t, bi.Status.LatestAuthentications, min(i+2, machineidv1.AuthenticationHistoryLimit))
@@ -432,7 +432,7 @@ func TestRegisterBotInstance(t *testing.T) {
 	require.NotEmpty(t, ident.BotInstanceID)
 
 	// The instance ID should match a bot instance record.
-	botInstance, err := srv.Auth().BotInstance.GetBotInstance(ctx, ident.BotName, ident.BotInstanceID)
+	botInstance, err := srv.Auth().BotInstance.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{BotScope: "", BotName: ident.BotName, InstanceId: ident.BotInstanceID}.Build())
 	require.NoError(t, err)
 
 	require.Equal(t, ident.BotName, botInstance.GetSpec().BotName)

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -33,6 +33,7 @@ import (
 	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -58,8 +59,10 @@ const (
 
 // BotInstancesCache is the subset of the cached resources that the Service queries.
 type BotInstancesCache interface {
-	// GetBotInstance returns the specified BotInstance resource.
-	GetBotInstance(ctx context.Context, botName, instanceID string) (*pb.BotInstance, error)
+	// GetBotInstance returns the specified BotInstance resource. A bot is
+	// identified by the request's (bot_scope, bot_name); bot_scope is empty
+	// for instances of unscoped bots.
+	GetBotInstance(ctx context.Context, req *pb.GetBotInstanceRequest) (*pb.BotInstance, error)
 
 	// ListBotInstances returns a page of BotInstance resources.
 	ListBotInstances(ctx context.Context, pageSize int, lastToken string, options *services.ListBotInstancesRequestOptions) ([]*pb.BotInstance, string, error)
@@ -129,7 +132,11 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 		return nil, trace.Wrap(err)
 	}
 
-	instance, err := b.backend.GetBotInstance(ctx, req.BotName, req.InstanceId)
+	instance, err := b.backend.GetBotInstance(ctx, &pb.GetBotInstanceRequest{
+		BotScope:   req.BotScope,
+		BotName:    req.BotName,
+		InstanceId: req.InstanceId,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -157,9 +164,7 @@ func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *pb.Dele
 		}
 	}
 
-	if err := b.backend.DeleteBotInstance(
-		ctx, instance.Spec.BotName, instance.Spec.InstanceId,
-	); err != nil {
+	if err := b.backend.DeleteBotInstance(ctx, req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -182,7 +187,7 @@ func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *pb.GetBotI
 		return nil, trace.Wrap(err)
 	}
 
-	res, err := b.cache.GetBotInstance(ctx, req.BotName, req.InstanceId)
+	res, err := b.cache.GetBotInstance(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -241,6 +246,21 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		return nil, trace.Wrap(err)
 	}
 
+	if filterBotScope := req.GetFilter().GetBotScope(); filterBotScope != "" {
+		// bot_scope is only designed to scope-qualify bot_name. If we want to
+		// introduce actual scope-filtering down the line, we'll introduce a
+		// new field with more control (i.e. exact, descendent)
+		if req.GetFilter().GetBotName() == "" {
+			return nil, trace.BadParameter(
+				"bot_scope filter requires bot_name",
+			)
+		}
+
+		if err := scopes.StrongValidate(filterBotScope); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	botInstances, nextToken, err := b.cache.ListBotInstances(
 		ctx,
 		int(req.PageSize),
@@ -249,6 +269,7 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 			SortField:        req.GetSortField(),
 			SortDesc:         req.GetSortDesc(),
 			FilterBotName:    req.GetFilter().GetBotName(),
+			FilterBotScope:   req.GetFilter().GetBotScope(),
 			FilterSearchTerm: req.GetFilter().GetSearchTerm(),
 			FilterQuery:      req.GetFilter().GetQuery(),
 			FilterFn: func(botInstance *pb.BotInstance) bool {
@@ -322,6 +343,18 @@ func (b *BotInstanceService) SubmitHeartbeat(ctx context.Context, req *pb.Submit
 		}
 	}
 
+	// A scoped bot's instances are stored namespaced by the bot's scope, which
+	// is encoded into the identity as BotScope. Certificates issued before the
+	// BotScope field existed lack it, so fall back to the scope pin - correct
+	// for those certs because bots are always pinned to their scope of origin.
+	// TODO(strideynet): remove the ScopePin fallback once sufficient time has
+	// passed that all bot certs carry BotScope. It must be removed before bots
+	// can be pinned to a scope other than their scope of origin.
+	botScope := ident.BotScope
+	if botScope == "" && ident.ScopePin != nil {
+		botScope = ident.ScopePin.GetScope()
+	}
+
 	b.logger.DebugContext(
 		ctx,
 		"Received bot instance heartbeat",
@@ -329,29 +362,33 @@ func (b *BotInstanceService) SubmitHeartbeat(ctx context.Context, req *pb.Submit
 		"bot_instance", botInstanceID,
 		"heartbeat", logutils.StringerAttr(req.Heartbeat),
 	)
-	_, err = b.backend.PatchBotInstance(ctx, botName, botInstanceID, func(instance *pb.BotInstance) (*pb.BotInstance, error) {
-		if instance.Status == nil {
-			instance.Status = &pb.BotInstanceStatus{}
-		}
-		// Set initial heartbeat if not set.
-		if instance.Status.InitialHeartbeat == nil {
-			instance.Status.InitialHeartbeat = req.Heartbeat
-		}
-		// If we're at or above the limit, remove enough of the front
-		// elements to make room for the new one at the end.
-		if len(instance.Status.LatestHeartbeats) >= heartbeatHistoryLimit {
-			toRemove := len(instance.Status.LatestHeartbeats) - heartbeatHistoryLimit + 1
-			instance.Status.LatestHeartbeats = instance.Status.LatestHeartbeats[toRemove:]
-		}
-		// Append the new heartbeat to the end.
-		instance.Status.LatestHeartbeats = append(instance.Status.LatestHeartbeats, req.Heartbeat)
+	_, err = b.backend.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Scope: botScope, Name: botName},
+		InstanceID: botInstanceID,
+		UpdateFn: func(instance *pb.BotInstance) (*pb.BotInstance, error) {
+			if instance.Status == nil {
+				instance.Status = &pb.BotInstanceStatus{}
+			}
+			// Set initial heartbeat if not set.
+			if instance.Status.InitialHeartbeat == nil {
+				instance.Status.InitialHeartbeat = req.Heartbeat
+			}
+			// If we're at or above the limit, remove enough of the front
+			// elements to make room for the new one at the end.
+			if len(instance.Status.LatestHeartbeats) >= heartbeatHistoryLimit {
+				toRemove := len(instance.Status.LatestHeartbeats) - heartbeatHistoryLimit + 1
+				instance.Status.LatestHeartbeats = instance.Status.LatestHeartbeats[toRemove:]
+			}
+			// Append the new heartbeat to the end.
+			instance.Status.LatestHeartbeats = append(instance.Status.LatestHeartbeats, req.Heartbeat)
 
-		if storeHeartbeatExtras() {
-			// Overwrite the service health.
-			instance.Status.ServiceHealth = req.ServiceHealth
-		}
+			if storeHeartbeatExtras() {
+				// Overwrite the service health.
+				instance.Status.ServiceHealth = req.ServiceHealth
+			}
 
-		return instance, nil
+			return instance, nil
+		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "patching bot instance")

--- a/lib/auth/machineid/machineidv1/bot_instance_service.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -218,14 +219,23 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, req *pb.ListB
 		sortField = req.GetSort().Field
 		sortDesc = req.GetSort().IsDesc
 	}
+	// V1 cannot express a scope filter, so pin it to mode ALL rather than letting it
+	// inherit the identity-based default and silently hide scoped instances. Left
+	// unset alongside a bot filter, which V2 rejects the combination of.
+	var scopeFilter *scopesv1.Filter
+	if req.GetFilterBotName() == "" {
+		scopeFilter = &scopesv1.Filter{Mode: scopesv1.Mode_MODE_ALL}
+	}
+
 	return b.ListBotInstancesV2(ctx, &pb.ListBotInstancesV2Request{
 		PageSize:  req.GetPageSize(),
 		PageToken: req.GetPageToken(),
 		SortField: sortField,
 		SortDesc:  sortDesc,
 		Filter: &pb.ListBotInstancesV2Request_Filters{
-			BotName:    req.GetFilterBotName(),
-			SearchTerm: req.GetFilterSearchTerm(),
+			BotName:     req.GetFilterBotName(),
+			SearchTerm:  req.GetFilterSearchTerm(),
+			ScopeFilter: scopeFilter,
 		},
 	})
 }
@@ -246,19 +256,34 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		return nil, trace.Wrap(err)
 	}
 
-	if filterBotScope := req.GetFilter().GetBotScope(); filterBotScope != "" {
-		// bot_scope is only designed to scope-qualify bot_name. If we want to
-		// introduce actual scope-filtering down the line, we'll introduce a
-		// new field with more control (i.e. exact, descendent)
-		if req.GetFilter().GetBotName() == "" {
+	f := req.GetFilter()
+	if err := scopes.ValidateFilter(f.GetScopeFilter()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var scopeFilter *scopesv1.Filter
+	if f.GetBotName() != "" {
+		// By-bot listing: bot_scope qualifies bot_name, which already pins the
+		// scope, so a scope_filter is meaningless and rejected.
+		if f.GetScopeFilter().GetMode() != scopesv1.Mode_MODE_UNSPECIFIED {
+			return nil, trace.BadParameter(
+				"scope_filter cannot be combined with a bot_name filter",
+			)
+		}
+		if f.GetBotScope() != "" {
+			if err := scopes.StrongValidate(f.GetBotScope()); err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
+	} else {
+		// Cross-bot listing: scope_filter selects the scopes, with identity-based
+		// defaults per RFD 0229i; bot_scope only exists to qualify bot_name.
+		if f.GetBotScope() != "" {
 			return nil, trace.BadParameter(
 				"bot_scope filter requires bot_name",
 			)
 		}
-
-		if err := scopes.StrongValidate(filterBotScope); err != nil {
-			return nil, trace.Wrap(err)
-		}
+		scopeFilter = authCtx.CheckerContext.ResolveScopeFilter(f.GetScopeFilter())
 	}
 
 	botInstances, nextToken, err := b.cache.ListBotInstances(
@@ -268,10 +293,11 @@ func (b *BotInstanceService) ListBotInstancesV2(ctx context.Context, req *pb.Lis
 		&services.ListBotInstancesRequestOptions{
 			SortField:        req.GetSortField(),
 			SortDesc:         req.GetSortDesc(),
-			FilterBotName:    req.GetFilter().GetBotName(),
-			FilterBotScope:   req.GetFilter().GetBotScope(),
-			FilterSearchTerm: req.GetFilter().GetSearchTerm(),
-			FilterQuery:      req.GetFilter().GetQuery(),
+			FilterBotName:    f.GetBotName(),
+			FilterBotScope:   f.GetBotScope(),
+			ScopeFilter:      scopeFilter,
+			FilterSearchTerm: f.GetSearchTerm(),
+			FilterQuery:      f.GetQuery(),
 			FilterFn: func(botInstance *pb.BotInstance) bool {
 				ruleCtx := authCtx.RuleContext()
 				ruleCtx.Resource153 = botInstance

--- a/lib/auth/machineid/machineidv1/bot_instance_service_test.go
+++ b/lib/auth/machineid/machineidv1/bot_instance_service_test.go
@@ -454,6 +454,24 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			assertErr:     assert.NoError,
 			wantHeartbeat: true,
 		},
+		{
+			// BotScope determines the storage scope even when the identity is
+			// pinned to a different (narrower) scope.
+			name:              "scoped identity with BotScope preferred over pin",
+			createBotInstance: true,
+			req: machineidv1.SubmitHeartbeatRequest_builder{
+				Heartbeat: machineidv1.BotInstanceStatusHeartbeat_builder{Hostname: "llama"}.Build(),
+			}.Build(),
+			identity: tlsca.Identity{
+				BotName:       botName,
+				BotInstanceID: botInstanceID,
+				BotScope:      "/scopes/test",
+				ScopePin:      scopesv1.Pin_builder{Kind: scopesv1.PinKind_PIN_KIND_USER, Scope: "/scopes/test/narrowed"}.Build(),
+				BotInternal:   true,
+			},
+			assertErr:     assert.NoError,
+			wantHeartbeat: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -473,9 +491,17 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			})
 			require.NoError(t, err)
 
+			// A scoped bot's instances are stored namespaced by the identity's
+			// BotScope, falling back to the pinned scope for older certs.
+			botScope := tt.identity.BotScope
+			if botScope == "" {
+				botScope = tt.identity.ScopePin.GetScope()
+			}
+
 			if tt.createBotInstance {
 				bi := newBotInstance(botName)
 				bi.Spec.InstanceId = botInstanceID
+				bi.Scope = botScope
 				_, err := backend.CreateBotInstance(ctx, bi)
 				require.NoError(t, err)
 			}
@@ -483,7 +509,7 @@ func TestBotInstanceServiceSubmitHeartbeat(t *testing.T) {
 			_, err = service.SubmitHeartbeat(ctx, tt.req)
 			tt.assertErr(t, err)
 			if tt.createBotInstance {
-				bi, err := backend.GetBotInstance(ctx, botName, botInstanceID)
+				bi, err := backend.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: botScope, BotName: botName, InstanceId: botInstanceID}.Build())
 				require.NoError(t, err)
 				if tt.wantHeartbeat {
 					assert.Empty(
@@ -557,7 +583,7 @@ func TestBotInstanceServiceSubmitHeartbeat_HeartbeatLimit(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	bi, err = backend.GetBotInstance(ctx, botName, botInstanceID)
+	bi, err = backend.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: botName, InstanceId: botInstanceID}.Build())
 	require.NoError(t, err)
 	assert.Len(t, bi.Status.LatestHeartbeats, heartbeatHistoryLimit)
 	assert.Equal(t, "0", bi.Status.InitialHeartbeat.Hostname)

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -3259,6 +3259,7 @@ func TestBotInstanceService_DeleteBotInstance(t *testing.T) {
 			_, err = client.BotInstanceServiceClient().DeleteBotInstance(ctx, &machineidv1pb.DeleteBotInstanceRequest{
 				BotName:    tt.instance.Spec.BotName,
 				InstanceId: tt.instance.Spec.InstanceId,
+				BotScope:   tt.instance.Scope,
 			})
 			tt.assertError(t, err)
 		})
@@ -3386,6 +3387,7 @@ func TestBotInstanceService_GetBotInstance(t *testing.T) {
 			got, err := client.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
 				BotName:    tt.instance.Spec.BotName,
 				InstanceId: tt.instance.Spec.InstanceId,
+				BotScope:   tt.instance.Scope,
 			})
 			tt.assertError(t, err)
 			if err == nil {
@@ -3558,6 +3560,52 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		got := listAll(t, client.BotInstanceServiceClient())
 		require.Empty(t, got)
 	})
+
+	t.Run("scope filter with bot name returns that bot's instances", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		want := grantedInstances[0]
+		res, err := client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+			PageSize: 100,
+			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+				BotName:  want.GetSpec().GetBotName(),
+				BotScope: "/scopes/granted",
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.Len(t, res.GetBotInstances(), 1)
+		require.Equal(t, want.GetSpec().GetInstanceId(), res.GetBotInstances()[0].GetSpec().GetInstanceId())
+	})
+
+	t.Run("scope filter without bot name is rejected", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		// bot_scope only qualifies bot_name; it cannot be used as a standalone
+		// scope filter.
+		_, err = client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+			PageSize: 100,
+			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+				BotScope: "/scopes/granted",
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+	})
+
+	t.Run("non-canonical scope filter is rejected", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		_, err = client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+			PageSize: 100,
+			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+				BotName:  grantedInstances[0].GetSpec().GetBotName(),
+				BotScope: "/scopes/granted/",
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+	})
 }
 
 func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
@@ -3677,13 +3725,18 @@ func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		got, err := adminClient.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
-			BotName:    botName,
-			InstanceId: instanceID,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, got.Status.InitialHeartbeat)
-		require.Equal(t, "scoped-host", got.Status.InitialHeartbeat.Hostname)
+		// The heartbeat lands in the backend and replicates to cache-backed
+		// reads through the scoped event watch, so allow for propagation.
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			got, err := srv.Auth().Cache.GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
+				BotScope:   "/scopes/test",
+				BotName:    botName,
+				InstanceId: instanceID,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, got.GetStatus().GetInitialHeartbeat())
+			require.Equal(t, "scoped-host", got.GetStatus().GetInitialHeartbeat().GetHostname())
+		}, 5*time.Second, 100*time.Millisecond)
 	})
 }
 

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -46,6 +46,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -3513,7 +3514,7 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		grantedIDs[bi.Spec.InstanceId] = struct{}{}
 	}
 
-	listAll := func(t *testing.T, client machineidv1pb.BotInstanceServiceClient) []*machineidv1pb.BotInstance {
+	listAll := func(t *testing.T, client machineidv1pb.BotInstanceServiceClient, scopeFilter *scopesv1.Filter) []*machineidv1pb.BotInstance {
 		t.Helper()
 		out, err := stream.Collect(clientutils.Resources(
 			t.Context(),
@@ -3523,6 +3524,9 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 				res, err := client.ListBotInstancesV2(ctx, &machineidv1pb.ListBotInstancesV2Request{
 					PageToken: nextToken,
 					PageSize:  int32(limit),
+					Filter: &machineidv1pb.ListBotInstancesV2Request_Filters{
+						ScopeFilter: scopeFilter,
+					},
 				})
 				return res.BotInstances, res.NextPageToken, err
 			}),
@@ -3531,22 +3535,80 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		return out
 	}
 
-	t.Run("unscoped user sees all instances", func(t *testing.T) {
+	allScopes := scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()
+
+	t.Run("unscoped user with mode ALL sees all instances", func(t *testing.T) {
 		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
 		require.NoError(t, err)
 
-		got := listAll(t, client.BotInstanceServiceClient())
+		got := listAll(t, client.BotInstanceServiceClient(), allScopes)
 		require.Len(t, got, len(allInstances))
 		for _, bi := range got {
 			require.Contains(t, allIDs, bi.Spec.InstanceId)
 		}
 	})
 
-	t.Run("scoped user sees only instances in granted scope", func(t *testing.T) {
+	t.Run("unscoped user without a scope filter sees only unscoped instances", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		// Defaults to MODE_UNSCOPED, so scoped instances are excluded despite the
+		// caller having RBAC for them. Exhaustive views must ask for mode ALL.
+		got := listAll(t, client.BotInstanceServiceClient(), nil)
+		require.Len(t, got, len(unscopedInstances))
+		for _, bi := range got {
+			require.Empty(t, bi.GetScope())
+		}
+	})
+
+	t.Run("unscoped user can filter to an exact scope", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		got := listAll(t, client.BotInstanceServiceClient(), scopesv1.Filter_builder{
+			Scope: "/scopes/granted",
+			Mode:  scopesv1.Mode_MODE_EXACT,
+		}.Build())
+		require.Len(t, got, len(grantedInstances))
+		for _, bi := range got {
+			require.Contains(t, grantedIDs, bi.GetSpec().GetInstanceId())
+		}
+	})
+
+	t.Run("unscoped user can filter to a scope and its descendants", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		// Every scoped instance lives under /scopes, so this selects them all.
+		got := listAll(t, client.BotInstanceServiceClient(), scopesv1.Filter_builder{
+			Scope: "/scopes",
+			Mode:  scopesv1.Mode_MODE_DESCENDANTS,
+		}.Build())
+		require.Len(t, got, len(grantedInstances)+len(ungrantedInstances))
+		for _, bi := range got {
+			require.NotEmpty(t, bi.GetScope())
+		}
+	})
+
+	t.Run("scoped user without a scope filter sees only instances in granted scope", func(t *testing.T) {
 		client, err := srv.NewClient(authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"))
 		require.NoError(t, err)
 
-		got := listAll(t, client.BotInstanceServiceClient())
+		// An omitted filter defaults to MODE_EXACT at the caller's pin.
+		got := listAll(t, client.BotInstanceServiceClient(), nil)
+		require.Len(t, got, len(grantedInstances))
+		for _, bi := range got {
+			require.Contains(t, grantedIDs, bi.GetSpec().GetInstanceId())
+		}
+	})
+
+	t.Run("scoped user with mode ALL is still limited by RBAC", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"))
+		require.NoError(t, err)
+
+		// Unlike watches, a list does not rewrite mode ALL for scoped callers; the
+		// per-resource RBAC check is what confines them.
+		got := listAll(t, client.BotInstanceServiceClient(), allScopes)
 		require.Len(t, got, len(grantedInstances))
 		for _, bi := range got {
 			require.Contains(t, grantedIDs, bi.Spec.InstanceId)
@@ -3557,11 +3619,44 @@ func TestBotInstanceService_ListBotInstancesV2(t *testing.T) {
 		client, err := srv.NewClient(authtest.TestScopedUser(scopedUser.GetName(), "/scopes/other"))
 		require.NoError(t, err)
 
-		got := listAll(t, client.BotInstanceServiceClient())
+		got := listAll(t, client.BotInstanceServiceClient(), allScopes)
 		require.Empty(t, got)
 	})
 
-	t.Run("scope filter with bot name returns that bot's instances", func(t *testing.T) {
+	t.Run("scope filter cannot be combined with a bot name filter", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		_, err = client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+			PageSize: 100,
+			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+				BotName:     grantedInstances[0].GetSpec().GetBotName(),
+				BotScope:    "/scopes/granted",
+				ScopeFilter: allScopes,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+	})
+
+	t.Run("scope filter with a scope but no mode is rejected", func(t *testing.T) {
+		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
+		require.NoError(t, err)
+
+		// Rejected as malformed rather than resolved to the identity default,
+		// which would silently discard the scope.
+		for _, botName := range []string{"", grantedInstances[0].GetSpec().GetBotName()} {
+			_, err = client.BotInstanceServiceClient().ListBotInstancesV2(t.Context(), machineidv1pb.ListBotInstancesV2Request_builder{
+				PageSize: 100,
+				Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+					BotName:     botName,
+					ScopeFilter: scopesv1.Filter_builder{Scope: "/scopes/granted"}.Build(),
+				}.Build(),
+			}.Build())
+			require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+		}
+	})
+
+	t.Run("bot scope with bot name returns that bot's instances", func(t *testing.T) {
 		client, err := srv.NewClient(authtest.TestUser(unscopedUser.GetName()))
 		require.NoError(t, err)
 

--- a/lib/cache/bot_instance.go
+++ b/lib/cache/bot_instance.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
@@ -76,8 +77,11 @@ func newBotInstanceCollection(upstream services.BotInstance, w types.WatchKind) 
 	}, nil
 }
 
-// GetBotInstance returns the specified BotInstance resource.
-func (c *Cache) GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error) {
+// GetBotInstance returns the specified BotInstance resource. A bot is
+// identified by the request's (bot_scope, bot_name): a lookup with the wrong
+// scope misses, just as it would against the backend's scope-namespaced key
+// ranges.
+func (c *Cache) GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/GetBotInstance")
 	defer span.End()
 
@@ -86,11 +90,11 @@ func (c *Cache) GetBotInstance(ctx context.Context, botName, instanceID string) 
 		collection: c.collections.botInstances,
 		index:      botInstanceNameIndex,
 		upstreamGet: func(ctx context.Context, _ string) (*machineidv1.BotInstance, error) {
-			return c.Config.BotInstanceService.GetBotInstance(ctx, botName, instanceID)
+			return c.Config.BotInstanceService.GetBotInstance(ctx, req)
 		},
 	}
 
-	out, err := getter.get(ctx, makeBotInstanceNameIndexKey(botName, instanceID))
+	out, err := getter.get(ctx, makeBotInstanceNameIndexKey(req.GetBotScope(), req.GetBotName(), req.GetInstanceId()))
 	return out, trace.Wrap(err)
 }
 
@@ -99,6 +103,13 @@ func (c *Cache) GetBotInstance(ctx context.Context, botName, instanceID string) 
 func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken string, options *services.ListBotInstancesRequestOptions) ([]*machineidv1.BotInstance, string, error) {
 	ctx, span := c.Tracer.Start(ctx, "cache/ListBotInstances")
 	defer span.End()
+
+	// A bot is identified by the pair (scope, name), so the scope filter only
+	// ever qualifies the name filter. Listing a whole scope will be a separate
+	// filter with explicit exact/descendant control.
+	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
+		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
+	}
 
 	index := botInstanceNameIndex
 	keyFn := keyForBotInstanceNameIndex
@@ -144,6 +155,14 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 			return c.Config.BotInstanceService.ListBotInstances(ctx, limit, start, options)
 		},
 		filter: func(b *machineidv1.BotInstance) bool {
+			// A bot is identified by (scope, name), so a by-bot filter also
+			// constrains the scope: a name without a scope means the unscoped
+			// bot. Only the unfiltered listing spans all scopes. This mirrors
+			// the backend's range routing in
+			// local.BotInstanceService.ListBotInstances.
+			if options.GetFilterBotName() != "" && b.GetScope() != options.GetFilterBotScope() {
+				return false
+			}
 			if !services.MatchBotInstance(b, options.GetFilterBotName(), options.GetFilterSearchTerm(), exp) {
 				return false
 			}
@@ -165,13 +184,16 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 
 func keyForBotInstanceNameIndex(botInstance *machineidv1.BotInstance) string {
 	return makeBotInstanceNameIndexKey(
+		botInstance.GetScope(),
 		botInstance.GetSpec().GetBotName(),
 		botInstance.GetMetadata().GetName(),
 	)
 }
 
-func makeBotInstanceNameIndexKey(botName string, instanceID string) string {
-	return botName + "/" + instanceID
+// makeBotInstanceNameIndexKey builds the primary index key for a bot
+// instance.
+func makeBotInstanceNameIndexKey(botScope, botName, instanceID string) string {
+	return scopes.MakeResourceCursor(botScope, botName+"/"+instanceID)
 }
 
 func keyForBotInstanceActiveAtIndex(botInstance *machineidv1.BotInstance) string {

--- a/lib/cache/bot_instance.go
+++ b/lib/cache/bot_instance.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
@@ -50,6 +51,18 @@ func newBotInstanceCollection(upstream services.BotInstance, w types.WatchKind) 
 	if upstream == nil {
 		return nil, trace.BadParameter("missing parameter upstream (BotInstance)")
 	}
+	// The seed must select the same set as the event stream, which is filtered
+	// per-event by services.WatchKindMatchesScope; an unfiltered seed would leave
+	// permanently stale out-of-scope entries in the store.
+	scopeFilter := w.ScopeFilter.ToProto()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// An omitted filter means match-all here but identity-based defaults at the
+	// authz layer, so require the config to say which is meant.
+	if scopeFilter.GetMode() == scopesv1.Mode_MODE_UNSPECIFIED {
+		return nil, trace.BadParameter("bot instance cache requires an explicit scope filter mode")
+	}
 
 	return &collection[*machineidv1.BotInstance, botInstanceIndex]{
 		store: newStore(
@@ -68,7 +81,9 @@ func newBotInstanceCollection(upstream services.BotInstance, w types.WatchKind) 
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*machineidv1.BotInstance, error) {
 			out, err := stream.Collect(clientutils.Resources(ctx,
 				func(ctx context.Context, limit int, start string) ([]*machineidv1.BotInstance, string, error) {
-					return upstream.ListBotInstances(ctx, limit, start, nil)
+					return upstream.ListBotInstances(ctx, limit, start, &services.ListBotInstancesRequestOptions{
+						ScopeFilter: scopeFilter,
+					})
 				},
 			))
 			return out, trace.Wrap(err)
@@ -89,8 +104,17 @@ func (c *Cache) GetBotInstance(ctx context.Context, req *machineidv1.GetBotInsta
 		cache:      c,
 		collection: c.collections.botInstances,
 		index:      botInstanceNameIndex,
-		upstreamGet: func(ctx context.Context, _ string) (*machineidv1.BotInstance, error) {
-			return c.Config.BotInstanceService.GetBotInstance(ctx, req)
+		upstreamGet: func(ctx context.Context, key string) (*machineidv1.BotInstance, error) {
+			bi, err := c.Config.BotInstanceService.GetBotInstance(ctx, req)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			// Mirror the healthy path: an instance outside the collection's
+			// scope filter is never in the store.
+			if !scopes.MatchScope(c.collections.botInstances.watch.ScopeFilter.ToProto(), bi.GetScope()) {
+				return nil, trace.NotFound("%q %q does not exist", types.KindBotInstance, key)
+			}
+			return bi, nil
 		},
 	}
 
@@ -104,11 +128,17 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 	ctx, span := c.Tracer.Start(ctx, "cache/ListBotInstances")
 	defer span.End()
 
-	// A bot is identified by the pair (scope, name), so the scope filter only
-	// ever qualifies the name filter. Listing a whole scope will be a separate
-	// filter with explicit exact/descendant control.
+	// See the field docs on ListBotInstancesRequestOptions for the rules
+	// enforced here.
 	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
 		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
+	}
+	scopeFilter := options.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	if scopeFilter.GetMode() != scopesv1.Mode_MODE_UNSPECIFIED && options.GetFilterBotName() != "" {
+		return nil, "", trace.BadParameter("scope filter cannot be combined with a bot name filter")
 	}
 
 	index := botInstanceNameIndex
@@ -152,7 +182,19 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 		isDesc:          isDesc,
 		defaultPageSize: defaults.DefaultChunkSize,
 		upstreamList: func(ctx context.Context, limit int, start string) ([]*machineidv1.BotInstance, string, error) {
-			return c.Config.BotInstanceService.ListBotInstances(ctx, limit, start, options)
+			// The backend enforces the request options but not the collection's
+			// scope filter; graft it onto the options' iteration filter so cache
+			// health doesn't change the visible set and pages still fill.
+			collectionFilter := c.collections.botInstances.watch.ScopeFilter.ToProto()
+			var opts services.ListBotInstancesRequestOptions
+			if options != nil {
+				opts = *options
+			}
+			inner := opts.FilterFn
+			opts.FilterFn = func(b *machineidv1.BotInstance) bool {
+				return scopes.MatchScope(collectionFilter, b.GetScope()) && (inner == nil || inner(b))
+			}
+			return c.Config.BotInstanceService.ListBotInstances(ctx, limit, start, &opts)
 		},
 		filter: func(b *machineidv1.BotInstance) bool {
 			// A bot is identified by (scope, name), so a by-bot filter also
@@ -161,6 +203,9 @@ func (c *Cache) ListBotInstances(ctx context.Context, pageSize int, lastToken st
 			// the backend's range routing in
 			// local.BotInstanceService.ListBotInstances.
 			if options.GetFilterBotName() != "" && b.GetScope() != options.GetFilterBotScope() {
+				return false
+			}
+			if !scopes.MatchScope(scopeFilter, b.GetScope()) {
 				return false
 			}
 			if !services.MatchBotInstance(b, options.GetFilterBotName(), options.GetFilterSearchTerm(), exp) {

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -18,8 +18,9 @@ package cache
 
 import (
 	"context"
-	"strconv"
+	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,507 +31,394 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
 // TestBotInstanceCache tests that CRUD operations on bot instances resources are
-// replicated from the backend to the cache.
+// replicated from the backend to the cache. Instances of scoped bots live in a
+// scope-namespaced backend range, so create/update/delete events for them must
+// round-trip through the cache's event watcher just like unscoped instances.
 func TestBotInstanceCache(t *testing.T) {
 	t.Parallel()
 
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
+	for _, botScope := range []string{"", "/scopes/test"} {
+		t.Run(fmt.Sprintf("scope=%q", botScope), func(t *testing.T) {
+			t.Parallel()
 
-	testResources153(t, p, testFuncs[*machineidv1.BotInstance]{
-		newResource: func(key string) (*machineidv1.BotInstance, error) {
-			return &machineidv1.BotInstance{
+			p := newTestPack(t, ForAuth)
+			t.Cleanup(p.Close)
+
+			testResources153(t, p, testFuncs[*machineidv1.BotInstance]{
+				newResource: func(key string) (*machineidv1.BotInstance, error) {
+					return machineidv1.BotInstance_builder{
+						Kind:     types.KindBotInstance,
+						Version:  types.V1,
+						Scope:    botScope,
+						Metadata: &headerv1.Metadata{},
+						Spec: machineidv1.BotInstanceSpec_builder{
+							BotName:    "bot-1",
+							InstanceId: key,
+						}.Build(),
+						Status: &machineidv1.BotInstanceStatus{},
+					}.Build(), nil
+				},
+				cacheGet: func(ctx context.Context, key string) (*machineidv1.BotInstance, error) {
+					return p.cache.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: botScope, BotName: "bot-1", InstanceId: key}.Build())
+				},
+				cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
+					return p.cache.ListBotInstances(ctx, pageSize, pageToken, nil)
+				},
+				create: func(ctx context.Context, resource *machineidv1.BotInstance) error {
+					_, err := p.botInstanceService.CreateBotInstance(ctx, resource)
+					return err
+				},
+				list: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
+					return p.botInstanceService.ListBotInstances(ctx, pageSize, pageToken, nil)
+				},
+				update: func(ctx context.Context, bi *machineidv1.BotInstance) error {
+					_, err := p.botInstanceService.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+						Bot:        scopes.QualifiedName{Scope: botScope, Name: "bot-1"},
+						InstanceID: bi.GetMetadata().GetName(),
+						UpdateFn: func(_ *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+							return bi, nil
+						},
+					})
+					return err
+				},
+				delete: func(ctx context.Context, key string) error {
+					return p.botInstanceService.DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: botScope, BotName: "bot-1", InstanceId: key}.Build())
+				},
+				deleteAll: func(ctx context.Context) error {
+					return p.botInstanceService.DeleteAllBotInstances(ctx)
+				},
+			})
+		})
+	}
+}
+
+// TestBotInstanceCacheBackendTokenParity verifies that the cache lister and
+// the backend lister agree on the ordering of the unified scoped+unscoped
+// listing and mint interchangeable page tokens. genericLister falls back to
+// the backend lister with the caller's token verbatim when the cache is
+// unhealthy, so a token minted by one side must resume correctly against the
+// other.
+func TestBotInstanceCacheBackendTokenParity(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		p := newTestPack(t, ForAuth)
+		t.Cleanup(p.Close)
+
+		instances := []struct {
+			botScope string
+			botName  string
+		}{
+			{botScope: "", botName: "bot-a"},
+			{botScope: "", botName: "bot-b"},
+			{botScope: "/bar", botName: "bot-c"},
+			{botScope: "/foo", botName: "bot-d"},
+		}
+		for _, i := range instances {
+			_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
 				Kind:     types.KindBotInstance,
 				Version:  types.V1,
+				Scope:    i.botScope,
 				Metadata: &headerv1.Metadata{},
-				Spec: &machineidv1.BotInstanceSpec{
-					BotName:    "bot-1",
-					InstanceId: key,
-				},
+				Spec: machineidv1.BotInstanceSpec_builder{
+					BotName:    i.botName,
+					InstanceId: uuid.New().String(),
+				}.Build(),
 				Status: &machineidv1.BotInstanceStatus{},
-			}, nil
-		},
-		cacheGet: func(ctx context.Context, key string) (*machineidv1.BotInstance, error) {
-			return p.cache.GetBotInstance(ctx, "bot-1", key)
-		},
-		cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
-			return p.cache.ListBotInstances(ctx, pageSize, pageToken, nil)
-		},
-		create: func(ctx context.Context, resource *machineidv1.BotInstance) error {
-			_, err := p.botInstanceService.CreateBotInstance(ctx, resource)
-			return err
-		},
-		list: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
-			return p.botInstanceService.ListBotInstances(ctx, pageSize, pageToken, nil)
-		},
-		update: func(ctx context.Context, bi *machineidv1.BotInstance) error {
-			_, err := p.botInstanceService.PatchBotInstance(ctx, "bot-1", bi.Metadata.GetName(), func(_ *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
-				return bi, nil
-			})
-			return err
-		},
-		delete: func(ctx context.Context, key string) error {
-			return p.botInstanceService.DeleteBotInstance(ctx, "bot-1", key)
-		},
-		deleteAll: func(ctx context.Context) error {
-			return p.botInstanceService.DeleteAllBotInstances(ctx)
-		},
-	}, withSkipPaginationTest())
-}
-
-// TestBotInstanceCachePaging tests that items from the cache are paginated.
-func TestBotInstanceCachePaging(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	for _, n := range []int{5, 1, 3, 4, 2} {
-		_, err := p.botInstanceService.CreateBotInstance(ctx, &machineidv1.BotInstance{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: &machineidv1.BotInstanceSpec{
-				BotName:    "bot-1",
-				InstanceId: "instance-" + strconv.Itoa(n),
-			},
-			Status: &machineidv1.BotInstanceStatus{},
-		})
-		require.NoError(t, err)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 5)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	// page size equal to total items
-	results, nextPageToken, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-	require.NoError(t, err)
-	require.Empty(t, nextPageToken)
-	require.Len(t, results, 5)
-	require.Equal(t, "instance-1", results[0].GetMetadata().GetName())
-	require.Equal(t, "instance-2", results[1].GetMetadata().GetName())
-	require.Equal(t, "instance-3", results[2].GetMetadata().GetName())
-	require.Equal(t, "instance-4", results[3].GetMetadata().GetName())
-	require.Equal(t, "instance-5", results[4].GetMetadata().GetName())
-
-	// page size smaller than total items
-	results, nextPageToken, err = p.cache.ListBotInstances(ctx, 3, "", nil)
-	require.NoError(t, err)
-	require.Equal(t, "bot-1/instance-4", nextPageToken)
-	require.Len(t, results, 3)
-	require.Equal(t, "instance-1", results[0].GetMetadata().GetName())
-	require.Equal(t, "instance-2", results[1].GetMetadata().GetName())
-	require.Equal(t, "instance-3", results[2].GetMetadata().GetName())
-
-	// next page
-	results, nextPageToken, err = p.cache.ListBotInstances(ctx, 3, nextPageToken, nil)
-	require.NoError(t, err)
-	require.Empty(t, nextPageToken)
-	require.Len(t, results, 2)
-	require.Equal(t, "instance-4", results[0].GetMetadata().GetName())
-	require.Equal(t, "instance-5", results[1].GetMetadata().GetName())
-}
-
-// TestBotInstanceCacheBotFilter tests that cache items are filtered by bot name.
-func TestBotInstanceCacheBotFilter(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	for n := range 10 {
-		_, err := p.botInstanceService.CreateBotInstance(ctx, &machineidv1.BotInstance{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: &machineidv1.BotInstanceSpec{
-				BotName:    "bot-" + strconv.Itoa(n%2),
-				InstanceId: "instance-" + strconv.Itoa(n),
-			},
-			Status: &machineidv1.BotInstanceStatus{},
-		})
-		require.NoError(t, err)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 10)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterBotName: "bot-1",
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 5)
-
-	for _, b := range results {
-		require.Equal(t, "bot-1", b.GetSpec().GetBotName())
-	}
-}
-
-// TestBotInstanceCacheSearchFilter tests that cache items are filtered by
-// search term.
-func TestBotInstanceCacheSearchFilter(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	for n := range 10 {
-		instance := &machineidv1.BotInstance{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: &machineidv1.BotInstanceSpec{
-				BotName:    "bot-1",
-				InstanceId: "instance-" + strconv.Itoa(n+1),
-			},
-			Status: &machineidv1.BotInstanceStatus{
-				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
-					{
-						Hostname: "host-" + strconv.Itoa(n%2),
-					},
-				},
-			},
+			}.Build())
+			require.NoError(t, err)
 		}
 
-		_, err := p.botInstanceService.CreateBotInstance(ctx, instance)
-		require.NoError(t, err)
-	}
+		synctest.Wait()
 
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 10)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterSearchTerm: "host-1",
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 5)
-}
-
-// TestBotInstanceCacheQueryFilter tests that cache items are filtered by query.
-func TestBotInstanceCacheQueryFilter(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	{
-		_, err := p.botInstanceService.CreateBotInstance(ctx, &machineidv1.BotInstance{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: &machineidv1.BotInstanceSpec{
-				BotName:    "bot-1",
-				InstanceId: "00000000-0000-0000-0000-000000000000",
-			},
-			Status: &machineidv1.BotInstanceStatus{
-				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
-					{
-						Hostname: "host-1",
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-	}
-
-	{
-		_, err := p.botInstanceService.CreateBotInstance(ctx, &machineidv1.BotInstance{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: &machineidv1.BotInstanceSpec{
-				BotName:    "bot-1",
-				InstanceId: uuid.New().String(),
-			},
-			Status: &machineidv1.BotInstanceStatus{
-				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
-					{
-						Hostname: "host-2",
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 2)
-	}, 10*time.Second, 100*time.Millisecond)
-
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterQuery: `status.latest_heartbeat.hostname == "host-1"`,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 1)
-	require.Equal(t, "00000000-0000-0000-0000-000000000000", results[0].Spec.InstanceId)
-}
-
-// TestBotInstanceCacheSorting tests that cache items are sorted.
-func TestBotInstanceCacheSorting(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	items := []struct {
-		botName           string
-		instanceId        string
-		recordedAtSeconds int64
-		version           string
-		hostname          string
-	}{
-		{"bot-1", "instance-1", 2, "2.0.0", "hostname-2"},
-		{"bot-1", "instance-3", 1, "2.0.0-rc1", "hostname-3"},
-		{"bot-2", "instance-2", 3, "1.0.0", "hostname-1"},
-	}
-
-	for _, b := range items {
-		instance := &machineidv1.BotInstance{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: &machineidv1.BotInstanceSpec{
-				BotName:    b.botName,
-				InstanceId: b.instanceId,
-			},
-			Status: &machineidv1.BotInstanceStatus{
-				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
-					{
-						RecordedAt: &timestamppb.Timestamp{
-							Seconds: b.recordedAtSeconds,
-						},
-						Version:  b.version,
-						Hostname: b.hostname,
-					},
-				},
-			},
+		names := func(instances []*machineidv1.BotInstance) []string {
+			out := make([]string, 0, len(instances))
+			for _, b := range instances {
+				out = append(out, b.GetSpec().GetBotName())
+			}
+			return out
 		}
 
-		_, err := p.botInstanceService.CreateBotInstance(ctx, instance)
+		// Both listings order unscoped instances first, then scoped grouped by
+		// scope.
+		wantOrder := []string{"bot-a", "bot-b", "bot-c", "bot-d"}
+		fromCache, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
 		require.NoError(t, err)
-	}
-
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
+		require.Equal(t, wantOrder, names(fromCache))
+		fromBackend, _, err := p.botInstanceService.ListBotInstances(ctx, 0, "", nil)
 		require.NoError(t, err)
-		require.Len(t, results, 3)
-	}, 10*time.Second, 100*time.Millisecond)
+		require.Equal(t, wantOrder, names(fromBackend))
 
-	t.Run("sort ascending by active_at_latest", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "active_at_latest",
-			SortDesc:  false,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-3", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-1", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-2", results[2].GetMetadata().GetName())
-	})
+		// Page tokens are interchangeable whether the next item is unscoped
+		// (pageSize 1) or scoped (pageSize 3).
+		for _, pageSize := range []int{1, 3} {
+			cachePage, cacheToken, err := p.cache.ListBotInstances(ctx, pageSize, "", nil)
+			require.NoError(t, err)
+			require.Equal(t, wantOrder[:pageSize], names(cachePage))
+			backendPage, backendToken, err := p.botInstanceService.ListBotInstances(ctx, pageSize, "", nil)
+			require.NoError(t, err)
+			require.Equal(t, wantOrder[:pageSize], names(backendPage))
+			require.Equal(t, backendToken, cacheToken)
 
-	t.Run("sort descending by active_at_latest", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "active_at_latest",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-2", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-1", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort ascending by bot_name", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil) // empty sort should default to `bot_name:asc`
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-1", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-2", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort descending by bot_name", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "bot_name",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-2", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-1", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort ascending by version", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "version_latest",
-			SortDesc:  false,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-2", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-1", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort descending by version", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "version_latest",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		assert.Equal(t, "instance-1", results[0].GetMetadata().GetName())
-		assert.Equal(t, "instance-3", results[1].GetMetadata().GetName())
-		assert.Equal(t, "instance-2", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort ascending by hostname", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "host_name_latest",
-			SortDesc:  false,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		require.Equal(t, "instance-2", results[0].GetMetadata().GetName())
-		require.Equal(t, "instance-1", results[1].GetMetadata().GetName())
-		require.Equal(t, "instance-3", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort descending by hostname", func(t *testing.T) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "host_name_latest",
-			SortDesc:  true,
-		})
-		require.NoError(t, err)
-		require.Len(t, results, 3)
-		require.Equal(t, "instance-3", results[0].GetMetadata().GetName())
-		require.Equal(t, "instance-1", results[1].GetMetadata().GetName())
-		require.Equal(t, "instance-2", results[2].GetMetadata().GetName())
-	})
-
-	t.Run("sort invalid field", func(t *testing.T) {
-		_, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-			SortField: "blah",
-		})
-		require.Error(t, err)
-		assert.ErrorContains(t, err, `unsupported sort "blah" but expected bot_name, active_at_latest, version_latest or host_name_latest`)
+			rest, _, err := p.botInstanceService.ListBotInstances(ctx, 0, cacheToken, nil)
+			require.NoError(t, err)
+			require.Equal(t, wantOrder[pageSize:], names(rest))
+			rest, _, err = p.cache.ListBotInstances(ctx, 0, backendToken, nil)
+			require.NoError(t, err)
+			require.Equal(t, wantOrder[pageSize:], names(rest))
+		}
 	})
 }
 
-// TestBotInstanceCacheFilterFn tests that FilterFn is applied during cache
-// iteration and that pages are filled correctly even when some items are
-// filtered out.
-func TestBotInstanceCacheFilterFn(t *testing.T) {
+type botInstanceSpec struct {
+	scope, botName, id string
+	hostname, version  string
+	activeAt           int64
+}
+
+func buildBotInstance(s botInstanceSpec) *machineidv1.BotInstance {
+	status := &machineidv1.BotInstanceStatus{}
+	if s.hostname != "" || s.version != "" || s.activeAt != 0 {
+		status = machineidv1.BotInstanceStatus_builder{
+			LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+				machineidv1.BotInstanceStatusHeartbeat_builder{
+					Hostname:   s.hostname,
+					Version:    s.version,
+					RecordedAt: &timestamppb.Timestamp{Seconds: s.activeAt},
+				}.Build(),
+			},
+		}.Build()
+	}
+	return machineidv1.BotInstance_builder{
+		Kind:     types.KindBotInstance,
+		Version:  types.V1,
+		Scope:    s.scope,
+		Metadata: &headerv1.Metadata{},
+		Spec: machineidv1.BotInstanceSpec_builder{
+			BotName:    s.botName,
+			InstanceId: s.id,
+		}.Build(),
+		Status: status,
+	}.Build()
+}
+
+// TestBotInstanceCacheList exercises Cache.ListBotInstances across filtering and
+// sorting.
+func TestBotInstanceCacheList(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
-
-	p := newTestPack(t, ForAuth)
-	t.Cleanup(p.Close)
-
-	// Create 10 instances across two bots: bot-0 and bot-1.
-	for n := range 10 {
-		_, err := p.botInstanceService.CreateBotInstance(ctx, &machineidv1.BotInstance{
-			Kind:     types.KindBotInstance,
-			Version:  types.V1,
-			Metadata: &headerv1.Metadata{},
-			Spec: &machineidv1.BotInstanceSpec{
-				BotName:    "bot-" + strconv.Itoa(n%2),
-				InstanceId: "instance-" + strconv.Itoa(n),
-			},
-			Status: &machineidv1.BotInstanceStatus{},
-		})
-		require.NoError(t, err)
+	botInstanceIDs := func(instances []*machineidv1.BotInstance) []string {
+		out := make([]string, 0, len(instances))
+		for _, b := range instances {
+			out = append(out, b.GetSpec().GetInstanceId())
+		}
+		return out
 	}
 
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 10)
-	}, 10*time.Second, 100*time.Millisecond)
+	sortInstances := []botInstanceSpec{
+		{botName: "alpha", id: "i-a", activeAt: 200, version: "2.0.0", hostname: "host-2"},
+		{botName: "beta", id: "i-b", activeAt: 100, version: "2.0.0-rc1", hostname: "host-3"},
+		{scope: "/east", botName: "alpha", id: "i-c", activeAt: 300, version: "1.0.0", hostname: "host-1"},
+	}
 
-	// FilterFn that only accepts even-numbered instances.
-	filterFn := func(b *machineidv1.BotInstance) bool {
+	evenFilter := func(b *machineidv1.BotInstance) bool {
 		id := b.GetSpec().GetInstanceId()
-		n := id[len(id)-1]
-		return n == '0' || n == '2' || n == '4' || n == '6' || n == '8'
+		return (id[len(id)-1]-'0')%2 == 0
 	}
 
-	// FilterFn alone: all even instances across both bots.
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterFn: filterFn,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 5)
-
-	// Pages should be full: request 3 items with a filter that accepts half.
-	results, nextPageToken, err := p.cache.ListBotInstances(ctx, 3, "", &services.ListBotInstancesRequestOptions{
-		FilterFn: filterFn,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 3)
-	require.NotEmpty(t, nextPageToken)
-
-	// Next page should contain the remaining 2 items.
-	results, nextPageToken, err = p.cache.ListBotInstances(ctx, 3, nextPageToken, &services.ListBotInstancesRequestOptions{
-		FilterFn: filterFn,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 2)
-	require.Empty(t, nextPageToken)
-
-	// FilterFn composed with FilterBotName: bot-0 has instances 0,2,4,6,8
-	// (even-numbered), all of which pass the FilterFn. bot-1 has instances
-	// 1,3,5,7,9 (odd-numbered), none of which pass the FilterFn.
-	results, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterBotName: "bot-0",
-		FilterFn:      filterFn,
-	})
-	require.NoError(t, err)
-	require.Len(t, results, 5)
-	for _, b := range results {
-		require.Equal(t, "bot-0", b.GetSpec().GetBotName())
+	filterFnInstances := []botInstanceSpec{
+		{botName: "bot", id: "i-0"},
+		{botName: "bot", id: "i-1"},
+		{botName: "bot", id: "i-2"},
+		{botName: "bot", id: "i-3"},
+		{scope: "/s", botName: "bot", id: "i-4"},
+		{scope: "/s", botName: "bot", id: "i-5"},
 	}
 
-	// bot-1 instances are all odd-numbered, so FilterFn rejects them all.
-	results, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterBotName: "bot-1",
-		FilterFn:      filterFn,
-	})
-	require.NoError(t, err)
-	require.Empty(t, results)
+	tests := []struct {
+		name      string
+		instances []botInstanceSpec
+		opts      *services.ListBotInstancesRequestOptions
+		want      []string
+		wantErr   string
+	}{
+		{
+			name: "no filter spans all scopes, unscoped first",
+			instances: []botInstanceSpec{
+				{botName: "bot-a", id: "u1"},
+				{scope: "/foo", botName: "bot-b", id: "s1"},
+				{botName: "bot-c", id: "u2"},
+			},
+			want: []string{"u1", "u2", "s1"},
+		},
+		{
+			name: "bot name filter matches only the unscoped bot of that name",
+			instances: []botInstanceSpec{
+				{botName: "web", id: "web-a"},
+				{botName: "web", id: "web-b"},
+				{scope: "/prod", botName: "web", id: "web-c"},
+				{botName: "db", id: "db-a"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterBotName: "web"},
+			want: []string{"web-a", "web-b"},
+		},
+		{
+			name: "bot name and scope filter matches the scoped bot",
+			instances: []botInstanceSpec{
+				{botName: "web", id: "web-u"},
+				{scope: "/prod", botName: "web", id: "web-p1"},
+				{scope: "/prod", botName: "web", id: "web-p2"},
+				{scope: "/prod", botName: "api", id: "api-p"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterBotName: "web", FilterBotScope: "/prod"},
+			want: []string{"web-p1", "web-p2"},
+		},
+		{
+			// A scope filter only qualifies a bot name, so it is rejected on its
+			// own rather than listing every instance in the scope.
+			name: "scope filter without a bot name filter is rejected",
+			instances: []botInstanceSpec{
+				{botName: "web", id: "web-u"},
+				{scope: "/prod", botName: "web", id: "web-p1"},
+			},
+			opts:    &services.ListBotInstancesRequestOptions{FilterBotScope: "/prod"},
+			wantErr: "bot scope filter requires a bot name filter",
+		},
+		{
+			name: "search term matches across scopes",
+			instances: []botInstanceSpec{
+				{botName: "runner", id: "r1", hostname: "host-match"},
+				{scope: "/foo", botName: "runner", id: "r2", hostname: "host-match"},
+				{botName: "runner", id: "r3", hostname: "host-other"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "host-match"},
+			want: []string{"r1", "r2"},
+		},
+		{
+			name: "predicate query matches across scopes",
+			instances: []botInstanceSpec{
+				{botName: "q", id: "q1", hostname: "host-1"},
+				{scope: "/foo", botName: "q", id: "q2", hostname: "host-1"},
+				{botName: "q", id: "q3", hostname: "host-2"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterQuery: `status.latest_heartbeat.hostname == "host-1"`},
+			want: []string{"q1", "q2"},
+		},
+		{
+			name:      "sort by bot_name ascending groups unscoped before scoped",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "bot_name"},
+			want:      []string{"i-a", "i-b", "i-c"},
+		},
+		{
+			name:      "sort by bot_name descending",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "bot_name", SortDesc: true},
+			want:      []string{"i-c", "i-b", "i-a"},
+		},
+		{
+			name:      "sort by active_at ascending is global across scopes",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "active_at_latest"},
+			want:      []string{"i-b", "i-a", "i-c"},
+		},
+		{
+			name:      "sort by active_at descending",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "active_at_latest", SortDesc: true},
+			want:      []string{"i-c", "i-a", "i-b"},
+		},
+		{
+			name:      "sort by version ascending is global across scopes",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "version_latest"},
+			want:      []string{"i-c", "i-b", "i-a"},
+		},
+		{
+			name:      "sort by version descending",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "version_latest", SortDesc: true},
+			want:      []string{"i-a", "i-b", "i-c"},
+		},
+		{
+			name:      "sort by host_name ascending is global across scopes",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "host_name_latest"},
+			want:      []string{"i-c", "i-a", "i-b"},
+		},
+		{
+			name:      "sort by host_name descending",
+			instances: sortInstances,
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "host_name_latest", SortDesc: true},
+			want:      []string{"i-b", "i-a", "i-c"},
+		},
+		{
+			name:      "unsupported sort field is rejected",
+			instances: []botInstanceSpec{{botName: "bot", id: "x1"}},
+			opts:      &services.ListBotInstancesRequestOptions{SortField: "nope"},
+			wantErr:   `unsupported sort "nope"`,
+		},
+		{
+			name:      "filter fn spans scopes",
+			instances: filterFnInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterFn: evenFilter},
+			want:      []string{"i-0", "i-2", "i-4"},
+		},
+		{
+			name:      "filter fn combined with bot name filter",
+			instances: filterFnInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterBotName: "bot", FilterFn: evenFilter},
+			want:      []string{"i-0", "i-2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+
+				p := newTestPack(t, ForAuth)
+				t.Cleanup(p.Close)
+
+				for _, s := range tc.instances {
+					_, err := p.botInstanceService.CreateBotInstance(ctx, buildBotInstance(s))
+					require.NoError(t, err)
+				}
+
+				synctest.Wait()
+
+				got, _, err := p.cache.ListBotInstances(ctx, 0, "", tc.opts)
+				if tc.wantErr != "" {
+					assert.ErrorContains(t, err, tc.wantErr)
+					return
+				}
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, botInstanceIDs(got))
+
+				// Also assert that pagination produces the same results (in
+				// particular, we're looking for cursor keys not lining up
+				// leading to skipped entries)
+				paged, err := stream.Collect(
+					clientutils.ResourcesWithPageSize(
+						ctx,
+						func(ctx context.Context, pageSize int, token string) ([]*machineidv1.BotInstance, string, error) {
+							return p.cache.ListBotInstances(ctx, pageSize, token, tc.opts)
+						},
+						2,
+					),
+				)
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, botInstanceIDs(paged))
+			})
+		})
+	}
 }
 
 // TestBotInstanceCacheFallback tests that requests fallback to the upstream when the cache is unhealthy.
@@ -545,16 +433,16 @@ func TestBotInstanceCacheFallback(t *testing.T) {
 	})
 	t.Cleanup(p.Close)
 
-	_, err := p.botInstanceService.CreateBotInstance(ctx, &machineidv1.BotInstance{
+	_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
 		Kind:     types.KindBotInstance,
 		Version:  types.V1,
 		Metadata: &headerv1.Metadata{},
-		Spec: &machineidv1.BotInstanceSpec{
+		Spec: machineidv1.BotInstanceSpec_builder{
 			BotName:    "bot-1",
 			InstanceId: "instance-1",
-		},
+		}.Build(),
 		Status: &machineidv1.BotInstanceStatus{},
-	})
+	}.Build())
 	require.NoError(t, err)
 
 	// Let the cache catch up
@@ -605,68 +493,68 @@ func TestKeyForVersionIndex(t *testing.T) {
 		{
 			name: "invalid version",
 			mutatorFn: func(b *machineidv1.BotInstance) {
-				b.Status = &machineidv1.BotInstanceStatus{
-					InitialHeartbeat: &machineidv1.BotInstanceStatusHeartbeat{
+				b.SetStatus(machineidv1.BotInstanceStatus_builder{
+					InitialHeartbeat: machineidv1.BotInstanceStatusHeartbeat_builder{
 						Version: "a.b.c",
-					},
-				}
+					}.Build(),
+				}.Build())
 			},
 			key: "000000.000000.000000-~/bot-instance-1",
 		},
 		{
 			name: "initial heartbeat",
 			mutatorFn: func(b *machineidv1.BotInstance) {
-				b.Status = &machineidv1.BotInstanceStatus{
-					InitialHeartbeat: &machineidv1.BotInstanceStatusHeartbeat{
+				b.SetStatus(machineidv1.BotInstanceStatus_builder{
+					InitialHeartbeat: machineidv1.BotInstanceStatusHeartbeat_builder{
 						Version: "1.0.0",
-					},
-				}
+					}.Build(),
+				}.Build())
 			},
 			key: "000001.000000.000000-~/bot-instance-1",
 		},
 		{
 			name: "latest heartbeat",
 			mutatorFn: func(b *machineidv1.BotInstance) {
-				b.Status = &machineidv1.BotInstanceStatus{
+				b.SetStatus(machineidv1.BotInstanceStatus_builder{
 					LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
-						{
+						machineidv1.BotInstanceStatusHeartbeat_builder{
 							Version: "1.0.0",
-						},
+						}.Build(),
 					},
-				}
+				}.Build())
 			},
 			key: "000001.000000.000000-~/bot-instance-1",
 		},
 		{
 			name: "with release",
 			mutatorFn: func(b *machineidv1.BotInstance) {
-				b.Status = &machineidv1.BotInstanceStatus{
-					InitialHeartbeat: &machineidv1.BotInstanceStatusHeartbeat{
+				b.SetStatus(machineidv1.BotInstanceStatus_builder{
+					InitialHeartbeat: machineidv1.BotInstanceStatusHeartbeat_builder{
 						Version: "1.0.0-dev",
-					},
-				}
+					}.Build(),
+				}.Build())
 			},
 			key: "000001.000000.000000-dev/bot-instance-1",
 		},
 		{
 			name: "with build",
 			mutatorFn: func(b *machineidv1.BotInstance) {
-				b.Status = &machineidv1.BotInstanceStatus{
-					InitialHeartbeat: &machineidv1.BotInstanceStatusHeartbeat{
+				b.SetStatus(machineidv1.BotInstanceStatus_builder{
+					InitialHeartbeat: machineidv1.BotInstanceStatusHeartbeat_builder{
 						Version: "1.0.0+build1",
-					},
-				}
+					}.Build(),
+				}.Build())
 			},
 			key: "000001.000000.000000-~/bot-instance-1",
 		},
 		{
 			name: "with release and build",
 			mutatorFn: func(b *machineidv1.BotInstance) {
-				b.Status = &machineidv1.BotInstanceStatus{
-					InitialHeartbeat: &machineidv1.BotInstanceStatusHeartbeat{
+				b.SetStatus(machineidv1.BotInstanceStatus_builder{
+					InitialHeartbeat: machineidv1.BotInstanceStatusHeartbeat_builder{
 						Version: "1.0.0-dev+build1",
-					},
-				}
+					}.Build(),
+				}.Build())
 			},
 			key: "000001.000000.000000-dev/bot-instance-1",
 		},
@@ -674,15 +562,15 @@ func TestKeyForVersionIndex(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			instance := &machineidv1.BotInstance{
+			instance := machineidv1.BotInstance_builder{
 				Kind:    types.KindBotInstance,
 				Version: types.V1,
-				Metadata: &headerv1.Metadata{
+				Metadata: headerv1.Metadata_builder{
 					Name: "bot-instance-1",
-				},
+				}.Build(),
 				Spec:   &machineidv1.BotInstanceSpec{},
 				Status: &machineidv1.BotInstanceStatus{},
-			}
+			}.Build()
 			tc.mutatorFn(instance)
 
 			versionKey := keyForBotInstanceVersionIndex(instance)

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -19,17 +19,19 @@ package cache
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"testing/synctest"
-	"time"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -97,6 +99,95 @@ func TestBotInstanceCache(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestBotInstanceCollectionSeedHonorsWatchScopeFilter verifies that the cache's
+// initial fetch selects the same set as its scope-filtered event stream, which an
+// unfiltered seed would not, leaving permanently stale out-of-scope entries.
+func TestBotInstanceCollectionSeedHonorsWatchScopeFilter(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	for i, scope := range []string{"", "/foo", "/foo/sub", "/bar"} {
+		_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
+			Kind:     types.KindBotInstance,
+			Version:  types.V1,
+			Scope:    scope,
+			Metadata: &headerv1.Metadata{},
+			Spec: machineidv1.BotInstanceSpec_builder{
+				BotName:    fmt.Sprintf("bot-%d", i),
+				InstanceId: uuid.New().String(),
+			}.Build(),
+			Status: &machineidv1.BotInstanceStatus{},
+		}.Build())
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name        string
+		scopeFilter *scopesv1.Filter
+		wantScopes  []string
+	}{
+		{
+			name:        "mode ALL seeds every scope",
+			scopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			wantScopes:  []string{"", "/bar", "/foo", "/foo/sub"},
+		},
+		{
+			name:        "mode UNSCOPED seeds only unscoped",
+			scopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+			wantScopes:  []string{""},
+		},
+		{
+			name:        "mode EXACT seeds one scope",
+			scopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: "/foo"}.Build(),
+			wantScopes:  []string{"/foo"},
+		},
+		{
+			name:        "mode DESCENDANTS seeds the scope and below",
+			scopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build(),
+			wantScopes:  []string{"/foo", "/foo/sub"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			collection, err := newBotInstanceCollection(p.botInstanceService, types.WatchKind{
+				Kind:        types.KindBotInstance,
+				ScopeFilter: types.ScopeFilterFromProto(tc.scopeFilter),
+			})
+			require.NoError(t, err)
+
+			seeded, err := collection.fetcher(t.Context(), false)
+			require.NoError(t, err)
+
+			gotScopes := make([]string, 0, len(seeded))
+			for _, bi := range seeded {
+				gotScopes = append(gotScopes, bi.GetScope())
+			}
+			slices.Sort(gotScopes)
+			require.Equal(t, tc.wantScopes, gotScopes)
+		})
+	}
+
+	t.Run("malformed watch filter is rejected at construction", func(t *testing.T) {
+		_, err := newBotInstanceCollection(p.botInstanceService, types.WatchKind{
+			Kind: types.KindBotInstance,
+			// EXACT requires a scope.
+			ScopeFilter: types.ScopeFilterFromProto(scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT}.Build()),
+		})
+		require.ErrorContains(t, err, "requires a non-empty scope")
+	})
+
+	t.Run("unspecified watch filter is rejected at construction", func(t *testing.T) {
+		_, err := newBotInstanceCollection(p.botInstanceService, types.WatchKind{
+			Kind: types.KindBotInstance,
+		})
+		require.ErrorContains(t, err, "explicit scope filter mode")
+	})
 }
 
 // TestBotInstanceCacheBackendTokenParity verifies that the cache lister and
@@ -233,6 +324,14 @@ func TestBotInstanceCacheList(t *testing.T) {
 		return (id[len(id)-1]-'0')%2 == 0
 	}
 
+	// Instance IDs name their scope, so expectations read as selected scopes.
+	scopeFilterInstances := []botInstanceSpec{
+		{botName: "u", id: "u"},
+		{scope: "/foo", botName: "f", id: "foo"},
+		{scope: "/foo/sub", botName: "fs", id: "foo-sub"},
+		{scope: "/bar", botName: "b", id: "bar"},
+	}
+
 	filterFnInstances := []botInstanceSpec{
 		{botName: "bot", id: "i-0"},
 		{botName: "bot", id: "i-1"},
@@ -281,15 +380,79 @@ func TestBotInstanceCacheList(t *testing.T) {
 			want: []string{"web-p1", "web-p2"},
 		},
 		{
-			// A scope filter only qualifies a bot name, so it is rejected on its
-			// own rather than listing every instance in the scope.
-			name: "scope filter without a bot name filter is rejected",
+			// A bot scope only qualifies a bot name, so it is rejected on its own
+			// rather than listing every instance in the scope. Standalone scope
+			// selection is ScopeFilter, covered below.
+			name: "bot scope without a bot name filter is rejected",
 			instances: []botInstanceSpec{
 				{botName: "web", id: "web-u"},
 				{scope: "/prod", botName: "web", id: "web-p1"},
 			},
 			opts:    &services.ListBotInstancesRequestOptions{FilterBotScope: "/prod"},
 			wantErr: "bot scope filter requires a bot name filter",
+		},
+		{
+			name:      "scope filter mode ALL spans all scopes",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			},
+			want: []string{"u", "bar", "foo", "foo-sub"},
+		},
+		{
+			// Unscoped is orthogonal to every scoped value, not the root.
+			name:      "scope filter mode UNSCOPED matches only unscoped instances",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+			},
+			want: []string{"u"},
+		},
+		{
+			name:      "scope filter mode EXACT matches one scope",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: "/foo"}.Build(),
+			},
+			want: []string{"foo"},
+		},
+		{
+			name:      "scope filter mode DESCENDANTS includes the scope and below",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build(),
+			},
+			want: []string{"foo", "foo-sub"},
+		},
+		{
+			name:      "scope filter with a bot filter is rejected",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				FilterBotName:  "f",
+				FilterBotScope: "/foo",
+				ScopeFilter:    scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+			},
+			wantErr: "scope filter cannot be combined with a bot name filter",
+		},
+		{
+			// Rejected even though it would be harmless as a predicate.
+			name:      "scope filter mode ALL with a bot filter is rejected",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				FilterBotName:  "f",
+				FilterBotScope: "/foo",
+				ScopeFilter:    scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			},
+			wantErr: "scope filter cannot be combined with a bot name filter",
+		},
+		{
+			name:      "malformed scope filter is rejected",
+			instances: scopeFilterInstances,
+			// EXACT requires a scope.
+			opts: &services.ListBotInstancesRequestOptions{
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT}.Build(),
+			},
+			wantErr: "requires a non-empty scope",
 		},
 		{
 			name: "search term matches across scopes",
@@ -421,60 +584,97 @@ func TestBotInstanceCacheList(t *testing.T) {
 	}
 }
 
-// TestBotInstanceCacheFallback tests that requests fallback to the upstream when the cache is unhealthy.
+// TestBotInstanceCacheFallback compares reads served by the unhealthy-cache
+// fallback against the healthy cache: both apply the collection's scope filter
+// to lists and gets, while sort support legitimately differs (the upstream
+// backend only supports bot_name-ascending iteration).
 func TestBotInstanceCacheFallback(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	for _, tt := range []struct {
+		name    string
+		neverOK bool
+	}{
+		{name: "HealthyCache", neverOK: false},
+		{name: "Fallback", neverOK: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
 
-	p := newTestPack(t, func(cfg Config) Config {
-		cfg.neverOK = true // Force the cache into an unhealthy state
-		return ForAuth(cfg)
-	})
-	t.Cleanup(p.Close)
+				p := newTestPack(t, func(cfg Config) Config {
+					cfg = ForAuth(cfg)
+					cfg.neverOK = tt.neverOK
+					for i, w := range cfg.Watches {
+						if w.Kind == types.KindBotInstance {
+							cfg.Watches[i].ScopeFilter = types.ScopeFilterFromProto(
+								scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build(),
+							)
+						}
+					}
+					return cfg
+				})
+				t.Cleanup(p.Close)
 
-	_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
-		Kind:     types.KindBotInstance,
-		Version:  types.V1,
-		Metadata: &headerv1.Metadata{},
-		Spec: machineidv1.BotInstanceSpec_builder{
-			BotName:    "bot-1",
-			InstanceId: "instance-1",
-		}.Build(),
-		Status: &machineidv1.BotInstanceStatus{},
-	}.Build())
-	require.NoError(t, err)
+				for i, scope := range []string{"", "/foo", "/foo/sub", "/bar"} {
+					_, err := p.botInstanceService.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
+						Kind:     types.KindBotInstance,
+						Version:  types.V1,
+						Scope:    scope,
+						Metadata: &headerv1.Metadata{},
+						Spec: machineidv1.BotInstanceSpec_builder{
+							BotName:    fmt.Sprintf("bot-%d", i),
+							InstanceId: fmt.Sprintf("instance-%d", i),
+						}.Build(),
+						Status: &machineidv1.BotInstanceStatus{},
+					}.Build())
+					require.NoError(t, err)
+				}
 
-	// Let the cache catch up
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
-		require.NoError(t, err)
-		require.Len(t, results, 1)
-	}, 10*time.Second, 100*time.Millisecond)
+				synctest.Wait()
 
-	// sort ascending by bot_name
-	results, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "bot_name",
-		SortDesc:  false,
-	})
-	require.NoError(t, err) // asc by bot_name is the only sort supported by the upstream
-	require.Len(t, results, 1)
+				// Lists apply the collection's scope filter regardless of health.
+				results, _, err := p.cache.ListBotInstances(ctx, 0, "", nil)
+				require.NoError(t, err)
+				gotScopes := make([]string, 0, len(results))
+				for _, bi := range results {
+					gotScopes = append(gotScopes, bi.GetScope())
+				}
+				slices.Sort(gotScopes)
+				require.Equal(t, []string{"/foo", "/foo/sub"}, gotScopes)
 
-	// sort descending by bot_name
-	_, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "bot_name",
-		SortDesc:  true,
-	})
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "unsupported sort, only ascending order is supported")
+				// So do gets: in-filter is retrievable, out-of-filter reads as absent.
+				gotFoo, err := p.cache.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{
+					BotName: "bot-1", InstanceId: "instance-1", BotScope: "/foo",
+				}.Build())
+				require.NoError(t, err)
+				require.Equal(t, "/foo", gotFoo.GetScope())
 
-	// sort ascending by active_at_latest
-	_, _, err = p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "active_at_latest",
-		SortDesc:  false,
-	})
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "unsupported sort, only bot_name field is supported, but got \"active_at_latest\"")
+				_, err = p.cache.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{
+					BotName: "bot-3", InstanceId: "instance-3", BotScope: "/bar",
+				}.Build())
+				require.True(t, trace.IsNotFound(err), "expected NotFound for out-of-filter instance, got %v", err)
+
+				// The healthy cache serves every sort from its indexes; the fallback
+				// surfaces the backend's ordering limits.
+				listErr := func(sortField string, desc bool) error {
+					_, _, err := p.cache.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
+						SortField: sortField,
+						SortDesc:  desc,
+					})
+					return err
+				}
+				require.NoError(t, listErr("bot_name", false))
+				if tt.neverOK {
+					require.ErrorContains(t, listErr("bot_name", true), "unsupported sort, only ascending order is supported")
+					require.ErrorContains(t, listErr("active_at_latest", false), `unsupported sort, only bot_name field is supported, but got "active_at_latest"`)
+				} else {
+					require.NoError(t, listErr("bot_name", true))
+					require.NoError(t, listErr("active_at_latest", false))
+				}
+			})
+		})
+	}
 }
 
 func TestKeyForVersionIndex(t *testing.T) {

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -224,7 +224,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindWorkloadIdentity, ScopeFilter: allScopes},
 		{Kind: types.KindHealthCheckConfig},
 		{Kind: types.KindRelayServer},
-		{Kind: types.KindBotInstance},
+		{Kind: types.KindBotInstance, ScopeFilter: allScopes},
 		{Kind: types.KindRecordingEncryption},
 		{Kind: types.KindInferenceModel},
 		{Kind: types.KindInferencePolicy},

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -224,7 +224,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindWorkloadIdentity},
 		{Kind: types.KindHealthCheckConfig},
 		{Kind: types.KindRelayServer},
-		{Kind: types.KindBotInstance},
+		{Kind: types.KindBotInstance, ScopeFilter: allScopes},
 		{Kind: types.KindRecordingEncryption},
 		{Kind: types.KindInferenceModel},
 		{Kind: types.KindInferencePolicy},

--- a/lib/cache/inventory/inventory_cache.go
+++ b/lib/cache/inventory/inventory_cache.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/cache"
@@ -590,7 +591,9 @@ func (ic *InventoryCache) setupWatcher(ctx context.Context) (types.Watcher, erro
 		Name: "inventory_cache",
 		Kinds: []types.WatchKind{
 			{Kind: types.KindInstance},
-			{Kind: types.KindBotInstance},
+			{Kind: types.KindBotInstance, ScopeFilter: types.ScopeFilterFromProto(
+				scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			)},
 		},
 	})
 	if err != nil {
@@ -667,7 +670,10 @@ func (ic *InventoryCache) populateBotInstances(ctx context.Context, limiter *rat
 			ctx,
 			defaults.DefaultChunkSize,
 			pageToken,
-			nil,
+			&services.ListBotInstancesRequestOptions{
+				// All scopes, matching this cache's watch filter.
+				ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			},
 		)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -1747,15 +1747,15 @@ func (m *mockBotInstanceCache) ListBotInstances(ctx context.Context, pageSize in
 	return m.bots, "", nil
 }
 
-func (m *mockBotInstanceCache) GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error) {
+func (m *mockBotInstanceCache) GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error) {
 	return nil, nil
 }
 
-func (m *mockBotInstanceCache) DeleteBotInstance(ctx context.Context, botName, instanceID string) error {
+func (m *mockBotInstanceCache) DeleteBotInstance(ctx context.Context, req *machineidv1.DeleteBotInstanceRequest) error {
 	return nil
 }
 
-func (m *mockBotInstanceCache) PatchBotInstance(ctx context.Context, botName, instanceID string, update func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error)) (*machineidv1.BotInstance, error) {
+func (m *mockBotInstanceCache) PatchBotInstance(ctx context.Context, opts services.PatchBotInstanceOpts) (*machineidv1.BotInstance, error) {
 	return nil, nil
 }
 

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -1913,8 +1913,11 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 	firstInstance, generation := testExtractBotParamsFromCerts(t, joinResult.Certs)
 	require.Equal(t, uint64(1), generation)
 
-	// The BotInstance should have the scope set.
+	// The BotInstance should have the scope set. A bot is identified by
+	// (scope, name), so the read must declare the bot's scope to address the
+	// scoped instance.
 	botInstance, err := adminClient.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
+		BotScope:   "/test",
 		BotName:    "test-scoped",
 		InstanceId: firstInstance,
 	})

--- a/lib/scopes/qualified.go
+++ b/lib/scopes/qualified.go
@@ -112,6 +112,14 @@ func (q QualifiedName) WeakValidate() error {
 	return nil
 }
 
+// MaybeSQN returns true if the given string *might* be a scope-qualified name. This function is intended to be used
+// for testing fields that may contain a mix of scope-qualified and unscoped names. Generally, any string that trips
+// this check should be considered to have been intended to be an SQN by the user, and treated as a typo if it fails
+// to parse as one.
+func MaybeSQN(s string) bool {
+	return strings.HasPrefix(s, separator) || strings.Contains(s, QualifiedNameSeparator)
+}
+
 // ParseQualifiedName parses a scope-qualified name string into its scope and name
 // components by splitting on the first occurrence of "::". Returns an error if the
 // separator is absent or either component is empty. This function does not validate

--- a/lib/scopes/qualified_test.go
+++ b/lib/scopes/qualified_test.go
@@ -304,6 +304,14 @@ func TestValidateQualifiedName(t *testing.T) {
 	}
 }
 
+func TestMaybeQualifiedName(t *testing.T) {
+	require.True(t, MaybeSQN("/foo/bar::llama"))
+	require.True(t, MaybeSQN("/llama"))
+	require.False(t, MaybeSQN("llama"))
+	require.False(t, MaybeSQN("llama/"))
+	require.False(t, MaybeSQN(""))
+}
+
 func TestSet(t *testing.T) {
 	t.Parallel()
 	tts := []struct {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2528,7 +2528,7 @@ func (process *TeleportProcess) initAuthService() error {
 				PrimaryCache:       cache,
 				Events:             as.Services,
 				Inventory:          as.Services,
-				BotInstanceBackend: as.Services,
+				BotInstanceBackend: as.Services.BotInstance,
 				Logger:             process.logger.With(teleport.ComponentKey, "inventory.cache"),
 				MetricsRegistry:    process.metricsRegistry.Wrap("inventory_cache"),
 			})

--- a/lib/services/bot_instance.go
+++ b/lib/services/bot_instance.go
@@ -26,6 +26,7 @@ import (
 
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
@@ -36,27 +37,45 @@ import (
 const BotUserPrefix = "bot-"
 
 // BotInstance is an interface for the BotInstance service.
+//
+// Bot instances belong to a bot, and bots are identified by their scope and
+// name: instances of scoped bots are stored in a scope-namespaced key range,
+// separate from instances of unscoped bots. Methods addressing an individual
+// instance take the owning bot's scope, which must be empty if the bot is
+// unscoped.
 type BotInstance interface {
-	// CreateBotInstance
+	// CreateBotInstance creates a new bot instance. It is stored in the key
+	// range determined by the scope set on the instance itself.
 	CreateBotInstance(ctx context.Context, botInstance *machineidv1.BotInstance) (*machineidv1.BotInstance, error)
 
-	// GetBotInstance
-	GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error)
+	// GetBotInstance returns the bot instance owned by the bot identified by
+	// the request's (bot_scope, bot_name) with the given instance ID.
+	GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error)
 
 	// ListBotInstances
 	ListBotInstances(ctx context.Context, pageSize int, lastToken string, options *ListBotInstancesRequestOptions) ([]*machineidv1.BotInstance, string, error)
 
-	// DeleteBotInstance
-	DeleteBotInstance(ctx context.Context, botName, instanceID string) error
+	// DeleteBotInstance deletes the bot instance owned by the bot identified
+	// by the request's (bot_scope, bot_name) with the given instance ID.
+	DeleteBotInstance(ctx context.Context, req *machineidv1.DeleteBotInstanceRequest) error
 
-	// PatchBotInstance fetches an existing bot instance by bot name and ID,
-	// then calls `updateFn` to apply any changes before persisting the
-	// resource.
-	PatchBotInstance(
-		ctx context.Context,
-		botName, instanceID string,
-		updateFn func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error),
-	) (*machineidv1.BotInstance, error)
+	// PatchBotInstance fetches the existing bot instance identified by the
+	// given options, then calls the options' UpdateFn to apply any changes
+	// before persisting the resource.
+	PatchBotInstance(ctx context.Context, opts PatchBotInstanceOpts) (*machineidv1.BotInstance, error)
+}
+
+// PatchBotInstanceOpts identifies the bot instance to be patched by
+// [BotInstance.PatchBotInstance] and holds the patch to apply to it.
+type PatchBotInstanceOpts struct {
+	// Bot is the scope-qualified name of the bot that owns the instance. The
+	// scope must be empty if the bot is unscoped.
+	Bot scopes.QualifiedName
+	// InstanceID is the ID of the instance to patch.
+	InstanceID string
+	// UpdateFn is applied to the fetched instance to produce the instance to
+	// persist. It may be called more than once if the write is retried.
+	UpdateFn func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error)
 }
 
 // ValidateBotInstance verifies that required fields for a new BotInstance are present
@@ -159,6 +178,13 @@ type ListBotInstancesRequestOptions struct {
 	// The name of the Bot to list BotInstances for. If empty, all BotInstances
 	// will be listed.
 	FilterBotName string
+	// The scope of the Bot to list BotInstances for. A bot is identified by the
+	// pair (scope, name), so this only ever qualifies FilterBotName and must be
+	// set alongside it; setting it without FilterBotName is an error. Leave
+	// empty if the bot is unscoped. This is deliberately not a scope filter for
+	// listing every BotInstance in a scope - that will be a separate field with
+	// explicit exact/descendant control.
+	FilterBotScope string
 	// A search term used to filter the results. If non-empty, it's used to
 	// match against supported fields.
 	FilterSearchTerm string
@@ -187,6 +213,13 @@ func (o *ListBotInstancesRequestOptions) GetFilterBotName() string {
 		return ""
 	}
 	return o.FilterBotName
+}
+
+func (o *ListBotInstancesRequestOptions) GetFilterBotScope() string {
+	if o == nil {
+		return ""
+	}
+	return o.FilterBotScope
 }
 
 func (o *ListBotInstancesRequestOptions) GetFilterSearchTerm() string {

--- a/lib/services/bot_instance.go
+++ b/lib/services/bot_instance.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils/typical"
@@ -182,9 +183,15 @@ type ListBotInstancesRequestOptions struct {
 	// pair (scope, name), so this only ever qualifies FilterBotName and must be
 	// set alongside it; setting it without FilterBotName is an error. Leave
 	// empty if the bot is unscoped. This is deliberately not a scope filter for
-	// listing every BotInstance in a scope - that will be a separate field with
-	// explicit exact/descendant control.
+	// listing every BotInstance in a scope - use ScopeFilter for that.
 	FilterBotScope string
+	// ScopeFilter selects BotInstances by the scope of their owning bot. A nil or
+	// MODE_UNSPECIFIED filter matches every scope; identity-derived defaulting is
+	// the caller's job (see ScopedAccessCheckerContext.ResolveScopeFilter).
+	//
+	// Mutually exclusive with FilterBotName, which already constrains the result
+	// to a single bot in a single scope.
+	ScopeFilter *scopesv1.Filter
 	// A search term used to filter the results. If non-empty, it's used to
 	// match against supported fields.
 	FilterSearchTerm string
@@ -220,6 +227,13 @@ func (o *ListBotInstancesRequestOptions) GetFilterBotScope() string {
 		return ""
 	}
 	return o.FilterBotScope
+}
+
+func (o *ListBotInstancesRequestOptions) GetScopeFilter() *scopesv1.Filter {
+	if o == nil {
+		return nil
+	}
+	return o.ScopeFilter
 }
 
 func (o *ListBotInstancesRequestOptions) GetFilterSearchTerm() string {

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -28,32 +28,49 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
-const (
-	botInstancePrefix = "bot_instance"
-)
+// botInstancePrefix is the backend prefix for bot instances. Instances of
+// scoped bots are namespaced by their bot's scope under the shared
+// scopedPrefix, keyed as
+// scoped/bot_instance/<encoded scope>/<bot name>/<instance id>. Instances
+// of unscoped bots remain keyed as bot_instance/<bot name>/<instance id>.
+const botInstancePrefix = "bot_instance"
+
+// botInstanceUnscopedWatchPrefix returns the backend key range containing
+// instances of unscoped bots.
+func botInstanceUnscopedWatchPrefix() backend.Key {
+	return backend.NewKey(botInstancePrefix)
+}
+
+// botInstanceScopedWatchPrefix returns the backend key range containing
+// instances of scoped bots.
+func botInstanceScopedWatchPrefix() backend.Key {
+	return backend.NewKey(scopedPrefix, botInstancePrefix)
+}
 
 // BotInstanceService exposes backend functionality for storing bot instances.
 type BotInstanceService struct {
-	service *generic.ServiceWrapper[*machineidv1.BotInstance]
+	service *generic.ScopeAwareServiceWrapper[*machineidv1.BotInstance]
 
 	clock clockwork.Clock
 }
 
 // NewBotInstanceService creates a new BotInstanceService with the given backend.
 func NewBotInstanceService(b backend.Backend, clock clockwork.Clock) (*BotInstanceService, error) {
-	service, err := generic.NewServiceWrapper(
-		generic.ServiceConfig[*machineidv1.BotInstance]{
-			Backend:       b,
-			ResourceKind:  types.KindBotInstance,
-			BackendPrefix: backend.NewKey(botInstancePrefix),
-			MarshalFunc:   services.MarshalBotInstance,
-			UnmarshalFunc: services.UnmarshalBotInstance,
-			ValidateFunc:  services.ValidateBotInstance,
+	service, err := generic.NewScopeAwareServiceWrapper(
+		generic.ScopeAwareServiceWrapperConfig[*machineidv1.BotInstance]{
+			Backend:               b,
+			ResourceKind:          types.KindBotInstance,
+			UnscopedBackendPrefix: backend.NewKey(botInstancePrefix),
+			ScopedBackendPrefix:   backend.NewKey(scopedPrefix, botInstancePrefix),
+			MarshalFunc:           services.MarshalBotInstance,
+			UnmarshalFunc:         services.UnmarshalBotInstance,
+			ValidateFunc:          services.ValidateBotInstance,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -64,7 +81,16 @@ func NewBotInstanceService(b backend.Backend, clock clockwork.Clock) (*BotInstan
 	}, nil
 }
 
-// CreateBotInstance inserts a new BotInstance into the backend.
+// serviceForBot returns a single-range service addressing the instances of the
+// bot identified by (botScope, botName): the bot's sub-range of the scoped key
+// range when botScope is non-empty, else its sub-range of the unscoped range.
+func (b *BotInstanceService) serviceForBot(botScope, botName string) (*generic.ServiceWrapper[*machineidv1.BotInstance], error) {
+	service, err := b.service.WithScopedResourcePrefix(scopes.QualifiedName{Scope: botScope, Name: botName})
+	return service, trace.Wrap(err)
+}
+
+// CreateBotInstance inserts a new BotInstance into the backend. It is stored
+// in the key range determined by the scope set on the instance itself.
 //
 // Note that new BotInstances will have their .Metadata.Name overwritten by the
 // instance UUID.
@@ -78,21 +104,30 @@ func (b *BotInstanceService) CreateBotInstance(ctx context.Context, instance *ma
 
 	instance.Metadata.Name = instance.Spec.InstanceId
 
-	serviceWithPrefix := b.service.WithPrefix(instance.Spec.BotName)
+	serviceWithPrefix, err := b.serviceForBot(instance.GetScope(), instance.GetSpec().GetBotName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	created, err := serviceWithPrefix.CreateResource(ctx, instance)
 	return created, trace.Wrap(err)
 }
 
-// GetBotInstance retreives a specific bot instance given a bot name and
-// instance ID.
-func (b *BotInstanceService) GetBotInstance(ctx context.Context, botName, instanceID string) (*machineidv1.BotInstance, error) {
-	serviceWithPrefix := b.service.WithPrefix(botName)
-	instance, err := serviceWithPrefix.GetResource(ctx, instanceID)
+// GetBotInstance retreives a specific bot instance given a bot scope, bot name
+// and instance ID. The scope must be empty if the owning bot is unscoped.
+func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *machineidv1.GetBotInstanceRequest) (*machineidv1.BotInstance, error) {
+	serviceWithPrefix, err := b.serviceForBot(req.GetBotScope(), req.GetBotName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	instance, err := serviceWithPrefix.GetResource(ctx, req.GetInstanceId())
 	return instance, trace.Wrap(err)
 }
 
-// ListBotInstances lists all matching bot instances. A bot name and/or search terms can be optionally provided.
-// If an non-empty bot name is provided, only instances for that bot will be fetched.
+// ListBotInstances lists all matching bot instances. A bot (scope, name) and/or search terms can be optionally provided.
+// If an non-empty bot name is provided, only instances for that bot will be fetched. The bot scope must be
+// provided alongside the name for a scoped bot's instances, and only ever qualifies the name - providing a
+// scope without a name is an error rather than a request for every instance in that scope. With no bot filter,
+// instances for all bots are listed, unscoped bots' instances first.
 // If an non-empty search term is provided, only instances with a value containing the term in supported fields are fetched.
 // Supported search fields include; bot name, instance id, hostname (latest), tbot version (latest), join method (latest).
 // Sorting by bot name in ascending order is supported - an error is returned for any other sort type.
@@ -103,13 +138,32 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	if options.GetSortDesc() {
 		return nil, "", trace.CompareFailed("unsupported sort, only ascending order is supported")
 	}
+	// A bot is identified by the pair (scope, name), so the scope filter only
+	// ever qualifies the name filter. Listing a whole scope will be a separate
+	// filter with explicit exact/descendant control.
+	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
+		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
+	}
 
-	var service *generic.ServiceWrapper[*machineidv1.BotInstance]
+	// Satisfied by both the scope-aware wrapper (unified listing across the
+	// unscoped and scoped key ranges) and a single-range service routed by the
+	// bot filter.
+	var service interface {
+		ListResources(ctx context.Context, pageSize int, nextToken string) ([]*machineidv1.BotInstance, string, error)
+		ListResourcesWithFilter(ctx context.Context, pageSize int, nextToken string, matcher func(*machineidv1.BotInstance) bool) ([]*machineidv1.BotInstance, string, error)
+	}
 	if options.GetFilterBotName() == "" {
-		// If botName is empty, return instances for all bots by not using a service prefix
+		// If no bot filter is set, return instances for all bots across both
+		// the unscoped and scoped key ranges.
 		service = b.service
 	} else {
-		service = b.service.WithPrefix(options.GetFilterBotName())
+		// The filter identifies exactly one bot, so read only that bot's
+		// sub-range.
+		routed, err := b.serviceForBot(options.GetFilterBotScope(), options.GetFilterBotName())
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		service = routed
 	}
 
 	var exp typical.Expression[*expression.Environment, bool]
@@ -143,11 +197,15 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	return r, nextToken, trace.Wrap(err)
 }
 
-// DeleteBotInstance deletes a specific bot instance matching the given bot name
-// and instance ID.
-func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, botName, instanceID string) error {
-	serviceWithPrefix := b.service.WithPrefix(botName)
-	return trace.Wrap(serviceWithPrefix.DeleteResource(ctx, instanceID))
+// DeleteBotInstance deletes a specific bot instance matching the given bot
+// scope, bot name and instance ID. The scope must be empty if the owning bot
+// is unscoped.
+func (b *BotInstanceService) DeleteBotInstance(ctx context.Context, req *machineidv1.DeleteBotInstanceRequest) error {
+	serviceWithPrefix, err := b.serviceForBot(req.GetBotScope(), req.GetBotName())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(serviceWithPrefix.DeleteResource(ctx, req.GetInstanceId()))
 }
 
 // DeleteAllBotInstances deletes all bot instances for all bots
@@ -155,24 +213,31 @@ func (b *BotInstanceService) DeleteAllBotInstances(ctx context.Context) error {
 	return trace.Wrap(b.service.DeleteAllResources(ctx))
 }
 
-// PatchBotInstance uses the supplied function to patch the bot instance
-// matching the given (botName, instanceID) key and persists the patched
-// resource. It will make multiple attempts if a `CompareFailed` error is
-// raised, automatically re-applying `updateFn()`.
+// PatchBotInstance uses the options' UpdateFn to patch the bot instance
+// identified by those same options and persists the patched resource. It will
+// make multiple attempts if a `CompareFailed` error is raised, automatically
+// re-applying UpdateFn.
 func (b *BotInstanceService) PatchBotInstance(
 	ctx context.Context,
-	botName, instanceID string,
-	updateFn func(*machineidv1.BotInstance) (*machineidv1.BotInstance, error),
+	opts services.PatchBotInstanceOpts,
 ) (*machineidv1.BotInstance, error) {
+	if opts.UpdateFn == nil {
+		return nil, trace.BadParameter("opts.UpdateFn is required")
+	}
+
 	const iterLimit = 3
 
 	for i := 0; i < iterLimit; i++ {
-		existing, err := b.GetBotInstance(ctx, botName, instanceID)
+		existing, err := b.GetBotInstance(ctx, &machineidv1.GetBotInstanceRequest{
+			BotScope:   opts.Bot.Scope,
+			BotName:    opts.Bot.Name,
+			InstanceId: opts.InstanceID,
+		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		updated, err := updateFn(utils.CloneProtoMsg(existing))
+		updated, err := opts.UpdateFn(utils.CloneProtoMsg(existing))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -186,9 +251,14 @@ func (b *BotInstanceService) PatchBotInstance(
 			return nil, trace.BadParameter("spec.instance_id: cannot be patched")
 		case updated.GetSpec().GetBotName() != existing.GetSpec().GetBotName():
 			return nil, trace.BadParameter("spec.bot_name: cannot be patched")
+		case updated.GetScope() != existing.GetScope():
+			return nil, trace.BadParameter("scope: cannot be patched")
 		}
 
-		serviceWithPrefix := b.service.WithPrefix(botName)
+		serviceWithPrefix, err := b.serviceForBot(opts.Bot.Scope, opts.Bot.Name)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		lease, err := serviceWithPrefix.ConditionalUpdateResource(ctx, updated)
 		if err != nil {
 			if trace.IsCompareFailed(err) {

--- a/lib/services/local/bot_instance.go
+++ b/lib/services/local/bot_instance.go
@@ -24,6 +24,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1/expression"
@@ -127,7 +128,8 @@ func (b *BotInstanceService) GetBotInstance(ctx context.Context, req *machineidv
 // If an non-empty bot name is provided, only instances for that bot will be fetched. The bot scope must be
 // provided alongside the name for a scoped bot's instances, and only ever qualifies the name - providing a
 // scope without a name is an error rather than a request for every instance in that scope. With no bot filter,
-// instances for all bots are listed, unscoped bots' instances first.
+// instances for all bots are listed, unscoped bots' instances first, narrowed by the options' scope filter if
+// one is set.
 // If an non-empty search term is provided, only instances with a value containing the term in supported fields are fetched.
 // Supported search fields include; bot name, instance id, hostname (latest), tbot version (latest), join method (latest).
 // Sorting by bot name in ascending order is supported - an error is returned for any other sort type.
@@ -138,11 +140,17 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	if options.GetSortDesc() {
 		return nil, "", trace.CompareFailed("unsupported sort, only ascending order is supported")
 	}
-	// A bot is identified by the pair (scope, name), so the scope filter only
-	// ever qualifies the name filter. Listing a whole scope will be a separate
-	// filter with explicit exact/descendant control.
+	// See the field docs on ListBotInstancesRequestOptions for the rules
+	// enforced here.
 	if options.GetFilterBotScope() != "" && options.GetFilterBotName() == "" {
 		return nil, "", trace.BadParameter("bot scope filter requires a bot name filter")
+	}
+	scopeFilter := options.GetScopeFilter()
+	if err := scopes.ValidateFilter(scopeFilter); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	if scopeFilter.GetMode() != scopesv1.Mode_MODE_UNSPECIFIED && options.GetFilterBotName() != "" {
+		return nil, "", trace.BadParameter("scope filter cannot be combined with a bot name filter")
 	}
 
 	// Satisfied by both the scope-aware wrapper (unified listing across the
@@ -179,12 +187,15 @@ func (b *BotInstanceService) ListBotInstances(ctx context.Context, pageSize int,
 	}
 
 	filterFn := options.GetFilterFn()
-	if options.GetFilterSearchTerm() == "" && exp == nil && filterFn == nil {
+	if options.GetFilterSearchTerm() == "" && exp == nil && filterFn == nil && scopes.IsMatchAll(scopeFilter) {
 		r, nextToken, err := service.ListResources(ctx, pageSize, lastKey)
 		return r, nextToken, trace.Wrap(err)
 	}
 
 	r, nextToken, err := service.ListResourcesWithFilter(ctx, pageSize, lastKey, func(item *machineidv1.BotInstance) bool {
+		if !scopes.MatchScope(scopeFilter, item.GetScope()) {
+			return false
+		}
 		if !services.MatchBotInstance(item, "", options.GetFilterSearchTerm(), exp) {
 			return false
 		}

--- a/lib/services/local/bot_instance_test.go
+++ b/lib/services/local/bot_instance_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -79,6 +80,13 @@ func withBotInstanceExpiry(expiry time.Time) func(*machineidv1.BotInstance) {
 		}
 
 		bi.Metadata.Expires = timestamppb.New(expiry)
+	}
+}
+
+// withBotInstanceScope sets the scope of a bot instance to the given value.
+func withBotInstanceScope(scope string) func(*machineidv1.BotInstance) {
+	return func(bi *machineidv1.BotInstance) {
+		bi.SetScope(scope)
 	}
 }
 
@@ -143,13 +151,13 @@ func withBotInstanceHeartbeatHostname(value string) func(*machineidv1.BotInstanc
 }
 
 // createInstances creates new bot instances for the named bot with random UUIDs
-func createInstances(t *testing.T, ctx context.Context, service *BotInstanceService, botName string, count int) map[string]struct{} {
+func createInstances(t *testing.T, ctx context.Context, service *BotInstanceService, botName string, count int, fns ...func(*machineidv1.BotInstance)) map[string]struct{} {
 	t.Helper()
 
 	ids := map[string]struct{}{}
 
 	for range count {
-		bi := newBotInstance(botName)
+		bi := newBotInstance(botName, fns...)
 		_, err := service.CreateBotInstance(ctx, bi)
 		require.NoError(t, err)
 
@@ -274,7 +282,7 @@ func TestBotInstanceInvalidGetters(t *testing.T) {
 	_, err = service.CreateBotInstance(ctx, newBotInstance("example"))
 	require.NoError(t, err)
 
-	_, err = service.GetBotInstance(ctx, "example", "invalid")
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: "example", InstanceId: "invalid"}.Build())
 	require.True(t, trace.IsNotFound(err))
 }
 
@@ -303,7 +311,10 @@ func TestBotInstanceCRUD(t *testing.T) {
 	require.Equal(t, bi.Spec.InstanceId, patched.Metadata.Name)
 
 	// we should be able to retrieve a matching instance
-	bi2, err := service.GetBotInstance(ctx, bi.Spec.BotName, bi.Spec.InstanceId)
+	bi2, err := service.GetBotInstance(ctx, &machineidv1.GetBotInstanceRequest{
+		BotName:    bi.Spec.BotName,
+		InstanceId: bi.Spec.InstanceId,
+	})
 	require.NoError(t, err)
 	require.EqualExportedValues(t, patched, bi2)
 	require.Equal(t, bi.Metadata.Name, bi2.Metadata.Name)
@@ -320,9 +331,13 @@ func TestBotInstanceCRUD(t *testing.T) {
 		Hostname: "foo",
 	}
 
-	patched, err = service.PatchBotInstance(ctx, bi.Spec.BotName, bi.Spec.InstanceId, func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
-		bi.Status.LatestHeartbeats = append([]*machineidv1.BotInstanceStatusHeartbeat{heartbeat}, bi.Status.LatestHeartbeats...)
-		return bi, nil
+	patched, err = service.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Name: bi.Spec.BotName},
+		InstanceID: bi.Spec.InstanceId,
+		UpdateFn: func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+			bi.Status.LatestHeartbeats = append([]*machineidv1.BotInstanceStatusHeartbeat{heartbeat}, bi.Status.LatestHeartbeats...)
+			return bi, nil
+		},
 	})
 	require.NoError(t, err)
 
@@ -330,10 +345,14 @@ func TestBotInstanceCRUD(t *testing.T) {
 	require.EqualExportedValues(t, heartbeat, patched.Status.LatestHeartbeats[0])
 
 	// delete the stored instance
-	require.NoError(t, service.DeleteBotInstance(ctx, bi.Spec.BotName, bi.Spec.InstanceId))
+	req := &machineidv1.DeleteBotInstanceRequest{
+		BotName:    bi.Spec.BotName,
+		InstanceId: bi.Spec.InstanceId,
+	}
+	require.NoError(t, service.DeleteBotInstance(ctx, req))
 
 	// subsequent delete attempts should fail
-	require.Error(t, service.DeleteBotInstance(ctx, bi.Spec.BotName, bi.Spec.InstanceId))
+	require.Error(t, service.DeleteBotInstance(ctx, req))
 }
 
 // TestBotInstanceList verifies list and filtering by bot functionality for bot
@@ -355,8 +374,11 @@ func TestBotInstanceList(t *testing.T) {
 
 	aIds := createInstances(t, ctx, service, "a", 3)
 	bIds := createInstances(t, ctx, service, "b", 4)
+	// "a" is also the name of a scoped bot in /foo; its instances live in the
+	// scoped key range.
+	scopedAIds := createInstances(t, ctx, service, "a", 2, withBotInstanceScope("/foo"))
 
-	// listing "a" should only return known "a" instances
+	// listing "a" should only return known instances of the unscoped bot "a"
 	aInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
 		FilterBotName: "a",
 	})
@@ -374,6 +396,23 @@ func TestBotInstanceList(t *testing.T) {
 		require.Contains(t, bIds, ins.Spec.InstanceId)
 	}
 
+	// listing "a" in scope /foo should only return the scoped bot's instances
+	scopedAInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
+		FilterBotName:  "a",
+		FilterBotScope: "/foo",
+	})
+	require.Len(t, scopedAInstances, 2)
+	for _, ins := range scopedAInstances {
+		require.Contains(t, scopedAIds, ins.GetSpec().GetInstanceId())
+	}
+
+	// a scope filter only qualifies a bot name, so listing scope /foo without a
+	// bot name is rejected rather than listing the whole scope
+	_, _, err = service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
+		FilterBotScope: "/foo",
+	})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+
 	allIds := map[string]struct{}{}
 	for i := range aIds {
 		allIds[i] = struct{}{}
@@ -381,15 +420,111 @@ func TestBotInstanceList(t *testing.T) {
 	for i := range bIds {
 		allIds[i] = struct{}{}
 	}
+	for i := range scopedAIds {
+		allIds[i] = struct{}{}
+	}
 
-	// Listing an empty bot name ("") should return all instances.
+	// Listing with no bot filter should return all instances, unscoped and
+	// scoped.
 	allInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
 		FilterBotName: "",
 	})
-	require.Len(t, allInstances, 7)
+	require.Len(t, allInstances, 9)
 	for _, ins := range allInstances {
 		require.Contains(t, allIds, ins.Spec.InstanceId)
 	}
+}
+
+// TestBotInstanceScopedCoexistence verifies that instances of same-named bots
+// in different scopes (and unscoped) are stored disjointly and are only
+// addressable under their own bot's scope.
+func TestBotInstanceScopedCoexistence(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
+	require.NoError(t, err)
+
+	// Three bots named "x": unscoped, in /foo, and in /bar.
+	unscoped := newBotInstance("x")
+	foo := newBotInstance("x", withBotInstanceScope("/foo"))
+	bar := newBotInstance("x", withBotInstanceScope("/bar"))
+	for _, bi := range []*machineidv1.BotInstance{unscoped, foo, bar} {
+		_, err := service.CreateBotInstance(ctx, bi)
+		require.NoError(t, err)
+	}
+
+	// The scoped instance is stored in the scope-namespaced key range.
+	encodedScope, err := scopes.EncodeForKey("/foo")
+	require.NoError(t, err)
+	_, err = mem.Get(ctx, backend.NewKey(scopedPrefix, botInstancePrefix, encodedScope, "x", foo.GetSpec().GetInstanceId()))
+	require.NoError(t, err)
+
+	// Each instance resolves only under its own bot's scope.
+	got, err := service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: "x", InstanceId: unscoped.GetSpec().GetInstanceId()}.Build())
+	require.NoError(t, err)
+	require.Empty(t, got.GetScope())
+	got, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/foo", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "/foo", got.GetScope())
+
+	// The wrong (or missing) scope does not resolve.
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/bar", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/foo", BotName: "x", InstanceId: unscoped.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+
+	// Patching routes by scope, and the scope itself cannot be patched.
+	patched, err := service.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Scope: "/foo", Name: "x"},
+		InstanceID: foo.GetSpec().GetInstanceId(),
+		UpdateFn: func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+			bi.GetStatus().SetLatestHeartbeats([]*machineidv1.BotInstanceStatusHeartbeat{
+				machineidv1.BotInstanceStatusHeartbeat_builder{Hostname: "scoped-host"}.Build(),
+			})
+			return bi, nil
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "/foo", patched.GetScope())
+
+	_, err = service.PatchBotInstance(ctx, services.PatchBotInstanceOpts{
+		Bot:        scopes.QualifiedName{Scope: "/foo", Name: "x"},
+		InstanceID: foo.GetSpec().GetInstanceId(),
+		UpdateFn: func(bi *machineidv1.BotInstance) (*machineidv1.BotInstance, error) {
+			bi.SetScope("/other")
+			return bi, nil
+		},
+	})
+	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+	require.ErrorContains(t, err, "scope: cannot be patched")
+
+	// Deleting under the wrong scope does not delete; the right scope deletes
+	// only that bot's instance.
+	err = service.DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "/bar", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	require.NoError(t, service.DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "/foo", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build()))
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/foo", BotName: "x", InstanceId: foo.GetSpec().GetInstanceId()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "", BotName: "x", InstanceId: unscoped.GetSpec().GetInstanceId()}.Build())
+	require.NoError(t, err)
+	_, err = service.GetBotInstance(ctx, machineidv1.GetBotInstanceRequest_builder{BotScope: "/bar", BotName: "x", InstanceId: bar.GetSpec().GetInstanceId()}.Build())
+	require.NoError(t, err)
+
+	// DeleteAllBotInstances empties both the unscoped and scoped ranges.
+	require.NoError(t, service.DeleteAllBotInstances(ctx))
+	remaining := listInstances(t, ctx, service, nil)
+	require.Empty(t, remaining)
 }
 
 // TestBotInstanceListWithSearchFilter verifies list and filtering with search

--- a/lib/services/local/bot_instance_test.go
+++ b/lib/services/local/bot_instance_test.go
@@ -31,6 +31,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
@@ -148,23 +149,6 @@ func withBotInstanceHeartbeatHostname(value string) func(*machineidv1.BotInstanc
 
 		bi.Status.InitialHeartbeat.Hostname = value
 	}
-}
-
-// createInstances creates new bot instances for the named bot with random UUIDs
-func createInstances(t *testing.T, ctx context.Context, service *BotInstanceService, botName string, count int, fns ...func(*machineidv1.BotInstance)) map[string]struct{} {
-	t.Helper()
-
-	ids := map[string]struct{}{}
-
-	for range count {
-		bi := newBotInstance(botName, fns...)
-		_, err := service.CreateBotInstance(ctx, bi)
-		require.NoError(t, err)
-
-		ids[bi.Spec.InstanceId] = struct{}{}
-	}
-
-	return ids
 }
 
 // listInstances fetches all instances from the BotInstanceService matching the botName filter
@@ -355,83 +339,298 @@ func TestBotInstanceCRUD(t *testing.T) {
 	require.Error(t, service.DeleteBotInstance(ctx, req))
 }
 
-// TestBotInstanceList verifies list and filtering by bot functionality for bot
-// instances.
+// listInstanceSpec declaratively describes a bot instance for
+// TestBotInstanceList cases.
+type listInstanceSpec struct {
+	scope, botName, id            string
+	hostname, version, joinMethod string
+}
+
+func (s listInstanceSpec) build() *machineidv1.BotInstance {
+	fns := []func(*machineidv1.BotInstance){withBotInstanceId(s.id)}
+	if s.scope != "" {
+		fns = append(fns, withBotInstanceScope(s.scope))
+	}
+	if s.hostname != "" {
+		fns = append(fns, withBotInstanceHeartbeatHostname(s.hostname))
+	}
+	if s.version != "" {
+		fns = append(fns, withBotInstanceHeartbeatVersion(s.version))
+	}
+	if s.joinMethod != "" {
+		fns = append(fns, withBotInstanceHeartbeatJoinMethod(s.joinMethod))
+	}
+	return newBotInstance(s.botName, fns...)
+}
+
+// TestBotInstanceList exercises ListBotInstances across filtering and sorting.
 func TestBotInstanceList(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
-	clock := clockwork.NewFakeClock()
-
-	mem, err := memory.New(memory.Config{
-		Context: ctx,
-		Clock:   clock,
-	})
-	require.NoError(t, err)
-
-	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	aIds := createInstances(t, ctx, service, "a", 3)
-	bIds := createInstances(t, ctx, service, "b", 4)
-	// "a" is also the name of a scoped bot in /foo; its instances live in the
-	// scoped key range.
-	scopedAIds := createInstances(t, ctx, service, "a", 2, withBotInstanceScope("/foo"))
-
-	// listing "a" should only return known instances of the unscoped bot "a"
-	aInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterBotName: "a",
-	})
-	require.Len(t, aInstances, 3)
-	for _, ins := range aInstances {
-		require.Contains(t, aIds, ins.Spec.InstanceId)
+	botInstanceIDs := func(instances []*machineidv1.BotInstance) []string {
+		out := make([]string, 0, len(instances))
+		for _, b := range instances {
+			out = append(out, b.GetSpec().GetInstanceId())
+		}
+		return out
 	}
 
-	// listing "b" should only return known "b" instances
-	bInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterBotName: "b",
-	})
-	require.Len(t, bInstances, 4)
-	for _, ins := range bInstances {
-		require.Contains(t, bIds, ins.Spec.InstanceId)
+	// Two unscoped bots and a same-named scoped bot, to prove bot filters are
+	// scope-strict.
+	botFilterInstances := []listInstanceSpec{
+		{botName: "db", id: "db-a"},
+		{botName: "web", id: "web-a"},
+		{botName: "web", id: "web-b"},
+		{scope: "/prod", botName: "web", id: "web-c"},
 	}
 
-	// listing "a" in scope /foo should only return the scoped bot's instances
-	scopedAInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterBotName:  "a",
-		FilterBotScope: "/foo",
-	})
-	require.Len(t, scopedAInstances, 2)
-	for _, ins := range scopedAInstances {
-		require.Contains(t, scopedAIds, ins.GetSpec().GetInstanceId())
+	// Instance IDs name their scope, so expectations read as selected scopes.
+	scopeFilterInstances := []listInstanceSpec{
+		{botName: "u", id: "u"},
+		{scope: "/foo", botName: "f", id: "foo"},
+		{scope: "/foo/sub", botName: "fs", id: "foo-sub"},
+		{scope: "/bar", botName: "b", id: "bar"},
 	}
 
-	// a scope filter only qualifies a bot name, so listing scope /foo without a
-	// bot name is rejected rather than listing the whole scope
-	_, _, err = service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		FilterBotScope: "/foo",
-	})
-	require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
-
-	allIds := map[string]struct{}{}
-	for i := range aIds {
-		allIds[i] = struct{}{}
+	filterFnInstances := []listInstanceSpec{
+		{botName: "bot", id: "i-0"},
+		{botName: "bot", id: "i-1"},
+		{scope: "/s", botName: "bot", id: "i-2"},
+		{scope: "/s", botName: "bot", id: "i-3"},
 	}
-	for i := range bIds {
-		allIds[i] = struct{}{}
-	}
-	for i := range scopedAIds {
-		allIds[i] = struct{}{}
+	evenFilter := func(b *machineidv1.BotInstance) bool {
+		id := b.GetSpec().GetInstanceId()
+		return (id[len(id)-1]-'0')%2 == 0
 	}
 
-	// Listing with no bot filter should return all instances, unscoped and
-	// scoped.
-	allInstances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterBotName: "",
-	})
-	require.Len(t, allInstances, 9)
-	for _, ins := range allInstances {
-		require.Contains(t, allIds, ins.Spec.InstanceId)
+	tests := []struct {
+		name      string
+		instances []listInstanceSpec
+		opts      *services.ListBotInstancesRequestOptions
+		want      []string
+		wantErr   string
+	}{
+		{
+			name:      "no filter spans both ranges, unscoped instances first",
+			instances: botFilterInstances,
+			want:      []string{"db-a", "web-a", "web-b", "web-c"},
+		},
+		{
+			name:      "bot name filter matches only the unscoped bot of that name",
+			instances: botFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterBotName: "web"},
+			want:      []string{"web-a", "web-b"},
+		},
+		{
+			name:      "bot name and scope filter matches the scoped bot",
+			instances: botFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterBotName: "web", FilterBotScope: "/prod"},
+			want:      []string{"web-c"},
+		},
+		{
+			// A bot scope only qualifies a bot name; standalone scope
+			// selection is ScopeFilter.
+			name:      "bot scope without a bot name filter is rejected",
+			instances: botFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterBotScope: "/prod"},
+			wantErr:   "bot scope filter requires a bot name filter",
+		},
+		{
+			name:      "scope filter mode ALL matches every scope",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build()},
+			want:      []string{"u", "bar", "foo", "foo-sub"},
+		},
+		{
+			// Unscoped is orthogonal to every scoped value, not the root.
+			name:      "scope filter mode UNSCOPED matches only unscoped instances",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build()},
+			want:      []string{"u"},
+		},
+		{
+			name:      "scope filter mode EXACT matches one scope",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT, Scope: "/foo"}.Build()},
+			want:      []string{"foo"},
+		},
+		{
+			name:      "scope filter mode DESCENDANTS includes the scope and below",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_DESCENDANTS, Scope: "/foo"}.Build()},
+			want:      []string{"foo", "foo-sub"},
+		},
+		{
+			name:      "scope filter mode ANCESTORS includes the scope and above",
+			instances: scopeFilterInstances,
+			opts:      &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ANCESTORS, Scope: "/foo/sub"}.Build()},
+			want:      []string{"foo", "foo-sub"},
+		},
+		{
+			name:      "malformed scope filter is rejected",
+			instances: scopeFilterInstances,
+			// EXACT requires a scope.
+			opts:    &services.ListBotInstancesRequestOptions{ScopeFilter: scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_EXACT}.Build()},
+			wantErr: "requires a non-empty scope",
+		},
+		{
+			name:      "scope filter with a bot filter is rejected",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				FilterBotName:  "f",
+				FilterBotScope: "/foo",
+				ScopeFilter:    scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_UNSCOPED}.Build(),
+			},
+			wantErr: "scope filter cannot be combined with a bot name filter",
+		},
+		{
+			// Rejected even though it would be harmless as a predicate, so the
+			// rule is one a caller can state without knowing the modes.
+			name:      "scope filter mode ALL with a bot filter is rejected",
+			instances: scopeFilterInstances,
+			opts: &services.ListBotInstancesRequestOptions{
+				FilterBotName:  "f",
+				FilterBotScope: "/foo",
+				ScopeFilter:    scopesv1.Filter_builder{Mode: scopesv1.Mode_MODE_ALL}.Build(),
+			},
+			wantErr: "scope filter cannot be combined with a bot name filter",
+		},
+		{
+			name: "search matches bot name",
+			instances: []listInstanceSpec{
+				{botName: "this-is-nicks-test-bot", id: "match"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "nick"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches instance id",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "cb2c3523-01f6-4258-966b-ace9f38f9862"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "CB2C352"},
+			want: []string{"cb2c3523-01f6-4258-966b-ace9f38f9862"},
+		},
+		{
+			name: "search matches join method",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", joinMethod: "kubernetes"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "uber"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches version",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", version: "1.0.0-dev-a2g3hd"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "1.0.0"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches version with v prefix",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", version: "1.0.0-dev-a2g3hd"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "v1.0.0"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches hostname",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", hostname: "svr-eu-tel-123-a"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "tel-123"},
+			want: []string{"match"},
+		},
+		{
+			name: "search matches across scopes",
+			instances: []listInstanceSpec{
+				{botName: "runner", id: "r1", hostname: "host-match"},
+				{scope: "/foo", botName: "runner", id: "r2", hostname: "host-match"},
+				{botName: "runner", id: "r3", hostname: "host-other"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterSearchTerm: "host-match"},
+			want: []string{"r1", "r2"},
+		},
+		{
+			name: "predicate query matches",
+			instances: []listInstanceSpec{
+				{botName: "test-bot", id: "match", hostname: "svr-eu-tel-123-a"},
+				{botName: "bot-not-matched", id: "decoy"},
+			},
+			opts: &services.ListBotInstancesRequestOptions{FilterQuery: `status.latest_heartbeat.hostname == "svr-eu-tel-123-a"`},
+			want: []string{"match"},
+		},
+		{
+			name:    "unsupported sort field is rejected",
+			opts:    &services.ListBotInstancesRequestOptions{SortField: "test_field"},
+			wantErr: `unsupported sort, only bot_name field is supported, but got "test_field"`,
+		},
+		{
+			name:    "descending sort is rejected",
+			opts:    &services.ListBotInstancesRequestOptions{SortField: "bot_name", SortDesc: true},
+			wantErr: "unsupported sort, only ascending order is supported",
+		},
+		{
+			name:      "filter fn spans both ranges",
+			instances: filterFnInstances,
+			opts:      &services.ListBotInstancesRequestOptions{FilterFn: evenFilter},
+			want:      []string{"i-0", "i-2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			clock := clockwork.NewFakeClock()
+
+			mem, err := memory.New(memory.Config{
+				Context: ctx,
+				Clock:   clock,
+			})
+			require.NoError(t, err)
+
+			service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
+			require.NoError(t, err)
+
+			for _, s := range tc.instances {
+				_, err := service.CreateBotInstance(ctx, s.build())
+				require.NoError(t, err)
+			}
+
+			got, _, err := service.ListBotInstances(ctx, 0, "", tc.opts)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, botInstanceIDs(got))
+
+			// Page-size-1 pagination must agree with the single-page listing;
+			// cursors that don't line up across the unscoped/scoped ranges
+			// would skip entries.
+			var paged []*machineidv1.BotInstance
+			var token string
+			for {
+				page, next, err := service.ListBotInstances(ctx, 1, token, tc.opts)
+				require.NoError(t, err)
+				paged = append(paged, page...)
+				if next == "" {
+					break
+				}
+				token = next
+			}
+			require.Equal(t, tc.want, botInstanceIDs(paged))
+		})
 	}
 }
 
@@ -525,185 +724,4 @@ func TestBotInstanceScopedCoexistence(t *testing.T) {
 	require.NoError(t, service.DeleteAllBotInstances(ctx))
 	remaining := listInstances(t, ctx, service, nil)
 	require.Empty(t, remaining)
-}
-
-// TestBotInstanceListWithSearchFilter verifies list and filtering with search
-// term functionality for bot instances.
-func TestBotInstanceListWithSearchFilter(t *testing.T) {
-	t.Parallel()
-
-	clock := clockwork.NewFakeClock()
-
-	tcs := []struct {
-		name       string
-		searchTerm string
-		instance   *machineidv1.BotInstance
-	}{
-		{
-			name:       "match on bot name",
-			searchTerm: "nick",
-			instance:   newBotInstance("this-is-nicks-test-bot"),
-		},
-		{
-			name:       "match on instance id",
-			searchTerm: "CB2C352",
-			instance:   newBotInstance("test-bot", withBotInstanceId("cb2c3523-01f6-4258-966b-ace9f38f9862")),
-		},
-		{
-			name:       "match on join method",
-			searchTerm: "uber",
-			instance:   newBotInstance("test-bot", withBotInstanceHeartbeatJoinMethod("kubernetes")),
-		},
-		{
-			name:       "match on version",
-			searchTerm: "1.0.0",
-			instance:   newBotInstance("test-bot", withBotInstanceHeartbeatVersion("1.0.0-dev-a2g3hd")),
-		},
-		{
-			name:       "match on version (with v)",
-			searchTerm: "v1.0.0",
-			instance:   newBotInstance("test-bot", withBotInstanceHeartbeatVersion("1.0.0-dev-a2g3hd")),
-		},
-		{
-			name:       "match on hostname",
-			searchTerm: "tel-123",
-			instance:   newBotInstance("test-bot", withBotInstanceHeartbeatHostname("svr-eu-tel-123-a")),
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := t.Context()
-
-			mem, err := memory.New(memory.Config{
-				Context: ctx,
-				Clock:   clock,
-			})
-			require.NoError(t, err)
-
-			service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-			require.NoError(t, err)
-
-			_, err = service.CreateBotInstance(ctx, tc.instance)
-			require.NoError(t, err)
-			_, err = service.CreateBotInstance(ctx, newBotInstance("bot-not-matched"))
-			require.NoError(t, err)
-
-			instances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-				FilterSearchTerm: tc.searchTerm,
-			})
-
-			require.Len(t, instances, 1)
-			require.Equal(t, tc.instance.Spec.InstanceId, instances[0].Spec.InstanceId)
-		})
-	}
-}
-
-// TestBotInstanceListWithQuery verifies list and filtering with query
-// functionality for bot instances.
-func TestBotInstanceListWithQuery(t *testing.T) {
-	t.Parallel()
-
-	clock := clockwork.NewFakeClock()
-	ctx := t.Context()
-	mem, err := memory.New(memory.Config{
-		Context: ctx,
-		Clock:   clock,
-	})
-	require.NoError(t, err)
-	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	instance := newBotInstance("test-bot", withBotInstanceHeartbeatHostname("svr-eu-tel-123-a"))
-	_, err = service.CreateBotInstance(ctx, instance)
-	require.NoError(t, err)
-	_, err = service.CreateBotInstance(ctx, newBotInstance("bot-not-matched"))
-	require.NoError(t, err)
-
-	instances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterQuery: `status.latest_heartbeat.hostname == "svr-eu-tel-123-a"`,
-	})
-
-	require.Len(t, instances, 1)
-	require.Equal(t, instance.Spec.InstanceId, instances[0].Spec.InstanceId)
-}
-
-// TestBotInstanceListWithSort verifies sorting returns a not-implemented error.
-func TestBotInstanceListWithSort(t *testing.T) {
-	t.Parallel()
-
-	clock := clockwork.NewFakeClock()
-
-	ctx := t.Context()
-
-	mem, err := memory.New(memory.Config{
-		Context: ctx,
-		Clock:   clock,
-	})
-	require.NoError(t, err)
-
-	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	_, _, err = service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "test_field",
-		SortDesc:  false,
-	})
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsupported sort, only bot_name field is supported, but got \"test_field\"")
-
-	_, _, err = service.ListBotInstances(ctx, 0, "", &services.ListBotInstancesRequestOptions{
-		SortField: "bot_name",
-		SortDesc:  true,
-	})
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unsupported sort, only ascending order is supported")
-
-	_, _, err = service.ListBotInstances(ctx, 0, "", nil)
-	require.NoError(t, err)
-}
-
-func TestBotInstanceListWithFilterFn(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	clock := clockwork.NewFakeClock()
-
-	mem, err := memory.New(memory.Config{
-		Context: ctx,
-		Clock:   clock,
-	})
-	require.NoError(t, err)
-
-	service, err := NewBotInstanceService(backend.NewSanitizer(mem), clock)
-	require.NoError(t, err)
-
-	// Create 10 instances for "test-bot".
-	var created []*machineidv1.BotInstance
-	for range 10 {
-		bi := newBotInstance("test-bot")
-		_, err := service.CreateBotInstance(ctx, bi)
-		require.NoError(t, err)
-		created = append(created, bi)
-	}
-
-	// Use a FilterFn that only accepts even-indexed instances.
-	accepted := map[string]struct{}{}
-	for i, bi := range created {
-		if i%2 == 0 {
-			accepted[bi.Spec.InstanceId] = struct{}{}
-		}
-	}
-
-	instances := listInstances(t, ctx, service, &services.ListBotInstancesRequestOptions{
-		FilterFn: func(bi *machineidv1.BotInstance) bool {
-			_, ok := accepted[bi.GetSpec().GetInstanceId()]
-			return ok
-		},
-	})
-
-	require.Len(t, instances, len(accepted))
-	for _, bi := range instances {
-		require.Contains(t, accepted, bi.Spec.InstanceId)
-	}
 }

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -3276,7 +3276,10 @@ func (p *globalNotificationParser) parse(event backend.Event) (types.Resource, e
 
 func newBotInstanceParser() *botInstanceParser {
 	return &botInstanceParser{
-		baseParser: newBaseParser(backend.NewKey(botInstancePrefix)),
+		baseParser: newBaseParser(
+			botInstanceUnscopedWatchPrefix(),
+			botInstanceScopedWatchPrefix(),
+		),
 	}
 }
 
@@ -3287,23 +3290,22 @@ type botInstanceParser struct {
 func (p *botInstanceParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		parts := event.Item.Key.Components()
-		if len(parts) != 3 {
-			return nil, trace.BadParameter("malformed key for %s event: %s", types.KindBotInstance, event.Item.Key)
+		bot, instanceID, err := botInstanceNameFromKey(event.Item.Key)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-
 		botInstance := &machineidv1.BotInstance{
 			Kind:    types.KindBotInstance,
 			Version: types.V1,
+			Scope:   bot.Scope,
 			Spec: &machineidv1.BotInstanceSpec{
-				BotName:    parts[1],
-				InstanceId: parts[2],
+				BotName:    bot.Name,
+				InstanceId: instanceID,
 			},
 			Metadata: &headerv1.Metadata{
-				Name: parts[2],
+				Name: instanceID,
 			},
 		}
-
 		return types.Resource153ToLegacy(botInstance), nil
 	case types.OpPut:
 		botInstance, err := services.UnmarshalBotInstance(
@@ -3316,6 +3318,49 @@ func (p *botInstanceParser) parse(event backend.Event) (types.Resource, error) {
 		return types.Resource153ToLegacy(botInstance), nil
 	default:
 		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}
+
+// botInstanceNameFromKey parses a bot instance backend key into the qualified
+// name of the owning bot and the instance ID. The scope must be carried on
+// delete events: consumers (e.g. the cache) key their stores by
+// (scope, bot name, instance id).
+func botInstanceNameFromKey(key backend.Key) (scopes.QualifiedName, string, error) {
+	switch {
+	case key.HasPrefix(botInstanceScopedWatchPrefix()):
+		components := key.TrimPrefix(botInstanceScopedWatchPrefix()).Components()
+		if len(components) != 3 {
+			return scopes.QualifiedName{}, "", trace.BadParameter(
+				"expected 3 components, got %d parsing backend key %v",
+				len(components),
+				key.String(),
+			)
+		}
+		encodedScope, botName, instanceID := components[0], components[1], components[2]
+		scope, err := scopes.DecodeFromKey(encodedScope)
+		if err != nil {
+			return scopes.QualifiedName{}, "", trace.Wrap(err)
+		}
+		return scopes.QualifiedName{
+			Scope: scope,
+			Name:  botName,
+		}, instanceID, nil
+	case key.HasPrefix(botInstanceUnscopedWatchPrefix()):
+		components := key.TrimPrefix(botInstanceUnscopedWatchPrefix()).Components()
+		if len(components) != 2 {
+			return scopes.QualifiedName{}, "", trace.BadParameter(
+				"expected 2 components, got %d parsing backend key %v",
+				len(components),
+				key.String(),
+			)
+		}
+		return scopes.QualifiedName{
+			Name: components[0],
+		}, components[1], nil
+	default:
+		return scopes.QualifiedName{}, "", trace.BadParameter(
+			"unexpected prefix parsing backend key %v", key.String(),
+		)
 	}
 }
 

--- a/lib/services/local/generic/scopeaware_wrapper.go
+++ b/lib/services/local/generic/scopeaware_wrapper.go
@@ -71,7 +71,59 @@ func NewScopeAwareServiceWrapper[T ScopedResourceMetadata](cfg ScopeAwareService
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &ScopeAwareServiceWrapper[T]{service: service}, nil
+
+	// TODO(strideynet): I'm not super keen on the way we instantiate a scoped
+	// and unscoped ServiceWrapper here. We already instantiate a scoped and
+	// unscoped service within ScopeAwareService. It feels pretty awkward that
+	// we then have a bunch of instantiated services floating around and that
+	// each one has to be used very carefully. There's just too many layers of
+	// indirection and it's not particularly cleanly layered.
+	//
+	// I see a few alternatives:
+	//
+	// 1. Re-architect ScopedAwareServiceWrapper to no longer depend on
+	//    ScopeAwareService and instead directly use the scoped and unscoped
+	//    ServiceWrappers. This effectively leaves us with ScopeAwareService
+	//    implemented twice (so a bit of duplication), but removes a layer of
+	//    indirection.
+	// 2. Remove scopedResourceMetadataAdapter and instead add GetScope directly
+	//    to resourceMetadataAdapter. This lets us directly wrap the Service
+	//    returned by ScopeAwareService.WithScopePrefix with a ServiceWrapper?
+	//    It keeps the indirection thru ScopeAwareService but avoids us forking
+	//    and instantiating ServiceWrappers here...
+	// 3. Introduce /another/ wrapper designed to wrap the Service[T] returned
+	//    by ScopeAwareService.WithScopePrefix?
+	newSingleRangeWrapper := func(prefix backend.Key) (*ServiceWrapper[T], error) {
+		return NewServiceWrapper(ServiceConfig[T]{
+			Backend:                     cfg.Backend,
+			ResourceKind:                cfg.ResourceKind,
+			PageLimit:                   cfg.PageLimit,
+			BackendPrefix:               prefix,
+			MarshalFunc:                 cfg.MarshalFunc,
+			UnmarshalFunc:               cfg.UnmarshalFunc,
+			ValidateFunc:                cfg.ValidateFunc,
+			RunWhileLockedRetryInterval: cfg.RunWhileLockedRetryInterval,
+		})
+	}
+
+	scopedWrapper, err := newSingleRangeWrapper(cfg.ScopedBackendPrefix)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var unscopedWrapper *ServiceWrapper[T]
+	if !cfg.ScopedOnly {
+		unscopedWrapper, err = newSingleRangeWrapper(cfg.UnscopedBackendPrefix)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return &ScopeAwareServiceWrapper[T]{
+		service:         service,
+		unscopedWrapper: unscopedWrapper,
+		scopedWrapper:   scopedWrapper,
+	}, nil
 }
 
 // ScopeAwareServiceWrapperConfig holds configuration options for a
@@ -111,6 +163,50 @@ type ScopeAwareServiceWrapperConfig[T ScopedResourceMetadata] struct {
 // exported; additional methods may be exported in the future as needed.
 type ScopeAwareServiceWrapper[T ScopedResourceMetadata] struct {
 	service *ScopeAwareService[scopedResourceMetadataAdapter[T]]
+
+	// unscopedWrapper and scopedWrapper are single-range ServiceWrapper views
+	// over the same key ranges as service's unscoped and scoped halves. They
+	// exist because WithScopePrefix must return a *ServiceWrapper[T], and
+	// service's inner services are generic over the scoped adapter type rather
+	// than T. unscopedWrapper is nil when the service is scoped-only.
+	unscopedWrapper *ServiceWrapper[T]
+	scopedWrapper   *ServiceWrapper[T]
+}
+
+// WithScopePrefix returns a single-range ServiceWrapper routed by the given
+// scope: the unscoped range when the scope is empty, otherwise the scoped
+// range namespaced by the encoded scope. It is the ServiceWrapper analog of
+// ScopeAwareService.WithScopePrefix, for callers that need to address one
+// scope's key range directly — e.g. to key dependent resources under a
+// sub-prefix via WithPrefix on the returned wrapper.
+func (s *ScopeAwareServiceWrapper[T]) WithScopePrefix(scope string) (*ServiceWrapper[T], error) {
+	if scope == "" {
+		if s.unscopedWrapper == nil {
+			return nil, trace.BadParameter("scoped-only storage service received an empty scope")
+		}
+		return s.unscopedWrapper, nil
+	}
+	encodedScope, err := scopes.EncodeForKey(scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return s.scopedWrapper.WithPrefix(encodedScope), nil
+}
+
+// WithScopedResourcePrefix returns a single-range ServiceWrapper with a prefix
+// for the given scope-qualified name appended to the backend prefix: the
+// unscoped range when the scope is empty, otherwise the scoped range
+// namespaced by the encoded scope. It is the ServiceWrapper analog of
+// ScopeAwareService.WithScopedResourcePrefix.
+//
+// This may be appropriate for dependent resources keyed by a unique scoped
+// resource, i.e. the instances of a scoped bot.
+func (s *ScopeAwareServiceWrapper[T]) WithScopedResourcePrefix(scopedName scopes.QualifiedName) (*ServiceWrapper[T], error) {
+	service, err := s.WithScopePrefix(scopedName.Scope)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return service.WithPrefix(scopedName.Name), nil
 }
 
 // CreateResource creates the given resource if it doesn't already exist. The

--- a/lib/services/local/generic/scopeaware_wrapper_test.go
+++ b/lib/services/local/generic/scopeaware_wrapper_test.go
@@ -576,6 +576,182 @@ func TestScopeAwareServiceWrapper_MakeBackendItem(t *testing.T) {
 	}
 }
 
+func TestScopeAwareServiceWrapper_WithScopePrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty scope routes to the unscoped range", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		qn := scopes.QualifiedName{Name: "foo"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+
+		routed, err := svc.WithScopePrefix("")
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testUnscopedPrefix, "foo").String(),
+			routed.BackendKey("foo").String(),
+		)
+
+		got, err := routed.GetResource(ctx, "foo")
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+	})
+
+	t.Run("scope routes to its scoped range", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		qn := scopes.QualifiedName{Scope: "/security", Name: "foo"}
+		_, err := svc.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+
+		routed, err := svc.WithScopePrefix("/security")
+		require.NoError(t, err)
+		encodedScope, err := scopes.EncodeForKey("/security")
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testScopedTopPrefix, testUnscopedPrefix, encodedScope, "foo").String(),
+			routed.BackendKey("foo").String(),
+		)
+
+		got, err := routed.GetResource(ctx, "foo")
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+
+		// A different scope's routed wrapper does not see it.
+		other, err := svc.WithScopePrefix("/other")
+		require.NoError(t, err)
+		_, err = other.GetResource(ctx, "foo")
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+	})
+
+	t.Run("sub-prefix keys dependent resources under the scope", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		qn := scopes.QualifiedName{Scope: "/security", Name: "child"}
+		routed, err := svc.WithScopePrefix(qn.Scope)
+		require.NoError(t, err)
+		sub := routed.WithPrefix("parent")
+
+		_, err = sub.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+
+		encodedScope, err := scopes.EncodeForKey(qn.Scope)
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testScopedTopPrefix, testUnscopedPrefix, encodedScope, "parent", "child").String(),
+			sub.BackendKey("child").String(),
+		)
+
+		got, err := sub.GetResource(ctx, "child")
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+
+		// The resource is not addressable at the scope's top level...
+		_, err = svc.GetResource(ctx, qn)
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got %v", err)
+
+		// ...but the unified list still ranges over it.
+		page, next, err := svc.ListResources(ctx, 100, "")
+		require.NoError(t, err)
+		require.Empty(t, next)
+		require.Equal(t, []scopes.QualifiedName{qn}, names(page))
+	})
+
+	t.Run("invalid scope errors", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		_, err := svc.WithScopePrefix("/not valid")
+		require.Error(t, err)
+	})
+
+	t.Run("scoped-only rejects the empty scope", func(t *testing.T) {
+		t.Parallel()
+		memBackend, err := memory.New(memory.Config{
+			Context: t.Context(),
+			Clock:   clockwork.NewFakeClock(),
+		})
+		require.NoError(t, err)
+		svc, err := NewScopeAwareServiceWrapper(ScopeAwareServiceWrapperConfig[*scopedTestResource153]{
+			ScopedOnly:          true,
+			Backend:             memBackend,
+			ResourceKind:        "scoped_generic_resource",
+			ScopedBackendPrefix: backend.NewKey(testScopedTopPrefix, testUnscopedPrefix),
+			PageLimit:           200,
+			MarshalFunc:         marshalScopedResource153,
+			UnmarshalFunc:       unmarshalScopedResource153,
+		})
+		require.NoError(t, err)
+
+		_, err = svc.WithScopePrefix("")
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got %v", err)
+
+		routed, err := svc.WithScopePrefix("/security")
+		require.NoError(t, err)
+		require.NotNil(t, routed)
+	})
+}
+
+func TestScopeAwareServiceWrapper_WithScopedResourcePrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty scope keys under the unscoped range", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+
+		routed, err := svc.WithScopedResourcePrefix(scopes.QualifiedName{Name: "parent"})
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testUnscopedPrefix, "parent", "child").String(),
+			routed.BackendKey("child").String(),
+		)
+	})
+
+	t.Run("scope keys under its scoped range", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		ctx := t.Context()
+
+		qn := scopes.QualifiedName{Scope: "/security", Name: "child"}
+		routed, err := svc.WithScopedResourcePrefix(scopes.QualifiedName{Scope: qn.Scope, Name: "parent"})
+		require.NoError(t, err)
+
+		encodedScope, err := scopes.EncodeForKey(qn.Scope)
+		require.NoError(t, err)
+		require.Equal(t,
+			backend.NewKey(testScopedTopPrefix, testUnscopedPrefix, encodedScope, "parent", "child").String(),
+			routed.BackendKey("child").String(),
+		)
+
+		_, err = routed.CreateResource(ctx, newScopedTestResource153(qn))
+		require.NoError(t, err)
+		got, err := routed.GetResource(ctx, "child")
+		require.NoError(t, err)
+		requireResourceBody(t, qn, got)
+
+		// Equivalent to routing by scope and adding the name prefix separately.
+		twoStep, err := svc.WithScopePrefix(qn.Scope)
+		require.NoError(t, err)
+		require.Equal(t,
+			twoStep.WithPrefix("parent").BackendKey("child").String(),
+			routed.BackendKey("child").String(),
+		)
+	})
+
+	t.Run("invalid scope errors", func(t *testing.T) {
+		t.Parallel()
+		svc := newScopeAwareWrapperForTest(t)
+		_, err := svc.WithScopedResourcePrefix(scopes.QualifiedName{Scope: "/not valid", Name: "parent"})
+		require.Error(t, err)
+	})
+}
+
 func TestScopeAwareServiceWrapper_BackendKey(t *testing.T) {
 	t.Parallel()
 	svc := newScopeAwareWrapperForTest(t)

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -468,13 +469,22 @@ func (h *Handler) listBotInstancesV2(_ http.ResponseWriter, r *http.Request, _ h
 		return nil, trace.Wrap(err)
 	}
 
+	botName := r.URL.Query().Get("bot_name")
+
+	// Exhaustive view, per the scope_filter field docs.
+	var scopeFilter *scopesv1.Filter
+	if botName == "" {
+		scopeFilter = &scopesv1.Filter{Mode: scopesv1.Mode_MODE_ALL}
+	}
+
 	request := &machineidv1.ListBotInstancesV2Request{
 		PageToken: r.URL.Query().Get("page_token"),
 		SortField: r.URL.Query().Get("sort_field"),
 		Filter: &machineidv1.ListBotInstancesV2Request_Filters{
-			BotName:    r.URL.Query().Get("bot_name"),
-			SearchTerm: r.URL.Query().Get("search"),
-			Query:      r.URL.Query().Get("query"),
+			BotName:     botName,
+			SearchTerm:  r.URL.Query().Get("search"),
+			Query:       r.URL.Query().Get("query"),
+			ScopeFilter: scopeFilter,
 		},
 	}
 

--- a/lib/web/machineid_test.go
+++ b/lib/web/machineid_test.go
@@ -883,7 +883,7 @@ func TestListBotInstancesPaging(t *testing.T) {
 
 					// remove instances before next test
 					for n := range tc.numInstances {
-						err = env.server.Auth().DeleteBotInstance(ctx, "bot-1", "instance-"+strconv.Itoa(n))
+						err = env.server.Auth().DeleteBotInstance(ctx, machineidv1.DeleteBotInstanceRequest_builder{BotScope: "", BotName: "bot-1", InstanceId: "instance-" + strconv.Itoa(n)}.Build())
 						require.NoError(t, err)
 					}
 				})
@@ -1130,7 +1130,10 @@ func TestListBotInstancesWithSearchTermFilter(t *testing.T) {
 					assert.Equal(t, "00000000-0000-0000-0000-000000000000", instances.BotInstances[0].InstanceId)
 
 					// remove before next test
-					err = env.server.Auth().DeleteBotInstance(ctx, spec.BotName, spec.InstanceId)
+					err = env.server.Auth().DeleteBotInstance(ctx, &machineidv1.DeleteBotInstanceRequest{
+						BotName:    spec.BotName,
+						InstanceId: spec.InstanceId,
+					})
 					require.NoError(t, err)
 				})
 			}

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -594,6 +595,12 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 		botScope, botName = qn.Scope, qn.Name
 	}
 
+	// Exhaustive view, per the scope_filter field docs.
+	var scopeFilter *scopesv1.Filter
+	if botName == "" {
+		scopeFilter = &scopesv1.Filter{Mode: scopesv1.Mode_MODE_ALL}
+	}
+
 	pageFunc := func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1pb.BotInstance, string, error) {
 		resp, err := client.BotInstanceServiceClient().ListBotInstancesV2(ctx, &machineidv1pb.ListBotInstancesV2Request{
 			PageSize:  int32(pageSize),
@@ -601,10 +608,11 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 			SortField: c.sortIndex,
 			SortDesc:  c.sortOrder == "descending",
 			Filter: &machineidv1pb.ListBotInstancesV2Request_Filters{
-				BotName:    botName,
-				BotScope:   botScope,
-				SearchTerm: c.search,
-				Query:      c.query,
+				BotName:     botName,
+				BotScope:    botScope,
+				SearchTerm:  c.search,
+				Query:       c.query,
+				ScopeFilter: scopeFilter,
 			},
 		})
 		return resp.GetBotInstances(), resp.GetNextPageToken(), trace.Wrap(err)
@@ -984,16 +992,16 @@ func splitEntries(flag string) []string {
 // a textual representation of a bot authentication record.
 func formatBotInstanceAuthentication(record *machineidv1pb.BotInstanceStatusAuthentication) string {
 	table := asciitable.MakeHeadlessTable(2)
-	table.AddRow([]string{"Authenticated At:", record.AuthenticatedAt.AsTime().Format(time.RFC3339)})
-	table.AddRow([]string{"Join Method:", cmp.Or(record.GetJoinAttrs().GetMeta().GetJoinMethod(), record.JoinMethod)})
-	table.AddRow([]string{"Join Token:", cmp.Or(record.GetJoinAttrs().GetMeta().GetJoinTokenName(), record.JoinToken)})
-	var meta fmt.Stringer = record.Metadata
+	table.AddRow([]string{"Authenticated At:", record.GetAuthenticatedAt().AsTime().Format(time.RFC3339)})
+	table.AddRow([]string{"Join Method:", cmp.Or(record.GetJoinAttrs().GetMeta().GetJoinMethod(), record.GetJoinMethod())})
+	table.AddRow([]string{"Join Token:", cmp.Or(record.GetJoinAttrs().GetMeta().GetJoinTokenName(), record.GetJoinToken())})
+	var meta fmt.Stringer = record.GetMetadata()
 	if attrs := record.GetJoinAttrs(); attrs != nil {
 		meta = attrs
 	}
 	table.AddRow([]string{"Join Metadata:", meta.String()})
-	table.AddRow([]string{"Generation:", fmt.Sprint(record.Generation)})
-	table.AddRow([]string{"Public Key:", fmt.Sprintf("<%d bytes>", len(record.PublicKey))})
+	table.AddRow([]string{"Generation:", fmt.Sprint(record.GetGeneration())})
+	table.AddRow([]string{"Public Key:", fmt.Sprintf("<%d bytes>", len(record.GetPublicKey()))})
 
 	return "\n" + indentString(table.AsBuffer().String(), "  ")
 }
@@ -1002,15 +1010,15 @@ func formatBotInstanceAuthentication(record *machineidv1pb.BotInstanceStatusAuth
 // a textual representation of a bot heartbeat.
 func formatBotInstanceHeartbeat(record *machineidv1pb.BotInstanceStatusHeartbeat) string {
 	table := asciitable.MakeHeadlessTable(2)
-	table.AddRow([]string{"Recorded At:", record.RecordedAt.AsTime().Format(time.RFC3339)})
-	table.AddRow([]string{"Is Startup:", fmt.Sprint(record.IsStartup)})
-	table.AddRow([]string{"Version:", record.Version})
-	table.AddRow([]string{"Hostname:", record.Hostname})
-	table.AddRow([]string{"Uptime:", record.Uptime.AsDuration().String()})
-	table.AddRow([]string{"Join Method:", record.JoinMethod})
-	table.AddRow([]string{"One Shot:", fmt.Sprint(record.OneShot)})
-	table.AddRow([]string{"Architecture:", record.Architecture})
-	table.AddRow([]string{"OS:", record.Os})
+	table.AddRow([]string{"Recorded At:", record.GetRecordedAt().AsTime().Format(time.RFC3339)})
+	table.AddRow([]string{"Is Startup:", fmt.Sprint(record.GetIsStartup())})
+	table.AddRow([]string{"Version:", record.GetVersion()})
+	table.AddRow([]string{"Hostname:", record.GetHostname()})
+	table.AddRow([]string{"Uptime:", record.GetUptime().AsDuration().String()})
+	table.AddRow([]string{"Join Method:", record.GetJoinMethod()})
+	table.AddRow([]string{"One Shot:", fmt.Sprint(record.GetOneShot())})
+	table.AddRow([]string{"Architecture:", record.GetArchitecture()})
+	table.AddRow([]string{"OS:", record.GetOs()})
 
 	return "\n" + indentString(table.AsBuffer().String(), "  ")
 }

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/set"
@@ -133,10 +134,10 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	c.botsInstances = bots.Command("instances", "Manage bot instances.").Alias("instance")
 
 	c.botsInstancesShow = c.botsInstances.Command("show", "Shows information about a specific bot instance.").Alias("get").Alias("describe")
-	c.botsInstancesShow.Arg("id", "The full ID of the bot instance, in the form of [bot name]/[uuid]").Required().StringVar(&c.instanceID)
+	c.botsInstancesShow.Arg("id", "The full ID of the bot instance, in the form of [bot name]/[uuid]. For an instance of a scoped bot, prefix the ID with the bot's scope: [scope]::[bot name]/[uuid].").Required().StringVar(&c.instanceID)
 
 	c.botsInstancesList = c.botsInstances.Command("list", "List bot instances.").Alias("ls")
-	c.botsInstancesList.Arg("name", "The name of the bot from which to list instances. If unset, lists instances from all bots.").StringVar(&c.botName)
+	c.botsInstancesList.Arg("name", "The name of the bot from which to list instances. For a scoped bot, provide a scope-qualified name of the form [scope]::[name]. If unset, lists instances from all bots.").StringVar(&c.botName)
 	c.botsInstancesList.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 	c.botsInstancesList.Flag("search", "Fuzzy search query used to filter bot instances").StringVar(&c.search)
 	c.botsInstancesList.Flag("query", "An expression in the Teleport predicate language used to filter bot instances").StringVar(&c.query)
@@ -577,6 +578,22 @@ func (c *BotsCommand) UpdateBot(ctx context.Context, client botsCommandClient) e
 
 // ListBotInstances lists bot instances, possibly filtering for a specific bot
 func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandClient) error {
+	// The bot may be given as a scope-qualified name (<scope>::<bot name>) to
+	// list instances of a scoped bot; a bare name lists instances of an
+	// unscoped bot.
+	botName := c.botName
+	var botScope string
+	if scopes.MaybeSQN(botName) {
+		qn, err := scopes.ParseQualifiedName(botName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if err := qn.StrongValidate(); err != nil {
+			return trace.Wrap(err)
+		}
+		botScope, botName = qn.Scope, qn.Name
+	}
+
 	pageFunc := func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1pb.BotInstance, string, error) {
 		resp, err := client.BotInstanceServiceClient().ListBotInstancesV2(ctx, &machineidv1pb.ListBotInstancesV2Request{
 			PageSize:  int32(pageSize),
@@ -584,7 +601,8 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 			SortField: c.sortIndex,
 			SortDesc:  c.sortOrder == "descending",
 			Filter: &machineidv1pb.ListBotInstancesV2Request_Filters{
-				BotName:    c.botName,
+				BotName:    botName,
+				BotScope:   botScope,
 				SearchTerm: c.search,
 				Query:      c.query,
 			},
@@ -596,11 +614,14 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 		if c.query != "" {
 			return nil, trace.NotImplemented("fallback not supported for requests with a query")
 		}
+		if botScope != "" {
+			return nil, trace.NotImplemented("fallback not supported for requests with a bot scope")
+		}
 		fallbackPageFunc := func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1pb.BotInstance, string, error) {
 			// Needed for backwards compatibility
 			//nolint:staticcheck // SA1019
 			resp, err := client.BotInstanceServiceClient().ListBotInstances(ctx, &machineidv1pb.ListBotInstancesRequest{
-				FilterBotName:    c.botName,
+				FilterBotName:    botName,
 				PageSize:         int32(pageSize),
 				PageToken:        pageToken,
 				FilterSearchTerm: c.search,
@@ -654,42 +675,42 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 		)
 
 		initialJoinMethod := cmp.Or(
-			i.Status.InitialAuthentication.GetJoinAttrs().GetMeta().GetJoinMethod(),
-			i.Status.InitialAuthentication.JoinMethod,
+			i.GetStatus().GetInitialAuthentication().GetJoinAttrs().GetMeta().GetJoinMethod(),
+			i.GetStatus().GetInitialAuthentication().GetJoinMethod(),
 		)
 
-		lastSeen := i.Status.InitialAuthentication.AuthenticatedAt.AsTime()
+		lastSeen := i.GetStatus().GetInitialAuthentication().GetAuthenticatedAt().AsTime()
 
-		if len(i.Status.LatestAuthentications) > 0 {
-			auth := i.Status.LatestAuthentications[len(i.Status.LatestAuthentications)-1]
+		if len(i.GetStatus().GetLatestAuthentications()) > 0 {
+			auth := i.GetStatus().GetLatestAuthentications()[len(i.GetStatus().GetLatestAuthentications())-1]
 
 			authJM := cmp.Or(
 				auth.GetJoinAttrs().GetMeta().GetJoinMethod(),
-				auth.JoinMethod,
+				auth.GetJoinMethod(),
 			)
 			if authJM == initialJoinMethod {
 				joinMethod = authJM
 			} else {
 				// If the join method changed, show the original method and latest
-				joinMethod = fmt.Sprintf("%s (%s)", auth.JoinMethod, initialJoinMethod)
+				joinMethod = fmt.Sprintf("%s (%s)", auth.GetJoinMethod(), initialJoinMethod)
 			}
 
-			if auth.AuthenticatedAt.AsTime().After(lastSeen) {
-				lastSeen = auth.AuthenticatedAt.AsTime()
+			if auth.GetAuthenticatedAt().AsTime().After(lastSeen) {
+				lastSeen = auth.GetAuthenticatedAt().AsTime()
 			}
 		}
 
-		if len(i.Status.LatestHeartbeats) == 0 {
+		if len(i.GetStatus().GetLatestHeartbeats()) == 0 {
 			hostname = "-"
 			version = "-"
 		} else {
-			hb := i.Status.LatestHeartbeats[len(i.Status.LatestHeartbeats)-1]
+			hb := i.GetStatus().GetLatestHeartbeats()[len(i.GetStatus().GetLatestHeartbeats())-1]
 
-			hostname = hb.Hostname
-			version = hb.Version
+			hostname = hb.GetHostname()
+			version = hb.GetVersion()
 
-			if hb.RecordedAt.AsTime().After(lastSeen) {
-				lastSeen = hb.RecordedAt.AsTime()
+			if hb.GetRecordedAt().AsTime().After(lastSeen) {
+				lastSeen = hb.GetRecordedAt().AsTime()
 			}
 		}
 
@@ -698,8 +719,15 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 			healthStatus = formatStatus(status, false) // Disable color, it messes with the table layout
 		}
 
+		// Instances of scoped bots are identified by the bot's scope-qualified
+		// name; instances of unscoped bots by the bot's bare name.
+		id := scopes.QualifiedName{
+			Scope: i.GetScope(),
+			Name:  i.GetSpec().GetBotName() + "/" + i.GetSpec().GetInstanceId(),
+		}.String()
+
 		t.AddRow([]string{
-			fmt.Sprintf("%s/%s", i.Spec.BotName, i.Spec.InstanceId), joinMethod,
+			id, joinMethod,
 			version, hostname, healthStatus, lastSeen.Format(time.RFC3339),
 		})
 	}
@@ -708,7 +736,8 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 	executableFileName := filepath.Base(os.Args[0])
 	fmt.Fprintf(c.stdout, "\nTo view more information on a particular instance, run:\n\n> %s bots instances show [id]\n", executableFileName)
 
-	if c.botName != "" {
+	// 'bots instances add' does not support scoped bots yet.
+	if c.botName != "" && botScope == "" {
 		fmt.Fprintf(c.stdout, "\nTo onboard a new instance for this bot, run:\n\n> %s bots instances add %s\n", executableFileName, c.botName)
 	}
 
@@ -783,7 +812,8 @@ func (c *BotsCommand) AddBotInstance(ctx context.Context, client botsCommandClie
 var showMessageTemplate = template.Must(template.New("show").Funcs(template.FuncMap{
 	"bold": bold,
 }).Parse(`Bot:    {{.instance.Spec.BotName}}
-ID:     {{.instance.Spec.InstanceId}}
+{{if .scope}}Scope:  {{.scope}}
+{{end}}ID:     {{.instance.Spec.InstanceId}}
 Status: {{.health_status}}
 
 Initial Authentication: {{.initial_authentication_table}}
@@ -798,15 +828,15 @@ Services:
 To view a full, machine-readable record including past heartbeats and
 authentication records, run:
 
-> {{.executable}} get bot_instance/{{.instance.Spec.BotName}}/{{.instance.Spec.InstanceId}}
-
+> {{.executable}} get {{.get_ref}}
+{{if .can_add_instance}}
 To onboard a new instance for this bot, run:
 
 > {{.executable}} bots instances add {{.instance.Spec.BotName}}
-`))
+{{end}}`))
 
 func (c *BotsCommand) ShowBotInstance(ctx context.Context, client botsCommandClient) error {
-	botName, instanceID, err := parseInstanceID(c.instanceID)
+	botScope, botName, instanceID, err := parseInstanceID(c.instanceID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -814,24 +844,25 @@ func (c *BotsCommand) ShowBotInstance(ctx context.Context, client botsCommandCli
 	instance, err := client.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
 		BotName:    botName,
 		InstanceId: instanceID,
+		BotScope:   botScope,
 	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	initialAuthenticationTable := formatBotInstanceAuthentication(instance.Status.InitialAuthentication)
+	initialAuthenticationTable := formatBotInstanceAuthentication(instance.GetStatus().GetInitialAuthentication())
 
 	var latestAuthenticationTable string
-	if len(instance.Status.LatestAuthentications) > 0 {
-		latest := instance.Status.LatestAuthentications[len(instance.Status.LatestAuthentications)-1]
+	if latestAuthentications := instance.GetStatus().GetLatestAuthentications(); len(latestAuthentications) > 0 {
+		latest := latestAuthentications[len(latestAuthentications)-1]
 		latestAuthenticationTable = formatBotInstanceAuthentication(latest)
 	} else {
 		latestAuthenticationTable = "No authentication records."
 	}
 
 	var heartbeatTable string
-	if len(instance.Status.LatestHeartbeats) > 0 {
-		latest := instance.Status.LatestHeartbeats[len(instance.Status.LatestHeartbeats)-1]
+	if latestHeartbeats := instance.GetStatus().GetLatestHeartbeats(); len(latestHeartbeats) > 0 {
+		latest := latestHeartbeats[len(latestHeartbeats)-1]
 		heartbeatTable = formatBotInstanceHeartbeat(latest)
 	} else {
 		heartbeatTable = "No heartbeat records."
@@ -847,9 +878,22 @@ func (c *BotsCommand) ShowBotInstance(ctx context.Context, client botsCommandCli
 		servicesTable = formatServices(instance.GetStatus().GetServiceHealth())
 	}
 
-	templateData := map[string]interface{}{
-		"executable":                   os.Args[0],
-		"instance":                     instance,
+	// Only the two-argument form of 'tctl get' can carry a scope, so use it for
+	// scoped and unscoped alike rather than changing shape between them.
+	instanceRef := instance.GetSpec().GetBotName() + "/" + instance.GetSpec().GetInstanceId()
+	if scope := instance.GetScope(); scope != "" {
+		instanceRef = scopes.QualifiedName{Scope: scope, Name: instanceRef}.String()
+	}
+	getRef := types.KindBotInstance + " " + instanceRef
+
+	templateData := map[string]any{
+		"executable": os.Args[0],
+		"instance":   instance,
+		"scope":      instance.GetScope(),
+		"get_ref":    getRef,
+		// A bare name in the 'instances add' hint would target the same-named
+		// unscoped bot, and that command can't onboard a scoped bot anyway.
+		"can_add_instance":             instance.GetScope() == "",
 		"initial_authentication_table": initialAuthenticationTable,
 		"latest_authentication_table":  latestAuthenticationTable,
 		"heartbeat_table":              heartbeatTable,
@@ -857,7 +901,7 @@ func (c *BotsCommand) ShowBotInstance(ctx context.Context, client botsCommandCli
 		"services_table":               servicesTable,
 	}
 
-	return trace.Wrap(showMessageTemplate.Execute(os.Stdout, templateData))
+	return trace.Wrap(showMessageTemplate.Execute(c.stdout, templateData))
 }
 
 // botJSONResponse is a response generated by the `tctl bots add` family of
@@ -1034,14 +1078,25 @@ func formatStatus(status machineidv1pb.BotInstanceHealthStatus, useColor bool) s
 }
 
 // parseInstanceID converts an instance ID string in the form of
-// '[bot name]/[uuid]' to separate bot name and UUID strings.
-func parseInstanceID(s string) (name string, uuid string, err error) {
-	name, uuid, ok := strings.Cut(s, "/")
-	if !ok {
-		return "", "", trace.BadParameter("invalid bot instance syntax, must be: [bot name]/[uuid]")
+// [scope::][bot name]/[uuid] into its component parts. The scope prefix
+// addresses an instance of a scoped bot; scope is empty when the prefix is
+// absent.
+func parseInstanceID(s string) (scope string, name string, uuid string, err error) {
+	if before, after, ok := strings.Cut(s, scopes.QualifiedNameSeparator); ok {
+		if err := scopes.StrongValidate(before); err != nil {
+			return "", "", "", trace.Wrap(err)
+		}
+		scope, s = before, after
+	} else if scopes.MaybeSQN(s) {
+		return "", "", "", trace.BadParameter("invalid bot instance syntax, must be: [scope::][bot name]/[uuid]")
 	}
 
-	return
+	name, uuid, ok := strings.Cut(s, "/")
+	if !ok {
+		return "", "", "", trace.BadParameter("invalid bot instance syntax, must be: [scope::][bot name]/[uuid]")
+	}
+
+	return scope, name, uuid, nil
 }
 
 // indentString prefixes each line (ending with \n) with the provided prefix.

--- a/tool/tctl/common/bots_command_test.go
+++ b/tool/tctl/common/bots_command_test.go
@@ -588,6 +588,194 @@ func TestListBotInstances(t *testing.T) {
 	})
 }
 
+// TestBotInstancesScoped exercises "tctl bots instances list/show" against
+// instances of scoped bots, which are addressed by prefixing the bot's name
+// with its scope: <scope>::<bot name>.
+func TestBotInstancesScoped(t *testing.T) {
+	t.Parallel()
+
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withEnableCache(true))
+	ctx := t.Context()
+	client, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	// An unscoped and a scoped bot sharing a name, to prove reads and filters
+	// are scope-strict.
+	unscopedInstance := createBotInstance(t, ctx, process)
+	scopedInstance := createBotInstance(t, ctx, process, func(instance *machineidv1pb.BotInstance) {
+		instance.SetScope("/staging")
+	})
+
+	// Give the auth cache a chance to catch-up
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		res, _, err := process.GetAuthServer().ListBotInstances(ctx, 0, "", nil)
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+	}, time.Second*10, time.Millisecond*50)
+
+	t.Run("list filter by scope-qualified bot name", func(t *testing.T) {
+		buf := strings.Builder{}
+		cmd := BotsCommand{
+			stdout:  &buf,
+			format:  teleport.JSON,
+			botName: "/staging::test-bot-1",
+		}
+
+		require.NoError(t, cmd.ListBotInstances(t.Context(), client))
+
+		res, err := services.UnmarshalProtoResourceArray[*machineidv1pb.BotInstance]([]byte(buf.String()))
+		require.NoError(t, err)
+
+		require.Len(t, res, 1)
+		assertContainsInstance(t, res, scopedInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("list filter by bare bot name excludes scoped bots", func(t *testing.T) {
+		buf := strings.Builder{}
+		cmd := BotsCommand{
+			stdout:  &buf,
+			format:  teleport.JSON,
+			botName: "test-bot-1",
+		}
+
+		require.NoError(t, cmd.ListBotInstances(t.Context(), client))
+
+		res, err := services.UnmarshalProtoResourceArray[*machineidv1pb.BotInstance]([]byte(buf.String()))
+		require.NoError(t, err)
+
+		require.Len(t, res, 1)
+		assertContainsInstance(t, res, unscopedInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("list text output shows scope-qualified id", func(t *testing.T) {
+		buf := strings.Builder{}
+		cmd := BotsCommand{
+			stdout: &buf,
+			format: teleport.Text,
+		}
+
+		require.NoError(t, cmd.ListBotInstances(t.Context(), client))
+
+		out := buf.String()
+		require.Contains(t, out, "/staging::test-bot-1/"+scopedInstance.GetSpec().GetInstanceId())
+		require.Contains(t, out, "test-bot-1/"+unscopedInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("list hides add hint for scoped bot", func(t *testing.T) {
+		buf := strings.Builder{}
+		cmd := BotsCommand{
+			stdout:  &buf,
+			format:  teleport.Text,
+			botName: "/staging::test-bot-1",
+		}
+
+		require.NoError(t, cmd.ListBotInstances(t.Context(), client))
+
+		require.NotContains(t, buf.String(), "bots instances add")
+	})
+
+	t.Run("list shows add hint for unscoped bot", func(t *testing.T) {
+		buf := strings.Builder{}
+		cmd := BotsCommand{
+			stdout:  &buf,
+			format:  teleport.Text,
+			botName: "test-bot-1",
+		}
+
+		require.NoError(t, cmd.ListBotInstances(t.Context(), client))
+
+		require.Contains(t, buf.String(), "bots instances add test-bot-1")
+	})
+
+	t.Run("show scoped instance", func(t *testing.T) {
+		buf := strings.Builder{}
+		cmd := BotsCommand{
+			stdout:     &buf,
+			instanceID: "/staging::test-bot-1/" + scopedInstance.GetSpec().GetInstanceId(),
+		}
+
+		require.NoError(t, cmd.ShowBotInstance(t.Context(), client))
+
+		out := buf.String()
+		require.Contains(t, out, "Scope:  /staging")
+		require.Contains(t, out, "get bot_instance /staging::test-bot-1/"+scopedInstance.GetSpec().GetInstanceId())
+		// The slash form can't carry a scope, so it must not be suggested here.
+		require.NotContains(t, out, "get bot_instance/test-bot-1")
+		require.NotContains(t, out, "bots instances add")
+	})
+
+	t.Run("show unscoped instance", func(t *testing.T) {
+		buf := strings.Builder{}
+		cmd := BotsCommand{
+			stdout:     &buf,
+			instanceID: "test-bot-1/" + unscopedInstance.GetSpec().GetInstanceId(),
+		}
+
+		require.NoError(t, cmd.ShowBotInstance(t.Context(), client))
+
+		out := buf.String()
+		require.NotContains(t, out, "Scope:")
+		require.Contains(t, out, "bots instances add test-bot-1")
+		// Same two-argument shape as the scoped case.
+		require.Contains(t, out, "get bot_instance test-bot-1/"+unscopedInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("show scoped instance without scope is not found", func(t *testing.T) {
+		cmd := BotsCommand{
+			stdout:     &strings.Builder{},
+			instanceID: "test-bot-1/" + scopedInstance.GetSpec().GetInstanceId(),
+		}
+
+		err := cmd.ShowBotInstance(t.Context(), client)
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got: %v", err)
+	})
+
+	t.Run("show scoped instance with wrong scope is not found", func(t *testing.T) {
+		cmd := BotsCommand{
+			stdout:     &strings.Builder{},
+			instanceID: "/prod::test-bot-1/" + scopedInstance.GetSpec().GetInstanceId(),
+		}
+
+		err := cmd.ShowBotInstance(t.Context(), client)
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got: %v", err)
+	})
+
+	t.Run("list filter with scope prefix but no separator is rejected", func(t *testing.T) {
+		cmd := BotsCommand{
+			stdout:  &strings.Builder{},
+			format:  teleport.JSON,
+			botName: "/staging",
+		}
+
+		err := cmd.ListBotInstances(t.Context(), client)
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+	})
+
+	t.Run("show with scope prefix but no separator is rejected", func(t *testing.T) {
+		cmd := BotsCommand{
+			stdout:     &strings.Builder{},
+			instanceID: "/staging/test-bot-1/" + scopedInstance.GetSpec().GetInstanceId(),
+		}
+
+		err := cmd.ShowBotInstance(t.Context(), client)
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+	})
+}
+
 func assertContainsInstance(t *testing.T, res []*machineidv1pb.BotInstance, instanceId string) {
 	assert.True(t, slices.ContainsFunc(res, func(in *machineidv1pb.BotInstance) bool {
 		return in.GetSpec().GetInstanceId() == instanceId
@@ -670,6 +858,19 @@ func TestListBotInstancesFallback(t *testing.T) {
 		err := cmd.ListBotInstances(ctx, authClient)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "fallback not supported for requests with a query")
+	})
+
+	t.Run("fallback not allowed for bot scope", func(t *testing.T) {
+		cmd := BotsCommand{
+			stdout: ptr(strings.Builder{}),
+			format: teleport.JSON,
+			// The bot scope filter is only available in ListBotInstancesV2.
+			botName: "/staging::test-bot-1",
+		}
+
+		err := cmd.ListBotInstances(ctx, authClient)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "fallback not supported for requests with a bot scope")
 	})
 }
 

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -75,6 +75,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -2487,6 +2488,19 @@ func (rc *ResourceCommand) getCollectionByScopedRef(ctx context.Context, client 
 func (rc *ResourceCommand) getCollectionByRef(ctx context.Context, client *authclient.Client, ref services.Ref, opts resources.GetOpts) (resources.Collection, error) {
 	if ref.Kind == "" {
 		return nil, trace.BadParameter("specify resource to list, e.g. 'tctl get roles'")
+	}
+
+	// ParseRef splits on '/', so a scope-qualified name given in the single-arg
+	// form arrives with its scope stranded in the name or the sub-kind. Kinds with
+	// only a scoped handler are already rejected below; kinds with both would
+	// otherwise treat it as an unscoped name and match nothing.
+	_, classicFound := resources.Handlers()[ref.Kind]
+	_, scopedFound := resources.ScopedHandlers()[ref.Kind]
+	if classicFound && scopedFound && (scopes.MaybeSQN(ref.Name) || scopes.MaybeSQN(ref.SubKind)) {
+		return nil, trace.BadParameter(
+			"resource type %q does not accept a scope-qualified name in the single-arg '<kind>/<name>' form, try:\n  tctl get %s <scope>::<name>",
+			ref.Kind, ref.Kind,
+		)
 	}
 
 	if handler, found := resources.Handlers()[ref.Kind]; found {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -75,6 +75,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/devicetrust"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -2548,6 +2549,19 @@ func (rc *ResourceCommand) getCollectionByScopedRef(ctx context.Context, client 
 func (rc *ResourceCommand) getCollectionByRef(ctx context.Context, client *authclient.Client, ref services.Ref, opts resources.GetOpts) (resources.Collection, error) {
 	if ref.Kind == "" {
 		return nil, trace.BadParameter("specify resource to list, e.g. 'tctl get roles'")
+	}
+
+	// ParseRef splits on '/', so a scope-qualified name given in the single-arg
+	// form arrives with its scope stranded in the name or the sub-kind. Kinds with
+	// only a scoped handler are already rejected below; kinds with both would
+	// otherwise treat it as an unscoped name and match nothing.
+	_, classicFound := resources.Handlers()[ref.Kind]
+	_, scopedFound := resources.ScopedHandlers()[ref.Kind]
+	if classicFound && scopedFound && (scopes.MaybeSQN(ref.Name) || scopes.MaybeSQN(ref.SubKind)) {
+		return nil, trace.BadParameter(
+			"resource type %q does not accept a scope-qualified name in the single-arg '<kind>/<name>' form, try:\n  tctl get %s <scope>::<name>",
+			ref.Kind, ref.Kind,
+		)
 	}
 
 	if handler, found := resources.Handlers()[ref.Kind]; found {

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -38,12 +38,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
@@ -1013,6 +1015,181 @@ func TestScopedAndUnscopedNodeResource(t *testing.T) {
 				require.FailNow(t, "timed out waiting for unscoped-node to be deleted")
 			case <-time.After(100 * time.Millisecond):
 			}
+		}
+	})
+}
+
+// TestScopedAndUnscopedBotInstanceResource exercises tctl get on bot instances,
+// which are double-registered as both a scoped and unscoped resource handler to
+// support a mix of scope-qualified and classic interactions. An instance of a
+// scoped bot is addressed as <scope>::<bot name>/<instance id>; a bare
+// <scope>::<bot name> lists the scoped bot's instances.
+func TestScopedAndUnscopedBotInstanceResource(t *testing.T) {
+	t.Parallel()
+
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{DataDir: t.TempDir()},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withEnableCache(true))
+	clt, err := testenv.NewDefaultAuthClient(auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	// Bot instances are created server-side on join and have no create RPC, so
+	// seed them directly through the auth server's backend service.
+	makeInstance := func(scope, botName string) *machineidv1pb.BotInstance {
+		instance, err := auth.GetAuthServer().CreateBotInstance(t.Context(), machineidv1pb.BotInstance_builder{
+			Scope: scope,
+			Spec: machineidv1pb.BotInstanceSpec_builder{
+				BotName:    botName,
+				InstanceId: uuid.NewString(),
+			}.Build(),
+			Status: machineidv1pb.BotInstanceStatus_builder{
+				InitialHeartbeat: machineidv1pb.BotInstanceStatusHeartbeat_builder{
+					RecordedAt: timestamppb.New(time.Now()),
+					IsStartup:  true,
+					Hostname:   "test-hostname",
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		return instance
+	}
+
+	classicInstance := makeInstance("", "classic-bot")
+	stagingInstance0 := makeInstance("/staging", "staging-bot")
+	stagingInstance1 := makeInstance("/staging", "staging-bot")
+	// Same bot name in a different scope, to prove reads are scope-strict.
+	prodInstance := makeInstance("/prod", "staging-bot")
+
+	// Poll until all instances appear via the list (cache propagation).
+	// runResourceCommand needs a *testing.T, so poll manually rather than via
+	// require.EventuallyWithT.
+	allInstances := []*machineidv1pb.BotInstance{classicInstance, stagingInstance0, stagingInstance1, prodInstance}
+	timeout := time.After(30 * time.Second)
+	for {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBotInstance, "--format=json"})
+		if err == nil {
+			propagated := 0
+			for _, instance := range allInstances {
+				if strings.Contains(buf.String(), instance.GetSpec().GetInstanceId()) {
+					propagated++
+				}
+			}
+			if propagated == len(allInstances) {
+				break
+			}
+		}
+		select {
+		case <-timeout:
+			require.FailNow(t, "timed out waiting for bot instances to appear in list")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	t.Run("list all shows scope-qualified bot name for instances of scoped bots", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBotInstance, "--format=text"})
+		require.NoError(t, err)
+		out := buf.String()
+		require.Contains(t, out, "/staging::staging-bot")
+		require.Contains(t, out, "/prod::staging-bot")
+		require.Contains(t, out, "classic-bot")
+	})
+
+	t.Run("single-arg unscoped get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{
+			"get",
+			types.KindBotInstance + "/classic-bot/" + classicInstance.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), classicInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("two-arg unscoped get is equivalent to the single-arg form", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance,
+			"classic-bot/" + classicInstance.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), classicInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("two-arg unscoped get of a missing instance is not found", func(t *testing.T) {
+		// Not the silently-empty list it would give if Name became a bot filter.
+		_, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance, "classic-bot/does-not-exist", "--format=json",
+		})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got: %v", err)
+	})
+
+	t.Run("scope-qualified get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance,
+			"/staging::staging-bot/" + stagingInstance0.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), stagingInstance0.GetSpec().GetInstanceId())
+	})
+
+	t.Run("scope-qualified get with scope mismatch", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance,
+			"/prod::staging-bot/" + stagingInstance0.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.True(t, trace.IsNotFound(err), "expected NotFound on scope mismatch, got: %v", err)
+	})
+
+	t.Run("scope-qualified list by bot", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBotInstance, "/staging::staging-bot", "--format=json"})
+		require.NoError(t, err)
+		out := buf.String()
+		require.Contains(t, out, stagingInstance0.GetSpec().GetInstanceId())
+		require.Contains(t, out, stagingInstance1.GetSpec().GetInstanceId())
+		require.NotContains(t, out, prodInstance.GetSpec().GetInstanceId())
+		require.NotContains(t, out, classicInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("unscoped list by bot excludes scoped bots of the same name", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBotInstance + "/staging-bot", "--format=json"})
+		require.NoError(t, err)
+		out := buf.String()
+		require.NotContains(t, out, stagingInstance0.GetSpec().GetInstanceId())
+		require.NotContains(t, out, stagingInstance1.GetSpec().GetInstanceId())
+		require.NotContains(t, out, prodInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("sub-kind with SQN is rejected with a hint", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance + "/staging-bot",
+			"/staging::" + stagingInstance0.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+		require.ErrorContains(t, err, "<scope>::<bot_name>/<instance_id>")
+	})
+
+	t.Run("SQN in the single-arg form is rejected with a hint", func(t *testing.T) {
+		for _, ref := range []string{
+			types.KindBotInstance + "//staging::staging-bot",
+			types.KindBotInstance + "//staging::staging-bot/" + stagingInstance0.GetSpec().GetInstanceId(),
+		} {
+			t.Run(ref, func(t *testing.T) {
+				_, err := runResourceCommand(t, clt, []string{"get", ref, "--format=json"})
+				require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+				require.ErrorContains(t, err, "single-arg")
+				require.ErrorContains(t, err, "<scope>::<name>")
+			})
 		}
 	})
 }

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -38,12 +38,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
@@ -1128,6 +1130,181 @@ func TestScopedAndUnscopedWorkloadIdentityResource(t *testing.T) {
 	t.Run("unscoped delete", func(t *testing.T) {
 		_, err := runResourceCommand(t, clt, []string{"rm", "workload_identity/classic-wi"})
 		require.NoError(t, err)
+	})
+}
+
+// TestScopedAndUnscopedBotInstanceResource exercises tctl get on bot instances,
+// which are double-registered as both a scoped and unscoped resource handler to
+// support a mix of scope-qualified and classic interactions. An instance of a
+// scoped bot is addressed as <scope>::<bot name>/<instance id>; a bare
+// <scope>::<bot name> lists the scoped bot's instances.
+func TestScopedAndUnscopedBotInstanceResource(t *testing.T) {
+	t.Parallel()
+
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{DataDir: t.TempDir()},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withEnableCache(true))
+	clt, err := testenv.NewDefaultAuthClient(auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	// Bot instances are created server-side on join and have no create RPC, so
+	// seed them directly through the auth server's backend service.
+	makeInstance := func(scope, botName string) *machineidv1pb.BotInstance {
+		instance, err := auth.GetAuthServer().CreateBotInstance(t.Context(), machineidv1pb.BotInstance_builder{
+			Scope: scope,
+			Spec: machineidv1pb.BotInstanceSpec_builder{
+				BotName:    botName,
+				InstanceId: uuid.NewString(),
+			}.Build(),
+			Status: machineidv1pb.BotInstanceStatus_builder{
+				InitialHeartbeat: machineidv1pb.BotInstanceStatusHeartbeat_builder{
+					RecordedAt: timestamppb.New(time.Now()),
+					IsStartup:  true,
+					Hostname:   "test-hostname",
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		return instance
+	}
+
+	classicInstance := makeInstance("", "classic-bot")
+	stagingInstance0 := makeInstance("/staging", "staging-bot")
+	stagingInstance1 := makeInstance("/staging", "staging-bot")
+	// Same bot name in a different scope, to prove reads are scope-strict.
+	prodInstance := makeInstance("/prod", "staging-bot")
+
+	// Poll until all instances appear via the list (cache propagation).
+	// runResourceCommand needs a *testing.T, so poll manually rather than via
+	// require.EventuallyWithT.
+	allInstances := []*machineidv1pb.BotInstance{classicInstance, stagingInstance0, stagingInstance1, prodInstance}
+	timeout := time.After(30 * time.Second)
+	for {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBotInstance, "--format=json"})
+		if err == nil {
+			propagated := 0
+			for _, instance := range allInstances {
+				if strings.Contains(buf.String(), instance.GetSpec().GetInstanceId()) {
+					propagated++
+				}
+			}
+			if propagated == len(allInstances) {
+				break
+			}
+		}
+		select {
+		case <-timeout:
+			require.FailNow(t, "timed out waiting for bot instances to appear in list")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	t.Run("list all shows scope-qualified bot name for instances of scoped bots", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBotInstance, "--format=text"})
+		require.NoError(t, err)
+		out := buf.String()
+		require.Contains(t, out, "/staging::staging-bot")
+		require.Contains(t, out, "/prod::staging-bot")
+		require.Contains(t, out, "classic-bot")
+	})
+
+	t.Run("single-arg unscoped get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{
+			"get",
+			types.KindBotInstance + "/classic-bot/" + classicInstance.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), classicInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("two-arg unscoped get is equivalent to the single-arg form", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance,
+			"classic-bot/" + classicInstance.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), classicInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("two-arg unscoped get of a missing instance is not found", func(t *testing.T) {
+		// Not the silently-empty list it would give if Name became a bot filter.
+		_, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance, "classic-bot/does-not-exist", "--format=json",
+		})
+		require.True(t, trace.IsNotFound(err), "expected NotFound, got: %v", err)
+	})
+
+	t.Run("scope-qualified get", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance,
+			"/staging::staging-bot/" + stagingInstance0.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), stagingInstance0.GetSpec().GetInstanceId())
+	})
+
+	t.Run("scope-qualified get with scope mismatch", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance,
+			"/prod::staging-bot/" + stagingInstance0.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.True(t, trace.IsNotFound(err), "expected NotFound on scope mismatch, got: %v", err)
+	})
+
+	t.Run("scope-qualified list by bot", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBotInstance, "/staging::staging-bot", "--format=json"})
+		require.NoError(t, err)
+		out := buf.String()
+		require.Contains(t, out, stagingInstance0.GetSpec().GetInstanceId())
+		require.Contains(t, out, stagingInstance1.GetSpec().GetInstanceId())
+		require.NotContains(t, out, prodInstance.GetSpec().GetInstanceId())
+		require.NotContains(t, out, classicInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("unscoped list by bot excludes scoped bots of the same name", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBotInstance + "/staging-bot", "--format=json"})
+		require.NoError(t, err)
+		out := buf.String()
+		require.NotContains(t, out, stagingInstance0.GetSpec().GetInstanceId())
+		require.NotContains(t, out, stagingInstance1.GetSpec().GetInstanceId())
+		require.NotContains(t, out, prodInstance.GetSpec().GetInstanceId())
+	})
+
+	t.Run("sub-kind with SQN is rejected with a hint", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{
+			"get", types.KindBotInstance + "/staging-bot",
+			"/staging::" + stagingInstance0.GetSpec().GetInstanceId(),
+			"--format=json",
+		})
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+		require.ErrorContains(t, err, "<scope>::<bot_name>/<instance_id>")
+	})
+
+	t.Run("SQN in the single-arg form is rejected with a hint", func(t *testing.T) {
+		for _, ref := range []string{
+			types.KindBotInstance + "//staging::staging-bot",
+			types.KindBotInstance + "//staging::staging-bot/" + stagingInstance0.GetSpec().GetInstanceId(),
+		} {
+			t.Run(ref, func(t *testing.T) {
+				_, err := runResourceCommand(t, clt, []string{"get", ref, "--format=json"})
+				require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+				require.ErrorContains(t, err, "single-arg")
+				require.ErrorContains(t, err, "<scope>::<name>")
+			})
+		}
 	})
 }
 

--- a/tool/tctl/common/resources/bot_instance.go
+++ b/tool/tctl/common/resources/bot_instance.go
@@ -1,0 +1,200 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+package resources
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type botInstanceCollection struct {
+	items []*machineidv1pb.BotInstance
+}
+
+func (c *botInstanceCollection) Resources() []types.Resource {
+	r := make([]types.Resource, 0, len(c.items))
+	for _, resource := range c.items {
+		r = append(r, types.ProtoResource153ToLegacy(resource))
+	}
+	return r
+}
+
+func (c *botInstanceCollection) WriteText(w io.Writer, verbose bool) error {
+	headers := []string{"Bot Name", "Instance ID"}
+
+	// TODO: consider adding additional (possibly verbose) fields showing
+	// last heartbeat, last auth, etc.
+	var rows [][]string
+	for _, item := range c.items {
+		botName := scopes.QualifiedName{
+			Scope: item.GetScope(),
+			Name:  item.GetSpec().GetBotName(),
+		}.String()
+		rows = append(rows, []string{botName, item.GetSpec().GetInstanceId()})
+	}
+
+	t := asciitable.MakeTable(headers, rows...)
+
+	// stable sort by name.
+	t.SortRowsBy([]int{0}, true)
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func botInstanceHandler() Handler {
+	return Handler{
+		getHandler:  getBotInstance,
+		singleton:   false,
+		description: "A single instance of the tbot agent running in Teleport.",
+	}
+}
+
+func getBotInstance(
+	ctx context.Context,
+	client *authclient.Client,
+	ref services.Ref,
+	opts GetOpts,
+) (Collection, error) {
+	c := client.BotInstanceServiceClient()
+
+	// services.ParseRef splits the bot name into SubKind only for the one-argument
+	// form 'bot_instance/<bot>/<id>'; the two-argument form leaves it in Name.
+	botName, instanceID := ref.SubKind, ref.Name
+	if botName == "" {
+		if bot, id, ok := strings.Cut(ref.Name, "/"); ok {
+			botName, instanceID = bot, id
+		}
+	}
+
+	if botName != "" && instanceID != "" {
+		bi, err := c.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{
+			BotName:    botName,
+			InstanceId: instanceID,
+		}.Build())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &botInstanceCollection{items: []*machineidv1pb.BotInstance{bi}}, nil
+	}
+
+	instances, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, pageToken string) ([]*machineidv1pb.BotInstance, string, error) {
+		// TODO(nicholasmarais1158) Use ListBotInstancesV2 instead.
+		//nolint:staticcheck // SA1019
+		resp, err := c.ListBotInstances(ctx, machineidv1pb.ListBotInstancesRequest_builder{
+			PageSize:  int32(limit),
+			PageToken: pageToken,
+
+			// Note: empty filter lists all bot instances
+			FilterBotName: ref.Name,
+		}.Build())
+
+		return resp.GetBotInstances(), resp.GetNextPageToken(), trace.Wrap(err)
+	}))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &botInstanceCollection{items: instances}, nil
+}
+
+// botInstanceScopedHandler returns a [ScopedHandler] for instances of scoped
+// bots. Bot instances support both classic (unscoped) and scope-qualified
+// access, so this is registered alongside the classic handler in
+// ScopedHandlers().
+func botInstanceScopedHandler() ScopedHandler {
+	return ScopedHandler{
+		getHandler:  getBotInstanceScoped,
+		description: "A single instance of the tbot agent running in Teleport.",
+	}
+}
+
+func getBotInstanceScoped(
+	ctx context.Context,
+	client *authclient.Client,
+	subKind string,
+	sqn *scopes.QualifiedName,
+	opts GetOpts,
+) (Collection, error) {
+	if subKind != "" {
+		// The generic rejectSubKind hint would suggest '<scope>::<subKind>',
+		// which is not how bot instances are addressed, so use a
+		// bot_instance-specific message.
+		return nil, trace.BadParameter(
+			"resource type %q does not support sub-kinds (got %q)\n"+
+				"hint: address an instance of a scoped bot with a scope-qualified name:\n"+
+				"  tctl get %s <scope>::<bot_name>/<instance_id>",
+			types.KindBotInstance, subKind, types.KindBotInstance,
+		)
+	}
+	if sqn == nil {
+		// No SQN was provided, so this is a list-all. The classic handler
+		// normally serves list-all (bot_instance is registered in both maps),
+		// but fall back to it here for safety.
+		return getBotInstance(ctx, client, services.Ref{Kind: types.KindBotInstance}, opts)
+	}
+
+	c := client.BotInstanceServiceClient()
+
+	// The name component is either <bot_name>/<instance_id>, addressing a
+	// single instance, or a bare <bot_name>, listing the scoped bot's
+	// instances. The scope travels in the request: the server resolves it
+	// against scope-qualified storage, so a wrong-scope read is a not-found
+	// and no client-side scope comparison is needed.
+	if botName, instanceID, ok := strings.Cut(sqn.Name, "/"); ok {
+		bi, err := c.GetBotInstance(ctx, machineidv1pb.GetBotInstanceRequest_builder{
+			BotName:    botName,
+			InstanceId: instanceID,
+			BotScope:   sqn.Scope,
+		}.Build())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &botInstanceCollection{items: []*machineidv1pb.BotInstance{bi}}, nil
+	}
+
+	instances, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, pageToken string) ([]*machineidv1pb.BotInstance, string, error) {
+		resp, err := c.ListBotInstancesV2(ctx, machineidv1pb.ListBotInstancesV2Request_builder{
+			PageSize:  int32(limit),
+			PageToken: pageToken,
+			Filter: machineidv1pb.ListBotInstancesV2Request_Filters_builder{
+				BotName:  sqn.Name,
+				BotScope: sqn.Scope,
+			}.Build(),
+		}.Build())
+
+		return resp.GetBotInstances(), resp.GetNextPageToken(), trace.Wrap(err)
+	}))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &botInstanceCollection{items: instances}, nil
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -38,6 +38,7 @@ func Handlers() map[string]Handler {
 	return map[string]Handler{
 		types.KindBeamsConfig:         beamsConfigHandler(),
 		types.KindAccessList:          accessListHandler(),
+		types.KindBotInstance:         botInstanceHandler(),
 		types.KindClientIPRestriction: clientIPRestrictionHandler(),
 		types.KindIntegration:         integrationHandler(),
 		types.KindNode:                serverHandler(),

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -38,6 +38,7 @@ func Handlers() map[string]Handler {
 	return map[string]Handler{
 		types.KindBeamsConfig:         beamsConfigHandler(),
 		types.KindAccessList:          accessListHandler(),
+		types.KindBotInstance:         botInstanceHandler(),
 		types.KindClientIPRestriction: clientIPRestrictionHandler(),
 		types.KindNode:                serverHandler(),
 		types.KindKubeServer:          kubeServerHandler(),

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -35,6 +35,7 @@ import (
 func ScopedHandlers() map[string]ScopedHandler {
 	return map[string]ScopedHandler{
 		types.KindNode:                        serverScopedHandler(),
+		types.KindBotInstance:                 botInstanceScopedHandler(),
 		scopedaccess.KindScopedRole:           scopedRoleScopedHandler(),
 		types.KindScopedToken:                 scopedTokenScopedHandler(),
 		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentScopedHandler(),

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -36,6 +36,7 @@ func ScopedHandlers() map[string]ScopedHandler {
 	return map[string]ScopedHandler{
 		types.KindNode:                        serverScopedHandler(),
 		types.KindWorkloadIdentity:            workloadIdentityScopedHandler(),
+		types.KindBotInstance:                 botInstanceScopedHandler(),
 		scopedaccess.KindScopedRole:           scopedRoleScopedHandler(),
 		types.KindScopedToken:                 scopedTokenScopedHandler(),
 		scopedaccess.KindScopedRoleAssignment: scopedRoleAssignmentScopedHandler(),

--- a/tool/tctl/common/scoped_ref.go
+++ b/tool/tctl/common/scoped_ref.go
@@ -120,6 +120,24 @@ func ParseScopedRef(ref, id string) (ScopedRef, error) {
 			qn.Name, _, _ = strings.Cut(qn.Name, ":")
 		}
 
+		// A bot instance is identified by <bot_name>/<uuid> under the bot's scope,
+		// so for bot_instance refs the name component of the SQN may itself be a
+		// two-part identifier containing a '/'. Validate the parts individually
+		// since whole-name validation would reject the separator.
+		if r.Kind == types.KindBotInstance {
+			if botName, instanceID, ok := strings.Cut(qn.Name, "/"); ok {
+				if err := scopes.StrongValidate(qn.Scope); err != nil {
+					return ScopedRef{}, trace.BadParameter("scope-qualified name %q has invalid scope: %v", qn, err)
+				}
+				for _, part := range []string{botName, instanceID} {
+					if err := scopes.StrongValidateSegment(part); err != nil {
+						return ScopedRef{}, trace.BadParameter("scope-qualified name %q has invalid name: %v", qn, err)
+					}
+				}
+				return ScopedRef{Kind: r.Kind, SubKind: subKind, Scope: qn.Scope, Name: qn.Name}, nil
+			}
+		}
+
 		if err := qn.StrongValidate(); err != nil {
 			return ScopedRef{}, trace.Wrap(err)
 		}


### PR DESCRIPTION
Backports #68390
Backports #68391
Backports #69126

## Manual Test Plan

### Test Environment

Local cluster

### Test Cases

- [x] Regression: Run unscoped `tbot` prior to switching this version, ensure unscoped bot instance remains visible via UI and `tctl` after upgrading to these changes. Ensure that on the next renewal, the bot instance remains the same.
- [x] Run `scoped` tbot with Kubernetes join method, ensure Bot Instance is scoped and that the Bot Instance ID remains the same upon consecutive renewals.
- [x] Run `scoped` tbot with Bound Keypair join method, ensure Bot Instance is scoped and that the Bot Instance ID remains the same upon consecutive renewals. Additionally, ensure that recovery behaves as expected.
- [x] `tctl get bot_instances` (by scoped bot, by unscoped bot, without bot)
- [x] `tctl bot instances ls` (and by scoped bot, by unscoped bot)
- [x] `tctl bot instances show` (for unscoped bot instance, scoped bot instance)
- [x] Regression:
  - [x] Validate Web UI still shows all unscoped Bot Instances to an unscoped user.
  - [x] Validate `tctl` still shows all unscoped Bot Instances to an unscoped user.
- [x] Validate `tctl` shows all unscoped and scoped Bot Instances to an unscoped user.
- [x] Validate Web UI shows all unscoped and scoped Bot Instances to an unscoped user.
- [x] Validate `tctl` shows scoped Bot Instances to scoped admin in their scope.

Agentic test plan: https://gist.github.com/strideynet/3e08382f1a544f8a2a6f9ba54aa229c0
