### PR TITLE
Don't allow invalid scopes in the scope picker

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -109,6 +109,7 @@ import (
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/services"
@@ -1527,7 +1528,35 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 
 		var assignedScopes []string
 		for _, assignment := range assignments {
-			for _, subAssignment := range assignment.GetSpec().GetAssignments() {
+			for subAssignment := range scopedaccess.WeakValidatedSubAssignments(assignment) {
+				roleRef, err := scopes.ParseQualifiedName(subAssignment.GetRole())
+				if err != nil {
+					continue
+				}
+
+				// This is currently inefficient if there are multiple references to
+				// the same scoped role in the assignments, but this will be alleviated
+				// later when caching is implemented for the scoped role reader.
+				res, err := c.cfg.UnsafeScopedRoleReader.GetScopedRole(
+					r.Context(),
+					scopedaccessv1.GetScopedRoleRequest_builder{
+						Name:  roleRef.Name,
+						Scope: roleRef.Scope,
+					}.Build())
+				if trace.IsNotFound(err) {
+					continue
+				}
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				if !scopedaccess.RoleIsEnforceableAt(res.GetRole(), scopes.EnforcementPoint{
+					ScopeOfOrigin: assignment.GetScope(),
+					ScopeOfEffect: subAssignment.GetScope(),
+				}) {
+					continue
+				}
+
 				assignedScopes = append(assignedScopes, subAssignment.GetScope())
 			}
 		}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -10172,6 +10172,17 @@ func TestUserContextWithScopes(t *testing.T) {
 						Role:  scopes.QualifiedName{Scope: "/test", Name: "role-a"}.String(),
 						Scope: "/test/a2",
 					}.Build(),
+					// This one should not appear; role does not exist.
+					scopedaccessv1.Assignment_builder{
+						Role:  scopes.QualifiedName{Scope: "/test", Name: "role-that-does-not-exist"}.String(),
+						Scope: "/test/broken1",
+					}.Build(),
+					// This one should not appear; role /test::role-a is not enforceable
+					// at scope /test/broken2.
+					scopedaccessv1.Assignment_builder{
+						Role:  scopes.QualifiedName{Scope: "/test", Name: "role-a"}.String(),
+						Scope: "/test/broken2",
+					}.Build(),
 				},
 			}.Build(),
 		}.Build(),


### PR DESCRIPTION
This change removes scopes from assignments that refer to roles that don't exist, as well as assignments that are unenforcable.

## Manual Test Plan
### Test Environment

Any cluster with user `u1` and a following set of resources:

```yaml
kind: scoped_role
metadata:
  name: test-role
scope: /test
spec:
  assignable_scopes: 
  - /test/foo
version: v1

---

kind: scoped_role_assignment
sub_kind: dynamic
metadata:
  name: test-role-assignment
scope: /test
spec:
  user: u1
  assignments:
    - role: /test::test-role
      scope: /test/foo
    - role: /test::role-that-does-not-exist
      scope: /test/broken1
    - role: /test::test-role
      scope: /test/broken2
version: v1
```

Turn on Scopes globally using TELEPORT_UNSTABLE_SCOPES=yes in the environment.
Using Chrome dev tools, add grv_teleport_use_login_scope_picker=true to the application's local storage.

### Test Cases
- [ ] User `u1` logs in and sees a scope selector.
   - [ ] `/test/broken` and `/test/broken2` are not available in the scope selector.
   - [ ] `/test/foo` is available and the user can log in to that scope.