### PR TITLE
[v18] Fix lock of delegated joining Bots when BotInstance is not found

### DIFF
--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -387,9 +387,9 @@ func (a *Server) updateBotInstance(
 		// codepath. (But may need to clean up log messages.)
 
 		// Set the initial generation counter. Note that with bot instances, the
-		// counter is now set for all join methods, but only enforced for token
-		// joins.
-		if currentIdentityGeneration > 0 {
+		// counter is now set for all join methods, but only enforced for some
+		// (see shouldEnforceGenerationCounter).
+		if currentIdentityGeneration > 0 && shouldEnforceGenerationCounter(req.Renewable, authRecord.GetJoinMethod()) {
 			// If the incoming identity has a nonzero generation, validate it
 			// using the legacy check. This will increment the counter on the
 			// request automatically
@@ -405,7 +405,14 @@ func (a *Server) updateBotInstance(
 			// Copy the value from the request into the auth record.
 			authRecord.Generation = int32(req.Generation)
 		} else {
-			// Otherwise, just set it to 1.
+			if currentIdentityGeneration > 0 {
+				a.logger.WarnContext(ctx, "bot rejoined with a nonzero generation but its instance record was not found, a fresh instance will be issued",
+					"bot_name", botName,
+					"missing_instance_id", botInstanceID,
+					"identity_generation", currentIdentityGeneration,
+					"join_method", authRecord.GetJoinMethod(),
+				)
+			}
 			req.Generation = 1
 			authRecord.Generation = 1
 		}

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -1052,6 +1052,26 @@ func TestRegisterBot_BotInstanceRejoin(t *testing.T) {
 
 	// Note: Lying via IAM join not tested as that must be routed through the
 	// join service (along with Azure and TPM).
+
+	// Simulate the instance record disappearing (expired, deleted, or backend
+	// rollback): the rejoin should be issued a fresh instance, not denied, and
+	// must not lock the join token.
+	require.NoError(t, a.BotInstance.DeleteBotInstance(ctx, botName, initialK8sInstanceID))
+
+	freshK8sResult, err := registerHelper(ctx, k8sToken, addr, func(p *joinclient.JoinParams) {
+		p.KubernetesReadFileFunc = k8sReadFileFunc
+		p.AuthClient = k8sClient
+	})
+	require.NoError(t, err)
+
+	freshK8sID, freshK8sGeneration := instanceIDFromCerts(t, freshK8sResult.Certs)
+	require.NotEmpty(t, freshK8sID)
+	require.NotEqual(t, initialK8sInstanceID, freshK8sID)
+	require.Equal(t, uint64(1), freshK8sGeneration)
+
+	locks, err := a.GetLocks(ctx, true, types.LockTarget{JoinToken: k8sToken.GetName()})
+	require.NoError(t, err)
+	require.Empty(t, locks)
 }
 
 // TestRegisterBotWithInvalidInstanceID ensures that client-specified instance


### PR DESCRIPTION
Backport #69325 to branch/v18

changelog: Fixed spurious lockout of delegated-join Bots when the BotInstance record does not exist (i.e database has been restored from backup).

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Perform delegated join, delete BotInstance, trigger a renewal, and observe that `tbot` can renew.

Agentic test plan: https://gist.github.com/strideynet/5839617ee97ac626b69af5557194d002
