### PR TITLE
gha: stop collecting contexts

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -44,8 +44,6 @@ jobs:
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
           values: |
             REVIEWERS_APP_ID,variable
             REVIEWERS_PRIVATE_KEY,secret

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -35,8 +35,6 @@ jobs:
       with:
         cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
         cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-        existing-gh-secrets: "${{ toJSON(secrets) }}"
-        existing-gh-variables: "${{ toJSON(vars) }}"
         values: |
           AMPLIFY_APP_IDS,variable
           IAM_ROLE,variable

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -28,8 +28,6 @@ jobs:
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
           values: |
             AMPLIFY_DOCS_DEPLOY_HOOK,secret
       - name: Call deployment webhook


### PR DESCRIPTION
This PR removes input variables from the `env-kvstore` action that are used to collect existing contexts for migration.

Migration is complete for the workflows "Bloat Check", "Docs Preview" and "Update docs webhook".

