### PR TITLE
Fix lock of delegated joining Bots when BotInstance is not found

### DIFF
--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -392,9 +392,9 @@ func (a *Server) updateBotInstance(
 		// codepath. (But may need to clean up log messages.)
 
 		// Set the initial generation counter. Note that with bot instances, the
-		// counter is now set for all join methods, but only enforced for token
-		// joins.
-		if currentIdentityGeneration > 0 {
+		// counter is now set for all join methods, but only enforced for some
+		// (see shouldEnforceGenerationCounter).
+		if currentIdentityGeneration > 0 && shouldEnforceGenerationCounter(req.Renewable, authRecord.GetJoinMethod()) {
 			// If the incoming identity has a nonzero generation, validate it
 			// using the legacy check. This will increment the counter on the
 			// request automatically
@@ -410,7 +410,14 @@ func (a *Server) updateBotInstance(
 			// Copy the value from the request into the auth record.
 			authRecord.SetGeneration(int32(req.Generation))
 		} else {
-			// Otherwise, just set it to 1.
+			if currentIdentityGeneration > 0 {
+				a.logger.WarnContext(ctx, "bot rejoined with a nonzero generation but its instance record was not found, a fresh instance will be issued",
+					"bot_name", botName,
+					"missing_instance_id", botInstanceID,
+					"identity_generation", currentIdentityGeneration,
+					"join_method", authRecord.GetJoinMethod(),
+				)
+			}
 			req.Generation = 1
 			authRecord.SetGeneration(1)
 		}

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1049,6 +1049,29 @@ func TestRegisterBot_BotInstanceRejoin(t *testing.T) {
 
 	// Note: Lying via IAM join not tested as that must be routed through the
 	// join service (along with Azure and TPM).
+
+	// Simulate the instance record disappearing (expired, deleted, or backend
+	// rollback): the rejoin should be issued a fresh instance, not denied, and
+	// must not lock the join token.
+	require.NoError(t, a.BotInstance.DeleteBotInstance(ctx, machineidv1pb.DeleteBotInstanceRequest_builder{
+		BotName:    botName,
+		InstanceId: initialK8sInstanceID,
+	}.Build()))
+
+	freshK8sResult, err := registerHelper(ctx, k8sToken, addr, func(p *joinclient.JoinParams) {
+		p.KubernetesReadFileFunc = k8sReadFileFunc
+		p.AuthClient = k8sClient
+	})
+	require.NoError(t, err)
+
+	freshK8sID, freshK8sGeneration := instanceIDFromCerts(t, freshK8sResult.Certs)
+	require.NotEmpty(t, freshK8sID)
+	require.NotEqual(t, initialK8sInstanceID, freshK8sID)
+	require.Equal(t, uint64(1), freshK8sGeneration)
+
+	locks, err := a.GetLocks(ctx, true, types.LockTarget{JoinToken: k8sToken.GetName()})
+	require.NoError(t, err)
+	require.Empty(t, locks)
 }
 
 // TestRegisterBotWithInvalidInstanceID ensures that client-specified instance


### PR DESCRIPTION
Whilst looking into a customer query, I spotted an underlying bug in renewal handling that can trigger a Bot lockout in the following circumstances:

- `tbot` is using a delegated join method.
- `tbot` attempts to renew, providing it's existing identity and fresh join proof
- The BotInstance associated with the existing identity no longer exists (i.e. a database rollback has occurred).

The correct behaviour in this case would be for a new BotInstance to be generated (with a new BotInstanceID).

The incorrect behaviour stems from logic intended to migrate from our legacy generation label (on the bot user) to the generation counter on the BotInstance resource. This logic reads the legacy generation label from the user, and, places a lock on the Bot if the generation counter in the existing certificate does not match - unfortunately, we do not write-back the legacy generation counter to a user for Bots using delegated joining. This means that these values will always mismatch for a delegated join bot.

For now, this patch leaves the behaviour for Bound Keypair and Token joins the same - however we will review this.

This patch is designed to fix the issue on v18 - I will follow up shortly with a patch for master/v19 which entirely removes the legacy generation counter mechanism (which has been scheduled for removal from v17).

Changelog: Fixed spurious lockout of delegated-join Bots when the BotInstance record does not exist (i.e database has been restored from backup).

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Perform delegated join, delete BotInstance, trigger a renewal, and observe that `tbot` can renew.

Agentic test plan: https://gist.github.com/strideynet/d0b0738a134ea5ad3a2ce46385394435
