### PR TITLE
tfgen: support including top-level access list scope field

### DIFF
--- a/lib/tfgen/testdata/TestGenerate_AccessListMemberWithScope.golden
+++ b/lib/tfgen/testdata/TestGenerate_AccessListMemberWithScope.golden
@@ -1,0 +1,19 @@
+resource "teleport_access_list_member" "some-member" {
+  scope = "/some/member-scope"
+  header = {
+    kind    = "access_list_member"
+    version = "v1"
+    metadata = {
+      name = "some-member"
+    }
+  }
+
+  spec = {
+    access_list       = "some-id"
+    name              = "some-member"
+    reason            = "some reason"
+    added_by          = "admin"
+    ineligible_status = "0"
+    membership_kind   = "1"
+  }
+}

--- a/lib/tfgen/testdata/TestGenerate_AccessListWithScope.golden
+++ b/lib/tfgen/testdata/TestGenerate_AccessListWithScope.golden
@@ -1,0 +1,31 @@
+resource "teleport_access_list" "some-access-list" {
+  scope = "/some/scope"
+  header = {
+    kind    = "access_list"
+    version = "v1"
+    metadata = {
+      name = "some-access-list"
+    }
+  }
+
+  spec = {
+    description = "An example scoped access list"
+    owners = [{
+      description       = "some description"
+      ineligible_status = "0"
+      membership_kind   = "1"
+      name              = "llama"
+    }]
+    audit = {
+      next_audit_date = "2023-02-02T00:00:00Z"
+      recurrence = {
+        frequency    = "3"
+        day_of_month = "1"
+      }
+      notifications = {
+        start = "336h0m0s"
+      }
+    }
+    title = "My Access List"
+  }
+}

--- a/lib/tfgen/tfgen.go
+++ b/lib/tfgen/tfgen.go
@@ -208,6 +208,14 @@ func generateResource(
 	// a header field, while other resources expect these fields as top-level fields.
 	_, hasHeaderField := resource.(*headerResourceWrapper)
 	if hasHeaderField {
+		// Access list resources have top level scope field:
+		scope := msg.AttributeNamed("scope")
+		if scope != nil && !opts.fieldsToOmit["scope"] {
+			tokens := valueToTokens(fieldPath{"scope"}, scope.Value, opts, false /* emitZeroVal */)
+			if tokens != nil {
+				resourceBlock.Body().SetAttributeRaw("scope", tokens)
+			}
+		}
 		if header := msg.AttributeNamed("header"); header != nil && !opts.fieldsToOmit["header"] {
 			tokens := messageToTokens(fieldPath{"header"}, header.Value, opts)
 			if tokens != nil {

--- a/lib/tfgen/tfgen_test.go
+++ b/lib/tfgen/tfgen_test.go
@@ -499,3 +499,49 @@ func goldenTest(t *testing.T, resource tfgen.Resource, opts ...tfgen.GenerateOpt
 		),
 	)
 }
+
+func TestGenerate_AccessListWithScope(t *testing.T) {
+	t.Parallel()
+
+	al, err := accesslist.NewAccessListWithScope(
+		header.Metadata{Name: "some-access-list"},
+		accesslist.Spec{
+			Title:       "My Access List",
+			Description: "An example scoped access list",
+			Owners: []accesslist.Owner{
+				{Name: "llama", Description: "some description"},
+			},
+			Audit: accesslist.Audit{
+				NextAuditDate: time.Date(2023, 02, 02, 0, 0, 0, 0, time.UTC),
+				Recurrence: accesslist.Recurrence{
+					Frequency:  accesslist.ThreeMonths,
+					DayOfMonth: accesslist.FirstDayOfMonth,
+				},
+			},
+		},
+		"/some/scope",
+	)
+	require.NoError(t, err)
+
+	alProto := tfgen.WrapHeaderResource(accesslistconv.ToProto(al))
+	goldenTest(t, alProto)
+}
+
+func TestGenerate_AccessListMemberWithScope(t *testing.T) {
+	t.Parallel()
+
+	member, err := accesslist.NewAccessListMemberWithScope(
+		header.Metadata{Name: "some-member"},
+		accesslist.AccessListMemberSpec{
+			AccessList: "some-id",
+			Name:       "some-member",
+			Reason:     "some reason",
+			AddedBy:    "admin",
+		},
+		"/some/member-scope",
+	)
+	require.NoError(t, err)
+
+	memProto := tfgen.WrapHeaderResource(accesslistconv.ToMemberProto(member))
+	goldenTest(t, memProto)
+}


### PR DESCRIPTION
addresses this review: https://github.com/gravitational/teleport/pull/68518#discussion_r3555218420

this PR adds support to include the top-level scope field for access lists when generating its tf config


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
 no test, the golden file testing should suffice
