### PR TITLE
feat: Beams BYOI prompt (tsh)

### DIFF
--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -2014,4 +2014,7 @@ type ClientI interface {
 
 	// BeamServiceClient returns a client for the beam service.
 	BeamServiceClient() beamsv1.BeamServiceClient
+
+	// BeamsConfigServiceClient returns a client for the beams config service.
+	BeamsConfigServiceClient() beamsv1.BeamsConfigServiceClient
 }

--- a/tool/tsh/common/beams_ls.go
+++ b/tool/tsh/common/beams_ls.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -44,9 +45,10 @@ type beamsLSCommand struct {
 	format string
 
 	// These helper functions can be overridden.
-	fetchFn        func(context.Context, *client.TeleportClient, bool) ([]*beamsv1.Beam, error)
-	proxyAddrFn    func(*CLIConf) (string, error)
-	humanizeTimeFn func(time.Time) string
+	fetchFn            func(context.Context, *client.TeleportClient, bool) ([]*beamsv1.Beam, error)
+	fetchBeamsConfigFn func(context.Context, *client.TeleportClient) (*beamsv1.BeamsConfig, error)
+	proxyAddrFn        func(*CLIConf) (string, error)
+	humanizeTimeFn     func(time.Time) string
 }
 
 func newBeamsLSCommand(parent *kingpin.CmdClause) *beamsLSCommand {
@@ -54,6 +56,7 @@ func newBeamsLSCommand(parent *kingpin.CmdClause) *beamsLSCommand {
 		CmdClause: parent.Command("ls", "List beam instances.").Alias("list"),
 	}
 	cmd.fetchFn = cmd.fetch
+	cmd.fetchBeamsConfigFn = cmd.fetchBeamsConfig
 	cmd.proxyAddrFn = cmd.proxyAddr
 	cmd.humanizeTimeFn = humanize.Time
 
@@ -83,7 +86,7 @@ func (c *beamsLSCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(c.print(cf, beams, proxyAddr))
+	return trace.Wrap(c.print(ctx, tc, cf.Stdout(), beams, proxyAddr))
 }
 
 func (c *beamsLSCommand) fetch(ctx context.Context, tc *client.TeleportClient, all bool) ([]*beamsv1.Beam, error) {
@@ -133,6 +136,27 @@ func (c *beamsLSCommand) fetch(ctx context.Context, tc *client.TeleportClient, a
 	return beams, nil
 }
 
+func (c *beamsLSCommand) fetchBeamsConfig(ctx context.Context, tc *client.TeleportClient) (*beamsv1.BeamsConfig, error) {
+	clusterClient, err := tc.ConnectToCluster(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer clusterClient.Close()
+
+	rootClient, err := clusterClient.ConnectToRootCluster(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rootClient.Close()
+
+	config, err := rootClient.BeamsConfigServiceClient().GetBeamsConfig(ctx, beamsv1.GetBeamsConfigRequest_builder{}.Build())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return config.GetBeamsConfig(), nil
+}
+
 func (c *beamsLSCommand) proxyAddr(cf *CLIConf) (string, error) {
 	_, proxyAddr, err := fetchProxyVersion(cf)
 	if err != nil {
@@ -141,7 +165,7 @@ func (c *beamsLSCommand) proxyAddr(cf *CLIConf) (string, error) {
 	return proxyAddr, nil
 }
 
-func (c *beamsLSCommand) print(cf *CLIConf, beams []*beamsv1.Beam, proxyAddr string) error {
+func (c *beamsLSCommand) print(ctx context.Context, tc *client.TeleportClient, w io.Writer, beams []*beamsv1.Beam, proxyAddr string) error {
 	// Convert to script/agent friendly representation.
 	formatted := make([]formattedBeam, len(beams))
 	for idx, beam := range beams {
@@ -149,15 +173,15 @@ func (c *beamsLSCommand) print(cf *CLIConf, beams []*beamsv1.Beam, proxyAddr str
 	}
 	switch strings.ToLower(c.format) {
 	case teleport.JSON:
-		return trace.Wrap(common.PrintJSONIndent(cf.Stdout(), formatted))
+		return trace.Wrap(common.PrintJSONIndent(w, formatted))
 	case teleport.YAML:
-		return trace.Wrap(common.PrintYAML(cf.Stdout(), formatted))
+		return trace.Wrap(common.PrintYAML(w, formatted))
 	default:
-		return trace.Wrap(c.printTable(cf.Stdout(), formatted))
+		return trace.Wrap(c.printTable(ctx, tc, w, formatted))
 	}
 }
 
-func (c *beamsLSCommand) printTable(w io.Writer, beams []formattedBeam) error {
+func (c *beamsLSCommand) printTable(ctx context.Context, tc *client.TeleportClient, w io.Writer, beams []formattedBeam) error {
 	headings := []string{"ID", "URL", "Region", "Expires"}
 
 	// We only show the owner column when the user passed the `--all` flag,
@@ -179,5 +203,41 @@ func (c *beamsLSCommand) printTable(w io.Writer, beams []formattedBeam) error {
 		}
 		table.AddRow(row)
 	}
-	return trace.Wrap(table.WriteTo(w))
+
+	err := table.WriteTo(w)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	showBYOIPrompt := func() bool {
+		config, err := c.fetchBeamsConfigFn(ctx, tc)
+		if err != nil {
+			// This is a best endeavors feature, so ignore any error fetching config
+			return false
+		}
+		anthropicAppName := config.GetSpec().GetLlm().GetAnthropic().GetAppName()
+		openaiAppName := config.GetSpec().GetLlm().GetOpenai().GetAppName()
+		return anthropicAppName == "anthropic" && openaiAppName == "openai"
+	}()
+
+	if showBYOIPrompt {
+		_, err = fmt.Fprint(w, byoiPrompt)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
 }
+
+const byoiPrompt = `
+╔══════════════════════════════════════════════════════════════╗
+║             Set up your LLM preference for Beams             ║
+║                      via Amazon Bedrock                      ║
+║                                                              ║
+║     Improve the privacy, scalability, and flexibility of     ║
+║                   your agentic workflows.                    ║
+║                                                              ║
+║            https://goteleport.com/docs/beams/byoi            ║
+╚══════════════════════════════════════════════════════════════╝
+`

--- a/tool/tsh/common/beams_ls_test.go
+++ b/tool/tsh/common/beams_ls_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -69,10 +70,13 @@ func TestBeamsLSCommand(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		format  string
-		all     bool
-		wantAll bool
+		name             string
+		format           string
+		all              bool
+		anthropicAppName string
+		openaiAppName    string
+		beamsConfigErr   error
+		wantAll          bool
 	}{
 		{
 			name:    "text format",
@@ -83,6 +87,21 @@ func TestBeamsLSCommand(t *testing.T) {
 			all:     true,
 			format:  teleport.Text,
 			wantAll: true,
+		},
+		{
+			name:           "text format with beams config error",
+			format:         teleport.Text,
+			beamsConfigErr: trace.AccessDenied("ahhh"),
+		},
+		{
+			name:             "text format with beams config customized anthropic",
+			format:           teleport.Text,
+			anthropicAppName: "anthropic-custom",
+		},
+		{
+			name:          "text format with beams config customized openai",
+			format:        teleport.Text,
+			openaiAppName: "openai-custom",
 		},
 		{
 			name:    "JSON format",
@@ -117,6 +136,39 @@ func TestBeamsLSCommand(t *testing.T) {
 				fetchFn: func(_ context.Context, _ *client.TeleportClient, all bool) ([]*beamsv1.Beam, error) {
 					gotAll = all
 					return beams, nil
+				},
+				fetchBeamsConfigFn: func(_ context.Context, _ *client.TeleportClient) (*beamsv1.BeamsConfig, error) {
+					if tt.beamsConfigErr != nil {
+						return nil, tt.beamsConfigErr
+					}
+
+					config := beamsv1.BeamsConfig_builder{
+						Kind:    "beams_config",
+						Version: "v1",
+						Metadata: headerv1.Metadata_builder{
+							Name: "beams-config",
+						}.Build(),
+						Spec: beamsv1.BeamsConfigSpec_builder{
+							Llm: beamsv1.LLMConfig_builder{
+								Anthropic: beamsv1.LLMEndpointConfig_builder{
+									AppName: "anthropic",
+								}.Build(),
+								Openai: beamsv1.LLMEndpointConfig_builder{
+									AppName: "openai",
+								}.Build(),
+							}.Build(),
+						}.Build(),
+					}.Build()
+
+					if tt.anthropicAppName != "" {
+						config.GetSpec().GetLlm().GetAnthropic().SetAppName(tt.anthropicAppName)
+					}
+
+					if tt.openaiAppName != "" {
+						config.GetSpec().GetLlm().GetOpenai().SetAppName(tt.anthropicAppName)
+					}
+
+					return config, nil
 				},
 				proxyAddrFn: func(*CLIConf) (string, error) {
 					return "proxy.example.com:443", nil

--- a/tool/tsh/common/testdata/TestBeamsLSCommand/text_format.golden
+++ b/tool/tsh/common/testdata/TestBeamsLSCommand/text_format.golden
@@ -3,3 +3,13 @@ ID      URL                                      Region       Expires
 alpha   https://alpha-app.proxy.example.com      us-east-1    3 hours from now 
 bravo                                            us-west-2    4 hours from now 
 charlie tcp://charlie-app.proxy.example.com:5432 eu-central-1 5 hours from now 
+
+╔══════════════════════════════════════════════════════════════╗
+║             Set up your LLM preference for Beams             ║
+║                      via Amazon Bedrock                      ║
+║                                                              ║
+║     Improve the privacy, scalability, and flexibility of     ║
+║                   your agentic workflows.                    ║
+║                                                              ║
+║            https://goteleport.com/docs/beams/byoi            ║
+╚══════════════════════════════════════════════════════════════╝

--- a/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_all.golden
+++ b/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_all.golden
@@ -3,3 +3,13 @@ ID      URL                                      Region       Expires          O
 alpha   https://alpha-app.proxy.example.com      us-east-1    3 hours from now alice 
 bravo                                            us-west-2    4 hours from now alice 
 charlie tcp://charlie-app.proxy.example.com:5432 eu-central-1 5 hours from now bob   
+
+╔══════════════════════════════════════════════════════════════╗
+║             Set up your LLM preference for Beams             ║
+║                      via Amazon Bedrock                      ║
+║                                                              ║
+║     Improve the privacy, scalability, and flexibility of     ║
+║                   your agentic workflows.                    ║
+║                                                              ║
+║            https://goteleport.com/docs/beams/byoi            ║
+╚══════════════════════════════════════════════════════════════╝

--- a/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_beams_config_customized_anthropic.golden
+++ b/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_beams_config_customized_anthropic.golden
@@ -1,0 +1,5 @@
+ID      URL                                      Region       Expires          
+------- ---------------------------------------- ------------ ---------------- 
+alpha   https://alpha-app.proxy.example.com      us-east-1    3 hours from now 
+bravo                                            us-west-2    4 hours from now 
+charlie tcp://charlie-app.proxy.example.com:5432 eu-central-1 5 hours from now 

--- a/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_beams_config_customized_openai.golden
+++ b/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_beams_config_customized_openai.golden
@@ -1,0 +1,5 @@
+ID      URL                                      Region       Expires          
+------- ---------------------------------------- ------------ ---------------- 
+alpha   https://alpha-app.proxy.example.com      us-east-1    3 hours from now 
+bravo                                            us-west-2    4 hours from now 
+charlie tcp://charlie-app.proxy.example.com:5432 eu-central-1 5 hours from now 

--- a/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_beams_config_error.golden
+++ b/tool/tsh/common/testdata/TestBeamsLSCommand/text_format_with_beams_config_error.golden
@@ -1,0 +1,5 @@
+ID      URL                                      Region       Expires          
+------- ---------------------------------------- ------------ ---------------- 
+alpha   https://alpha-app.proxy.example.com      us-east-1    3 hours from now 
+bravo                                            us-west-2    4 hours from now 
+charlie tcp://charlie-app.proxy.example.com:5432 eu-central-1 5 hours from now 


### PR DESCRIPTION
## Summary

This change adds a prompt to the result of `tsh beams ls` to advertise the BYOI (Bring Your Own Inference) feature. This feature is relevant only for clusters with beams enabled.

The prompt is hidden when the LLM section of the beams_config resource is modified indicating BYOI is in use. 

Depends on: https://github.com/gravitational/teleport/pull/67670

## Changes

- Add prompt
- Update tests

## Demo

https://github.com/user-attachments/assets/e241ae20-e071-447d-b8b2-97116a5e466e

## Manual Test Plan

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

### Test Environment

Local cluster with beams enabled. A dev build of tsh. A dev build of tctl including support for the beams_config resource.

### Test Cases

- [x] Shows for a clean cluster
- [x] Hidden when either llm app name is different from the defaults
  - [x] anthropic
  - [x] openai
- [x] Hidden when the user does not have permission to **read** `beams_config` 
