### PR TITLE
Fix `KubernetesAccessSection` flakiness

### DIFF
--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.test.tsx
@@ -177,8 +177,10 @@ describe('KubernetesAccessSection', () => {
       createOptionText: 'Group: group2',
     });
 
-    await user.type(screen.getByPlaceholderText('label key'), 'some-key');
-    await user.type(screen.getByPlaceholderText('label value'), 'some-value');
+    await user.click(screen.getByPlaceholderText('label key'));
+    await user.paste('some-key');
+    await user.click(screen.getByPlaceholderText('label value'));
+    await user.paste('some-value');
 
     await selectEvent.create(screen.getByLabelText('Users'), 'joe', {
       createOptionText: 'User: joe',
@@ -198,11 +200,11 @@ describe('KubernetesAccessSection', () => {
     expect(screen.getByLabelText('Namespace *')).toHaveValue('*');
     await selectEvent.select(screen.getByLabelText('Kind (plural)'), 'jobs');
     await user.clear(screen.getByLabelText('API Group *'));
-    await user.type(screen.getByLabelText('API Group *'), 'api-group-name');
+    await user.paste('api-group-name');
     await user.clear(screen.getByLabelText('Name *'));
-    await user.type(screen.getByLabelText('Name *'), 'job-name');
+    await user.paste('job-name');
     await user.clear(screen.getByLabelText('Namespace *'));
-    await user.type(screen.getByLabelText('Namespace *'), 'job-namespace');
+    await user.paste('job-namespace');
     await selectEvent.select(screen.getByLabelText('Verbs'), [
       'create',
       'delete',
@@ -246,17 +248,17 @@ describe('KubernetesAccessSection', () => {
       screen.getByRole('button', { name: 'Add a Kubernetes Resource' })
     );
     await user.clear(screen.getByLabelText('Name *'));
-    await user.type(screen.getByLabelText('Name *'), 'res1');
+    await user.paste('res1');
     await user.click(
       screen.getByRole('button', { name: 'Add Another Kubernetes Resource' })
     );
     await user.clear(screen.getAllByLabelText('Name *')[1]);
-    await user.type(screen.getAllByLabelText('Name *')[1], 'res2');
+    await user.paste('res2');
     await user.click(
       screen.getByRole('button', { name: 'Add Another Kubernetes Resource' })
     );
     await user.clear(screen.getAllByLabelText('Name *')[2]);
-    await user.type(screen.getAllByLabelText('Name *')[2], 'res3');
+    await user.paste('res3');
     expect(onChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
         resources: [


### PR DESCRIPTION
## Purpose

This PR solves https://github.com/gravitational/teleport/issues/60097

Fixes the `KubernetesAccessSection` unit test occasionally timing out.

I was able to reproduce the flakiness locally and this fix solved it. `user.type` and `user.paste` in this test can be used interchangeably, however `user.type` types each character one by one with each keystroke having its own event loop and triggering a re-render, in a constrained environment the time taken for each adds up and was likely what was causing the timeouts. 