### PR TITLE
feat: Beams BYOI banner (web)

### DIFF
--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -2014,4 +2014,7 @@ type ClientI interface {
 
 	// BeamServiceClient returns a client for the beam service.
 	BeamServiceClient() beamsv1.BeamServiceClient
+
+	// BeamsConfigServiceClient returns a client for the beams config service.
+	BeamsConfigServiceClient() beamsv1.BeamsConfigServiceClient
 }

--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -159,6 +159,8 @@ type UserACL struct {
 	AutoUpdateAgentReport ResourceAccess `json:"autoUpdateAgentReport"`
 	// Beam defines access to Beams
 	Beam ResourceAccess `json:"beam"`
+	// BeamsConfig defines access to Beams config
+	BeamsConfig ResourceAccess `json:"beamsConfig"`
 	// MobileDevice defines permissions for the mobile_device resource.
 	MobileDevice MobileDeviceAccess `json:"mobileDevice"`
 }
@@ -280,8 +282,10 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 
 	beamsEntitlement := modules.GetProtoEntitlement(&features, entitlements.Beams)
 	var beam ResourceAccess
+	var beamsConfig ResourceAccess
 	if beamsEntitlement.Enabled {
 		beam = newAccess(userRoles, ctx, types.KindBeam)
+		beamsConfig = newAccess(userRoles, ctx, types.KindBeamsConfig)
 	}
 
 	mobileDevice := MobileDeviceAccess{
@@ -345,6 +349,7 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 		AutoUpdateAgentRollout:   autoUpdateAgentRollout,
 		AutoUpdateAgentReport:    autoUpdateAgentReport,
 		Beam:                     beam,
+		BeamsConfig:              beamsConfig,
 		MobileDevice:             mobileDevice,
 	}
 }

--- a/tool/tctl/common/resources/beams_config.go
+++ b/tool/tctl/common/resources/beams_config.go
@@ -75,7 +75,7 @@ func updateBeamsConfig(ctx context.Context, client *authclient.Client, raw servi
 		}.Build()); err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Println("beams_config has been created")
+		fmt.Println("beams_config has been updated")
 		return nil
 	}
 

--- a/web/packages/teleport/src/mocks/contexts.ts
+++ b/web/packages/teleport/src/mocks/contexts.ts
@@ -91,6 +91,7 @@ export const allAccessAcl: Acl = {
   inferenceModel: fullAccess,
   inferenceSecret: fullAccess,
   beam: fullAccess,
+  beamsConfig: fullAccess,
   classifier: fullAccess,
   mobileDevice: { createEnrollToken: true },
 };

--- a/web/packages/teleport/src/services/resources/types.ts
+++ b/web/packages/teleport/src/services/resources/types.ts
@@ -263,6 +263,8 @@ export enum ResourceKind {
   AutoUpdateVersion = 'autoupdate_version',
   Bot = 'bot',
   BotInstance = 'bot_instance',
+  Beam = 'beam',
+  BeamsConfig = 'beams_config',
   CertAuthority = 'cert_authority',
   ClusterAlert = 'cluster_alert',
   ClusterAuditConfig = 'cluster_audit_config',

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -399,29 +399,17 @@ export const storageService = {
   },
 
   /**
-   * Returns true if the user has dismissed the BYOI banner in the current
-   * browser session.
-   *
-   * NOTE: uses session storage instead of local storage
+   * Returns true if the user has dismissed the BYOI banner.
    */
   getBeamsByoiBannerDismissed(): boolean {
-    const item = window.sessionStorage.getItem(
-      KeysEnum.BEAMS_BYOI_BANNER_DISMISSED
-    );
-    if (item) {
-      return JSON.parse(item);
-    }
-    return false;
+    return this.getParsedJSONValue(KeysEnum.BEAMS_BYOI_BANNER_DISMISSED, false);
   },
 
   /**
-   * Sets whether the user has dismissed the BYOI banner in the current browser
-   * session.
-   *
-   * NOTE: uses session storage instead of local storage
+   * Sets whether the user has dismissed the BYOI banner.
    */
   setBeamsByoiBannerDismissed(dismissed: boolean) {
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       KeysEnum.BEAMS_BYOI_BANNER_DISMISSED,
       JSON.stringify(dismissed)
     );

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -397,4 +397,33 @@ export const storageService = {
   setScopeSelected(s: boolean) {
     window.localStorage.setItem(KeysEnum.SCOPE_SELECTED, JSON.stringify(s));
   },
+
+  /**
+   * Returns true if the user has dismissed the BYOI banner in the current
+   * browser session.
+   *
+   * NOTE: uses session storage instead of local storage
+   */
+  getBeamsByoiBannerDismissed(): boolean {
+    const item = window.sessionStorage.getItem(
+      KeysEnum.BEAMS_BYOI_BANNER_DISMISSED
+    );
+    if (item) {
+      return JSON.parse(item);
+    }
+    return false;
+  },
+
+  /**
+   * Sets whether the user has dismissed the BYOI banner in the current browser
+   * session.
+   *
+   * NOTE: uses session storage instead of local storage
+   */
+  setBeamsByoiBannerDismissed(dismissed: boolean) {
+    window.sessionStorage.setItem(
+      KeysEnum.BEAMS_BYOI_BANNER_DISMISSED,
+      JSON.stringify(dismissed)
+    );
+  },
 };

--- a/web/packages/teleport/src/services/storageService/types.ts
+++ b/web/packages/teleport/src/services/storageService/types.ts
@@ -72,6 +72,7 @@ export const KeysEnum = {
   // TODO(bl-nero): Remove this once the login scope picker is operational.
   USE_LOGIN_SCOPE_PICKER: 'grv_teleport_use_login_scope_picker',
   SCOPE_SELECTED: 'grv_teleport_scope_selected',
+  BEAMS_BYOI_BANNER_DISMISSED: 'grv_teleport_beams_byoi_banner_dismissed',
 };
 
 // SurveyRequest is the request for sending data to the back end

--- a/web/packages/teleport/src/services/user/makeAcl.ts
+++ b/web/packages/teleport/src/services/user/makeAcl.ts
@@ -105,6 +105,7 @@ export function makeAcl(json): Acl {
   const classifier = json.classifier || defaultAccess;
 
   const beam = json.beam || defaultAccess;
+  const beamsConfig = json.beamsConfig || defaultAccess;
 
   const mobileDevice = json.mobileDevice || defaultMobileDeviceAccess;
 
@@ -163,6 +164,7 @@ export function makeAcl(json): Acl {
     inferenceSecret,
     classifier,
     beam,
+    beamsConfig,
     mobileDevice,
   };
 }

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -146,6 +146,7 @@ export interface Acl {
   inferenceSecret: Access;
   classifier: Access;
   beam: Access;
+  beamsConfig: Access;
   mobileDevice: MobileDeviceAccess;
 }
 

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -396,6 +396,13 @@ test('undefined values in context response gives proper default values', async (
       create: false,
       remove: false,
     },
+    beamsConfig: {
+      list: false,
+      read: false,
+      edit: false,
+      create: false,
+      remove: false,
+    },
     classifier: {
       list: false,
       read: false,

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -323,6 +323,10 @@ export default class StoreUserContext extends Store<UserContext> {
     return this.state.acl.beam;
   }
 
+  getBeamsConfigAccess() {
+    return this.state.acl.beamsConfig;
+  }
+
   getMobileDeviceAccess() {
     return this.state.acl.mobileDevice;
   }

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -249,6 +249,7 @@ class TeleportContext implements types.Context {
         userContext.getInferenceSecretAccess().list,
       listBeam: userContext.getBeamAccess().list,
       readBeam: userContext.getBeamAccess().read,
+      readBeamsConfig: userContext.getBeamsConfigAccess().read,
     };
   }
 }
@@ -307,6 +308,7 @@ export const disabledFeatureFlags: types.FeatureFlags = {
   sessionSummaries: false,
   listBeam: false,
   readBeam: false,
+  readBeamsConfig: false,
 };
 
 export default TeleportContext;

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -253,6 +253,7 @@ export interface FeatureFlags {
   sessionSummaries: boolean;
   listBeam: boolean;
   readBeam: boolean;
+  readBeamsConfig: boolean;
 }
 
 // LockedFeatures are used for determining which features are disabled in the user's cluster.


### PR DESCRIPTION
## Summary

This is an assortment of foundational changes required for the Beams BYOI (Bring Your Own Inference) prompt. The main changes are in teleport.e (https://github.com/gravitational/teleport.e/pull/9352).

Depends on: https://github.com/gravitational/teleport/pull/67670

## Changes

- Expose `beams_config` ACL to the frontend
- Add a **local storage** key and get/set utils
- Fix success copy for `tctl edit 'beams_config'`

## Demo

See [e PR](https://github.com/gravitational/teleport.e/pull/9352).

## Manual Test Plan 

See [e PR](https://github.com/gravitational/teleport.e/pull/9352).