### PR TITLE
Add new private key policy for public Device Trust endpoints

### DIFF
--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -116,17 +116,19 @@ func (p PrivateKeyPolicy) MFAVerified() bool {
 	return p.isHardwareKeyTouchVerified() || p.isHardwareKeyPINVerified()
 }
 
-func (p PrivateKeyPolicy) validate() error {
+func (p PrivateKeyPolicy) validateRequireablePolicy() error {
 	switch p {
 	case PrivateKeyPolicyNone,
 		PrivateKeyPolicyHardwareKey,
 		PrivateKeyPolicyHardwareKeyTouch,
 		PrivateKeyPolicyHardwareKeyPIN,
-		PrivateKeyPolicyHardwareKeyTouchAndPIN,
-		PrivateKeyPolicyWebSession:
+		PrivateKeyPolicyHardwareKeyTouchAndPIN:
 		return nil
 	}
-	return trace.BadParameter("%q is not a valid key policy", p)
+	// Key policies like [PrivateKeyPolicyWebSession] mark an identity as exempt
+	// from key policy checks, so they satisfy every requirement and can never be
+	// one themselves.
+	return trace.BadParameter("%q is not a valid key policy that can be required", p)
 }
 
 // PolicyThatSatisfiesSet returns least restrictive policy necessary to satisfy the given set of policies.
@@ -178,7 +180,7 @@ func ParsePrivateKeyPolicyError(err error) (PrivateKeyPolicy, error) {
 	}
 
 	policy := PrivateKeyPolicy(subMatches[2])
-	if err := policy.validate(); err != nil {
+	if err := policy.validateRequireablePolicy(); err != nil {
 		return "", trace.Wrap(err)
 	}
 	return policy, nil

--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -53,12 +53,29 @@ const (
 	// Instead, this policy must be accompanied by WebAuthn prompts for important operations
 	// in order to pass hardware key policy requirements.
 	PrivateKeyPolicyWebSession PrivateKeyPolicy = "web_session"
+	// PrivateKeyPolicyDeviceTrustPublic is a special case used for the public
+	// Device Trust Service (teleport.devicetrust.public.v1). Clients of that
+	// service hold no user key at all. Instead, they authenticate using either a
+	// short-lived, single-use token (CreatePairedDeviceEnrollToken, EnrollDevice)
+	// or by solving a challenge using a previously enrolled key stored in a TPM
+	// (AuthenticateDevice). As such, a private key policy cannot be enforced
+	// against those clients.
+	//
+	// This policy does not provide the same hardware key guarantee as the above
+	// policies and it must be used only in Device Trust scenarios.
+	PrivateKeyPolicyDeviceTrustPublic PrivateKeyPolicy = "device_trust_public"
 )
 
 // IsSatisfiedBy returns whether this key policy is satisfied by the given key policy.
 func (requiredPolicy PrivateKeyPolicy) IsSatisfiedBy(keyPolicy PrivateKeyPolicy) bool {
 	// Web sessions are treated as a special case that meets all private key policy requirements.
 	if keyPolicy == PrivateKeyPolicyWebSession {
+		return true
+	}
+
+	// Public Device Trust identities have no client key at all and are used only
+	// for specific RPCs.
+	if keyPolicy == PrivateKeyPolicyDeviceTrustPublic {
 		return true
 	}
 

--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -149,9 +149,14 @@ func (p PrivateKeyPolicy) validateRequireablePolicy() error {
 }
 
 // PolicyThatSatisfiesSet returns least restrictive policy necessary to satisfy the given set of policies.
+// Only policies that can be required are accepted.
 func PolicyThatSatisfiesSet(policies []PrivateKeyPolicy) (PrivateKeyPolicy, error) {
 	setPolicy := PrivateKeyPolicyNone
 	for _, policy := range policies {
+		if err := policy.validateRequireablePolicy(); err != nil {
+			return PrivateKeyPolicyNone, trace.Wrap(err)
+		}
+
 		if policy.IsSatisfiedBy(setPolicy) {
 			continue
 		}

--- a/api/utils/keys/policy_test.go
+++ b/api/utils/keys/policy_test.go
@@ -190,6 +190,26 @@ func TestGetPolicyFromSet(t *testing.T) {
 	}
 }
 
+func TestGetPolicyFromSetRejectsNonRequireablePolicies(t *testing.T) {
+	rejectedPolicies := append(slices.Clone(identityOnlyPrivateKeyPolicies),
+		keys.PrivateKeyPolicy("unknown_key_policy"))
+
+	for _, policy := range rejectedPolicies {
+		t.Run(string(policy), func(t *testing.T) {
+			for _, policySet := range [][]keys.PrivateKeyPolicy{
+				{policy},
+				{keys.PrivateKeyPolicyHardwareKeyTouch, policy},
+				{policy, keys.PrivateKeyPolicyHardwareKeyTouch},
+			} {
+				returnedPolicy, err := keys.PolicyThatSatisfiesSet(policySet)
+				assert.ErrorAs(t, err, new(*trace.BadParameterError), "policy set %v", policySet)
+				// This is just to a get better failure message if the test fails.
+				assert.Equal(t, keys.PrivateKeyPolicyNone, returnedPolicy, "policy set %v", policySet)
+			}
+		})
+	}
+}
+
 // TestParsePrivateKeyPolicyError tests private key policy error parsing and checking.
 func TestParsePrivateKeyPolicyError(t *testing.T) {
 	type testCase struct {

--- a/api/utils/keys/policy_test.go
+++ b/api/utils/keys/policy_test.go
@@ -22,18 +22,21 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/utils/keys"
 )
 
 var (
-	privateKeyPolicies = []keys.PrivateKeyPolicy{
+	requireablePrivateKeyPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyNone,
 		keys.PrivateKeyPolicyHardwareKey,
 		keys.PrivateKeyPolicyHardwareKeyTouch,
 		keys.PrivateKeyPolicyHardwareKeyPIN,
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
+	}
+	identityOnlyPrivateKeyPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyWebSession,
 	}
 	hardwareKeyPolicies = []keys.PrivateKeyPolicy{
@@ -60,20 +63,13 @@ var (
 )
 
 func TestIsRequiredPolicyMet(t *testing.T) {
-	privateKeyPolicies := []keys.PrivateKeyPolicy{
-		keys.PrivateKeyPolicyNone,
-		keys.PrivateKeyPolicyHardwareKey,
-		keys.PrivateKeyPolicyHardwareKeyTouch,
-		keys.PrivateKeyPolicyHardwareKeyPIN,
-		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
-	}
 	for _, tc := range []struct {
 		requiredPolicy     keys.PrivateKeyPolicy
 		satisfyingPolicies []keys.PrivateKeyPolicy
 	}{
 		{
 			requiredPolicy:     keys.PrivateKeyPolicyNone,
-			satisfyingPolicies: privateKeyPolicies,
+			satisfyingPolicies: requireablePrivateKeyPolicies,
 		}, {
 			requiredPolicy:     keys.PrivateKeyPolicyHardwareKey,
 			satisfyingPolicies: hardwareKeyPolicies,
@@ -89,13 +85,29 @@ func TestIsRequiredPolicyMet(t *testing.T) {
 		},
 	} {
 		t.Run(string(tc.requiredPolicy), func(t *testing.T) {
-			for _, keyPolicy := range privateKeyPolicies {
+			for _, keyPolicy := range requireablePrivateKeyPolicies {
 				if tc.requiredPolicy.IsSatisfiedBy(keyPolicy) {
 					require.Contains(t, tc.satisfyingPolicies, keyPolicy, "Policy %q does not meet %q but IsRequirePolicyMet(%v, %v) returned true", keyPolicy, tc.requiredPolicy, tc.requiredPolicy, keyPolicy)
 				} else {
 					require.NotContains(t, tc.satisfyingPolicies, keyPolicy, "Policy %q does meet %q but IsRequirePolicyMet(%v, %v) returned false", keyPolicy, tc.requiredPolicy, tc.requiredPolicy, keyPolicy)
 				}
 			}
+		})
+	}
+}
+
+func TestIdentityOnlyPrivateKeyPolicies(t *testing.T) {
+	for _, policy := range identityOnlyPrivateKeyPolicies {
+		t.Run(string(policy), func(t *testing.T) {
+			for _, requiredPolicy := range requireablePrivateKeyPolicies {
+				assert.True(t, requiredPolicy.IsSatisfiedBy(policy), "%q does not satisfy %q", policy, requiredPolicy)
+			}
+
+			assert.False(t, policy.IsHardwareKeyPolicy(), "%q must not count as a hardware key policy", policy)
+			assert.False(t, policy.MFAVerified(), "%q must not count as MFA verification", policy)
+
+			_, err := keys.ParsePrivateKeyPolicyError(keys.NewPrivateKeyPolicyError(policy))
+			assert.Error(t, err, "%q must not parse as a required policy", policy)
 		})
 	}
 }
@@ -207,7 +219,7 @@ func TestParsePrivateKeyPolicyError(t *testing.T) {
 		},
 	}
 
-	for _, policy := range privateKeyPolicies {
+	for _, policy := range requireablePrivateKeyPolicies {
 		testCases = append(testCases, testCase{
 			desc:              fmt.Sprintf("valid key policy: %v", policy),
 			errIn:             keys.NewPrivateKeyPolicyError(policy),

--- a/api/utils/keys/policy_test.go
+++ b/api/utils/keys/policy_test.go
@@ -38,6 +38,7 @@ var (
 	}
 	identityOnlyPrivateKeyPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyWebSession,
+		keys.PrivateKeyPolicyDeviceTrustPublic,
 	}
 	hardwareKeyPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyHardwareKey,
@@ -45,20 +46,24 @@ var (
 		keys.PrivateKeyPolicyHardwareKeyPIN,
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
 		keys.PrivateKeyPolicyWebSession,
+		keys.PrivateKeyPolicyDeviceTrustPublic,
 	}
 	hardwareKeyTouchPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyHardwareKeyTouch,
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
 		keys.PrivateKeyPolicyWebSession,
+		keys.PrivateKeyPolicyDeviceTrustPublic,
 	}
 	hardwareKeyPINPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyHardwareKeyPIN,
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
 		keys.PrivateKeyPolicyWebSession,
+		keys.PrivateKeyPolicyDeviceTrustPublic,
 	}
 	hardwareKeyTouchAndPINPolicies = []keys.PrivateKeyPolicy{
 		keys.PrivateKeyPolicyHardwareKeyTouchAndPIN,
 		keys.PrivateKeyPolicyWebSession,
+		keys.PrivateKeyPolicyDeviceTrustPublic,
 	}
 )
 


### PR DESCRIPTION
This is pretty much done and was authored by me, but it doesn't have to land right now and I don't want to spend time just yet on addressing feedback (see my status update from Aug 3rd).

The policy is used in https://github.com/gravitational/teleport.e/pull/9342.