### PR TITLE
Disable directory sharing icon for Linux desktop

### DIFF
--- a/web/packages/shared/components/DesktopSession/DesktopSessionWithSharing.tsx
+++ b/web/packages/shared/components/DesktopSession/DesktopSessionWithSharing.tsx
@@ -40,6 +40,7 @@ export type DesktopSessionWithSharingProps = {
   customConnectionState?(args: { retry(): void }): React.ReactElement;
   hasAnotherSession(): Promise<boolean>;
   keyboardLayout?: number;
+  linuxDesktop?: boolean;
 };
 
 /**
@@ -58,7 +59,7 @@ export function DesktopSessionWithSharing(
           isConnected={controls.isConnected}
           onDisconnect={controls.onDisconnect}
           userHost={`${props.username} on ${props.desktop}`}
-          canShareDirectory={controls.canShareDirectory}
+          canShareDirectory={!props.linuxDesktop && controls.canShareDirectory}
           isSharingClipboard={controls.isSharingClipboard}
           clipboardSharingMessage={controls.clipboardSharingMessage}
           onCtrlAltDel={controls.onCtrlAltDel}

--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -170,6 +170,7 @@ export function DesktopSession() {
         }
       }}
       aclAttempt={aclAttempt}
+      linuxDesktop={linuxDesktop}
       browserSupportsSharing={navigator.userAgent.includes('Chrome')}
       hasAnotherSession={hasAnotherSession}
       keyboardLayout={preferences.keyboardLayout}


### PR DESCRIPTION
Disable directory sharing icon for Linux desktop



<!-- Provide a descriptive entry for the changelog of the next release. -->


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [x] Share directory icon is disabled in Linux desktop session
- [x] Tooltip says its disabled 
