### PR TITLE
Remove unhealthyPodEvictionPolicy setting from unittest values

### DIFF
--- a/examples/chart/teleport-kube-agent/.lint/pdb.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/pdb.yaml
@@ -5,4 +5,3 @@ highAvailability:
   podDisruptionBudget:
     enabled: true
     minAvailable: 2
-    unhealthyPodEvictionPolicy: "AlwaysAllow"


### PR DESCRIPTION
Follow-up to #69332. Removes `unhealthyPodEvictionPolicy=AlwaysAllow` from the values file shared by pdb unit tests.

I discovered I had the default setting in the values file used by unit tests. This made no difference for v19 where it matched the default, but backporting that change (#69304) where we're changing the default revealed that the new test from #69332 was still a false positive.

## Manual Test Plan
### Test Environment

local / N/A - unittest change only

### Test Cases

- [x] Run helm unit tests

   ```
   make -C examples/chart` test-teleport-kube-agent
   ```

   The presubmits do this too, of course. But since this PR changes only tests, the correct manual test is simply exercising those tests.