### PR TITLE
bug(Discovery): fix org unit UI validation for subscription scope

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -278,7 +278,11 @@ export function ScopeSection({
 }: ScopeSectionProps) {
   const isOrganization = scope === 'organization';
   const includeValidationResult = useRule(
-    includeOrgUnitsRule(orgUnits.include)
+    isOrganization
+      ? includeOrgUnitsRule(orgUnits.include)
+      : () => ({
+          valid: true,
+        })
   );
 
   return (


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/66122
Previous PR: https://github.com/gravitational/teleport/pull/68961

small fix to disable Organization include list validation when subscription scope is selected

Will include in v18 backport PR https://github.com/gravitational/teleport/pull/69328

## demo

https://github.com/user-attachments/assets/d807e0fe-98a3-4cb8-b990-f6506d076114


## Manual Test Plan

local

### Test Environment

### Test Cases
- [x] Navigate to `/web/integrations/new/aws-cloud`
- [x] Under `Scope`, select `Organization`
- [x] Delete `Include Organizational Units` values
- [x] Verify `Copy Terraform Module` returns a validation error when clicked `At least one organizational unit is required.`
- [x] Under `Scope`, select `Single Account`
- [x] Verify `Copy Terraform Module` returns no error under `Single Account` scope