### PR TITLE
Allow scoping Datadog incident notifications

### DIFF
--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -857,9 +857,10 @@ func (c *PluginDatadogAccessSettings) CheckAndSetDefaults() error {
 	if c.ApiEndpoint == "" {
 		return trace.BadParameter("api_endpoint must be set")
 	}
-	if c.FallbackRecipient == "" {
-		return trace.BadParameter("fallback_recipient must be set")
-	}
+	// fallback_recipient is optional. When it is empty, only Access Requests
+	// routed by an Access Monitoring Rule or by the notify-services annotation
+	// on the requesting role create an incident, which lets an operator scope
+	// incidents to a subset of requests.
 	return nil
 }
 

--- a/api/types/plugin_test.go
+++ b/api/types/plugin_test.go
@@ -1199,10 +1199,17 @@ func TestPluginDatadogValidation(t *testing.T) {
 					ApiEndpoint: "https://api.testdatadogserver.com",
 				},
 			},
-			creds: nil,
+			creds: &PluginCredentialsV1{
+				Credentials: &PluginCredentialsV1_StaticCredentialsRef{
+					&PluginStaticCredentialsRef{
+						Labels: map[string]string{
+							"label1": "value1",
+						},
+					},
+				},
+			},
 			assertErr: func(t require.TestingT, err error, args ...any) {
-				require.True(t, trace.IsBadParameter(err))
-				require.Contains(t, err.Error(), "fallback_recipient must be set")
+				require.NoError(t, err)
 			},
 		},
 		{

--- a/docs/pages/identity-governance/access-requests/plugins/datadog-hosted.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/datadog-hosted.mdx
@@ -181,6 +181,38 @@ plugin will add these to the list of users to notify.
 
 </details>
 
+<details>
+<summary>Scoping which Access Requests create an incident</summary>
+
+By default every Access Request creates an incident, because the fallback
+recipient matches all of them. To limit incidents to a subset of requests, leave
+the fallback recipient empty and route the requests you care about explicitly,
+either with an [Access Monitoring
+Rule](../notification-routing-rules.mdx) or with the
+`teleport.dev/notify-services` annotation on the requesting role:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: editor-requester
+spec:
+  allow:
+    request:
+      annotations:
+        teleport.dev/notify-services:
+        - teleport-access
+      roles: ['editor']
+```
+
+The annotation holds Datadog team handles or user emails, and it is
+authoritative for the requests it covers: only the annotated recipients are
+notified, and suggested reviewers are not. Requests that match no Access
+Monitoring Rule, carry no annotation, and have no recipient configured for their
+role create no incident.
+
+</details>
+
 ## Step 5/6. Test your Datadog Incident Management plugin
 
 ### Create an Access Request

--- a/docs/pages/includes/helm-reference/zz_generated.access-datadog.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-datadog.mdx
@@ -145,6 +145,30 @@ containing the Datadog Application key. The secret name is set via `datadog.appl
 Access Request notifications. The recipient can be a Datadog user email or
 a team handle.
 
+Leaving this empty and setting `datadog.roleToRecipients` instead scopes
+incidents to the mapped roles: Access Requests for any other role create no
+incident, unless they match an Access Monitoring Rule or carry the
+`teleport.dev/notify-services` annotation.
+
+### `datadog.roleToRecipients`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`datadog.roleToRecipients` maps a requested Teleport role name to
+the recipients notified for it. Each recipient can be a Datadog user email
+or a team handle. The `*` key acts as the fallback for roles that have no
+entry, and is equivalent to `datadog.fallbackRecipient`.
+
+For example:
+```yaml
+datadog:
+  roleToRecipients:
+    "prod-admin": ["sre-oncall", "security@example.com"]
+    "*": ["admin@example.com"]
+```
+
 ### `datadog.severity`
 
 | Type | Default |

--- a/examples/chart/access/datadog/templates/configmap.yaml
+++ b/examples/chart/access/datadog/templates/configmap.yaml
@@ -22,7 +22,12 @@ data:
     severity = "{{ .Values.datadog.severity }}"
 
     [role_to_recipients]
-    "*" = ["{{ .Values.datadog.fallbackRecipient }}"]
+    {{- with .Values.datadog.fallbackRecipient }}
+    "*" = [{{ . | quote }}]
+    {{- end }}
+    {{- range $role, $recipients := .Values.datadog.roleToRecipients }}
+    {{ $role | quote }} = {{ toJson $recipients }}
+    {{- end }}
 
     [log]
     output = "{{ .Values.log.output }}"

--- a/examples/chart/access/datadog/tests/configmap_test.yaml
+++ b/examples/chart/access/datadog/tests/configmap_test.yaml
@@ -22,6 +22,34 @@ tests:
     asserts:
       - matchSnapshot: {}
 
+  - it: should render role_to_recipients entries when defined
+    set:
+      datadog:
+        fallbackRecipient: admin@example.com
+        roleToRecipients:
+          prod-admin: ["sre-oncall", "security@example.com"]
+    asserts:
+      - matchRegex:
+          path: data["teleport-datadog.toml"]
+          pattern: '"\*" = \["admin@example\.com"\]'
+      - matchRegex:
+          path: data["teleport-datadog.toml"]
+          pattern: '"prod-admin" = \["sre-oncall","security@example\.com"\]'
+
+  - it: should omit the catch-all recipient when no fallback recipient is set
+    set:
+      datadog:
+        fallbackRecipient: ""
+        roleToRecipients:
+          prod-admin: ["sre-oncall"]
+    asserts:
+      - notMatchRegex:
+          path: data["teleport-datadog.toml"]
+          pattern: '"\*" ='
+      - matchRegex:
+          path: data["teleport-datadog.toml"]
+          pattern: '"prod-admin" = \["sre-oncall"\]'
+
   - it: should not contain annotations when not defined
     asserts:
       - isNull:

--- a/examples/chart/access/datadog/values.schema.json
+++ b/examples/chart/access/datadog/values.schema.json
@@ -371,6 +371,27 @@
                         "datadog-team-handle"
                     ]
                 },
+                "roleToRecipients": {
+                    "$id": "#/properties/datadog/properties/roleToRecipients",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "examples": [
+                        {
+                            "*": [
+                                "admin@example.com"
+                            ],
+                            "prod-admin": [
+                                "sre-oncall"
+                            ]
+                        }
+                    ]
+                },
                 "severity": {
                     "$id": "#/properties/datadog/properties/severity",
                     "type": "string",

--- a/examples/chart/access/datadog/values.yaml
+++ b/examples/chart/access/datadog/values.yaml
@@ -76,7 +76,25 @@ datadog:
   # datadog.fallbackRecipient(string) -- specifies the default recipient for
   # Access Request notifications. The recipient can be a Datadog user email or
   # a team handle.
+  #
+  # Leaving this empty and setting `datadog.roleToRecipients` instead scopes
+  # incidents to the mapped roles: Access Requests for any other role create no
+  # incident, unless they match an Access Monitoring Rule or carry the
+  # `teleport.dev/notify-services` annotation.
   fallbackRecipient: ""
+  # datadog.roleToRecipients(object) -- maps a requested Teleport role name to
+  # the recipients notified for it. Each recipient can be a Datadog user email
+  # or a team handle. The `*` key acts as the fallback for roles that have no
+  # entry, and is equivalent to `datadog.fallbackRecipient`.
+  #
+  # For example:
+  # ```yaml
+  # datadog:
+  #   roleToRecipients:
+  #     "prod-admin": ["sre-oncall", "security@example.com"]
+  #     "*": ["admin@example.com"]
+  # ```
+  roleToRecipients: {}
   # datadog.severity(string) -- specifies the Datadog incident severity.
   severity: "SEV-3"
 

--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -443,6 +443,24 @@ func (a *App) getMessageRecipients(ctx context.Context, req types.AccessRequest)
 			recipientSet.Add(*rec)
 		}
 		return recipientSet.ToSlice()
+	case types.PluginTypeDatadog:
+		// When a request carries the notify-services annotation, it is
+		// authoritative for that request: only the annotated Datadog team
+		// handles or user emails are notified. Requests without the annotation
+		// keep resolving recipients from role_to_recipients and the suggested
+		// reviewers below.
+		recipients, ok := req.GetSystemAnnotations()[types.TeleportNamespace+types.ReqAnnotationNotifySchedulesLabel]
+		if ok {
+			for _, recipient := range recipients {
+				rec, err := a.bot.FetchRecipient(ctx, recipient)
+				if err != nil {
+					log.WarnContext(ctx, "Failed to fetch Datadog recipient", "error", err)
+					continue
+				}
+				recipientSet.Add(*rec)
+			}
+			return recipientSet.ToSlice()
+		}
 	}
 
 	validEmailSuggReviewers := []string{}

--- a/integrations/access/datadog/cmd/teleport-datadog/example_config.toml
+++ b/integrations/access/datadog/cmd/teleport-datadog/example_config.toml
@@ -37,7 +37,10 @@ severity = "SEV-3"
 #
 # Provide datadog user_email/team recipients for access requests for specific roles.
 # role.suggested_reviewers will automatically be treated as additional email recipients.
-# "*" must be provided to match non-specified roles.
+# "*" matches the roles that have no entry of their own. Omit it to only create
+# incidents for the roles listed here, for requests routed by an Access
+# Monitoring Rule, or for requests whose role carries the
+# "teleport.dev/notify-services" annotation.
 #
 # "dev" = "dev-team"
 # "*" = ["cloud@email.com", "cloud-team"]

--- a/integrations/access/datadog/config.go
+++ b/integrations/access/datadog/config.go
@@ -125,11 +125,11 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.Log.Severity == "" {
 		c.Log.Severity = "info"
 	}
-	if len(c.Recipients) == 0 {
-		return trace.BadParameter("missing required value role_to_recipients.")
-	} else if len(c.Recipients[types.Wildcard]) == 0 {
-		return trace.BadParameter("missing required value role_to_recipients[%v].", types.Wildcard)
-	}
+	// role_to_recipients is optional, and a catch-all entry in it is not
+	// required. Recipients can also come from Access Monitoring Rules or from
+	// the notify-services annotation on the requesting role, and a deployment
+	// may deliberately scope incidents to a subset of roles. This matches the
+	// Opsgenie and PagerDuty plugins, which impose no recipient requirement.
 	c.PluginType = types.PluginTypeDatadog
 	return nil
 }

--- a/integrations/access/datadog/testlib/suite.go
+++ b/integrations/access/datadog/testlib/suite.go
@@ -40,6 +40,7 @@ import (
 
 const (
 	ApprovalTeamName = "teleport-approval"
+	NotifyTeamName   = "teleport-notify"
 )
 
 // DatadogBaseSuite is the Datadog Incident Management plugin test suite.
@@ -85,6 +86,29 @@ func (s *DatadogBaseSuite) startApp() {
 
 	app := datadog.NewDatadogApp(s.appConfig)
 	integration.RunAndWaitReady(t, app)
+}
+
+// clearRequesterRoleAccessRequestAnnotation removes an access request annotation
+// from the requester roles. The roles are shared by the whole suite, so a test
+// that relies on an annotation being absent has to clear it explicitly.
+func (s *DatadogBaseSuite) clearRequesterRoleAccessRequestAnnotation(ctx context.Context, annotationKey string) {
+	t := s.T()
+	t.Helper()
+	adminClient := s.Ruler()
+
+	roles := []string{integration.OSSRequesterRoleName}
+	if s.TeleportFeatures().AdvancedAccessWorkflows {
+		roles = append(roles, integration.AdvancedRequesterRoleName)
+	}
+	for _, roleName := range roles {
+		role, err := adminClient.GetRole(ctx, roleName)
+		require.NoError(t, err)
+		conditions := role.GetAccessRequestConditions(types.Allow)
+		delete(conditions.Annotations, annotationKey)
+		role.SetAccessRequestConditions(types.Allow, conditions)
+		_, err = adminClient.UpdateRole(ctx, role)
+		require.NoError(t, err)
+	}
 }
 
 // DatadogSuiteOSS contains all tests that support running against a Teleport
@@ -133,6 +157,69 @@ func (s *DatadogSuiteOSS) TestIncidentCreation() {
 	assert.Equal(t, incident.Data.ID, pluginData.SentMessages[0].MessageID)
 	assert.Equal(t, fmt.Sprintf("@%s", integration.Reviewer1UserName), incident.Data.Attributes.NotificationHandles[0].Handle)
 	assert.Equal(t, "active", incident.Data.Attributes.Fields.State.Value)
+}
+
+// TestIncidentCreationForNotifyServices validates that when the requesting role
+// carries the notify-services annotation, the incident is routed to the
+// annotated Datadog teams instead of the suggested reviewers.
+func (s *DatadogSuiteOSS) TestIncidentCreationForNotifyServices() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	s.AnnotateRequesterRoleAccessRequests(
+		ctx,
+		types.TeleportNamespace+types.ReqAnnotationNotifySchedulesLabel,
+		[]string{NotifyTeamName},
+	)
+
+	s.startApp()
+
+	// Test setup: we create an access request and wait for its incident.
+	req := s.CreateAccessRequest(ctx, integration.RequesterOSSUserName, []string{
+		integration.Reviewer1UserName,
+	})
+
+	pluginData := s.checkPluginData(ctx, req.GetName(), func(data accessrequest.PluginData) bool {
+		return len(data.SentMessages) > 0
+	})
+	require.Len(t, pluginData.SentMessages, 1)
+
+	incident, err := s.fakeDatadog.CheckNewIncident(ctx)
+	require.NoError(t, err, "no new incidents stored")
+
+	require.NotNil(t, incident.Data.Attributes.Fields.Teams)
+	assert.Equal(t, []string{NotifyTeamName}, incident.Data.Attributes.Fields.Teams.Value)
+	assert.Empty(t, incident.Data.Attributes.NotificationHandles,
+		"the annotation is authoritative, suggested reviewers must not be notified")
+}
+
+// TestNoIncidentWithoutRecipients validates that a request resolving to no
+// recipients creates no incident. Here no Access Monitoring Rule matches, the
+// requesting role carries no notify-services annotation, role_to_recipients is
+// empty and the request suggests no reviewers.
+func (s *DatadogSuiteOSS) TestNoIncidentWithoutRecipients() {
+	t := s.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	// Other tests in the suite annotate the requester roles, and roles are
+	// shared by the whole suite.
+	s.clearRequesterRoleAccessRequestAnnotation(
+		ctx,
+		types.TeleportNamespace+types.ReqAnnotationNotifySchedulesLabel,
+	)
+
+	s.startApp()
+
+	// Test setup: we create an access request without suggested reviewers.
+	_ = s.CreateAccessRequest(ctx, integration.RequesterOSSUserName, nil)
+
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer timeoutCancel()
+
+	_, err := s.fakeDatadog.CheckNewIncident(timeoutCtx)
+	assert.Error(t, err, "no incident should be created when the request has no recipients")
 }
 
 // TestApproval tests that when a request is approved, its corresponding incident


### PR DESCRIPTION
## Problem

The Datadog Incident Management plugin creates an incident for **every** Access Request in the cluster, and no configuration narrows that down. Two mandatory settings guarantee that at least one recipient always resolves:

- `api/types/plugin.go` — `fallback_recipient must be set` on the plugin resource.
- `integrations/access/datadog/config.go` — `role_to_recipients` and `role_to_recipients["*"]` are both required.

`getMessageRecipients()` creates an incident whenever the resolved recipient list is non-empty, and the Datadog `FetchRecipient` never returns an error, so an operator cannot empty the list by pointing the fallback at a non-existent handle either.

For deployments that adopt the plugin mainly for on-call auto-approval (`teleport.dev/schedules`) of a few production roles, this means every unrelated request also pages the fallback recipient. In our cluster the plugin produced 208 incidents in 11 days, while only 2 request policies actually rely on on-call auto-approval; the rest are non-production requests reviewed by a human, and Slack already notifies the reviewers.

The Opsgenie plugin does not have this problem: it imposes no recipient requirement, and its notifications are routed by the `teleport.dev/notify-services` annotation. This PR gives the Datadog plugin the same capability. Related: #65345.

## Changes

- `role_to_recipients` and its `*` entry are no longer required by the plugin config, matching the Opsgenie, PagerDuty, Jira and Mattermost plugins.
- `fallback_recipient` is no longer required on the `PluginDatadogAccessSettings` resource.
- `teleport.dev/notify-services` on the requesting role now routes Datadog notifications. When the annotation is present it is authoritative for that request (only the annotated team handles or user emails are notified); when it is absent, `role_to_recipients` and the suggested reviewers keep being used exactly as before.
- The Helm chart exposes `datadog.roleToRecipients` and only renders the `"*"` entry when `datadog.fallbackRecipient` is set.
- Docs: chart reference regenerated, and the plugin guide gains a section on scoping which requests create an incident.

A request that matches no Access Monitoring Rule, carries no annotation and has no recipient configured for its role now creates no incident.

## Backwards compatibility

Existing deployments are unaffected. Every current configuration defines a catch-all recipient — the chart hardcodes `"*" = [fallbackRecipient]` and the hosted plugin requires the field — so recipients keep resolving for every request. The new behaviour only applies once an operator deliberately removes the catch-all.

Changelog: The Datadog Incident Management plugin can now scope incidents to specific roles: `role_to_recipients`, its `*` entry and `fallback_recipient` are optional, and the `teleport.dev/notify-services` annotation routes notifications.

## Manual Test Plan

### Test Environment

macOS, Go 1.26, in-process auth server (`MinimalAuthHelper`), `helm unittest` for the chart.

### Test Cases

- [x] `go test ./integrations/access/datadog/...` — full OSS suite passes, including two new cases: `TestIncidentCreationForNotifyServices` (annotation routes the incident to the annotated team and suppresses suggested reviewers) and `TestNoIncidentWithoutRecipients` (no recipients, no incident).
- [x] `go test ./integrations/access/accessrequest/... ./integrations/access/opsgenie/... ./integrations/access/common/...` — other plugins unchanged.
- [x] `go test ./api/types/` — `PluginDatadogAccessSettings` validation, including the updated case for an empty fallback recipient.
- [x] `helm unittest examples/chart/access/datadog` — existing configmap snapshot unchanged when `fallbackRecipient` is set; new cases cover a `roleToRecipients` map and the omission of the `"*"` entry.
- [ ] Not verified: the enterprise test suite (no license locally) and the hosted plugin running with an empty `fallback_recipient`, which needs a Cloud tenant.

Made with [Cursor](https://cursor.com)