### PR TITLE
tctl acl update/create: support output terraform (dry-run)

### DIFF
--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -53,7 +53,16 @@ import (
 
 // Command implements the `tctl acl` family of commands.
 type Command struct {
-	format string
+	// format is the response print format (default text).
+	format    string
+	formatSet bool
+
+	// output when set is like a dry run where the resource config is printed
+	// instead of actual resources being created.
+	// Cannot use together with format.
+	output string
+
+	cfg *servicecfg.Config
 
 	ls            *kingpin.CmdClause
 	get           *kingpin.CmdClause
@@ -176,6 +185,8 @@ type Command struct {
 const (
 	memberKindUser = "user"
 	memberKindList = "list"
+
+	outputTerraform = "terraform"
 )
 
 const auditFrequencyText = "Audit recurrence in months (1, 3, 6, or 12)."
@@ -213,7 +224,9 @@ grants you set directly (--member-grant-roles, etc.) — there are no
 auto-generated supporting roles.`
 
 // Initialize allows Command to plug itself into the CLI parser
-func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config) {
+func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, cfg *servicecfg.Config) {
+	c.cfg = cfg
+
 	acl := app.Command("acl", "Manage Access Lists.").Alias("access-lists")
 
 	c.ls = acl.Command("ls", "List cluster Access Lists.")
@@ -265,7 +278,8 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 
 	c.update = acl.Command("update", updateHelpText)
 	c.update.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
-	c.update.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.update.Flag("format", "Output format.").Default(teleport.Text).IsSetByUser(&c.formatSet).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.update.Flag("output", "Print the resulting resource config without applying the update (dry-run).").EnumVar(&c.output, outputTerraform)
 	c.update.Flag("title", "New display name for the access list.").IsSetByUser(&c.titleSet).StringVar(&c.title)
 	c.update.Flag("description", "New description.").IsSetByUser(&c.descriptionSet).StringVar(&c.description)
 	c.update.Flag("audit-frequency", auditFrequencyText+" Changing this resets the next audit date to now + frequency.").PlaceHolder("6").IsSetByUser(&c.auditFrequencySet).IntVar(&c.auditFrequency)
@@ -281,7 +295,8 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 
 	c.create = acl.Command("create", createHelpText)
 	c.create.Flag("access-type", "How members are granted access: 'standing' (members receive persistent access to the resources described by the resource flags) or 'access-request' (members must request access; owners review). When omitted, a plain access list is created with no auto-generated roles.").EnumVar(&c.accessType, accessTypeLongTerm, accessTypeShortTerm)
-	c.create.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.create.Flag("format", "Output format.").Default(teleport.Text).IsSetByUser(&c.formatSet).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.create.Flag("output", "Print the resulting resource config without applying create (dry-run).").EnumVar(&c.output, outputTerraform)
 	c.create.Flag("title", "Display name for the access list.").IsSetByUser(&c.titleSet).StringVar(&c.title)
 	c.create.Flag("audit-frequency", auditFrequencyText).Default("6").PlaceHolder("6").IntVar(&c.auditFrequency)
 	c.create.Flag("audit-day", auditDayText).Default("1").PlaceHolder("1").IntVar(&c.auditDay)

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -51,7 +51,16 @@ import (
 
 // Command implements the `tctl acl` family of commands.
 type Command struct {
-	format string
+	// format is the response print format (default text).
+	format    string
+	formatSet bool
+
+	// output when set is like a dry run where the resource config is printed
+	// instead of actual resources being created.
+	// Cannot use together with format.
+	output string
+
+	cfg *servicecfg.Config
 
 	ls            *kingpin.CmdClause
 	get           *kingpin.CmdClause
@@ -174,6 +183,8 @@ type Command struct {
 const (
 	memberKindUser = "user"
 	memberKindList = "list"
+
+	outputTerraform = "terraform"
 )
 
 const auditFrequencyText = "Audit recurrence in months (1, 3, 6, or 12)."
@@ -211,7 +222,9 @@ grants you set directly (--member-grant-roles, etc.) — there are no
 auto-generated supporting roles.`
 
 // Initialize allows Command to plug itself into the CLI parser
-func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, _ *servicecfg.Config) {
+func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, cfg *servicecfg.Config) {
+	c.cfg = cfg
+
 	acl := app.Command("acl", "Manage Access Lists.").Alias("access-lists")
 
 	c.ls = acl.Command("ls", "List cluster Access Lists.")
@@ -263,7 +276,8 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 
 	c.update = acl.Command("update", updateHelpText)
 	c.update.Arg("access-list-name", "The Access List name.").Required().StringVar(&c.accessListName)
-	c.update.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.update.Flag("format", "Output format.").Default(teleport.Text).IsSetByUser(&c.formatSet).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.update.Flag("output", "Print the resulting resource config without applying the update (dry-run).").EnumVar(&c.output, outputTerraform)
 	c.update.Flag("title", "New display name for the access list.").IsSetByUser(&c.titleSet).StringVar(&c.title)
 	c.update.Flag("description", "New description.").IsSetByUser(&c.descriptionSet).StringVar(&c.description)
 	c.update.Flag("audit-frequency", auditFrequencyText+" Changing this resets the next audit date to now + frequency.").PlaceHolder("6").IsSetByUser(&c.auditFrequencySet).IntVar(&c.auditFrequency)
@@ -279,7 +293,8 @@ func (c *Command) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags
 
 	c.create = acl.Command("create", createHelpText)
 	c.create.Flag("access-type", "How members are granted access: 'standing' (members receive persistent access to the resources described by the resource flags) or 'access-request' (members must request access; owners review). When omitted, a plain access list is created with no auto-generated roles.").EnumVar(&c.accessType, accessTypeLongTerm, accessTypeShortTerm)
-	c.create.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.create.Flag("format", "Output format.").Default(teleport.Text).IsSetByUser(&c.formatSet).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.create.Flag("output", "Print the resulting resource config without applying create (dry-run).").EnumVar(&c.output, outputTerraform)
 	c.create.Flag("title", "Display name for the access list.").IsSetByUser(&c.titleSet).StringVar(&c.title)
 	c.create.Flag("audit-frequency", auditFrequencyText).Default("6").PlaceHolder("6").IntVar(&c.auditFrequency)
 	c.create.Flag("audit-day", auditDayText).Default("1").PlaceHolder("1").IntVar(&c.auditDay)

--- a/tool/tctl/common/accesslist/create.go
+++ b/tool/tctl/common/accesslist/create.go
@@ -59,6 +59,11 @@ func (c *Command) Create(ctx context.Context, client *authclient.Client) error {
 		return trace.Wrap(err)
 	}
 
+	// Requested dry-run: print the resource config instead of creating anything.
+	if c.output != "" {
+		return trace.Wrap(c.dryRunCreate(newAccessList, members))
+	}
+
 	createResponse, err := c.createAccessList(ctx, client, newAccessList, members)
 	if err != nil {
 		return trace.Wrap(err)
@@ -68,6 +73,10 @@ func (c *Command) Create(ctx context.Context, client *authclient.Client) error {
 }
 
 func (c *Command) validateCreate() error {
+	if c.output != "" && c.formatSet {
+		return trace.BadParameter("--output and --format cannot be combined")
+	}
+
 	if c.accessType == "" {
 		if c.anyAccessFlagsSet() {
 			return trace.BadParameter("resource access flags (--node-labels, --logins, --aws-ic-assignments, etc.) require --access-type")
@@ -317,6 +326,18 @@ func (c *Command) buildMembers(accessListName scopes.QualifiedName) ([]*accessli
 		members = append(members, m)
 	}
 	return members, nil
+}
+
+func (c *Command) dryRunCreate(newAccessList *accesslist.AccessList, members []*accesslist.AccessListMember) error {
+	var accessRoles []*types.RoleV6
+	if c.accessType != "" {
+		var err error
+		accessRoles, err = c.buildResourceAccessRoles()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return trace.Wrap(c.writeOutput(newAccessList, accessRoles, members, presetType(c.accessType)))
 }
 
 // CreateResponse is a structured response when `format=json`

--- a/tool/tctl/common/accesslist/create.go
+++ b/tool/tctl/common/accesslist/create.go
@@ -54,6 +54,11 @@ func (c *Command) Create(ctx context.Context, client *authclient.Client) error {
 		return trace.Wrap(err)
 	}
 
+	// Requested dry-run: print the resource config instead of creating anything.
+	if c.output != "" {
+		return trace.Wrap(c.dryRunCreate(newAccessList, members))
+	}
+
 	createResponse, err := c.createAccessList(ctx, client, newAccessList, members)
 	if err != nil {
 		return trace.Wrap(err)
@@ -63,6 +68,10 @@ func (c *Command) Create(ctx context.Context, client *authclient.Client) error {
 }
 
 func (c *Command) validateCreate() error {
+	if c.output != "" && c.formatSet {
+		return trace.BadParameter("--output and --format cannot be combined")
+	}
+
 	if c.accessType == "" {
 		if c.anyAccessFlagsSet() {
 			return trace.BadParameter("resource access flags (--node-labels, --logins, --aws-ic-assignments, etc.) require --access-type")
@@ -312,6 +321,18 @@ func (c *Command) buildMembers(accessListName scopes.QualifiedName) ([]*accessli
 		members = append(members, m)
 	}
 	return members, nil
+}
+
+func (c *Command) dryRunCreate(newAccessList *accesslist.AccessList, members []*accesslist.AccessListMember) error {
+	var accessRoles []*types.RoleV6
+	if c.accessType != "" {
+		var err error
+		accessRoles, err = c.buildResourceAccessRoles()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return trace.Wrap(c.writeOutput(newAccessList, accessRoles, members, presetType(c.accessType)))
 }
 
 // CreateResponse is a structured response when `format=json`

--- a/tool/tctl/common/accesslist/output.go
+++ b/tool/tctl/common/accesslist/output.go
@@ -1,0 +1,77 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package accesslist
+
+import (
+	"fmt"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/accesslists/preset"
+	"github.com/gravitational/teleport/lib/accesslists/terraform"
+	"github.com/gravitational/trace"
+)
+
+func (c *Command) writeOutput(al *accesslist.AccessList, accessRoles []*types.RoleV6, members []*accesslist.AccessListMember, alPresetType string) error {
+	switch c.output {
+	case outputTerraform:
+		return trace.Wrap(c.writeOutputTerraform(al, accessRoles, members, alPresetType))
+	default:
+		return trace.BadParameter("unsupported output %q", c.output)
+	}
+}
+
+func (c *Command) writeOutputTerraform(al *accesslist.AccessList, accessRoles []*types.RoleV6, members []*accesslist.AccessListMember, alPresetType string) error {
+	var providerBlock *terraform.ProviderBlock
+	if c.cfg != nil {
+		addrs := c.cfg.AuthServerAddresses()
+		if len(addrs) > 0 {
+			providerBlock = &terraform.ProviderBlock{
+				TeleportVersion: teleport.SemVer().Major,
+				ProxyAddr:       addrs[0].String(),
+			}
+		}
+	}
+
+	tfConfig := ""
+	var err error
+	if alPresetType == "" {
+		tfConfig, err = terraform.GenerateConfig(al, members, providerBlock)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	} else {
+		roles := make([]terraform.AccessRole, 0, len(accessRoles))
+		for _, role := range accessRoles {
+			roles = append(roles, terraform.AccessRole{Role: role})
+		}
+		tfConfig, err = terraform.GenerateConfigWithPresetBuilder(terraform.ConfigParams{
+			PresetType:    preset.PresetType(alPresetType),
+			AccessListID:  al.GetName(),
+			AccessList:    al,
+			AccessRoles:   roles,
+			Members:       members,
+			ProviderBlock: providerBlock,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	fmt.Fprint(c.Stdout, tfConfig)
+	return nil
+}

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -354,6 +354,10 @@ func (c *Command) buildOwnersForUpdate(al *accesslist.AccessList) ([]accesslist.
 }
 
 func (c *Command) buildUpdatedAccessRoles(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) ([]*types.RoleV6, error) {
+	if err := rejectUnknownGrants(al); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if c.removeAccess {
 		return nil, nil // no roles appended means "remove these access roles from al grants"
 	}
@@ -390,12 +394,6 @@ func (c *Command) buildUpdatedAccessRoles(ctx context.Context, client *authclien
 
 // updateAccessListWithPreset updates an access list spec/meta and its related access roles.
 func (c *Command) updateAccessListWithPreset(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) (*accesslist.AccessList, []string, []string, error) {
-	// The backend replaces grants wholesale without validating them, so this
-	// is the only place hand-edited grants are caught before they are dropped.
-	if err := rejectUnknownGrants(al); err != nil {
-		return nil, nil, nil, trace.Wrap(err)
-	}
-
 	updatedAccessRoles, err := c.buildUpdatedAccessRoles(ctx, client, al)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -49,6 +49,10 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 		return trace.BadParameter("no update flags are set")
 	}
 
+	if c.output != "" && c.formatSet {
+		return trace.BadParameter("--output and --format cannot be combined")
+	}
+
 	// To avoid non-atomic partial writes, member updates are to be run
 	// separately from updates to access list meta/spec. Combining
 	// both means there will be partial failures where grants may be
@@ -104,6 +108,12 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		// Requested dry-run.
+		if c.output != "" {
+			return trace.Wrap(c.dryRunUpdate(ctx, client, al, updatedMembers))
+		}
+
 		updatedAccessList, _, err = client.AccessListClient().UpsertAccessListWithMembers(ctx, al, updatedMembers)
 		if err != nil {
 			return trace.Wrap(err)
@@ -124,6 +134,15 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 				return trace.BadParameter("an access list must have at least one owner")
 			}
 			al.Spec.Owners = updatedOwners
+		}
+
+		// Requested dry-run.
+		if c.output != "" {
+			members, err := c.collectAllMembers(ctx, client, aclName)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			return trace.Wrap(c.dryRunUpdate(ctx, client, al, members))
 		}
 
 		if al.IsPreset() && (c.anyAccessFlagsSet() || c.removeAccess) {
@@ -329,39 +348,53 @@ func (c *Command) buildOwnersForUpdate(al *accesslist.AccessList) ([]accesslist.
 	return newOwners, removedOwners, trace.NewAggregate(userErr, listErr)
 }
 
+func (c *Command) buildUpdatedAccessRoles(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) ([]*types.RoleV6, error) {
+	if c.removeAccess {
+		return nil, nil // no roles appended means "remove these access roles from al grants"
+	}
+
+	var updatedAccessRoles []*types.RoleV6
+	var standardRoleUpdateFn applyAccessFlagsToRole
+
+	if c.anyStandardAccessFlagsSet() {
+		standardRoleUpdateFn = c.applyStandardAccessFlagsToRole
+	}
+	standardRole, err := resolveAccessRole(ctx, client, al, standardRolePrefixName, standardRoleUpdateFn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var awsicRoleUpdateFn applyAccessFlagsToRole
+	if c.awsicAssignmentsSet {
+		awsicRoleUpdateFn = c.applyAWSICFlagsToRole
+	}
+	awsicRole, err := resolveAccessRole(ctx, client, al, awsicRolePrefixName, awsicRoleUpdateFn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if standardRole != nil {
+		updatedAccessRoles = append(updatedAccessRoles, standardRole)
+	}
+	if awsicRole != nil {
+		updatedAccessRoles = append(updatedAccessRoles, awsicRole)
+	}
+
+	return updatedAccessRoles, nil
+}
+
 // updateAccessListWithPreset updates an access list spec/meta and its related access roles.
 func (c *Command) updateAccessListWithPreset(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) (*accesslist.AccessList, []string, []string, error) {
+	// The backend replaces grants wholesale without validating them, so this
+	// is the only place hand-edited grants are caught before they are dropped.
 	if err := rejectUnknownGrants(al); err != nil {
 		return nil, nil, nil, trace.Wrap(err)
 	}
 
-	var updatedAccessRoles []*types.RoleV6
-	if !c.removeAccess {
-		var standardRoleUpdateFn applyAccessFlagsToRole
-		if c.anyStandardAccessFlagsSet() {
-			standardRoleUpdateFn = c.applyStandardAccessFlagsToRole
-		}
-		standardRole, err := resolveAccessRole(ctx, client, al, standardRolePrefixName, standardRoleUpdateFn)
-		if err != nil {
-			return nil, nil, nil, trace.Wrap(err)
-		}
-
-		var awsicRoleUpdateFn applyAccessFlagsToRole
-		if c.awsicAssignmentsSet {
-			awsicRoleUpdateFn = c.applyAWSICFlagsToRole
-		}
-		awsicRole, err := resolveAccessRole(ctx, client, al, awsicRolePrefixName, awsicRoleUpdateFn)
-		if err != nil {
-			return nil, nil, nil, trace.Wrap(err)
-		}
-
-		if standardRole != nil {
-			updatedAccessRoles = append(updatedAccessRoles, standardRole)
-		}
-		if awsicRole != nil {
-			updatedAccessRoles = append(updatedAccessRoles, awsicRole)
-		}
-	} // else, no roles appended means "remove these access roles from al grants"
+	updatedAccessRoles, err := c.buildUpdatedAccessRoles(ctx, client, al)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
 
 	grpcClient := accesslistv1.NewAccessListServiceClient(client.GetConnection())
 	resp, err := grpcClient.UpdateAccessListWithPreset(ctx, accesslistv1.UpdateAccessListWithPresetRequest_builder{
@@ -399,6 +432,34 @@ func (c *Command) printUpdateText(r UpdateJSONResponse) {
 	}
 
 	c.printRolesToBeDeleted(r.RolesToDelete)
+}
+
+func (c *Command) dryRunUpdate(ctx context.Context, client *authclient.Client, al *accesslist.AccessList, members []*accesslist.AccessListMember) error {
+	alPresetType := al.GetAllLabels()[accesslist.AccessListPresetLabel]
+
+	var accessRoles []*types.RoleV6
+	if alPresetType != "" {
+		var err error
+		accessRoles, err = c.buildUpdatedAccessRoles(ctx, client, al)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return trace.Wrap(c.writeOutput(al, accessRoles, membersForDryRunUpdate(members), alPresetType))
+}
+
+func membersForDryRunUpdate(members []*accesslist.AccessListMember) []*accesslist.AccessListMember {
+	out := make([]*accesslist.AccessListMember, 0, len(members))
+	for _, member := range members {
+		memberCopy := member.Clone()
+		// These fields will be filled in the backend
+		memberCopy.Metadata.Revision = ""
+		memberCopy.Spec.Joined = time.Time{}
+		memberCopy.Spec.AddedBy = ""
+		out = append(out, memberCopy)
+	}
+	return out
 }
 
 // resolveAccessRole returns the access role to send for upsert. A role is

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -49,6 +49,10 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 		return trace.BadParameter("no update flags are set")
 	}
 
+	if c.output != "" && c.formatSet {
+		return trace.BadParameter("--output and --format cannot be combined")
+	}
+
 	// To avoid non-atomic partial writes, member updates are to be run
 	// separately from updates to access list meta/spec. Combining
 	// both means there will be partial failures where grants may be
@@ -109,6 +113,12 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		// Requested dry-run.
+		if c.output != "" {
+			return trace.Wrap(c.dryRunUpdate(ctx, client, al, updatedMembers))
+		}
+
 		updatedAccessList, _, err = client.AccessListClient().UpsertAccessListWithMembers(ctx, al, updatedMembers)
 		if err != nil {
 			return trace.Wrap(err)
@@ -129,6 +139,15 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 				return trace.BadParameter("an access list must have at least one owner")
 			}
 			al.Spec.Owners = updatedOwners
+		}
+
+		// Requested dry-run.
+		if c.output != "" {
+			members, err := c.collectAllMembers(ctx, client, aclName)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			return trace.Wrap(c.dryRunUpdate(ctx, client, al, members))
 		}
 
 		if al.IsPreset() && (c.anyAccessFlagsSet() || c.removeAccess) {
@@ -334,39 +353,53 @@ func (c *Command) buildOwnersForUpdate(al *accesslist.AccessList) ([]accesslist.
 	return newOwners, removedOwners, trace.NewAggregate(userErr, listErr)
 }
 
+func (c *Command) buildUpdatedAccessRoles(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) ([]*types.RoleV6, error) {
+	if c.removeAccess {
+		return nil, nil // no roles appended means "remove these access roles from al grants"
+	}
+
+	var updatedAccessRoles []*types.RoleV6
+	var standardRoleUpdateFn applyAccessFlagsToRole
+
+	if c.anyStandardAccessFlagsSet() {
+		standardRoleUpdateFn = c.applyStandardAccessFlagsToRole
+	}
+	standardRole, err := resolveAccessRole(ctx, client, al, standardRolePrefixName, standardRoleUpdateFn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var awsicRoleUpdateFn applyAccessFlagsToRole
+	if c.awsicAssignmentsSet {
+		awsicRoleUpdateFn = c.applyAWSICFlagsToRole
+	}
+	awsicRole, err := resolveAccessRole(ctx, client, al, awsicRolePrefixName, awsicRoleUpdateFn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if standardRole != nil {
+		updatedAccessRoles = append(updatedAccessRoles, standardRole)
+	}
+	if awsicRole != nil {
+		updatedAccessRoles = append(updatedAccessRoles, awsicRole)
+	}
+
+	return updatedAccessRoles, nil
+}
+
 // updateAccessListWithPreset updates an access list spec/meta and its related access roles.
 func (c *Command) updateAccessListWithPreset(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) (*accesslist.AccessList, []string, []string, error) {
+	// The backend replaces grants wholesale without validating them, so this
+	// is the only place hand-edited grants are caught before they are dropped.
 	if err := rejectUnknownGrants(al); err != nil {
 		return nil, nil, nil, trace.Wrap(err)
 	}
 
-	var updatedAccessRoles []*types.RoleV6
-	if !c.removeAccess {
-		var standardRoleUpdateFn applyAccessFlagsToRole
-		if c.anyStandardAccessFlagsSet() {
-			standardRoleUpdateFn = c.applyStandardAccessFlagsToRole
-		}
-		standardRole, err := resolveAccessRole(ctx, client, al, standardRolePrefixName, standardRoleUpdateFn)
-		if err != nil {
-			return nil, nil, nil, trace.Wrap(err)
-		}
-
-		var awsicRoleUpdateFn applyAccessFlagsToRole
-		if c.awsicAssignmentsSet {
-			awsicRoleUpdateFn = c.applyAWSICFlagsToRole
-		}
-		awsicRole, err := resolveAccessRole(ctx, client, al, awsicRolePrefixName, awsicRoleUpdateFn)
-		if err != nil {
-			return nil, nil, nil, trace.Wrap(err)
-		}
-
-		if standardRole != nil {
-			updatedAccessRoles = append(updatedAccessRoles, standardRole)
-		}
-		if awsicRole != nil {
-			updatedAccessRoles = append(updatedAccessRoles, awsicRole)
-		}
-	} // else, no roles appended means "remove these access roles from al grants"
+	updatedAccessRoles, err := c.buildUpdatedAccessRoles(ctx, client, al)
+	if err != nil {
+		return nil, nil, nil, trace.Wrap(err)
+	}
 
 	grpcClient := accesslistv1.NewAccessListServiceClient(client.GetConnection())
 	resp, err := grpcClient.UpdateAccessListWithPreset(ctx, accesslistv1.UpdateAccessListWithPresetRequest_builder{
@@ -404,6 +437,34 @@ func (c *Command) printUpdateText(r UpdateJSONResponse) {
 	}
 
 	c.printRolesToBeDeleted(r.RolesToDelete)
+}
+
+func (c *Command) dryRunUpdate(ctx context.Context, client *authclient.Client, al *accesslist.AccessList, members []*accesslist.AccessListMember) error {
+	alPresetType := al.GetAllLabels()[accesslist.AccessListPresetLabel]
+
+	var accessRoles []*types.RoleV6
+	if alPresetType != "" {
+		var err error
+		accessRoles, err = c.buildUpdatedAccessRoles(ctx, client, al)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return trace.Wrap(c.writeOutput(al, accessRoles, membersForDryRunUpdate(members), alPresetType))
+}
+
+func membersForDryRunUpdate(members []*accesslist.AccessListMember) []*accesslist.AccessListMember {
+	out := make([]*accesslist.AccessListMember, 0, len(members))
+	for _, member := range members {
+		memberCopy := member.Clone()
+		// These fields will be filled in the backend
+		memberCopy.Metadata.Revision = ""
+		memberCopy.Spec.Joined = time.Time{}
+		memberCopy.Spec.AddedBy = ""
+		out = append(out, memberCopy)
+	}
+	return out
 }
 
 // resolveAccessRole returns the access role to send for upsert. A role is

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -349,6 +349,10 @@ func (c *Command) buildOwnersForUpdate(al *accesslist.AccessList) ([]accesslist.
 }
 
 func (c *Command) buildUpdatedAccessRoles(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) ([]*types.RoleV6, error) {
+	if err := rejectUnknownGrants(al); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if c.removeAccess {
 		return nil, nil // no roles appended means "remove these access roles from al grants"
 	}
@@ -385,12 +389,6 @@ func (c *Command) buildUpdatedAccessRoles(ctx context.Context, client *authclien
 
 // updateAccessListWithPreset updates an access list spec/meta and its related access roles.
 func (c *Command) updateAccessListWithPreset(ctx context.Context, client *authclient.Client, al *accesslist.AccessList) (*accesslist.AccessList, []string, []string, error) {
-	// The backend replaces grants wholesale without validating them, so this
-	// is the only place hand-edited grants are caught before they are dropped.
-	if err := rejectUnknownGrants(al); err != nil {
-		return nil, nil, nil, trace.Wrap(err)
-	}
-
 	updatedAccessRoles, err := c.buildUpdatedAccessRoles(ctx, client, al)
 	if err != nil {
 		return nil, nil, nil, trace.Wrap(err)


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/8271 

This PR supports `tctl acl create/update --output=terraform` command to print terraform configs without applying the changes (dry-run)


Integration test is located in enterprise: https://github.com/gravitational/teleport.e/pull/9363 (it includes example output of the command through golden files)


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: `tctl acl create` and `tctl acl update` now support `--output=terraform` to print the Terraform config for the resulting resources instead of applying the change (dry-run).



<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

cloud staging

### Test Cases
both cases tests for a custom and a preset list:

- [x] `tctl acl create --output=terraform ...` prints terraform config, and does not create the resources
- [x] `tctl acl update ABCD --output=terraform ...` prints terraform config, and does not update the resource