### PR TITLE
[v18] Fix cert client selection for prefetched MFA checks

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -121,6 +121,11 @@ func RouteToDatabaseToProto(dbRoute tlsca.RouteToDatabase) proto.RouteToDatabase
 	}
 }
 
+// MFAChecker answers whether MFA is required for a target resource.
+type MFAChecker interface {
+	IsMFARequired(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error)
+}
+
 // ReissueParams encodes optional parameters for
 // user certificate reissue.
 type ReissueParams struct {
@@ -149,10 +154,9 @@ type ReissueParams struct {
 	// MFACheck is RouteToCluster's answer to the MFA requirement check for this
 	// request's target resource, when the caller already has it.
 	MFACheck *proto.IsMFARequiredResponse
-	// AuthClient runs the MFA requirement check if given and MFACheck is nil.
+	// MFAChecker runs the MFA requirement check if given and MFACheck is nil.
 	// It must be a client of RouteToCluster's auth server, since only that cluster can answer the check.
-	// It never issues the certs, which always come from the root cluster.
-	AuthClient authclient.ClientI
+	MFAChecker MFAChecker
 	// RequesterName identifies who is sending the cert reissue request.
 	RequesterName proto.UserCertsRequest_Requester
 	// TTL defines the maximum time-to-live for user certificates.

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -146,10 +146,12 @@ type ReissueParams struct {
 	// mimics LocalKeystore and remove this.
 	ExistingCreds *KeyRing
 
-	// MFACheck is optional parameter passed if MFA check was already done.
-	// It can be nil.
+	// MFACheck is RouteToCluster's answer to the MFA requirement check for this
+	// request's target resource, when the caller already has it.
 	MFACheck *proto.IsMFARequiredResponse
-	// AuthClient is the client used for the MFACheck that can be reused
+	// AuthClient runs the MFA requirement check if given and MFACheck is nil.
+	// It must be a client of RouteToCluster's auth server, since only that cluster can answer the check.
+	// It never issues the certs, which always come from the root cluster.
 	AuthClient authclient.ClientI
 	// RequesterName identifies who is sending the cert reissue request.
 	RequesterName proto.UserCertsRequest_Requester

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -632,6 +632,19 @@ func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params Reissu
 		}
 	} else {
 		mfaRequired = params.MFACheck.Required
+
+		// Mirror the reuse above:
+		// If the caller supplied an auth client for the root cluster, store it for reuse.
+		if params.RouteToCluster == c.root && params.AuthClient != nil {
+			certClient = &ClusterClient{
+				tc:          c.tc,
+				ProxyClient: c.ProxyClient,
+				AuthClient:  params.AuthClient,
+				Tracer:      c.Tracer,
+				cluster:     c.root,
+				root:        c.root,
+			}
+		}
 	}
 
 	// SSH certs can be used without embedding the node name.
@@ -645,7 +658,8 @@ func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params Reissu
 	// At this point, a connection to the root cluster is required to generate
 	// an MFA verified certificate OR to issue certificates with the target
 	// embedded in them for routing.
-	if params.RouteToCluster != certClient.root {
+	// Connect unless certClient is already backed by the root cluster.
+	if certClient.cluster != certClient.root {
 		authClient, err := c.ConnectToRootCluster(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -921,10 +921,8 @@ func (c *ClusterClient) mfaRequired(ctx context.Context, dial dialAuthClientFunc
 		return false, nil, noop, trace.Wrap(err)
 	}
 
-	// The caller's client answers the check, but nothing here can tell
-	// which cluster it serves, so it must not issue the certs.
-	if params.AuthClient != nil {
-		resp, err := params.AuthClient.IsMFARequired(ctx, req)
+	if params.MFAChecker != nil {
+		resp, err := params.MFAChecker.IsMFARequired(ctx, req)
 		if err != nil {
 			return false, nil, noop, trace.Wrap(err)
 		}

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -516,9 +516,16 @@ func (c *ClusterClient) performSessionMFACeremony(ctx context.Context, rootClien
 		return nil, trace.Wrap(err)
 	}
 
-	mfaAgainstRoot := c.cluster == rootClient.cluster
+	// mfaAgainstRoot tells PerformSessionMFACeremony not to ask c.AuthClient whether MFA is required,
+	// leaving the root to evaluate it while creating the challenge.
+	// So ask c.AuthClient only when its cluster holds the target, since no other cluster can answer for it,
+	// and skip it when that cluster is the root.
+	connectedIsRoot := c.cluster == c.root
+	targetElsewhere := params.RouteToCluster != "" && params.RouteToCluster != c.cluster
+	mfaAgainstRoot := connectedIsRoot || targetElsewhere
+
 	var leafClusterName string
-	if !mfaAgainstRoot {
+	if !connectedIsRoot {
 		leafClusterName = c.cluster
 	}
 

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -567,6 +567,13 @@ type IssueUserCertsWithMFAResult struct {
 // IssueUserCertsWithMFA generates a single-use certificate for the user. If MFA is required
 // to access the resource the provided [mfa.Prompt] will be used to perform the MFA ceremony.
 func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params ReissueParams) (*IssueUserCertsWithMFAResult, error) {
+	return c.issueUserCertsWithMFA(ctx, c.ConnectToCluster, params)
+}
+
+// dialAuthClientFunc dials the auth server of the named cluster.
+type dialAuthClientFunc func(ctx context.Context, clusterName string) (authclient.ClientI, error)
+
+func (c *ClusterClient) issueUserCertsWithMFA(ctx context.Context, dial dialAuthClientFunc, params ReissueParams) (*IssueUserCertsWithMFAResult, error) {
 	ctx, span := c.Tracer.Start(
 		ctx,
 		"ClusterClient/IssueUserCertsWithMFA",
@@ -590,27 +597,11 @@ func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params Reissu
 		}
 	}
 
-	// If the caller provided an auth client, use it.
-	// Otherwise, dial an auth client to the route's cluster if the MFA requirement check must be performed.
-	authClient, closeAuthClient, err := c.reissueAuthClient(ctx, params)
+	mfaRequired, rootAuthClient, releaseRootAuthClient, err := c.mfaRequired(ctx, dial, params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer closeAuthClient()
-
-	mfaRequired := params.MFACheck.GetRequired()
-	if params.MFACheck == nil {
-		sshLogin := cmp.Or(params.SSHLogin, c.tc.HostLogin)
-		mfaRequiredReq, err := params.isMFARequiredRequest(sshLogin)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		resp, err := authClient.IsMFARequired(ctx, mfaRequiredReq)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		mfaRequired = resp.Required
-	}
+	defer releaseRootAuthClient()
 
 	// SSH certs can be used without embedding the node name.
 	if !mfaRequired && params.usage() == proto.UserCertsRequest_SSH && keyRing.Cert != nil {
@@ -620,7 +611,7 @@ func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params Reissu
 		}, nil
 	}
 
-	certClient, closeCertClient, err := c.reissueCertClient(ctx, params, authClient)
+	certClient, closeCertClient, err := c.rootClusterClient(ctx, dial, rootAuthClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -900,37 +891,73 @@ func PerformSessionMFACeremony(ctx context.Context, params PerformSessionMFACere
 	}, nil
 }
 
-// reissueAuthClient returns the auth client that should be used to check the MFA requirement.
-func (c *ClusterClient) reissueAuthClient(ctx context.Context, params ReissueParams) (authclient.ClientI, func(), error) {
-	if params.MFACheck == nil && params.AuthClient == nil {
-		authClient, err := c.ConnectToCluster(ctx, params.RouteToCluster)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-		return authClient, func() { authClient.Close() }, nil
+// mfaRequired reports whether MFA is required for the target.
+// When it dials the root cluster to ask, it hands that client back so the certs can be issued with it.
+func (c *ClusterClient) mfaRequired(ctx context.Context, dial dialAuthClientFunc, params ReissueParams) (bool, authclient.ClientI, func() error, error) {
+	if params.MFACheck != nil {
+		return params.MFACheck.Required, nil, noop, nil
 	}
-	// Never close the caller's client.
-	return params.AuthClient, func() {}, nil
+
+	sshLogin := cmp.Or(params.SSHLogin, c.tc.HostLogin)
+	req, err := params.isMFARequiredRequest(sshLogin)
+	if err != nil {
+		return false, nil, noop, trace.Wrap(err)
+	}
+
+	// The caller's client answers the check, but nothing here can tell
+	// which cluster it serves, so it must not issue the certs.
+	if params.AuthClient != nil {
+		resp, err := params.AuthClient.IsMFARequired(ctx, req)
+		if err != nil {
+			return false, nil, noop, trace.Wrap(err)
+		}
+		return resp.Required, nil, noop, nil
+	}
+
+	authClient, err := dial(ctx, params.RouteToCluster)
+	if err != nil {
+		return false, nil, noop, trace.Wrap(err)
+	}
+
+	resp, err := authClient.IsMFARequired(ctx, req)
+	if err != nil {
+		return false, nil, noop, trace.NewAggregate(err, authClient.Close())
+	}
+
+	if params.RouteToCluster != c.root {
+		// A leaf's client answers the check and nothing more.
+		return resp.Required, nil, noop, trace.Wrap(authClient.Close())
+	}
+
+	return resp.Required, authClient, authClient.Close, nil
 }
 
-// reissueCertClient returns the cluster client that issues the certs.
-// Certs must be issued by the root cluster's auth server, to generate an MFA verified certificate.
-func (c *ClusterClient) reissueCertClient(ctx context.Context, params ReissueParams, authClient authclient.ClientI) (*ClusterClient, func(), error) {
+// rootClusterClient returns a cluster client whose auth client serves the root cluster,
+// which is where certs must be issued.
+// An MFA verified cert can only be minted where the challenge was validated,
+// and routing needs the target embedded by the root.
+// It reuses the client held for the MFA check when that client was dialed for the root,
+// so a call opens at most one root connection.
+func (c *ClusterClient) rootClusterClient(ctx context.Context, dial dialAuthClientFunc, rootAuthClient authclient.ClientI) (*ClusterClient, func() error, error) {
 	switch {
-	case params.RouteToCluster == c.root && authClient != nil:
-		// If we're connected to the root cluster and the caller provided an auth client, use it.
-		return c.withRootAuthClient(authClient), func() {}, nil
+	case rootAuthClient != nil:
+		// The client dialed for the MFA check serves the root, so reuse it.
+		return c.withRootAuthClient(rootAuthClient), noop, nil
 	case c.cluster != c.root:
-		// If we're connected to a leaf cluster, we need to connect to the root cluster to issue the certs.
-		rootAuthClient, err := c.ConnectToRootCluster(ctx)
+		// This client is backed by a leaf, so connect to the root.
+		var err error
+		rootAuthClient, err = dial(ctx, c.root)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-		return c.withRootAuthClient(rootAuthClient), func() { rootAuthClient.Close() }, nil
+		return c.withRootAuthClient(rootAuthClient), rootAuthClient.Close, nil
 	default:
-		return c, func() {}, nil
+		// This client is already backed by the root.
+		return c, noop, nil
 	}
 }
+
+func noop() error { return nil }
 
 func (c *ClusterClient) withRootAuthClient(authClient authclient.ClientI) *ClusterClient {
 	return &ClusterClient{

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -590,18 +590,16 @@ func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params Reissu
 		}
 	}
 
-	certClient := c
-	var mfaRequired bool
-	if params.MFACheck == nil {
-		var err error
-		authClient := params.AuthClient
-		if authClient == nil {
-			authClient, err = c.ConnectToCluster(ctx, params.RouteToCluster)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-		}
+	// If the caller provided an auth client, use it.
+	// Otherwise, dial an auth client to the route's cluster if the MFA requirement check must be performed.
+	authClient, closeAuthClient, err := c.reissueAuthClient(ctx, params)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer closeAuthClient()
 
+	mfaRequired := params.MFACheck.GetRequired()
+	if params.MFACheck == nil {
 		sshLogin := cmp.Or(params.SSHLogin, c.tc.HostLogin)
 		mfaRequiredReq, err := params.isMFARequiredRequest(sshLogin)
 		if err != nil {
@@ -612,39 +610,6 @@ func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params Reissu
 			return nil, trace.Wrap(err)
 		}
 		mfaRequired = resp.Required
-
-		// If connected to the root cluster, store the client so that it
-		// can be reused below.
-		if params.RouteToCluster == c.root {
-			certClient = &ClusterClient{
-				tc:          c.tc,
-				ProxyClient: c.ProxyClient,
-				AuthClient:  authClient,
-				Tracer:      c.Tracer,
-				cluster:     c.root,
-				root:        c.root,
-			}
-		}
-
-		// only close the new auth client and not the copied cluster client.
-		if params.AuthClient == nil {
-			defer authClient.Close()
-		}
-	} else {
-		mfaRequired = params.MFACheck.Required
-
-		// Mirror the reuse above:
-		// If the caller supplied an auth client for the root cluster, store it for reuse.
-		if params.RouteToCluster == c.root && params.AuthClient != nil {
-			certClient = &ClusterClient{
-				tc:          c.tc,
-				ProxyClient: c.ProxyClient,
-				AuthClient:  params.AuthClient,
-				Tracer:      c.Tracer,
-				cluster:     c.root,
-				root:        c.root,
-			}
-		}
 	}
 
 	// SSH certs can be used without embedding the node name.
@@ -655,27 +620,11 @@ func (c *ClusterClient) IssueUserCertsWithMFA(ctx context.Context, params Reissu
 		}, nil
 	}
 
-	// At this point, a connection to the root cluster is required to generate
-	// an MFA verified certificate OR to issue certificates with the target
-	// embedded in them for routing.
-	// Connect unless certClient is already backed by the root cluster.
-	if certClient.cluster != certClient.root {
-		authClient, err := c.ConnectToRootCluster(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		certClient = &ClusterClient{
-			tc:          c.tc,
-			ProxyClient: c.ProxyClient,
-			AuthClient:  authClient,
-			Tracer:      c.Tracer,
-			cluster:     c.root,
-			root:        c.root,
-		}
-		// only close the new auth client and not the copied cluster client.
-		defer authClient.Close()
+	certClient, closeCertClient, err := c.reissueCertClient(ctx, params, authClient)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
+	defer closeCertClient()
 
 	// MFA is not required, but the user requires a new certificate with the
 	// target included in it for routing.
@@ -949,4 +898,47 @@ func PerformSessionMFACeremony(ctx context.Context, params PerformSessionMFACere
 		NewCerts:            newCerts,
 		ReusableMFAResponse: reusableMFAResponse,
 	}, nil
+}
+
+// reissueAuthClient returns the auth client that should be used to check the MFA requirement.
+func (c *ClusterClient) reissueAuthClient(ctx context.Context, params ReissueParams) (authclient.ClientI, func(), error) {
+	if params.MFACheck == nil && params.AuthClient == nil {
+		authClient, err := c.ConnectToCluster(ctx, params.RouteToCluster)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		return authClient, func() { authClient.Close() }, nil
+	}
+	// Never close the caller's client.
+	return params.AuthClient, func() {}, nil
+}
+
+// reissueCertClient returns the cluster client that issues the certs.
+// Certs must be issued by the root cluster's auth server, to generate an MFA verified certificate.
+func (c *ClusterClient) reissueCertClient(ctx context.Context, params ReissueParams, authClient authclient.ClientI) (*ClusterClient, func(), error) {
+	switch {
+	case params.RouteToCluster == c.root && authClient != nil:
+		// If we're connected to the root cluster and the caller provided an auth client, use it.
+		return c.withRootAuthClient(authClient), func() {}, nil
+	case c.cluster != c.root:
+		// If we're connected to a leaf cluster, we need to connect to the root cluster to issue the certs.
+		rootAuthClient, err := c.ConnectToRootCluster(ctx)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		return c.withRootAuthClient(rootAuthClient), func() { rootAuthClient.Close() }, nil
+	default:
+		return c, func() {}, nil
+	}
+}
+
+func (c *ClusterClient) withRootAuthClient(authClient authclient.ClientI) *ClusterClient {
+	return &ClusterClient{
+		tc:          c.tc,
+		ProxyClient: c.ProxyClient,
+		AuthClient:  authClient,
+		Tracer:      c.Tracer,
+		cluster:     c.root,
+		root:        c.root,
+	}
 }

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -510,10 +510,15 @@ func (c *ClusterClient) performSessionMFACeremony(ctx context.Context, rootClien
 		return nil, trace.Wrap(err)
 	}
 
-	sshLogin := cmp.Or(params.SSHLogin, c.tc.HostLogin)
-	mfaRequiredReq, err := params.isMFARequiredRequest(sshLogin)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	// A nil request tells PerformSessionMFACeremony that the requirement is settled, so no cluster is asked again.
+	// Only the cluster holding the target could answer, and it already has.
+	var mfaRequiredReq *proto.IsMFARequiredRequest
+	if !params.MFACheck.GetRequired() {
+		sshLogin := cmp.Or(params.SSHLogin, c.tc.HostLogin)
+		mfaRequiredReq, err = params.isMFARequiredRequest(sshLogin)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// mfaAgainstRoot tells PerformSessionMFACeremony not to ask c.AuthClient whether MFA is required,
@@ -658,6 +663,12 @@ func (c *ClusterClient) issueUserCertsWithMFA(ctx context.Context, dial dialAuth
 		}
 	}
 
+	// The cluster holding the target has answered by now, so record it and spare the ceremony from asking again.
+	params.MFACheck = &proto.IsMFARequiredResponse{
+		Required:    true,
+		MFARequired: proto.MFARequired_MFA_REQUIRED_YES,
+	}
+
 	// Perform the MFA ceremony and add the new credential to the KeyRing.
 	result, err := c.performSessionMFACeremony(ctx, certClient, params, keyRing)
 	if err != nil {
@@ -755,7 +766,6 @@ func PerformSessionMFACeremony(ctx context.Context, params PerformSessionMFACere
 	// If connecting to a host in a leaf cluster and MFA failed check to see
 	// if the leaf cluster requires MFA. If it doesn't return an error indicating
 	// that MFA was not required instead of the error received from the root cluster.
-	var mfaKnownToBeRequired bool
 	if mfaRequiredReq != nil && !params.MFAAgainstRoot {
 		mfaRequiredResp, err := currentClient.IsMFARequired(ctx, mfaRequiredReq)
 		log.DebugContext(ctx, "MFA requirement acquired from leaf", "mfa_required", mfaRequiredResp.GetMFARequired())
@@ -766,7 +776,6 @@ func PerformSessionMFACeremony(ctx context.Context, params PerformSessionMFACere
 			return nil, trace.Wrap(services.ErrSessionMFANotRequired)
 		}
 		mfaRequiredReq = nil // Already checked, don't check again at root.
-		mfaKnownToBeRequired = true
 	}
 
 	allowReuse := mfav1.ChallengeAllowReuse_CHALLENGE_ALLOW_REUSE_NO
@@ -780,7 +789,7 @@ func PerformSessionMFACeremony(ctx context.Context, params PerformSessionMFACere
 			// not an exhaustive list, but connection problem and limit exceeded are
 			// almost surely caused by network conditions or general problems rather
 			// than being from the actual handling of the request
-			if !mfaKnownToBeRequired && (trace.IsConnectionProblem(err) || trace.IsLimitExceeded(err)) {
+			if mfaRequiredReq != nil && (trace.IsConnectionProblem(err) || trace.IsLimitExceeded(err)) {
 				return nil, trace.Wrap(MFARequiredUnknown(trace.Unwrap(err)))
 			}
 			return nil, trace.Wrap(err)

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -529,9 +529,10 @@ func (c *ClusterClient) performSessionMFACeremony(ctx context.Context, rootClien
 	targetElsewhere := params.RouteToCluster != "" && params.RouteToCluster != c.cluster
 	mfaAgainstRoot := connectedIsRoot || targetElsewhere
 
+	// leafClusterName only names the target's cluster in the MFA prompt, and the root is not worth naming.
 	var leafClusterName string
-	if !connectedIsRoot {
-		leafClusterName = c.cluster
+	if params.RouteToCluster != c.root {
+		leafClusterName = params.RouteToCluster
 	}
 
 	var promptOpts []mfa.PromptOpt

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -48,12 +48,18 @@ import (
 type fakeAuthClient struct {
 	authclient.ClientI
 
-	isMFARequired     func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error)
-	generateUserCerts func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error)
+	isMFARequired               func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error)
+	generateUserCerts           func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error)
+	createAuthenticateChallenge func(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error)
+	close                       func() error
 }
 
 func (f fakeAuthClient) Close() error {
-	return nil
+	if f.close == nil {
+		return nil
+	}
+
+	return f.close()
 }
 
 func (f fakeAuthClient) IsMFARequired(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
@@ -73,7 +79,11 @@ func (f fakeAuthClient) GenerateUserCerts(ctx context.Context, req proto.UserCer
 }
 
 func (f fakeAuthClient) CreateAuthenticateChallenge(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
-	return &proto.MFAAuthenticateChallenge{WebauthnChallenge: &webauthnpb.CredentialAssertion{}}, nil
+	if f.createAuthenticateChallenge == nil {
+		return &proto.MFAAuthenticateChallenge{WebauthnChallenge: &webauthnpb.CredentialAssertion{}}, nil
+	}
+
+	return f.createAuthenticateChallenge(ctx, req)
 }
 
 type fakePrompt struct {
@@ -687,17 +697,19 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 
 	// The clusters a cell can involve, named so the assertions can say which one served each step.
 	const (
-		root = "root"
-		leaf = "leaf"
+		root  = "root"
+		leaf1 = "leaf1"
+		leaf2 = "leaf2"
 	)
 
 	// The auth clients a cell can involve, named so the assertions can say which one served each step.
 	const (
-		connected  = "connected"
-		callerRoot = "caller root"
-		callerLeaf = "caller leaf"
-		dialedRoot = "dialed root"
-		dialedLeaf = "dialed leaf"
+		connected   = "connected"
+		callerRoot  = "caller root"
+		callerLeaf  = "caller leaf"
+		dialedRoot  = "dialed root"
+		dialedLeaf1 = "dialed leaf1"
+		dialedLeaf2 = "dialed leaf2"
 	)
 
 	ca := newTestAuthority(t)
@@ -713,7 +725,7 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	for _, cluster := range []string{root, leaf} {
+	for _, cluster := range []string{root, leaf1, leaf2} {
 		require.NoError(t, localAgent.clientStore.AddKeyRing(ca.makeSignedKeyRing(t, KeyRingIndex{
 			ProxyHost:   root,
 			ClusterName: cluster,
@@ -742,39 +754,50 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 	}
 
 	connectedIssues := outcome{issuer: connected}
+	// The ceremony re-checks the requirement at the connected leaf whenever this client is
+	// backed by one, whatever the request routes to.
 	leafDialsRoot := outcome{issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}}
 
 	// Every permutation the loops below generate must appear here, so a missing row fails the test.
 	want := map[inputs]outcome{
 		// A prefetched check is supplied, so the caller's client is not used and the issuer is always the root cluster's auth server.
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:         connectedIssues,
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf}:         leafDialsRoot,
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: root}:         connectedIssues,
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: leaf}:         leafDialsRoot,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}: connectedIssues,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf}: leafDialsRoot,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: root}: connectedIssues,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: leaf}: leafDialsRoot,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}: connectedIssues,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf}: leafDialsRoot,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: root}: connectedIssues,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: leaf}: leafDialsRoot,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
-		// No caller client.
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}: {issuer: connected, checks: counts{connected: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{dialedRoot: 1, connected: 1}, dials: counts{root: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: root}: {issuer: connected, checks: counts{dialedLeaf: 1}, dials: counts{leaf: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{connected: 2}, dials: counts{root: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
+
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
+
+		// No caller client, no prefetched check.
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{connected: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{dialedRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{dialedLeaf1: 1}, dials: counts{leaf1: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{connected: 2}, dials: counts{root: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{dialedLeaf2: 1, connected: 1}, dials: counts{leaf2: 1, root: 1}},
 
 		// A caller client is supplied, so the requirement check is answered by it, but the certs are still issued by the root cluster's auth server.
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}: {issuer: connected, checks: counts{callerRoot: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: root}: {issuer: connected, checks: counts{callerRoot: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}: {issuer: connected, checks: counts{callerLeaf: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: root}: {issuer: connected, checks: counts{callerLeaf: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerRoot: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerRoot: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
+
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerLeaf: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerLeaf: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
 	}
 
 	// newClusterClient returns a client connected to the named cluster, backed by authClient.
@@ -814,85 +837,107 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 		require.Equal(t, want, got, what)
 	}
 
+	topologies := []struct{ routeToCluster, clientCluster string }{
+		{root, root},
+		{root, leaf1},
+		{leaf1, root},
+		{leaf1, leaf1},
+		{leaf2, leaf1},
+	}
+
 	for _, callerClient := range []string{"", callerRoot, callerLeaf} {
 		for _, prefetchedMFACheck := range []bool{true, false} {
-			for _, routeToCluster := range []string{root, leaf} {
-				for _, clientCluster := range []string{root, leaf} {
-					in := inputs{
-						callerClient:       callerClient,
-						prefetchedMFACheck: prefetchedMFACheck,
-						routeToCluster:     routeToCluster,
-						clientCluster:      clientCluster,
-					}
-
-					name := "no caller client"
-					if in.callerClient != "" {
-						name = in.callerClient
-					}
-					if in.prefetchedMFACheck {
-						name += ", prefetched check"
-					} else {
-						name += ", checked requirement"
-					}
-					name += ", routed to " + in.routeToCluster + ", " + in.clientCluster + " client"
-
-					t.Run(name, func(t *testing.T) {
-						t.Parallel()
-
-						expected, ok := want[in]
-						require.True(t, ok, "no expectation declared for %+v", in)
-
-						// One counting client per candidate, so every step names the auth server that served it.
-						checks, certRequests := counts{}, counts{}
-						authClients := map[string]fakeAuthClient{}
-						for _, name := range []string{connected, callerRoot, callerLeaf, dialedRoot, dialedLeaf} {
-							authClients[name] = fakeAuthClient{
-								isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
-									checks[name]++
-									return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
-								},
-								generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-									certRequests[name]++
-									return generateUserCerts(ctx, req)
-								},
-							}
-						}
-
-						clt := newClusterClient(in.clientCluster, authClients[connected])
-
-						params := ReissueParams{NodeName: "test", RouteToCluster: in.routeToCluster}
-						if in.prefetchedMFACheck {
-							params.MFACheck = &proto.IsMFARequiredResponse{
-								MFARequired: proto.MFARequired_MFA_REQUIRED_YES,
-								Required:    true,
-							}
-						}
-						if in.callerClient != "" {
-							params.AuthClient = authClients[in.callerClient]
-						}
-
-						// A fake dial stands in for the proxy, mirroring ConnectToCluster.
-						// The connected cluster resolves without opening a connection.
-						dials := counts{}
-						dial := func(_ context.Context, clusterName string) (authclient.ClientI, error) {
-							if clusterName == in.clientCluster {
-								return clt.CurrentCluster(), nil
-							}
-							dials[clusterName]++
-							return authClients["dialed "+clusterName], nil
-						}
-
-						result, err := clt.issueUserCertsWithMFA(context.Background(), dial, params)
-						require.NoError(t, err)
-						require.NotNil(t, result)
-						require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, result.MFARequired)
-						require.NotEmpty(t, result.KeyRing.Cert)
-
-						requireCounts(t, counts{expected.issuer: 1}, certRequests, "the root cluster's auth server must issue the certs, and nothing else")
-						requireCounts(t, expected.checks, checks, "auth servers asked whether MFA is required")
-						requireCounts(t, expected.dials, dials, "clusters dialed")
-					})
+			for _, topology := range topologies {
+				in := inputs{
+					callerClient:       callerClient,
+					prefetchedMFACheck: prefetchedMFACheck,
+					routeToCluster:     topology.routeToCluster,
+					clientCluster:      topology.clientCluster,
 				}
+
+				name := "no caller client"
+				if in.callerClient != "" {
+					name = in.callerClient
+				}
+				if in.prefetchedMFACheck {
+					name += ", prefetched check"
+				} else {
+					name += ", checked requirement"
+				}
+				name += ", routed to " + in.routeToCluster + ", " + in.clientCluster + " client"
+
+				t.Run(name, func(t *testing.T) {
+					t.Parallel()
+
+					expected, ok := want[in]
+					require.True(t, ok, "no expectation declared for %+v", in)
+
+					checks, certRequests, challenges, closes := counts{}, counts{}, counts{}, counts{}
+					var certRoutes []string
+					authClients := map[string]fakeAuthClient{}
+					for _, name := range []string{connected, callerRoot, callerLeaf, dialedRoot, dialedLeaf1, dialedLeaf2} {
+						authClients[name] = fakeAuthClient{
+							isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+								checks[name]++
+								return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
+							},
+							generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+								certRequests[name]++
+								certRoutes = append(certRoutes, req.RouteToCluster)
+								return generateUserCerts(ctx, req)
+							},
+							createAuthenticateChallenge: func(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
+								challenges[name]++
+								return &proto.MFAAuthenticateChallenge{WebauthnChallenge: &webauthnpb.CredentialAssertion{}}, nil
+							},
+							close: func() error {
+								closes[name]++
+								return nil
+							},
+						}
+					}
+
+					clt := newClusterClient(in.clientCluster, authClients[connected])
+
+					params := ReissueParams{NodeName: "test", RouteToCluster: in.routeToCluster}
+					if in.prefetchedMFACheck {
+						params.MFACheck = &proto.IsMFARequiredResponse{
+							MFARequired: proto.MFARequired_MFA_REQUIRED_YES,
+							Required:    true,
+						}
+					}
+					if in.callerClient != "" {
+						params.AuthClient = authClients[in.callerClient]
+					}
+
+					dials := counts{}
+					dial := func(_ context.Context, clusterName string) (authclient.ClientI, error) {
+						if clusterName == in.clientCluster {
+							return clt.CurrentCluster(), nil
+						}
+						dials[clusterName]++
+						return authClients["dialed "+clusterName], nil
+					}
+
+					result, err := clt.issueUserCertsWithMFA(context.Background(), dial, params)
+					require.NoError(t, err)
+					require.NotNil(t, result)
+					require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, result.MFARequired)
+					require.NotEmpty(t, result.KeyRing.Cert)
+
+					requireCounts(t, counts{expected.issuer: 1}, certRequests, "the root cluster's auth server must issue the certs, and nothing else")
+					requireCounts(t, counts{expected.issuer: 1}, challenges, "the MFA challenge must come from the auth server that issues the certs")
+					requireCounts(t, expected.checks, checks, "auth servers asked whether MFA is required")
+					requireCounts(t, expected.dials, dials, "clusters dialed")
+
+					require.Equal(t, []string{in.routeToCluster}, certRoutes, "cert requests, by routed cluster")
+
+					wantCloses := counts{}
+					for cluster := range expected.dials {
+						wantCloses["dialed "+cluster] = 1
+					}
+					requireCounts(t, wantCloses, closes, "auth clients closed")
+				})
 			}
 		}
 	}

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -754,9 +754,8 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 	}
 
 	connectedIssues := outcome{issuer: connected}
-	// The ceremony re-checks the requirement at the connected leaf whenever this client is
-	// backed by one, whatever the request routes to.
-	leafDialsRoot := outcome{issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}}
+	leafDialsRoot := outcome{issuer: dialedRoot, dials: counts{root: 1}}
+	leafRechecksAndDialsRoot := outcome{issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}}
 
 	// Every permutation the loops below generate must appear here, so a missing row fails the test.
 	want := map[inputs]outcome{
@@ -764,40 +763,40 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafRechecksAndDialsRoot,
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
 		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
 		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
 		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafRechecksAndDialsRoot,
 		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafRechecksAndDialsRoot,
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
 		// No caller client, no prefetched check.
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{connected: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{dialedRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{dialedRoot: 1}, dials: counts{root: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{dialedLeaf1: 1}, dials: counts{leaf1: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{connected: 2}, dials: counts{root: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{dialedLeaf2: 1, connected: 1}, dials: counts{leaf2: 1, root: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{dialedLeaf2: 1}, dials: counts{leaf2: 1, root: 1}},
 
 		// A caller client is supplied, so the requirement check is answered by it, but the certs are still issued by the root cluster's auth server.
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerRoot: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerRoot: 1}, dials: counts{root: 1}},
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerRoot: 1}},
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1}, dials: counts{root: 1}},
 
 		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerLeaf: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerLeaf: 1}, dials: counts{root: 1}},
 		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerLeaf: 1}},
 		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1}, dials: counts{root: 1}},
 	}
 
 	// newClusterClient returns a client connected to the named cluster, backed by authClient.

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -755,7 +755,6 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 
 	connectedIssues := outcome{issuer: connected}
 	leafDialsRoot := outcome{issuer: dialedRoot, dials: counts{root: 1}}
-	leafRechecksAndDialsRoot := outcome{issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}}
 
 	// Every permutation the loops below generate must appear here, so a missing row fails the test.
 	want := map[inputs]outcome{
@@ -763,39 +762,39 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafRechecksAndDialsRoot,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
 		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
 		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
 		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafRechecksAndDialsRoot,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
 		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafRechecksAndDialsRoot,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
 		// No caller client, no prefetched check.
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{connected: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{dialedRoot: 1}, dials: counts{root: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{dialedLeaf1: 1}, dials: counts{leaf1: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{connected: 2}, dials: counts{root: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{dialedLeaf2: 1}, dials: counts{leaf2: 1, root: 1}},
 
 		// A caller client is supplied, so the requirement check is answered by it, but the certs are still issued by the root cluster's auth server.
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerRoot: 1}},
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerRoot: 1}, dials: counts{root: 1}},
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerRoot: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1}, dials: counts{root: 1}},
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1}, dials: counts{root: 1}},
 
 		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerLeaf: 1}},
 		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerLeaf: 1}, dials: counts{root: 1}},
 		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerLeaf: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1}, dials: counts{root: 1}},
 		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1}, dials: counts{root: 1}},
 	}
 

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -244,7 +244,7 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 			name: "ssh login falls back to host login",
 			params: ReissueParams{
 				NodeName: "test",
-				AuthClient: fakeAuthClient{
+				MFAChecker: fakeAuthClient{
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						nodeReq, ok := req.Target.(*proto.IsMFARequiredRequest_Node)
 						require.True(t, ok)
@@ -270,7 +270,7 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 			params: ReissueParams{
 				NodeName: "test",
 				SSHLogin: "override-login",
-				AuthClient: fakeAuthClient{
+				MFAChecker: fakeAuthClient{
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						nodeReq, ok := req.Target.(*proto.IsMFARequiredRequest_Node)
 						require.True(t, ok)
@@ -436,7 +436,7 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 			params: ReissueParams{
 				NodeName:       "test",
 				RouteToCluster: "leaf",
-				AuthClient: fakeAuthClient{
+				MFAChecker: fakeAuthClient{
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_NO, Required: false}, nil
 					},
@@ -456,7 +456,7 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 			params: ReissueParams{
 				NodeName:       "test",
 				RouteToCluster: "leaf",
-				AuthClient: fakeAuthClient{
+				MFAChecker: fakeAuthClient{
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
 					},
@@ -480,7 +480,7 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 				},
 				RequesterName:       proto.UserCertsRequest_TSH_DB_EXEC,
 				ReusableMFAResponse: &proto.MFAAuthenticateResponse{},
-				AuthClient: fakeAuthClient{
+				MFAChecker: fakeAuthClient{
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_NO, Required: false}, nil
 					},
@@ -550,7 +550,7 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 				},
 				RequesterName:       proto.UserCertsRequest_TSH_DB_EXEC,
 				ReusableMFAResponse: &proto.MFAAuthenticateResponse{},
-				AuthClient: fakeAuthClient{
+				MFAChecker: fakeAuthClient{
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
 					},
@@ -579,11 +579,10 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 			params: ReissueParams{
 				NodeName:       "test",
 				RouteToCluster: "leaf",
-				AuthClient: fakeAuthClient{
+				MFAChecker: fakeAuthClient{
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
 					},
-					generateUserCerts: defaultGenerateUserCerts,
 				},
 			},
 			wantPromptReason: `MFA is required to access node "test" from leaf cluster "leaf"`,
@@ -599,9 +598,6 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 			agent := agent
 			if test.agent != nil {
 				agent = test.agent
-			}
-			if test.params.AuthClient != nil {
-				defer test.params.AuthClient.Close()
 			}
 
 			suite := test.signatureAlgorithmSuite
@@ -909,7 +905,7 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 						}
 					}
 					if in.callerClient != "" {
-						params.AuthClient = authClients[in.callerClient]
+						params.MFAChecker = authClients[in.callerClient]
 					}
 
 					dials := counts{}

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -168,6 +168,8 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 		return &proto.Certs{SSH: sshCert, TLS: tlsCert}, nil
 	}
 
+	var rootCertRequests int
+
 	tests := []struct {
 		name                    string
 		mfaRequired             proto.MFARequired
@@ -573,6 +575,28 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 			assertion: func(t *testing.T, result *IssueUserCertsWithMFAResult, err error) {
 				require.NoError(t, err)
 				require.NotNil(t, result)
+			},
+		},
+		{
+			// Certs must still be requested from the root cluster, not from the leaf the client is connected to.
+			name:          "prefetched MFA check issues certs from the root cluster",
+			mfaRequired:   proto.MFARequired_MFA_REQUIRED_YES,
+			clientCluster: "leaf",
+			params: ReissueParams{
+				NodeName:       "test",
+				RouteToCluster: "test",
+				MFACheck:       &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true},
+				AuthClient: fakeAuthClient{
+					generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+						rootCertRequests++
+						return defaultGenerateUserCerts(ctx, req)
+					},
+				},
+			},
+			assertion: func(t *testing.T, result *IssueUserCertsWithMFAResult, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, 1, rootCertRequests, "certs must be issued by the root cluster's auth server")
 			},
 		},
 	}

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -92,6 +92,48 @@ func (f fakePrompt) Run(ctx context.Context, chal *proto.MFAAuthenticateChalleng
 	}, nil
 }
 
+// newTestGenerateUserCerts returns a [fakeAuthClient] GenerateUserCerts
+// implementation that issues certificates signed by the given test authority.
+func newTestGenerateUserCerts(t *testing.T, ca testAuthority, clock clockwork.Clock, caSigner ssh.Signer) func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+	return func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+		var sshCert, tlsCert []byte
+		var err error
+		if req.SSHPublicKey != nil {
+			sshCert, err = ca.keygen.GenerateUserCert(sshca.UserCertificateRequest{
+				CASigner:          caSigner,
+				PublicUserKey:     req.SSHPublicKey,
+				TTL:               req.Expires.Sub(clock.Now()),
+				CertificateFormat: req.Format,
+				Identity: sshca.Identity{
+					Username:       req.Username,
+					RouteToCluster: req.RouteToCluster,
+				},
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
+		if req.TLSPublicKey != nil {
+			pub, err := keys.ParsePublicKey(req.TLSPublicKey)
+			require.NoError(t, err)
+			identity := tlsca.Identity{
+				Username: req.Username,
+				Groups:   []string{"groups"},
+			}
+			subject, err := identity.Subject()
+			require.NoError(t, err)
+			tlsCert, err = ca.tlsCA.GenerateCertificate(tlsca.CertificateRequest{
+				Clock:     clock,
+				PublicKey: pub,
+				Subject:   subject,
+				NotAfter:  req.Expires,
+			})
+			require.NoError(t, err)
+		}
+		return &proto.Certs{SSH: sshCert, TLS: tlsCert}, nil
+	}
+}
+
 func TestIssueUserCertsWithMFA(t *testing.T) {
 	ca := newTestAuthority(t)
 	clock := clockwork.NewFakeClock()
@@ -130,45 +172,7 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 
 	failedPrompt := fakePrompt{err: errors.New("prompt failed intentionally")}
 
-	defaultGenerateUserCerts := func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-		var sshCert, tlsCert []byte
-		var err error
-		if req.SSHPublicKey != nil {
-			sshCert, err = ca.keygen.GenerateUserCert(sshca.UserCertificateRequest{
-				CASigner:          caSigner,
-				PublicUserKey:     req.SSHPublicKey,
-				TTL:               req.Expires.Sub(clock.Now()),
-				CertificateFormat: req.Format,
-				Identity: sshca.Identity{
-					Username:       req.Username,
-					RouteToCluster: req.RouteToCluster,
-				},
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-		}
-		if req.TLSPublicKey != nil {
-			pub, err := keys.ParsePublicKey(req.TLSPublicKey)
-			require.NoError(t, err)
-			identity := tlsca.Identity{
-				Username: req.Username,
-				Groups:   []string{"groups"},
-			}
-			subject, err := identity.Subject()
-			require.NoError(t, err)
-			tlsCert, err = ca.tlsCA.GenerateCertificate(tlsca.CertificateRequest{
-				Clock:     clock,
-				PublicKey: pub,
-				Subject:   subject,
-				NotAfter:  req.Expires,
-			})
-			require.NoError(t, err)
-		}
-		return &proto.Certs{SSH: sshCert, TLS: tlsCert}, nil
-	}
-
-	var rootCertRequests int
+	defaultGenerateUserCerts := newTestGenerateUserCerts(t, ca, clock, caSigner)
 
 	tests := []struct {
 		name                    string
@@ -179,6 +183,9 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 		signatureAlgorithmSuite types.SignatureAlgorithmSuite
 		// clientCluster overrides the ClusterClient's cluster field. Defaults to "test".
 		clientCluster string
+		// generateUserCerts overrides GenerateUserCerts on the connected cluster's auth client.
+		// Defaults to issuing them from the test authority.
+		generateUserCerts func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error)
 		// wantPromptReason, when non-empty, asserts the PromptReason passed to the
 		// MFA prompt constructor.
 		wantPromptReason string
@@ -234,11 +241,11 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 						require.Equal(t, "default-login", nodeReq.Node.Login)
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
 					},
-					generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-						require.Equal(t, "default-login", req.SSHLogin)
-						return defaultGenerateUserCerts(ctx, req)
-					},
 				},
+			},
+			generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+				require.Equal(t, "default-login", req.SSHLogin)
+				return defaultGenerateUserCerts(ctx, req)
 			},
 			assertion: func(t *testing.T, result *IssueUserCertsWithMFAResult, err error) {
 				require.NoError(t, err)
@@ -260,11 +267,11 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 						require.Equal(t, "override-login", nodeReq.Node.Login)
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
 					},
-					generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-						require.Equal(t, "override-login", req.SSHLogin)
-						return defaultGenerateUserCerts(ctx, req)
-					},
 				},
+			},
+			generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+				require.Equal(t, "override-login", req.SSHLogin)
+				return defaultGenerateUserCerts(ctx, req)
 			},
 			assertion: func(t *testing.T, result *IssueUserCertsWithMFAResult, err error) {
 				require.NoError(t, err)
@@ -467,14 +474,14 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_NO, Required: false}, nil
 					},
-					generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-						// Ensure no MFA response is passed.
-						if req.MFAResponse != nil {
-							return nil, trace.BadParameter("mfa response is not nil")
-						}
-						return defaultGenerateUserCerts(ctx, req)
-					},
 				},
+			},
+			generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+				// Ensure no MFA response is passed.
+				if req.MFAResponse != nil {
+					return nil, trace.BadParameter("mfa response is not nil")
+				}
+				return defaultGenerateUserCerts(ctx, req)
 			},
 			prompt: failedPrompt, // should not be called
 			assertion: func(t *testing.T, result *IssueUserCertsWithMFAResult, err error) {
@@ -537,15 +544,15 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
 					},
-					generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-						// This is the fake reusable MFA response passed in the first call.
-						if req.MFAResponse != nil && req.MFAResponse.Response == nil {
-							return nil, trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
-						}
-						// The second call should continue here.
-						return defaultGenerateUserCerts(ctx, req)
-					},
 				},
+			},
+			generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+				// This is the fake reusable MFA response passed in the first call.
+				if req.MFAResponse != nil && req.MFAResponse.Response == nil {
+					return nil, trace.Wrap(&mfa.ErrExpiredReusableMFAResponse)
+				}
+				// The second call should continue here.
+				return defaultGenerateUserCerts(ctx, req)
 			},
 			assertion: func(t *testing.T, result *IssueUserCertsWithMFAResult, err error) {
 				require.NoError(t, err)
@@ -577,28 +584,6 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 				require.NotNil(t, result)
 			},
 		},
-		{
-			// Certs must still be requested from the root cluster, not from the leaf the client is connected to.
-			name:          "prefetched MFA check issues certs from the root cluster",
-			mfaRequired:   proto.MFARequired_MFA_REQUIRED_YES,
-			clientCluster: "leaf",
-			params: ReissueParams{
-				NodeName:       "test",
-				RouteToCluster: "test",
-				MFACheck:       &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true},
-				AuthClient: fakeAuthClient{
-					generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-						rootCertRequests++
-						return defaultGenerateUserCerts(ctx, req)
-					},
-				},
-			},
-			assertion: func(t *testing.T, result *IssueUserCertsWithMFAResult, err error) {
-				require.NoError(t, err)
-				require.NotNil(t, result)
-				require.Equal(t, 1, rootCertRequests, "certs must be issued by the root cluster's auth server")
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -618,6 +603,10 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 
 			var capturedPromptCfg *libmfa.PromptConfig
 			clientCluster := cmp.Or(test.clientCluster, "test")
+			generateUserCerts := defaultGenerateUserCerts
+			if test.generateUserCerts != nil {
+				generateUserCerts = test.generateUserCerts
+			}
 			clt := &ClusterClient{
 				tc: &TeleportClient{
 					localAgent: agent,
@@ -650,16 +639,30 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 							return nil, trace.NotImplemented("mfa unknown")
 						}
 					},
-					generateUserCerts: defaultGenerateUserCerts,
+					generateUserCerts: generateUserCerts,
 				},
 				Tracer:  tracing.NoopTracer("test"),
 				cluster: clientCluster,
 				root:    "test",
 			}
 
+			// Auth clients for other clusters, so cases whose client is connected to a leaf can reach the root without a proxy.
+			dial := func(_ context.Context, clusterName string) (authclient.ClientI, error) {
+				// Mirror ConnectToCluster: the connected cluster resolves without opening a connection.
+				if clusterName == clientCluster {
+					return clt.CurrentCluster(), nil
+				}
+				return fakeAuthClient{
+					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+						return &proto.IsMFARequiredResponse{MFARequired: test.mfaRequired, Required: test.mfaRequired == proto.MFARequired_MFA_REQUIRED_YES}, nil
+					},
+					generateUserCerts: defaultGenerateUserCerts,
+				}, nil
+			}
+
 			ctx := context.Background()
 
-			result, err := clt.IssueUserCertsWithMFA(ctx, test.params)
+			result, err := clt.issueUserCertsWithMFA(ctx, dial, test.params)
 			test.assertion(t, result, err)
 
 			if test.wantPromptReason != "" {
@@ -667,5 +670,230 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 				require.Equal(t, test.wantPromptReason, capturedPromptCfg.PromptReason)
 			}
 		})
+	}
+}
+
+// TestIssueUserCertsWithMFAAuthClientMatrix runs IssueUserCertsWithMFA over every permutation of the inputs
+// that decide which auth server serves the request, and asserts:
+// - which one answered the MFA requirement check,
+// - which one issued the certs,
+// - which clusters were dialed.
+//
+// Whatever the caller passes, the certs must come from the root cluster's auth server.
+// A client connected to the root issues them with its own auth client; one connected to a leaf dials the root first.
+// A caller-supplied client only answers the requirement check, so handing over a leaf's client cannot move the issuance.
+func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
+	t.Parallel()
+
+	// The clusters a cell can involve, named so the assertions can say which one served each step.
+	const (
+		root = "root"
+		leaf = "leaf"
+	)
+
+	// The auth clients a cell can involve, named so the assertions can say which one served each step.
+	const (
+		connected  = "connected"
+		callerRoot = "caller root"
+		callerLeaf = "caller leaf"
+		dialedRoot = "dialed root"
+		dialedLeaf = "dialed leaf"
+	)
+
+	ca := newTestAuthority(t)
+	clock := clockwork.NewFakeClock()
+
+	localAgent, err := NewLocalAgent(LocalAgentConfig{
+		ClientStore: NewMemClientStore(),
+		ProxyHost:   root,
+		Username:    "alice",
+		Insecure:    true,
+		Site:        root,
+		LoadAllCAs:  false,
+	})
+	require.NoError(t, err)
+
+	for _, cluster := range []string{root, leaf} {
+		require.NoError(t, localAgent.clientStore.AddKeyRing(ca.makeSignedKeyRing(t, KeyRingIndex{
+			ProxyHost:   root,
+			ClusterName: cluster,
+			Username:    "alice",
+		}, false)))
+	}
+
+	pemBytes, ok := fixtures.PEMBytes["rsa"]
+	require.True(t, ok, "RSA key not found in fixtures")
+	caSigner, err := ssh.ParsePrivateKey(pemBytes)
+	require.NoError(t, err)
+
+	generateUserCerts := newTestGenerateUserCerts(t, ca, clock, caSigner)
+
+	type inputs struct {
+		callerClient       string // which auth client the caller supplies, if any
+		prefetchedMFACheck bool   // whether ReissueParams.MFACheck is set
+		routeToCluster     string // the cluster the caller wants to reach
+		clientCluster      string // the cluster the connected auth client belongs to
+	}
+	type counts = map[string]int // counts how often each auth client, or each cluster, was used.
+	type outcome struct {
+		issuer string // the auth client expected to issue the certs
+		checks counts // every auth client asked whether MFA is required
+		dials  counts // every cluster a connection is opened to
+	}
+
+	connectedIssues := outcome{issuer: connected}
+	leafDialsRoot := outcome{issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}}
+
+	// Every permutation the loops below generate must appear here, so a missing row fails the test.
+	want := map[inputs]outcome{
+		// A prefetched check is supplied, so the caller's client is not used and the issuer is always the root cluster's auth server.
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:         connectedIssues,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf}:         leafDialsRoot,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: root}:         connectedIssues,
+		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: leaf}:         leafDialsRoot,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}: connectedIssues,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf}: leafDialsRoot,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: root}: connectedIssues,
+		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: leaf}: leafDialsRoot,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}: connectedIssues,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf}: leafDialsRoot,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: root}: connectedIssues,
+		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf, clientCluster: leaf}: leafDialsRoot,
+
+		// No caller client.
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}: {issuer: connected, checks: counts{connected: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{dialedRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: root}: {issuer: connected, checks: counts{dialedLeaf: 1}, dials: counts{leaf: 1}},
+		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{connected: 2}, dials: counts{root: 1}},
+
+		// A caller client is supplied, so the requirement check is answered by it, but the certs are still issued by the root cluster's auth server.
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}: {issuer: connected, checks: counts{callerRoot: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: root}: {issuer: connected, checks: counts{callerRoot: 1}},
+		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{callerRoot: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}: {issuer: connected, checks: counts{callerLeaf: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: root}: {issuer: connected, checks: counts{callerLeaf: 1}},
+		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf, clientCluster: leaf}: {issuer: dialedRoot, checks: counts{callerLeaf: 1, connected: 1}, dials: counts{root: 1}},
+	}
+
+	// newClusterClient returns a client connected to the named cluster, backed by authClient.
+	newClusterClient := func(cluster string, authClient authclient.ClientI) *ClusterClient {
+		return &ClusterClient{
+			tc: &TeleportClient{
+				localAgent: localAgent,
+				Config: Config{
+					WebProxyAddr: "proxy.example.com",
+					SiteName:     root,
+					HostLogin:    "default-login",
+					Tracer:       tracing.NoopTracer("test"),
+					MFAPromptConstructor: func(cfg *libmfa.PromptConfig) mfa.Prompt {
+						return fakePrompt{}
+					},
+					Stderr: io.Discard,
+				},
+				lastPing: &webclient.PingResponse{
+					Auth: webclient.AuthenticationSettings{
+						SignatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1,
+					},
+				},
+			},
+			ProxyClient: &proxy.Client{},
+			AuthClient:  authClient,
+			Tracer:      tracing.NoopTracer("test"),
+			cluster:     cluster,
+			root:        root,
+		}
+	}
+
+	requireCounts := func(t *testing.T, want, got counts, what string) {
+		if want == nil { // A nil expectation means the step must not have happened at all.
+			require.Empty(t, got, what)
+			return
+		}
+		require.Equal(t, want, got, what)
+	}
+
+	for _, callerClient := range []string{"", callerRoot, callerLeaf} {
+		for _, prefetchedMFACheck := range []bool{true, false} {
+			for _, routeToCluster := range []string{root, leaf} {
+				for _, clientCluster := range []string{root, leaf} {
+					in := inputs{
+						callerClient:       callerClient,
+						prefetchedMFACheck: prefetchedMFACheck,
+						routeToCluster:     routeToCluster,
+						clientCluster:      clientCluster,
+					}
+
+					name := "no caller client"
+					if in.callerClient != "" {
+						name = in.callerClient
+					}
+					if in.prefetchedMFACheck {
+						name += ", prefetched check"
+					} else {
+						name += ", checked requirement"
+					}
+					name += ", routed to " + in.routeToCluster + ", " + in.clientCluster + " client"
+
+					t.Run(name, func(t *testing.T) {
+						t.Parallel()
+
+						expected, ok := want[in]
+						require.True(t, ok, "no expectation declared for %+v", in)
+
+						// One counting client per candidate, so every step names the auth server that served it.
+						checks, certRequests := counts{}, counts{}
+						authClients := map[string]fakeAuthClient{}
+						for _, name := range []string{connected, callerRoot, callerLeaf, dialedRoot, dialedLeaf} {
+							authClients[name] = fakeAuthClient{
+								isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+									checks[name]++
+									return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
+								},
+								generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+									certRequests[name]++
+									return generateUserCerts(ctx, req)
+								},
+							}
+						}
+
+						clt := newClusterClient(in.clientCluster, authClients[connected])
+
+						params := ReissueParams{NodeName: "test", RouteToCluster: in.routeToCluster}
+						if in.prefetchedMFACheck {
+							params.MFACheck = &proto.IsMFARequiredResponse{
+								MFARequired: proto.MFARequired_MFA_REQUIRED_YES,
+								Required:    true,
+							}
+						}
+						if in.callerClient != "" {
+							params.AuthClient = authClients[in.callerClient]
+						}
+
+						// A fake dial stands in for the proxy, mirroring ConnectToCluster.
+						// The connected cluster resolves without opening a connection.
+						dials := counts{}
+						dial := func(_ context.Context, clusterName string) (authclient.ClientI, error) {
+							if clusterName == in.clientCluster {
+								return clt.CurrentCluster(), nil
+							}
+							dials[clusterName]++
+							return authClients["dialed "+clusterName], nil
+						}
+
+						result, err := clt.issueUserCertsWithMFA(context.Background(), dial, params)
+						require.NoError(t, err)
+						require.NotNil(t, result)
+						require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, result.MFARequired)
+						require.NotEmpty(t, result.KeyRing.Cert)
+
+						requireCounts(t, counts{expected.issuer: 1}, certRequests, "the root cluster's auth server must issue the certs, and nothing else")
+						requireCounts(t, expected.checks, checks, "auth servers asked whether MFA is required")
+						requireCounts(t, expected.dials, dials, "clusters dialed")
+					})
+				}
+			}
+		}
 	}
 }

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -758,7 +758,6 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 
 	// Every permutation the loops below generate must appear here, so a missing row fails the test.
 	want := map[inputs]outcome{
-		// A prefetched check is supplied, so the caller's client is not used and the issuer is always the root cluster's auth server.
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
@@ -777,14 +776,12 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
 		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
-		// No caller client, no prefetched check.
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{connected: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{dialedRoot: 1}, dials: counts{root: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{dialedLeaf1: 1}, dials: counts{leaf1: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{dialedLeaf2: 1}, dials: counts{leaf2: 1, root: 1}},
 
-		// A caller client is supplied, so the requirement check is answered by it, but the certs are still issued by the root cluster's auth server.
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerRoot: 1}},
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerRoot: 1}, dials: counts{root: 1}},
 		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerRoot: 1}},

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -691,7 +691,7 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 //
 // Whatever the caller passes, the certs must come from the root cluster's auth server.
 // A client connected to the root issues them with its own auth client; one connected to a leaf dials the root first.
-// A caller-supplied client only answers the requirement check, so handing over a leaf's client cannot move the issuance.
+// A caller-supplied client only answers the requirement check and never issues the certs.
 func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 	t.Parallel()
 
@@ -703,10 +703,13 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 	)
 
 	// The auth clients a cell can involve, named so the assertions can say which one served each step.
+	// The caller's clients are named after the answer they give rather than after a cluster,
+	// because nothing in the code can tell which cluster a caller-supplied client serves.
+	// Every client but callerNo reports that MFA is required.
 	const (
 		connected   = "connected"
-		callerRoot  = "caller root"
-		callerLeaf  = "caller leaf"
+		callerYes   = "caller yes"
+		callerNo    = "caller no"
 		dialedRoot  = "dialed root"
 		dialedLeaf1 = "dialed leaf1"
 		dialedLeaf2 = "dialed leaf2"
@@ -748,13 +751,15 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 	}
 	type counts = map[string]int // counts how often each auth client, or each cluster, was used.
 	type outcome struct {
-		issuer string // the auth client expected to issue the certs
-		checks counts // every auth client asked whether MFA is required
-		dials  counts // every cluster a connection is opened to
+		issuer         string // the auth client expected to issue the certs, empty when none are issued
+		checks         counts // every auth client asked whether MFA is required
+		dials          counts // every cluster a connection is opened to
+		mfaNotRequired bool   // true when the MFA check returned that MFA is not required
 	}
 
 	connectedIssues := outcome{issuer: connected}
 	leafDialsRoot := outcome{issuer: dialedRoot, dials: counts{root: 1}}
+	callerDeclines := outcome{checks: counts{callerNo: 1}, mfaNotRequired: true}
 
 	// Every permutation the loops below generate must appear here, so a missing row fails the test.
 	want := map[inputs]outcome{
@@ -764,17 +769,17 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
 		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
-		{callerClient: callerRoot, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
+		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
+		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
+		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
-		{callerClient: callerLeaf, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
+		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
+		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
+		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{connected: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{dialedRoot: 1}, dials: counts{root: 1}},
@@ -782,17 +787,17 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}},
 		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{dialedLeaf2: 1}, dials: counts{leaf2: 1, root: 1}},
 
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerRoot: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerRoot: 1}, dials: counts{root: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerRoot: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1}, dials: counts{root: 1}},
-		{callerClient: callerRoot, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerRoot: 1}, dials: counts{root: 1}},
+		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerYes: 1}},
+		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerYes: 1}, dials: counts{root: 1}},
+		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerYes: 1}},
+		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerYes: 1}, dials: counts{root: 1}},
+		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerYes: 1}, dials: counts{root: 1}},
 
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerLeaf: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerLeaf: 1}, dials: counts{root: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerLeaf: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1}, dials: counts{root: 1}},
-		{callerClient: callerLeaf, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerLeaf: 1}, dials: counts{root: 1}},
+		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   callerDeclines,
+		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  callerDeclines,
+		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  callerDeclines,
+		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: callerDeclines,
+		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: callerDeclines,
 	}
 
 	// newClusterClient returns a client connected to the named cluster, backed by authClient.
@@ -840,7 +845,7 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 		{leaf2, leaf1},
 	}
 
-	for _, callerClient := range []string{"", callerRoot, callerLeaf} {
+	for _, callerClient := range []string{"", callerYes, callerNo} {
 		for _, prefetchedMFACheck := range []bool{true, false} {
 			for _, topology := range topologies {
 				in := inputs{
@@ -870,10 +875,14 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 					checks, certRequests, challenges, closes := counts{}, counts{}, counts{}, counts{}
 					var certRoutes []string
 					authClients := map[string]fakeAuthClient{}
-					for _, name := range []string{connected, callerRoot, callerLeaf, dialedRoot, dialedLeaf1, dialedLeaf2} {
+					for _, name := range []string{connected, callerYes, callerNo, dialedRoot, dialedLeaf1, dialedLeaf2} {
+						required := name != callerNo
 						authClients[name] = fakeAuthClient{
 							isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 								checks[name]++
+								if !required {
+									return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_NO}, nil
+								}
 								return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil
 							},
 							generateUserCerts: func(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
@@ -917,15 +926,24 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 					result, err := clt.issueUserCertsWithMFA(context.Background(), dial, params)
 					require.NoError(t, err)
 					require.NotNil(t, result)
-					require.Equal(t, proto.MFARequired_MFA_REQUIRED_YES, result.MFARequired)
 					require.NotEmpty(t, result.KeyRing.Cert)
 
-					requireCounts(t, counts{expected.issuer: 1}, certRequests, "the root cluster's auth server must issue the certs, and nothing else")
-					requireCounts(t, counts{expected.issuer: 1}, challenges, "the MFA challenge must come from the auth server that issues the certs")
+					wantMFARequired := proto.MFARequired_MFA_REQUIRED_YES
+					wantIssuer := counts{expected.issuer: 1}
+					wantCertRoutes := []string{in.routeToCluster}
+					if expected.mfaNotRequired {
+						wantMFARequired = proto.MFARequired_MFA_REQUIRED_NO
+						wantIssuer = counts{}
+						wantCertRoutes = nil
+					}
+					require.Equal(t, wantMFARequired, result.MFARequired)
+
+					requireCounts(t, wantIssuer, certRequests, "the root cluster's auth server must issue the certs, and nothing else")
+					requireCounts(t, wantIssuer, challenges, "the MFA challenge must come from the auth server that issues the certs")
 					requireCounts(t, expected.checks, checks, "auth servers asked whether MFA is required")
 					requireCounts(t, expected.dials, dials, "clusters dialed")
 
-					require.Equal(t, []string{in.routeToCluster}, certRoutes, "cert requests, by routed cluster")
+					require.Equal(t, wantCertRoutes, certRoutes, "cert requests, by routed cluster")
 
 					wantCloses := counts{}
 					for cluster := range expected.dials {

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -738,7 +738,7 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 	generateUserCerts := newTestGenerateUserCerts(t, ca, clock, caSigner)
 
 	type inputs struct {
-		callerClient       string // which auth client the caller supplies, if any
+		mfaChecker         string // which MFA checker the caller supplies, if any
 		prefetchedMFACheck bool   // whether ReissueParams.MFACheck is set
 		routeToCluster     string // the cluster the caller wants to reach
 		clientCluster      string // the cluster the connected auth client belongs to
@@ -757,41 +757,41 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 
 	// Every permutation the loops below generate must appear here, so a missing row fails the test.
 	want := map[inputs]outcome{
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
-		{callerClient: "", prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
+		{mfaChecker: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
+		{mfaChecker: "", prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
+		{mfaChecker: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
+		{mfaChecker: "", prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{mfaChecker: "", prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
-		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
-		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
-		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
-		{callerClient: callerYes, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
+		{mfaChecker: callerYes, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
+		{mfaChecker: callerYes, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
+		{mfaChecker: callerYes, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
+		{mfaChecker: callerYes, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{mfaChecker: callerYes, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
-		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
-		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
-		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
-		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
-		{callerClient: callerNo, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
+		{mfaChecker: callerNo, prefetchedMFACheck: true, routeToCluster: root, clientCluster: root}:   connectedIssues,
+		{mfaChecker: callerNo, prefetchedMFACheck: true, routeToCluster: root, clientCluster: leaf1}:  leafDialsRoot,
+		{mfaChecker: callerNo, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: root}:  connectedIssues,
+		{mfaChecker: callerNo, prefetchedMFACheck: true, routeToCluster: leaf1, clientCluster: leaf1}: leafDialsRoot,
+		{mfaChecker: callerNo, prefetchedMFACheck: true, routeToCluster: leaf2, clientCluster: leaf1}: leafDialsRoot,
 
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{connected: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{dialedRoot: 1}, dials: counts{root: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{dialedLeaf1: 1}, dials: counts{leaf1: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}},
-		{callerClient: "", prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{dialedLeaf2: 1}, dials: counts{leaf2: 1, root: 1}},
+		{mfaChecker: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{connected: 1}},
+		{mfaChecker: "", prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{dialedRoot: 1}, dials: counts{root: 1}},
+		{mfaChecker: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{dialedLeaf1: 1}, dials: counts{leaf1: 1}},
+		{mfaChecker: "", prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{connected: 1}, dials: counts{root: 1}},
+		{mfaChecker: "", prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{dialedLeaf2: 1}, dials: counts{leaf2: 1, root: 1}},
 
-		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerYes: 1}},
-		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerYes: 1}, dials: counts{root: 1}},
-		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerYes: 1}},
-		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerYes: 1}, dials: counts{root: 1}},
-		{callerClient: callerYes, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerYes: 1}, dials: counts{root: 1}},
+		{mfaChecker: callerYes, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   {issuer: connected, checks: counts{callerYes: 1}},
+		{mfaChecker: callerYes, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  {issuer: dialedRoot, checks: counts{callerYes: 1}, dials: counts{root: 1}},
+		{mfaChecker: callerYes, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  {issuer: connected, checks: counts{callerYes: 1}},
+		{mfaChecker: callerYes, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerYes: 1}, dials: counts{root: 1}},
+		{mfaChecker: callerYes, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: {issuer: dialedRoot, checks: counts{callerYes: 1}, dials: counts{root: 1}},
 
-		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   callerDeclines,
-		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  callerDeclines,
-		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  callerDeclines,
-		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: callerDeclines,
-		{callerClient: callerNo, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: callerDeclines,
+		{mfaChecker: callerNo, prefetchedMFACheck: false, routeToCluster: root, clientCluster: root}:   callerDeclines,
+		{mfaChecker: callerNo, prefetchedMFACheck: false, routeToCluster: root, clientCluster: leaf1}:  callerDeclines,
+		{mfaChecker: callerNo, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: root}:  callerDeclines,
+		{mfaChecker: callerNo, prefetchedMFACheck: false, routeToCluster: leaf1, clientCluster: leaf1}: callerDeclines,
+		{mfaChecker: callerNo, prefetchedMFACheck: false, routeToCluster: leaf2, clientCluster: leaf1}: callerDeclines,
 	}
 
 	// newClusterClient returns a client connected to the named cluster, backed by authClient.
@@ -839,19 +839,19 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 		{leaf2, leaf1},
 	}
 
-	for _, callerClient := range []string{"", callerYes, callerNo} {
+	for _, mfaChecker := range []string{"", callerYes, callerNo} {
 		for _, prefetchedMFACheck := range []bool{true, false} {
 			for _, topology := range topologies {
 				in := inputs{
-					callerClient:       callerClient,
+					mfaChecker:         mfaChecker,
 					prefetchedMFACheck: prefetchedMFACheck,
 					routeToCluster:     topology.routeToCluster,
 					clientCluster:      topology.clientCluster,
 				}
 
-				name := "no caller client"
-				if in.callerClient != "" {
-					name = in.callerClient
+				name := "no MFA checker"
+				if in.mfaChecker != "" {
+					name = in.mfaChecker
 				}
 				if in.prefetchedMFACheck {
 					name += ", prefetched check"
@@ -904,8 +904,8 @@ func TestIssueUserCertsWithMFAAuthClientMatrix(t *testing.T) {
 							Required:    true,
 						}
 					}
-					if in.callerClient != "" {
-						params.MFAChecker = authClients[in.callerClient]
+					if in.mfaChecker != "" {
+						params.MFAChecker = authClients[in.mfaChecker]
 					}
 
 					dials := counts{}

--- a/lib/client/cluster_client_test.go
+++ b/lib/client/cluster_client_test.go
@@ -577,10 +577,8 @@ func TestIssueUserCertsWithMFA(t *testing.T) {
 			mfaRequired:   proto.MFARequired_MFA_REQUIRED_YES,
 			clientCluster: "leaf",
 			params: ReissueParams{
-				NodeName: "test",
-				// In real world RouteToCluster would be "leaf", but this doesn't work
-				// with how the test is currently set up.
-				RouteToCluster: "test",
+				NodeName:       "test",
+				RouteToCluster: "leaf",
 				AuthClient: fakeAuthClient{
 					isMFARequired: func(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 						return &proto.IsMFARequiredResponse{MFARequired: proto.MFARequired_MFA_REQUIRED_YES, Required: true}, nil


### PR DESCRIPTION
Backport of #69152 to `branch/v18`.

Clean cherry-pick of all 12 commits, no conflicts.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan

Run on this branch, not ported from #69152: both the client and the servers are v18.

### Test Environment

- `tsh` built from this branch, `v18.10.0`. Servers on `teleport-distroless:18.10.1`, the newest published v18 patch. Before and after comparisons use a `tsh` built the same way from `origin/branch/v18` without this change.
- Root cluster `root` with trusted leaves `leaf1` and `leaf2`, one kind cluster each, each providing an SSH node, an HTTP app, a postgres database and a kube cluster.
- Roles `mfa-required` (`require_session_mfa: true`) and `mfa-optional`, mapped leaf to root. WebAuthn security key.

### Test Cases

#### Connected to the root, MFA required

- [x] `tsh ssh root@root-node`: prompt `MFA is required to access node "root-node"`, no leaf suffix, session runs.
- [x] Database, app and kube prompt the same way, naming the resource with no leaf suffix, and all connect (`tsh proxy db` into `psql`, `tsh app login` + `tsh proxy app` into `curl`, `tsh proxy kube` and `tsh kube credentials`).
- [x] A `leaf2` target names the leaf: `MFA is required to access Kubernetes cluster "leaf2-kube" from leaf cluster "leaf2"`.
- [x] Three connections through one `tsh proxy db` with `mfa_verification_interval: 2m` on the role: the first prompts, the second reuses the valid cert, the third prompts again after expiry. Two prompts for three connections.

#### Connected to a leaf, MFA required

- [x] Node, database, app and kube all prompt with the target's cluster named, `MFA is required to access <kind> "<name>" from leaf cluster "leaf1"`, and all four connect.
- [x] The root mints the cert even though `tsh` is connected to the leaf: every cert came back with `Issuer: O=root, CN=root` and `street` naming the target cluster, `leaf1`, `leaf2` or `root` as requested.
- [x] `tsh --debug` no longer logs `MFA requirement acquired from leaf`, which the baseline logs once for the same command.
- [x] `tsh ssh root@env=lab hostname` against two nodes sharing a label, the one path that prefetches the requirement check and hands it to the ceremony: both nodes prompt naming `leaf1` and both run the command. The baseline logs `MFA requirement acquired from leaf` twice here, once per node. With two nodes sharing a hostname the prompt names them by UUID, which is pre-existing behaviour and identical on both binaries.

#### Target in a cluster other than the one tsh is connected to

`kubectl` reaches this through the kubeconfig exec plugin: `tsh kube credentials --kube-cluster=X --teleport-cluster=Y` takes the target from the context and the connected cluster from the profile, and has no `--cluster` flag. Profile on `leaf1`:

- [x] A `leaf2` target prompts naming `leaf2` and succeeds, not naming the connected `leaf1`. A `root` target prompts with no suffix and succeeds. Both through `kubectl` and through `tsh kube credentials` directly, and the two `kubectl` runs reach different physical clusters.
- [x] Both fail on the baseline with `unable to determine if a MFA ceremony is required: kubernetes cluster "leaf2-kube" not found`, and the same for `root-kube`: it asked `leaf1` about a resource only the target's cluster can see.
- [x] With `leaf1`'s auth scaled to zero and every cluster the request needs healthy, a `leaf2` target still succeeds and the cert still routes to `leaf2`. The baseline fails the same command with `unable to determine if a MFA ceremony is required: connection error ... handshake failed: EOF`, since it insists on asking the stopped `leaf1`.

#### MFA not required

Role `mfa-optional`. The swap needs a fresh login, since roles travel in the cert.

- [x] Node, database and kube on `root` and `leaf1` all connect with no prompt.
- [x] Both cross-cluster targets succeed with no prompt, certs still signed by the root and routed to the target, and now cached on disk.
- [x] `tsh ssh nobody@root-node` is denied without a prompt, under both roles.

#### Failure cases

- [x] Abandoning the ceremony: exit 1, no cert on stdout, nothing added to the key store. The client fell back to browser MFA and reported `ERROR: timed out waiting for callback` rather than the `context canceled` a Ctrl-C gives.
- [x] Leaf auth stopped with a target in that same leaf: `connection error ... handshake failed: EOF`, no prompt, and not wrapped as a failure to determine the MFA requirement. A connection problem, not an access denial.
- [x] Root auth stopped: exit 1 at `/webapi/ping` with HTTP 504 and no prompt. That is before any MFA work, so it does not cover the change to how a failure is reported once the requirement is already settled, which needs the root to break while creating the challenge.
