### PR TITLE
Improve acl-lifecycle skill doc

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -51,11 +51,10 @@ Example invocations:
 
 ### teleport-acl-lifecycle
 
-Helps create, update, and delete Teleport access lists with `tctl` — listing
-available resources before choosing grant targets, drafting standing,
-request-based (Access Request), or custom lists, updating owners, members,
-and grants on existing lists, and safely retiring lists (including detaching
-blocking parent nesting before delete).
+Helps give users access to specific Teleport resources. Browse available
+servers, databases, applications, Kubernetes clusters, and more, choose which
+ones and how users connect to them, then create, update, or retire the access
+list that grants that access.
 
 Install:
 

--- a/skills/teleport-acl-lifecycle/SKILL.md
+++ b/skills/teleport-acl-lifecycle/SKILL.md
@@ -5,13 +5,15 @@ description: Use for Teleport access list work with tctl; listing available reso
 
 # Teleport Access List Lifecycle
 
-Use `tctl` to list resources, create access lists, update existing access
-lists, and delete access lists. Route first, then read only the referenced leaf
-files for that route.
+Use this skill to give users access to specific Teleport resources. Browse
+available servers, databases, applications, Kubernetes clusters, and more,
+choose which ones and how users connect to them, then create, update, or retire
+the access list that grants that access.
 
 ## Route First
 
-Choose exactly one route before running commands:
+Choose exactly one route before running commands, then read only the files
+referenced for that route:
 
 | User intent | Examples | Do this |
 | --- | --- | --- |


### PR DESCRIPTION
I didn't realize that the first header description was used in docs:
<img width="1047" height="94" alt="image" src="https://github.com/user-attachments/assets/19b3b31c-a666-48d1-a56e-425de4a1ca04" />


This PR improves the unhelpful description of the skill

