### PR TITLE
`lib/client/proxy/insecure`: Add support for `api/client.ALPNConnUpgradePing`

### DIFF
--- a/lib/client/proxy/insecure/insecure.go
+++ b/lib/client/proxy/insecure/insecure.go
@@ -55,6 +55,12 @@ type ConnectionConfig struct {
 	Insecure bool
 	// Log is the logger.
 	Log *slog.Logger
+	// ALPNConnUpgradePing wraps an ALPN-upgraded connection with the Ping
+	// protocol so that it survives L7 load balancer idle timeouts. Callers that
+	// issue long-lived or blocking RPCs must set this. Otherwise no traffic flows
+	// on the upgraded tunnel while the server waits and the connection can be
+	// dropped.
+	ALPNConnUpgradePing bool
 }
 
 // NewConnection attempts to connect to the proxy insecure grpc server.
@@ -81,6 +87,7 @@ func NewConnection(
 		apidefaults.DefaultIOTimeout,
 		client.WithInsecureSkipVerify(params.Insecure),
 		client.WithALPNConnUpgrade(alpnConnUpgrade),
+		client.WithALPNConnUpgradePing(params.ALPNConnUpgradePing),
 	)
 
 	//nolint:staticcheck // ignore deprecation until https://github.com/grpc/grpc-go/issues/7556 is fixed, at which point we should switch to grpc.NewClient.

--- a/lib/mobile/verify/enroll/enroll.go
+++ b/lib/mobile/verify/enroll/enroll.go
@@ -79,6 +79,10 @@ func (c *Client) CreateMobileEnrollToken(pairingToken string, deviceData *Device
 			Clock:       clockwork.NewRealClock(),
 			Insecure:    c.insecure,
 			Log:         slog.Default(),
+			// CreatePairedDeviceEnrollToken blocks until the enrollment is
+			// approved in the Web UI, so keep the upgraded connection alive to
+			// survive L7 load balancer idle timeouts.
+			ALPNConnUpgradePing: true,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
This adds an optional flag `ALPNConnUpgradePing` which is passed to `client.WithALPNConnUpgradePing`, a `client.NewDialer` option. This is what `lib/client` uses with TLS routing enabled. It has no effect unless `alpnConnUpgrade` resolves to true and sets `alpnConnUpgradeRequired` on `dialProxyConfig`.

https://github.com/gravitational/teleport/blob/79059bd9acaba6b215fd69da95280bb872ca65ce/lib/client/proxy/insecure/insecure.go#L82-L91

I'm leaving existing callers that use `lib/client/proxy/insecure` (join clients and secret scanners) unchanged to keep the scope small. The client we use for the mobile app should have it set to true because one of the RPCs that we add is going to wait for user input (the flow is similar to headless login).

