### PR TITLE
Add docs for cleanup of deactivated Okta user assignments

### DIFF
--- a/docs/pages/identity-governance/integrations/okta/reference.mdx
+++ b/docs/pages/identity-governance/integrations/okta/reference.mdx
@@ -118,11 +118,11 @@ to see these resources.
 
 ### Warnings about assignments for deactivated users
 
-A deactivated Okta user can be reactivated. Teleport keeps some Okta assignments
-for deactivated users where Teleport is still responsible for revoking access in
+A deactivated Okta user can be reactivated. Teleport keeps some Okta assignments 
+for deactivated users where Teleport is still responsible for revoking access in 
 Okta if the user is reactivated.
 
-Teleport will log a warning for each of a deactivated Okta user's remaining
+Teleport will log a warning for each of a deactivated user's remaining 
 Okta assignments that need to be cleaned up.
 
 ```text
@@ -139,8 +139,8 @@ $ tctl delete okta_assignments/my-assignment
 ```
 
 <Admonition type="warning">
-If you remove the Okta assignment manually and then reactivate the user in Okta,
-This can result in any previously authorized access through an Access Request
+If you remove the Okta assignment manually and then reactivate the user in Okta, 
+this can result in previously authorized access through an Access Request 
 (JIT) to be reinstated as standing access.
 </Admonition>
 

--- a/docs/pages/identity-governance/integrations/okta/reference.mdx
+++ b/docs/pages/identity-governance/integrations/okta/reference.mdx
@@ -135,7 +135,7 @@ To stop the warnings, either:
 - Remove the Okta assignment from Teleport manually: 
 
 ```code
-$ tctl delete okta_assignments/my-assignment
+$ tctl rm okta_assignments/my-assignment
 ```
 
 <Admonition type="warning">

--- a/docs/pages/identity-governance/integrations/okta/reference.mdx
+++ b/docs/pages/identity-governance/integrations/okta/reference.mdx
@@ -115,3 +115,32 @@ If they are, double check the user permissions and ensure that the user has
 appropriate resource and label level access to the groups and applications. You
 may need to tweak the `app_labels` and `group_labels` sections of a role in order
 to see these resources.
+
+### Warnings about assignments for deactivated users
+
+A deactivated Okta user can be reactivated. Teleport keeps some Okta assignments
+for deactivated users where Teleport is still responsible for revoking access in
+Okta if the user is reactivated.
+
+Teleport will log a warning for each of a deactivated Okta user's remaining
+Okta assignments that need to be cleaned up.
+
+```text
+This assignment's user is deactivated. The okta_assignment will be automatically removed when the user is removed in Okta. 
+```
+
+To stop the warnings, either: 
+
+- Remove the user from Okta. This will result in any Okta assignments for that user in Teleport being removed.
+- Remove the Okta assignment from Teleport manually: 
+
+```code
+$ tctl delete okta_assignments/my-assignment
+```
+
+<Admonition type="warning">
+If you remove the Okta assignment manually and then reactivate the user in Okta,
+This can result in any previously authorized access through an Access Request
+(JIT) to be reinstated as standing access.
+</Admonition>
+


### PR DESCRIPTION
Add troubleshooting section to Okta integration docs for handling pending cleanup assignments for deactivated Okta users.
