### PR TITLE
docs: app access and auto-discovery guides: friction points found during agent testing

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
@@ -151,13 +151,15 @@ integration '<Var name="my-integration"/>' has been created
 
 ### Validate the integration
 
-To validate the integration without making a mutating AWS change, run:
+To validate the integration without modifying any AWS resources, run::
 
 ```code
 $ tctl integrations test <Var name="my-integration"/>
 ```
 
-This command calls AWS STS `GetCallerIdentity` using the OIDC token exchange, confirming that AWS trusts Teleport's identity provider and can assume the configured IAM role. If the integration is working, the command returns the AWS account ID and assumed role ARN, and you can skip ahead to [Next steps](#next-steps).
+This command calls AWS STS `GetCallerIdentity` using the OIDC token exchange, confirming that AWS trusts Teleport's identity provider and can assume the configured IAM role.
+
+If the integration is working, the command returns the AWS account ID and assumed role ARN, and you can skip ahead to [Next steps](#next-steps).
 
 If `tctl integrations test` fails, use the following steps to narrow down where
 the problem is.

--- a/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
@@ -151,6 +151,17 @@ integration '<Var name="my-integration"/>' has been created
 
 ### Validate the integration
 
+To validate the integration without making a mutating AWS change, run:
+
+```code
+$ tctl integrations test <Var name="my-integration"/>
+```
+
+This command calls AWS STS `GetCallerIdentity` using the OIDC token exchange, confirming that AWS trusts Teleport's identity provider and can assume the configured IAM role. If the integration is working, the command returns the AWS account ID and assumed role ARN, and you can skip ahead to [Next steps](#next-steps).
+
+If `tctl integrations test` fails, use the following steps to narrow down where
+the problem is.
+
 First, confirm the integration resource was created:
 
 ```code
@@ -200,14 +211,6 @@ A successful response returns a JSON document:
 
 If this endpoint is not reachable or does not return valid JSON, AWS will not be
 able to validate tokens issued by Teleport and the integration will not work.
-
-<Admonition type="tip">
-Starting in a future Teleport release, the `tctl integrations test` command
-will provide end-to-end validation of the AWS OIDC trust relationship. It
-calls AWS STS `GetCallerIdentity` using the OIDC token exchange, confirming
-that AWS trusts Teleport's identity provider and can assume the configured IAM
-role. A successful result returns the AWS account ID and assumed role ARN.
-</Admonition>
 
 After the set up is complete, you can now use the "Enroll New Resource" flow in Teleport Web UI, or other integration dependent features.
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/awsoidc-integration.mdx
@@ -151,7 +151,7 @@ integration '<Var name="my-integration"/>' has been created
 
 ### Validate the integration
 
-To validate the integration without modifying any AWS resources, run::
+To validate the integration without modifying any AWS resources, run:
 
 ```code
 $ tctl integrations test <Var name="my-integration"/>

--- a/docs/pages/enroll-resources/application-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/application-access/getting-started.mdx
@@ -55,6 +55,13 @@ For this tutorial, verify your environment meets the following requirements:
 
 (!docs/pages/includes/dns-app-access.mdx!)
 
+<Admonition type="warning">
+If you are self-hosting Teleport, you must configure wildcard DNS and TLS
+certificates before applications will be accessible. Without this, browsers
+will fail to connect to application subdomains like
+`https://grafana.teleport.example.com`.
+</Admonition>
+
 ### Rights and permissions
 
 This tutorial assumes that you have administrative rights for the Teleport cluster

--- a/docs/pages/enroll-resources/application-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/application-access/getting-started.mdx
@@ -56,10 +56,11 @@ For this tutorial, verify your environment meets the following requirements:
 (!docs/pages/includes/dns-app-access.mdx!)
 
 <Admonition type="warning">
-If you are self-hosting Teleport, you must configure wildcard DNS and TLS
-certificates before applications will be accessible. Without this, browsers
-will fail to connect to application subdomains like
-`https://grafana.teleport.example.com`.
+If you are self-hosting Teleport, the simplest approach is to configure wildcard
+DNS and TLS certificates (e.g., `*.teleport.example.com`). Without wildcard coverage, 
+you must provision individual DNS records and TLS certificates for each application 
+subdomain (e.g., `grafana.teleport.example.com`). Either way, browsers will fail to 
+connect to application subdomains that lack valid DNS and TLS configuration.
 </Admonition>
 
 ### Rights and permissions

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -260,31 +260,29 @@ Please make sure to update lib/service/servicecfg/app.go and lib/services/app.go
 if you change this section header or move this page.
 */}
 
-An application name must be unique across root and leaf clusters in a
-trusted clusters environment. Validation rules depend on where the app
-is registered:
+An application name must be unique across root and leaf clusters in a Trusted
+Clusters environment. Validation rules depend on where the app is registered:
 
-- **Static config (`app_service.apps` in YAML)**: lowercase
-  alphanumeric and `-`, max 63 characters, no dots, must start and end
-  with alphanumeric. Mixed-case names are rejected at startup, as are
-  duplicate names.
-- **Dynamic resources (`tctl create app`, integrations, Kubernetes
-  operator)**: lowercase alphanumeric, `-`, `_`, or `.`, max 253
-  characters. On Teleport Cloud, avoid `.` in app names: the tenant
-  wildcard certificate only covers one subdomain level
-  (`*.<tenant>.teleport.sh`), so dotted names will fail TLS
-  validation. Underscores are accepted by the Auth Service and the
-  cluster's wildcard cert, but strict TLS clients
-  (OpenSSL with `verify_hostname`) and proxies like NGINX (with
-  `underscores_in_headers off`) may reject them at access time.
+- **Static config** (`app_service.apps` in YAML): lowercase alphanumeric and
+  `-`, max 63 characters, no dots. Must start and end with an alphanumeric
+  character. Mixed-case names and duplicates are rejected at startup.
+- **Dynamic resources** (`tctl create app`, integrations, Kubernetes Operator):
+  lowercase alphanumeric, `-`, `_`, or `.`, max 253 characters.
 
-`public_addr` (if set) must be a bare, lowercase DNS hostname. URI
+<Admonition type="warning" title="Characters that can cause issues">
+On Teleport Enterprise (Cloud), avoid `.` in app names. The tenant wildcard
+certificate only covers one subdomain level (`*.<tenant>.teleport.sh`), so
+dotted names fail TLS validation. Underscores are accepted by the Auth Service
+but strict TLS clients (OpenSSL with `verify_hostname`) and proxies like NGINX
+(with `underscores_in_headers off`) may reject them.
+</Admonition>
+
+If you set `public_addr`, it must be a bare, lowercase DNS hostname. URI
 schemes, ports, IP addresses, and uppercase letters are rejected.
 
-Two apps that route to the same FQDN create an ambiguous request, so
-Teleport does its best to reject such collisions. When `proxy_service`
-is colocated in the same static configuration, it rejects them at
-startup.
+Two apps that route to the same FQDN create an ambiguous routing state.
+Teleport rejects such collisions when `proxy_service` is colocated in the same
+static configuration.
 
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`
 e.g. `grafana.teleport.example.com`. You can also override `public_addr` e.g

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -270,19 +270,30 @@ Clusters environment. Validation rules depend on where the app is registered:
   lowercase alphanumeric, `-`, `_`, or `.`, max 253 characters.
 
 <Admonition type="warning" title="Characters that can cause issues">
-On Teleport Enterprise (Cloud), avoid `.` in app names. The tenant wildcard
-certificate only covers one subdomain level (`*.<tenant>.teleport.sh`), so
-dotted names fail TLS validation. Underscores are accepted by the Auth Service
-but strict TLS clients (OpenSSL with `verify_hostname`) and proxies like NGINX
-(with `underscores_in_headers off`) may reject them.
+Avoid `.` in app names. The tenant wildcard certificate only covers one subdomain 
+level (`*.<tenant>.teleport.sh`), so dotted names fail TLS validation. Underscores 
+are accepted by the Auth Service but strict TLS clients (OpenSSL with `verify_hostname`)
+and proxies like NGINX (with `underscores_in_headers off`) may reject them.
 </Admonition>
 
 If you set `public_addr`, it must be a bare, lowercase DNS hostname. URI
 schemes, ports, IP addresses, and uppercase letters are rejected.
 
-Two apps that route to the same FQDN create an ambiguous routing state.
-Teleport rejects such collisions when `proxy_service` is colocated in the same
-static configuration.
+Two apps that resolve to the same FQDN create an ambiguous routing state.
+Teleport detects several forms of this collision in static configuration
+(`app_service.apps` in YAML) and rejects them at startup:
+
+| Collision type | Example | Detected | Condition | Since |
+|---|---|---|---|---|
+| Duplicate explicit `public_addr` | Two apps set `public_addr: dash.example.com` | Always | — | v19 |
+| Duplicate `name` | Two apps named `dash` derive the same FQDN | Always | — | v19 |
+| Derived address matches explicit | `name: kibana` derives `kibana.tele.example.com`, colliding with another app's `public_addr` | Conditionally | `proxy_service.public_addr` or `auth_service.cluster_name` must be in the same config file | v19 |
+| App claims the proxy address | `public_addr: tele.example.com` matches the proxy's own address | Always | Checked against registered proxies in the backend | v18 |
+
+If none of these checks can detect the collision — for example, when the
+conflicting apps are registered by separate agents that each lack
+`proxy_service.public_addr` in their config — Teleport does not reject the
+configuration at startup, and routing behavior is undefined.
 
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`
 e.g. `grafana.teleport.example.com`. You can also override `public_addr` e.g

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -266,8 +266,8 @@ Clusters environment. Validation rules depend on where the app is registered:
 - **Static config** (`app_service.apps` in YAML): lowercase alphanumeric and
   `-`, max 63 characters, no dots. Must start and end with an alphanumeric
   character. Mixed-case names and duplicates are rejected at startup.
-- **Dynamic resources** (`tctl create app`, integrations, Kubernetes Operator):
-  lowercase alphanumeric, `-`, `_`, or `.`, max 253 characters.
+- **Dynamic resources** (`tctl create my-app.yaml`, Terraform provider, 
+  Kubernetes Operator, gRPC API and AWS OIDC and IAM Roles Anywhere integrations):
 
 <Admonition type="warning" title="Characters that can cause issues">
 Avoid `.` in app names. The tenant wildcard certificate only covers one subdomain 

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -124,20 +124,22 @@ Install Teleport on the EC2 instance that will run the Discovery Service:
 
 (!docs/pages/includes/auto-discovery/ec2-config.mdx!)
 
+<Admonition type="warning">
+For this guided flow, use the **Static configuration** tab above, not
+**Dynamic configuration**. Dynamic configuration is recommended in general,
+but `teleport discovery bootstrap` in the next step only reads a local
+`discovery_service.aws` matcher in `/etc/teleport.yaml` — it cannot detect a
+dynamic `discovery_config` resource. If you want to use dynamic
+`discovery_config`, follow [Manual EC2 Auto-Discovery
+Configuration](ec2-discovery-manual.mdx) instead of this guide.
+</Admonition>
+
 ## Step 5/6. Bootstrap the Discovery Service AWS configuration
 
-<Admonition type="warning">
-This step only works if you configured EC2 discovery using a local
-`discovery_service.aws` matcher in `/etc/teleport.yaml` in Step 4.
-`teleport discovery bootstrap` reads its configuration from that local file
-only. If you instead configured a dynamic `discovery_config` resource in Step
-4, this command will not detect it, will report that no additional
-configuration is required, and will not create the IAM policy that EC2
-discovery needs — leaving Step 6 unable to enroll instances. If you're using a
-dynamic `discovery_config`, either add an equivalent matcher to
-`/etc/teleport.yaml` before running this command, or configure the required
-IAM policies and SSM documents manually by following [Manual EC2
-Auto-Discovery Configuration](ec2-discovery-manual.mdx) instead of this step.
+<Admonition type="note">
+This step requires the local `discovery_service.aws` matcher you configured
+in Step 4. `teleport discovery bootstrap` reads its configuration from
+`/etc/teleport.yaml` only.
 </Admonition>
 
 On the same Node as above, run `teleport discovery bootstrap`. This command

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -1,7 +1,6 @@
 ---
 title: Guided EC2 Auto-Discovery Configuration
-sidebar_label: Guided Setup for Single Account
-sidebar_position: 1
+sidebar_label: Guided
 description: How to configure Teleport EC2 auto-discovery using Teleport to configure permissions
 page_type: how-to
 tags:
@@ -34,20 +33,26 @@ If you manage multiple AWS accounts in an AWS Organization, see [Organization-le
 
 - AWS account with EC2 instances and permissions to create and attach IAM
 policies.
-- EC2 instances to enroll with your Teleport cluster. These instances must be
-  running Ubuntu/Debian/RHEL/Amazon Linux 2/Amazon Linux 2023 and SSM agent
-  version 3.1 or greater if making use of the default Teleport install script.
-  (For other Linux distributions, you can install Teleport manually.)
+- EC2 instances to enroll with your Teleport cluster. These instances must
+  meet the following requirements:
+  - Running Ubuntu/Debian/RHEL/Amazon Linux 2/Amazon Linux 2023, and SSM agent
+    version 3.1 or greater if making use of the default Teleport install
+    script. (For other Linux distributions, you can install Teleport
+    manually.)
+  - Include the `AmazonSSMManagedInstanceCore` IAM policy so they can receive
+    commands from the Discovery Service. For a list of permissions included in
+    the policy, see the [AWS
+    documentation](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html).
+  - Have the SSM agent installed and running. Amazon Linux 2 and Amazon Linux
+    2023 include it by default. For Ubuntu and Debian instances, install it
+    manually or via user data before discovery can enroll them. See the [AWS
+    Systems Manager
+    documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-install-ssm-agent.html)
+    for installation instructions.
 - An EC2 instance to run the Teleport Discovery Service. This instance must have
   an instance profile. In this guide, we assume the instance role is called
   `TeleportDiscoveryService`.
 - (!docs/pages/includes/tctl.mdx!)
-
-All EC2 instances that are to be added to the Teleport cluster by the Discovery
-Service must include the `AmazonSSMManagedInstanceCore` IAM policy in order to
-receive commands from the Discovery Service. For a list of permissions included
-in the policy, see the [AWS
-documentation](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html).
 
 ## Step 1/6. Create an EC2 invite token
 
@@ -97,6 +102,11 @@ the command.
      --policy-arn ${POLICY_ARN}
    ```
 
+   <Admonition type="note">
+   IAM policy changes can take 1–2 minutes to propagate. Wait before
+   proceeding to avoid permission errors when the Discovery Service starts.
+   </Admonition>
+
 ## Step 3/6. Install Teleport on the Discovery Node
 
 <Admonition type="tip">
@@ -116,9 +126,24 @@ Install Teleport on the EC2 instance that will run the Discovery Service:
 
 ## Step 5/6. Bootstrap the Discovery Service AWS configuration
 
+<Admonition type="warning">
+This step only works if you configured EC2 discovery using a local
+`discovery_service.aws` matcher in `/etc/teleport.yaml` in Step 4.
+`teleport discovery bootstrap` reads its configuration from that local file
+only. If you instead configured a dynamic `discovery_config` resource in Step
+4, this command will not detect it, will report that no additional
+configuration is required, and will not create the IAM policy that EC2
+discovery needs — leaving Step 6 unable to enroll instances. If you're using a
+dynamic `discovery_config`, either add an equivalent matcher to
+`/etc/teleport.yaml` before running this command, or configure the required
+IAM policies and SSM documents manually by following [Manual EC2
+Auto-Discovery Configuration](ec2-discovery-manual.mdx) instead of this step.
+</Admonition>
+
 On the same Node as above, run `teleport discovery bootstrap`. This command
-will generate and display the additional IAM policies and AWS Systems Manager (SSM) documents
-required to enable the Discovery Service:
+reads the configuration from Step 4 and creates the IAM policies and SSM
+documents that the Discovery Service requires, including the SSM document
+referenced by `document_name` in the configuration:
 
 ```code
 $ sudo teleport discovery bootstrap

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -1,7 +1,6 @@
 ---
 title: Manual EC2 Auto-Discovery Configuration
-sidebar_label: Manual Setup for Single Account
-sidebar_position: 2
+sidebar_label: Manual
 description: How to configure Teleport EC2 auto-discovery with manually configured permissions
 page_type: how-to
 tags:
@@ -33,21 +32,27 @@ If you manage multiple AWS accounts in an AWS Organization, see [Organization-le
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - AWS account with EC2 instances and permissions to create and attach IAM
-  policies.
-- EC2 instances to enroll with your Teleport cluster. These instances must be
-  running Ubuntu/Debian/RHEL/Amazon Linux 2/Amazon Linux 2023 and SSM agent
-  version 3.1 or greater if making use of the default Teleport install script.
-  (For other Linux distributions, you can install Teleport manually.)
+policies.
+- EC2 instances to enroll with your Teleport cluster. These instances must
+  meet the following requirements:
+  - Running Ubuntu/Debian/RHEL/Amazon Linux 2/Amazon Linux 2023, and SSM agent
+    version 3.1 or greater if making use of the default Teleport install
+    script. (For other Linux distributions, you can install Teleport
+    manually.)
+  - Include the `AmazonSSMManagedInstanceCore` IAM policy so they can receive
+    commands from the Discovery Service. For a list of permissions included in
+    the policy, see the [AWS
+    documentation](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html).
+  - Have the SSM agent installed and running. Amazon Linux 2 and Amazon Linux
+    2023 include it by default. For Ubuntu and Debian instances, install it
+    manually or via user data before discovery can enroll them. See the [AWS
+    Systems Manager
+    documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-install-ssm-agent.html)
+    for installation instructions.
 - An EC2 instance to run the Teleport Discovery Service. This instance must have
   an instance profile. In this guide, we assume the instance role is called
   `TeleportDiscoveryService`.
 - (!docs/pages/includes/tctl.mdx!)
-
-All EC2 instances that are to be added to the Teleport cluster by the Discovery
-Service must include the `AmazonSSMManagedInstanceCore` IAM policy in order to
-receive commands from the Discovery Service. For a list of permissions included
-in the policy, see the [AWS
-documentation](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html).
 
 ## Step 1/5. Create an EC2 invite token
 
@@ -92,6 +97,11 @@ Linux servers running on your AWS infrastructure and install Teleport on them.
    $ aws iam attach-role-policy --role-name TeleportDiscoveryService \
      --policy-arn ${POLICY_ARN}
    ```
+
+   <Admonition type="note">
+   IAM policy changes can take 1–2 minutes to propagate. Wait before
+   proceeding to avoid permission errors when the Discovery Service starts.
+   </Admonition>
 
 ## Step 3/5. Install Teleport on the Discovery Node
 


### PR DESCRIPTION
Resolves https://github.com/gravitational/teleport/issues/68654

Addresses the highest-friction documentation issues identified during a live audit/agent run through of the Application Access and Auto-Discovery guides via Claude Code running on Beams, using AWS test account
