### PR TITLE
`lib/devicetrust/grpcproxy`: Forward client IP in a header

### DIFF
--- a/lib/devicetrust/client_src_addr.go
+++ b/lib/devicetrust/client_src_addr.go
@@ -18,6 +18,7 @@ package devicetrust
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strconv"
 
@@ -43,22 +44,31 @@ func WithForwardedClientSrcAddr(ctx context.Context, addr net.Addr) context.Cont
 	return metadata.AppendToOutgoingContext(ctx, clientSrcAddrKey, addr.String())
 }
 
+// ErrClientSrcAddrNotForwarded means that the Proxy Service did not forward the
+// calling device's source address.
+var ErrClientSrcAddrNotForwarded = errors.New("the Proxy Service did not forward the client source address")
+
 // ForwardedClientSrcAddrFromContext returns the device source address that the
 // Proxy Service forwarded with an incoming public Device Trust RPC.
 //
 // Any client can attach metadata to a request, so a caller must establish that
 // the peer holds the Proxy builtin role before it trusts the result.
+//
+// Every error here describes a Proxy that sent nothing usable, which a device
+// has no way to bring about. None of them carry a [trace] kind, so they reach a
+// device as an unclassified server-side failure instead of something it might
+// act on, and callers pass them through rather than reinterpreting them.
 func ForwardedClientSrcAddrFromContext(ctx context.Context) (*net.TCPAddr, error) {
 	vals := metadata.ValueFromIncomingContext(ctx, clientSrcAddrKey)
 	switch len(vals) {
 	case 1:
 	case 0:
-		return nil, trace.NotFound("client source address not forwarded")
+		return nil, trace.Wrap(ErrClientSrcAddrNotForwarded)
 	default:
 		// A single Proxy hop sets the key exactly once. Picking one of several
 		// values would let whoever supplied the extra one choose the address
 		// that gets enforced.
-		return nil, trace.BadParameter("client source address forwarded more than once")
+		return nil, trace.Errorf("client source address forwarded more than once")
 	}
 
 	host, port, err := net.SplitHostPort(vals[0])
@@ -70,11 +80,11 @@ func ForwardedClientSrcAddrFromContext(ctx context.Context) (*net.TCPAddr, error
 	// the Proxy observed, and IP pinning compares numeric addresses.
 	ip := net.ParseIP(host)
 	if ip == nil {
-		return nil, trace.BadParameter("forwarded client source address %q is not an IP address", host)
+		return nil, trace.Errorf("forwarded client source address %q is not an IP address", host)
 	}
 	portNum, err := strconv.Atoi(port)
 	if err != nil {
-		return nil, trace.BadParameter("forwarded client source port %q is not a number", port)
+		return nil, trace.Errorf("forwarded client source port %q is not a number", port)
 	}
 
 	return &net.TCPAddr{IP: ip, Port: portNum}, nil

--- a/lib/devicetrust/client_src_addr.go
+++ b/lib/devicetrust/client_src_addr.go
@@ -1,0 +1,81 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package devicetrust
+
+import (
+	"context"
+	"net"
+	"strconv"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc/metadata"
+)
+
+// clientSrcAddrKey is the gRPC metadata key carrying the source address of the
+// device that called a public Device Trust RPC.
+//
+// The public RPCs are unauthenticated from the end user's perspective, so a
+// device reaches the Auth Service through the Proxy Service and Auth sees the
+// Proxy as its peer. Without the forwarded address Auth has no way to tell
+// where the device connected from.
+const clientSrcAddrKey = "devicetrust-client-src-addr"
+
+// WithForwardedClientSrcAddr returns a context that carries addr to the Auth
+// Service on outgoing public Device Trust RPCs.
+//
+// Only the Proxy Service may set this, see
+// [ForwardedClientSrcAddrFromContext].
+func WithForwardedClientSrcAddr(ctx context.Context, addr net.Addr) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, clientSrcAddrKey, addr.String())
+}
+
+// ForwardedClientSrcAddrFromContext returns the device source address that the
+// Proxy Service forwarded with an incoming public Device Trust RPC.
+//
+// Any client can attach metadata to a request, so a caller must establish that
+// the peer holds the Proxy builtin role before it trusts the result.
+func ForwardedClientSrcAddrFromContext(ctx context.Context) (*net.TCPAddr, error) {
+	vals := metadata.ValueFromIncomingContext(ctx, clientSrcAddrKey)
+	switch len(vals) {
+	case 1:
+	case 0:
+		return nil, trace.NotFound("client source address not forwarded")
+	default:
+		// A single Proxy hop sets the key exactly once. Picking one of several
+		// values would let whoever supplied the extra one choose the address
+		// that gets enforced.
+		return nil, trace.BadParameter("client source address forwarded more than once")
+	}
+
+	host, port, err := net.SplitHostPort(vals[0])
+	if err != nil {
+		return nil, trace.Wrap(err, "parse forwarded client source address")
+	}
+
+	// Reject anything that would need resolving: the address has to be the one
+	// the Proxy observed, and IP pinning compares numeric addresses.
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, trace.BadParameter("forwarded client source address %q is not an IP address", host)
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		return nil, trace.BadParameter("forwarded client source port %q is not a number", port)
+	}
+
+	return &net.TCPAddr{IP: ip, Port: portNum}, nil
+}

--- a/lib/devicetrust/client_src_addr_test.go
+++ b/lib/devicetrust/client_src_addr_test.go
@@ -21,11 +21,13 @@ import (
 	"net"
 	"testing"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
+	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/lib/devicetrust"
 )
 
@@ -50,9 +52,41 @@ func TestForwardedClientSrcAddr(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("returns NotFound when nothing was forwarded", func(t *testing.T) {
+	t.Run("reports that nothing was forwarded", func(t *testing.T) {
 		_, err := devicetrust.ForwardedClientSrcAddrFromContext(t.Context())
-		assert.ErrorAs(t, err, new(*trace.NotFoundError))
+		assert.ErrorIs(t, err, devicetrust.ErrClientSrcAddrNotForwarded)
+	})
+
+	// A device cannot keep the Proxy from forwarding its address, so none of
+	// these may reach it as an error about its own request. NotFound especially:
+	// the enroll pairing RPC uses it for a pairing that is gone, which would
+	// have a device stop polling over what is really a Proxy fault.
+	t.Run("blames no error on the calling device", func(t *testing.T) {
+		for _, test := range []struct {
+			name string
+			ctx  context.Context
+		}{
+			{name: "nothing forwarded", ctx: t.Context()},
+			{
+				name: "forwarded twice",
+				ctx: asIncoming(t, devicetrust.WithForwardedClientSrcAddr(
+					devicetrust.WithForwardedClientSrcAddr(t.Context(),
+						&net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 4242}),
+					&net.TCPAddr{IP: net.ParseIP("192.0.2.11"), Port: 4242})),
+			},
+			{
+				name: "malformed",
+				ctx: metadata.NewIncomingContext(t.Context(),
+					metadata.Pairs("devicetrust-client-src-addr", "not-an-address")),
+			},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := devicetrust.ForwardedClientSrcAddrFromContext(test.ctx)
+				require.Error(t, err)
+				assert.Equal(t, codes.Unknown, status.Code(trail.ToGRPC(err)),
+					"error reaches the device as %v", status.Code(trail.ToGRPC(err)))
+			})
+		}
 	})
 
 	// A second value would otherwise let whoever supplied it pick the address
@@ -64,7 +98,6 @@ func TestForwardedClientSrcAddr(t *testing.T) {
 			&net.TCPAddr{IP: net.ParseIP("192.0.2.11"), Port: 4242})
 
 		_, err := devicetrust.ForwardedClientSrcAddrFromContext(asIncoming(t, ctx))
-		assert.ErrorAs(t, err, new(*trace.BadParameterError))
 		assert.ErrorContains(t, err, "more than once")
 	})
 

--- a/lib/devicetrust/client_src_addr_test.go
+++ b/lib/devicetrust/client_src_addr_test.go
@@ -1,0 +1,115 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package devicetrust_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/gravitational/teleport/lib/devicetrust"
+)
+
+func TestForwardedClientSrcAddr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round trips the address the proxy observed", func(t *testing.T) {
+		want := &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 4242}
+
+		got, err := devicetrust.ForwardedClientSrcAddrFromContext(
+			asIncoming(t, devicetrust.WithForwardedClientSrcAddr(t.Context(), want)))
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("round trips an IPv6 address", func(t *testing.T) {
+		want := &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 4242}
+
+		got, err := devicetrust.ForwardedClientSrcAddrFromContext(
+			asIncoming(t, devicetrust.WithForwardedClientSrcAddr(t.Context(), want)))
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns NotFound when nothing was forwarded", func(t *testing.T) {
+		_, err := devicetrust.ForwardedClientSrcAddrFromContext(t.Context())
+		assert.ErrorAs(t, err, new(*trace.NotFoundError))
+	})
+
+	// A second value would otherwise let whoever supplied it pick the address
+	// that gets enforced.
+	t.Run("rejects a second forwarded address", func(t *testing.T) {
+		ctx := devicetrust.WithForwardedClientSrcAddr(t.Context(),
+			&net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 4242})
+		ctx = devicetrust.WithForwardedClientSrcAddr(ctx,
+			&net.TCPAddr{IP: net.ParseIP("192.0.2.11"), Port: 4242})
+
+		_, err := devicetrust.ForwardedClientSrcAddrFromContext(asIncoming(t, ctx))
+		assert.ErrorAs(t, err, new(*trace.BadParameterError))
+		assert.ErrorContains(t, err, "more than once")
+	})
+
+	for _, test := range []struct {
+		name, addr, wantErr string
+	}{
+		{
+			name:    "no port",
+			addr:    "192.0.2.10",
+			wantErr: "parse forwarded client source address",
+		},
+		{
+			name:    "hostname instead of an IP",
+			addr:    "device.example.com:4242",
+			wantErr: "is not an IP address",
+		},
+		{
+			name:    "named port",
+			addr:    "192.0.2.10:https",
+			wantErr: "is not a number",
+		},
+		{
+			name:    "empty",
+			addr:    "",
+			wantErr: "parse forwarded client source address",
+		},
+	} {
+		t.Run("rejects "+test.name, func(t *testing.T) {
+			// Spelled out rather than taken from the package, so that a change
+			// to the wire key shows up as a failure here.
+			ctx := metadata.NewIncomingContext(t.Context(),
+				metadata.Pairs("devicetrust-client-src-addr", test.addr))
+
+			_, err := devicetrust.ForwardedClientSrcAddrFromContext(ctx)
+			assert.Error(t, err)
+			assert.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+// asIncoming turns the outgoing metadata that [devicetrust.WithForwardedClientSrcAddr]
+// sets into incoming metadata, standing in for the gRPC round trip.
+func asIncoming(t *testing.T, ctx context.Context) context.Context {
+	t.Helper()
+	md, ok := metadata.FromOutgoingContext(ctx)
+	require.True(t, ok, "no outgoing metadata in context")
+	return metadata.NewIncomingContext(ctx, md)
+}

--- a/lib/devicetrust/grpcproxy/grpcproxy.go
+++ b/lib/devicetrust/grpcproxy/grpcproxy.go
@@ -21,8 +21,10 @@ import (
 	"log/slog"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/grpc/peer"
 
 	publicdevicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1"
+	"github.com/gravitational/teleport/lib/devicetrust"
 )
 
 // AuthClient is a subset of the full Auth API that must be connected.
@@ -62,6 +64,25 @@ type Service struct {
 // CreatePairedDeviceEnrollToken forwards the request to the same RPC in the
 // Auth Service.
 func (s *Service) CreatePairedDeviceEnrollToken(ctx context.Context, req *publicdevicepb.CreatePairedDeviceEnrollTokenRequest) (*publicdevicepb.CreatePairedDeviceEnrollTokenResponse, error) {
+	ctx, err := forwardClientSrcAddr(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	res, err := s.authClient.PublicDevicesClient().CreatePairedDeviceEnrollToken(ctx, req)
 	return res, trace.Wrap(err)
+}
+
+// forwardClientSrcAddr adds the calling device's source address to ctx.
+//
+// This service terminates the device's connection, so the Auth Service only
+// ever sees this Proxy as its peer and cannot observe the address itself.
+// Metadata the device sent does not carry over to the outgoing call, so a
+// device cannot choose the address the Auth Service enforces.
+func forwardClientSrcAddr(ctx context.Context) (context.Context, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return nil, trace.Errorf("no peer address for the calling device")
+	}
+	return devicetrust.WithForwardedClientSrcAddr(ctx, p.Addr), nil
 }

--- a/lib/devicetrust/grpcproxy/grpcproxy_test.go
+++ b/lib/devicetrust/grpcproxy/grpcproxy_test.go
@@ -28,13 +28,21 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	publicdevicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/public/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	grpcinterceptors "github.com/gravitational/teleport/api/utils/grpc/interceptors"
+	"github.com/gravitational/teleport/lib/devicetrust"
 )
+
+// testClientAddr stands in for the address of the device calling the proxy.
+// bufconn reports a placeholder peer address, so the proxy's inbound server has
+// a real one injected instead.
+var testClientAddr = &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 4242}
 
 func TestService_CreatePairedDeviceEnrollToken(t *testing.T) {
 	t.Parallel()
@@ -62,6 +70,44 @@ func TestService_CreatePairedDeviceEnrollToken(t *testing.T) {
 		assert.Empty(t, cmp.Diff(req, fake.getLastReq(), protocmp.Transform()))
 	})
 
+	t.Run("forwards the address the calling device connected from", func(t *testing.T) {
+		fake := &fakeAuthService{}
+		client := newProxyClient(t, fake)
+
+		_, err := client.CreatePairedDeviceEnrollToken(t.Context(),
+			publicdevicepb.CreatePairedDeviceEnrollTokenRequest_builder{
+				EnrollPairingToken: "pairing-token",
+			}.Build())
+		require.NoError(t, err)
+
+		got, err := devicetrust.ForwardedClientSrcAddrFromContext(
+			metadata.NewIncomingContext(t.Context(), fake.getLastMD()))
+		require.NoError(t, err)
+		assert.Equal(t, testClientAddr, got)
+	})
+
+	// The device picking its own source address would defeat IP pinning, so what
+	// it sends must not reach the auth service.
+	t.Run("ignores a source address supplied by the calling device", func(t *testing.T) {
+		fake := &fakeAuthService{}
+		client := newProxyClient(t, fake)
+
+		spoofed := devicetrust.WithForwardedClientSrcAddr(t.Context(),
+			&net.TCPAddr{IP: net.ParseIP("198.51.100.7"), Port: 1})
+		_, err := client.CreatePairedDeviceEnrollToken(spoofed,
+			publicdevicepb.CreatePairedDeviceEnrollTokenRequest_builder{
+				EnrollPairingToken: "pairing-token",
+			}.Build())
+		require.NoError(t, err)
+
+		// A single value, so the spoofed address neither won nor turned the
+		// forwarded address ambiguous.
+		got, err := devicetrust.ForwardedClientSrcAddrFromContext(
+			metadata.NewIncomingContext(t.Context(), fake.getLastMD()))
+		require.NoError(t, err)
+		assert.Equal(t, testClientAddr, got)
+	})
+
 	t.Run("propagates errors from the auth service", func(t *testing.T) {
 		fake := &fakeAuthService{err: trace.AccessDenied("denied")}
 		client := newProxyClient(t, fake)
@@ -83,11 +129,13 @@ type fakeAuthService struct {
 
 	mu      sync.Mutex
 	lastReq *publicdevicepb.CreatePairedDeviceEnrollTokenRequest
+	lastMD  metadata.MD
 }
 
-func (f *fakeAuthService) CreatePairedDeviceEnrollToken(_ context.Context, req *publicdevicepb.CreatePairedDeviceEnrollTokenRequest) (*publicdevicepb.CreatePairedDeviceEnrollTokenResponse, error) {
+func (f *fakeAuthService) CreatePairedDeviceEnrollToken(ctx context.Context, req *publicdevicepb.CreatePairedDeviceEnrollTokenRequest) (*publicdevicepb.CreatePairedDeviceEnrollTokenResponse, error) {
 	f.mu.Lock()
 	f.lastReq = req
+	f.lastMD, _ = metadata.FromIncomingContext(ctx)
 	f.mu.Unlock()
 	return f.resp, f.err
 }
@@ -96,6 +144,12 @@ func (f *fakeAuthService) getLastReq() *publicdevicepb.CreatePairedDeviceEnrollT
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.lastReq
+}
+
+func (f *fakeAuthService) getLastMD() metadata.MD {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastMD
 }
 
 // fakeAuthClient adapts a public Device Trust client to the [AuthClient] interface.
@@ -117,18 +171,27 @@ func newProxyClient(t *testing.T, authSvc publicdevicepb.DeviceTrustServiceServe
 	proxy, err := New(ServiceConfig{AuthClient: authClient})
 	require.NoError(t, err)
 
-	return newGRPCClient(t, proxy)
+	return newGRPCClient(t, proxy, withPeerAddr(testClientAddr))
+}
+
+// withPeerAddr reports addr as the peer address to the handler, standing in for
+// the address a device would connect from over a real transport.
+func withPeerAddr(addr net.Addr) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		return handler(peer.NewContext(ctx, &peer.Peer{Addr: addr}), req)
+	}
 }
 
 // newGRPCClient serves svc on an in-memory bufconn listener and returns a client
 // dialed over it. bufconn keeps the transport off the real network so tests can
 // run inside a synctest bubble.
-func newGRPCClient(t *testing.T, svc publicdevicepb.DeviceTrustServiceServer) publicdevicepb.DeviceTrustServiceClient {
+func newGRPCClient(t *testing.T, svc publicdevicepb.DeviceTrustServiceServer, extra ...grpc.UnaryServerInterceptor) publicdevicepb.DeviceTrustServiceClient {
 	t.Helper()
 
 	lis := bufconn.Listen(1024)
 	server := grpc.NewServer(
-		grpc.ChainUnaryInterceptor(grpcinterceptors.GRPCServerUnaryErrorInterceptor),
+		grpc.ChainUnaryInterceptor(
+			append([]grpc.UnaryServerInterceptor{grpcinterceptors.GRPCServerUnaryErrorInterceptor}, extra...)...),
 	)
 	publicdevicepb.RegisterDeviceTrustServiceServer(server, svc)
 	go func() {


### PR DESCRIPTION
* e counterpart: https://github.com/gravitational/teleport.e/pull/9343

TODO:

* [ ] Author the code.