### PR TITLE
[v18] Validate access list name length on creation

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -78,6 +78,9 @@ func parseReviewFrequency(input string) ReviewFrequency {
 // MaxAllowedDepth is the maximum allowed depth for nested access lists.
 const MaxAllowedDepth = 10
 
+// MaxNameLength is the maximum permitted byte length of an access-list name.
+const MaxNameLength = 512
+
 var (
 	// MembershipKindUnspecified is the default membership kind (treated as 'user').
 	MembershipKindUnspecified = accesslistv1.MembershipKind_MEMBERSHIP_KIND_UNSPECIFIED.String()

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -78,7 +78,7 @@ func parseReviewFrequency(input string) ReviewFrequency {
 // MaxAllowedDepth is the maximum allowed depth for nested access lists.
 const MaxAllowedDepth = 10
 
-// MaxNameLength is the maximum permitted byte length of an access-list name.
+// MaxNameLength is the maximum permitted byte length of an access list name.
 const MaxNameLength = 512
 
 var (

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -46,6 +46,11 @@ var (
 // storing it. If the existingAccessList is non-nil it also checks if this is a valid update
 // transition. It takes into account validation of the nested access lists membership.
 func ValidateAccessListWithMembers(ctx context.Context, existingAccessList, accessList *accesslist.AccessList, members []*accesslist.AccessListMember, g AccessListAndMembersGetter) error {
+	if existingAccessList == nil {
+		if err := validateAccessListCreate(accessList); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	if err := validateAccessList(accessList); err != nil {
 		return trace.Wrap(err)
 	}
@@ -55,6 +60,15 @@ func ValidateAccessListWithMembers(ctx context.Context, existingAccessList, acce
 	if err := validateAccessListNesting(ctx, accessList, members, g); err != nil {
 		return trace.Wrap(err)
 	}
+	return nil
+}
+
+// validateAccessListCreate enforces validation rules that only apply during creation
+func validateAccessListCreate(a *accesslist.AccessList) error {
+	if len(a.Metadata.Name) > accesslist.MaxNameLength {
+		return trace.BadParameter("name is too long (max %d)", accesslist.MaxNameLength)
+	}
+
 	return nil
 }
 

--- a/lib/accesslists/validate.go
+++ b/lib/accesslists/validate.go
@@ -63,7 +63,7 @@ func ValidateAccessListWithMembers(ctx context.Context, existingAccessList, acce
 	return nil
 }
 
-// validateAccessListCreate enforces validation rules that only apply during creation
+// validateAccessListCreate enforces validation rules that only apply during creation.
 func validateAccessListCreate(a *accesslist.AccessList) error {
 	if len(a.Metadata.Name) > accesslist.MaxNameLength {
 		return trace.BadParameter("name is too long (max %d)", accesslist.MaxNameLength)

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -21,6 +21,7 @@ package accesslists
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -756,6 +757,27 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 		})
 	})
 
+	t.Run("name length is validated on create", func(t *testing.T) {
+		t.Run("name length is too long", func(t *testing.T) {
+			accessList := newAccessList(t, strings.Repeat("x", accesslist.MaxNameLength+1), clock)
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.ErrorContains(t, err, "name is too long")
+		})
+
+		t.Run("name length is not too long", func(t *testing.T) {
+			accessList := newAccessList(t, strings.Repeat("x", accesslist.MaxNameLength-1), clock)
+			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("name length is not validated on update", func(t *testing.T) {
+		// access list whose name is too long
+		accessList := newAccessList(t, strings.Repeat("x", accesslist.MaxNameLength+1), clock)
+
+		err := ValidateAccessListWithMembers(ctx, accessList, accessList, nil, &mockAccessListAndMembersGetter{})
+		require.NoError(t, err)
+	})
 }
 
 func TestAccessListValidateWithMembers_members(t *testing.T) {

--- a/lib/accesslists/validate_test.go
+++ b/lib/accesslists/validate_test.go
@@ -758,17 +758,37 @@ func TestAccessListValidateWithMembers_basic(t *testing.T) {
 	})
 
 	t.Run("name length is validated on create", func(t *testing.T) {
-		t.Run("name length is too long", func(t *testing.T) {
-			accessList := newAccessList(t, strings.Repeat("x", accesslist.MaxNameLength+1), clock)
-			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
-			require.ErrorContains(t, err, "name is too long")
-		})
+		testCases := []struct {
+			name           string
+			accessListName string
+			wantErr        string
+		}{
+			{
+				name:           "name too long",
+				accessListName: strings.Repeat("x", accesslist.MaxNameLength+1),
+				wantErr:        "name is too long",
+			},
+			{
+				name:           "longest allowed name",
+				accessListName: strings.Repeat("x", accesslist.MaxNameLength),
+			},
+			{
+				name:           "short name",
+				accessListName: "x",
+			},
+		}
+		for _, test := range testCases {
+			t.Run(test.name, func(t *testing.T) {
+				accessList := newAccessList(t, test.accessListName, clock)
+				err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
 
-		t.Run("name length is not too long", func(t *testing.T) {
-			accessList := newAccessList(t, strings.Repeat("x", accesslist.MaxNameLength-1), clock)
-			err := ValidateAccessListWithMembers(ctx, nil, accessList, nil, &mockAccessListAndMembersGetter{})
-			require.NoError(t, err)
-		})
+				if test.wantErr != "" {
+					require.ErrorContains(t, err, test.wantErr)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		}
 	})
 
 	t.Run("name length is not validated on update", func(t *testing.T) {


### PR DESCRIPTION
Backport #69008 to branch/v18

changelog: Added creation-time validation to disallow Access List names longer than 512 bytes.

## Manual Test Plan
### Test Environment
- Local Teleport checkout on macOS

### Test Cases
- [x] `go test ./lib/accesslists -run 'TestAccessListValidateWithMembers_basic' -count=1`
- [x] Verify a new Access List creation with a name with 512 bytes is accepted.
- [x] Verify a new Access List creation with a name longer than 512 bytes is rejected.
    - Ran `tctl create <access-list.yaml>` specifying a name with 513 characters (which was rejected)
- [x] Verify an existing Access List with an oversized legacy name can still be updated.
    - Ran `tctl create <access-list.yaml>` specifying a name with 513 characters with `branch/v18` branch checked out (which was accepted)
    - Updated to latest version of this branch
    - Ran `tctl acl update <access-list-name> --description test-description` and it was accepted
