### PR TITLE
Prefer new sub-CA override over legacy workload override when signing SVIDs.

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6217,6 +6217,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		OverrideGetter:             cfg.AuthServer,
 		ClusterName:                clusterName.GetClusterName(),
 		GetSigstorePolicyEvaluator: cfg.AuthServer.GetSigstorePolicyEvaluator,
+		IsEnterpriseBuild:          cfg.AuthServer.modules.IsEnterpriseBuild,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating workload identity issuance service")

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -42,18 +42,21 @@ import (
 	"github.com/gravitational/teleport"
 	apiproto "github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	traitv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trait/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/api/utils/tlsutils"
 	apiworkloadidentity "github.com/gravitational/teleport/api/workloadidentity"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/jwt"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/subca"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/oidc"
@@ -95,6 +98,7 @@ type issuerCache interface {
 	GetProxies() ([]types.Server, error)
 	ListProxyServers(context.Context, int, string) ([]types.Server, string, error)
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
+	GetCertAuthorityOverride(ctx context.Context, id types.CertAuthorityOverrideID) (*subcav1.CertAuthorityOverride, error)
 	ListResources(ctx context.Context, req apiproto.ListResourcesRequest) (*types.ListResourcesResponse, error)
 }
 
@@ -109,6 +113,7 @@ type IssuanceServiceConfig struct {
 	KeyStore                   KeyStorer
 	OverrideGetter             services.WorkloadIdentityX509CAOverrideGetter
 	GetSigstorePolicyEvaluator func() SigstorePolicyEvaluator
+	IsEnterpriseBuild          func() bool
 
 	ClusterName string
 }
@@ -127,6 +132,7 @@ type IssuanceService struct {
 	keyStore                   KeyStorer
 	overrideGetter             services.WorkloadIdentityX509CAOverrideGetter
 	getSigstorePolicyEvaluator func() SigstorePolicyEvaluator
+	isEnterpriseBuild          func() bool
 
 	clusterName string
 }
@@ -150,6 +156,8 @@ func NewIssuanceService(cfg *IssuanceServiceConfig) (*IssuanceService, error) {
 		return nil, trace.BadParameter("cluster name is required")
 	case cfg.GetSigstorePolicyEvaluator == nil:
 		return nil, trace.BadParameter("sigstore policy evaluator is required")
+	case cfg.IsEnterpriseBuild == nil:
+		return nil, trace.BadParameter("enterprise build check is required")
 	}
 
 	if cfg.Logger == nil {
@@ -168,6 +176,7 @@ func NewIssuanceService(cfg *IssuanceServiceConfig) (*IssuanceService, error) {
 		keyStore:                   cfg.KeyStore,
 		overrideGetter:             cfg.OverrideGetter,
 		getSigstorePolicyEvaluator: cfg.GetSigstorePolicyEvaluator,
+		isEnterpriseBuild:          cfg.IsEnterpriseBuild,
 
 		clusterName: cfg.ClusterName,
 	}, nil
@@ -766,6 +775,17 @@ func x509Template(
 	return c
 }
 
+// getX509CA returns the X.509 CA and trust chain used to sign SVIDs.
+//
+// When useIssuerOverrides is true, it checks for an active CA override:
+//
+//   - The sub-CA override resolver (cert_authority_override resources) is checked first. If an override is active, the
+//     override certificate replaces the self-signed CA cert, and the trust chain from the override is returned.
+//
+//   - If no sub-CA override is found and the legacy override getter is configured, it falls back to the legacy
+//     workload_identity_x509_issuer_override system for backward compatibility.
+//
+// TODO(espadolini): support alternate overrides depending on the trust domain, once that's fleshed out
 func (s *IssuanceService) getX509CA(
 	ctx context.Context,
 	caType types.CertAuthType,
@@ -774,16 +794,22 @@ func (s *IssuanceService) getX509CA(
 	ctx, span := tracer.Start(ctx, "IssuanceService/getX509CA")
 	defer func() { tracing.EndSpan(span, err) }()
 
-	const loadKeysTrue = true
-	ca, err := s.cache.GetCertAuthority(ctx, types.CertAuthID{
-		Type:       caType,
-		DomainName: s.clusterName,
-	}, loadKeysTrue)
+	ca, err := s.cache.GetCertAuthority(
+		ctx, types.CertAuthID{
+			Type:       caType,
+			DomainName: s.clusterName,
+		},
+		true, // Load keys.
+	)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 
 	tlsCert, tlsSigner, err := s.keyStore.GetTLSCertAndSigner(ctx, ca)
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "getting CA cert and key")
+		return nil, nil, trace.Wrap(err)
 	}
+
 	tlsCA, err := tlsca.FromCertAndSigner(tlsCert, tlsSigner)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -792,14 +818,49 @@ func (s *IssuanceService) getX509CA(
 	if !useIssuerOverrides {
 		return tlsCA, nil, nil
 	}
-	// TODO(espadolini): support alternate overrides depending on the trust
-	// domain, once that's fleshed out
-	newCA, chain, err := s.overrideGetter.GetWorkloadIdentityX509CAOverride(ctx, "", tlsCA)
+
+	subCAResolver, err := subca.LoadCAOverrideResolver(
+		ctx,
+		s.cache,
+		s.isEnterpriseBuild(),
+		types.CertAuthorityOverrideID{
+			ClusterName: s.clusterName,
+			CAType:      subca.CertAuthTypeToSubKind(caType),
+		},
+	)
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "getting CA override")
+		return nil, nil, trace.Wrap(err)
 	}
 
-	return newCA, chain, nil
+	// Returns the override cert if active for this key, or the original self-signed cert otherwise.
+	result, err := subCAResolver.CalculateOverride(subca.Certificate{PEM: tlsCert})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	tlsCA, err = tlsca.FromCertAndSigner(result.CACertificate.PEM, tlsSigner)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	if result.OverrideActive {
+		chain, err := pemChainToDER(result.CAChain.ToPEMs())
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		return tlsCA, chain, nil
+	}
+
+	// No sub-CA override active for this key, fall back to the legacy override.
+	//
+	// TODO(cthach): DELETE IN v20.0 fall back path once all clusters have migrated from workload to sub-CA overrides.
+	tlsCA, chain, err := s.overrideGetter.GetWorkloadIdentityX509CAOverride(ctx, "", tlsCA)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return tlsCA, chain, nil
 }
 
 func rawAttrsToStruct(in *workloadidentityv1pb.Attrs) (*apievents.Struct, error) {
@@ -1294,4 +1355,19 @@ func verifyCertValidityWithSkew(cert *x509.Certificate, now time.Time) error {
 	}
 
 	return nil
+}
+
+func pemChainToDER(chain [][]byte) ([][]byte, error) {
+	der := make([][]byte, len(chain))
+
+	for i, certPEM := range chain {
+		cert, err := tlsutils.ParseCertificatePEM(certPEM)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		der[i] = cert.Raw
+	}
+
+	return der, nil
 }

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -810,13 +810,13 @@ func (s *IssuanceService) getX509CA(
 		return nil, nil, trace.Wrap(err)
 	}
 
-	tlsCA, err := tlsca.FromCertAndSigner(tlsCert, tlsSigner)
+	selfSignedCA, err := tlsca.FromCertAndSigner(tlsCert, tlsSigner)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
 	if !useIssuerOverrides {
-		return tlsCA, nil, nil
+		return selfSignedCA, nil, nil
 	}
 
 	subCAResolver, err := subca.LoadCAOverrideResolver(
@@ -832,35 +832,36 @@ func (s *IssuanceService) getX509CA(
 		return nil, nil, trace.Wrap(err)
 	}
 
-	// Returns the override cert if active for this key, or the original self-signed cert otherwise.
+	// Returns the override CA if active for this key, or the original self-signed CA otherwise.
 	result, err := subCAResolver.CalculateOverride(subca.Certificate{PEM: tlsCert})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	tlsCA, err = tlsca.FromCertAndSigner(result.CACertificate.PEM, tlsSigner)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
 	if result.OverrideActive {
+		overrideCA, err := tlsca.FromCertAndSigner(result.CACertificate.PEM, tlsSigner)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
 		chain, err := pemChainToDER(result.CAChain.ToPEMs())
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
 
-		return tlsCA, chain, nil
+		return overrideCA, chain, nil
 	}
 
-	// No sub-CA override active for this key, fall back to the legacy override.
+	// No sub-CA override active for this key, fall back to the legacy override. If no override is found, return the
+	// self-signed CA.
 	//
 	// TODO(cthach): DELETE IN v20.0 fall back path once all clusters have migrated from workload to sub-CA overrides.
-	tlsCA, chain, err := s.overrideGetter.GetWorkloadIdentityX509CAOverride(ctx, "", tlsCA)
+	signingCA, chain, err := s.overrideGetter.GetWorkloadIdentityX509CAOverride(ctx, "", selfSignedCA)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	return tlsCA, chain, nil
+	return signingCA, chain, nil
 }
 
 func rawAttrsToStruct(in *workloadidentityv1pb.Attrs) (*apievents.Struct, error) {

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"iter"
 	"log/slog"
@@ -49,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/clientutils"
-	"github.com/gravitational/teleport/api/utils/tlsutils"
 	apiworkloadidentity "github.com/gravitational/teleport/api/workloadidentity"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
@@ -777,15 +777,10 @@ func x509Template(
 
 // getX509CA returns the X.509 CA and trust chain used to sign SVIDs.
 //
-// When useIssuerOverrides is true, it checks for an active CA override:
-//
-//   - The sub-CA override resolver (cert_authority_override resources) is checked first. If an override is active, the
-//     override certificate replaces the self-signed CA cert, and the trust chain from the override is returned.
-//
-//   - If no sub-CA override is found and the legacy override getter is configured, it falls back to the legacy
-//     workload_identity_x509_issuer_override system for backward compatibility.
-//
-// TODO(espadolini): support alternate overrides depending on the trust domain, once that's fleshed out
+// If useIssuerOverrides is false, the self-signed CA is returned. Otherwise, it checks for an active CA override:
+//   - The sub-CA override resolver (cert_authority_override resources) is checked first. If a CA override resource
+//     exists, then it's used to calculate the CA cert and trust chain.
+//   - Otherwise it falls back to the legacy workload_identity_x509_issuer_override resource.
 func (s *IssuanceService) getX509CA(
 	ctx context.Context,
 	caType types.CertAuthType,
@@ -794,12 +789,14 @@ func (s *IssuanceService) getX509CA(
 	ctx, span := tracer.Start(ctx, "IssuanceService/getX509CA")
 	defer func() { tracing.EndSpan(span, err) }()
 
+	const loadKeys = true
 	ca, err := s.cache.GetCertAuthority(
-		ctx, types.CertAuthID{
+		ctx,
+		types.CertAuthID{
 			Type:       caType,
 			DomainName: s.clusterName,
 		},
-		true, // Load keys.
+		loadKeys,
 	)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -832,7 +829,20 @@ func (s *IssuanceService) getX509CA(
 		return nil, nil, trace.Wrap(err)
 	}
 
-	// Returns the override CA if active for this key, or the original self-signed CA otherwise.
+	if !subCAResolver.HasCAOverride() {
+		// No CA override resource exists, fall back to the legacy workload override. If no legacy override is found,
+		// return the self-signed CA.
+		//
+		// TODO(cthach): DELETE IN v20.0 remove this entire block and return the self-signed CA once all clusters
+		// have migrated from workload to sub-CA overrides.
+		signingCA, chain, err := s.overrideGetter.GetWorkloadIdentityX509CAOverride(ctx, "", selfSignedCA)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		return signingCA, chain, nil
+	}
+
 	result, err := subCAResolver.CalculateOverride(subca.Certificate{PEM: tlsCert})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -844,7 +854,7 @@ func (s *IssuanceService) getX509CA(
 			return nil, nil, trace.Wrap(err)
 		}
 
-		chain, err := pemChainToDER(result.CAChain.ToPEMs())
+		chain, err := certificatesToDER(result.CAChain)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -852,16 +862,9 @@ func (s *IssuanceService) getX509CA(
 		return overrideCA, chain, nil
 	}
 
-	// No sub-CA override active for this key, fall back to the legacy override. If no override is found, return the
-	// self-signed CA.
-	//
-	// TODO(cthach): DELETE IN v20.0 fall back path once all clusters have migrated from workload to sub-CA overrides.
-	signingCA, chain, err := s.overrideGetter.GetWorkloadIdentityX509CAOverride(ctx, "", selfSignedCA)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	return signingCA, chain, nil
+	// CA override resource exists but no override matches the selected signing key. Return the self-signed CA
+	// rather than falling back to a different trust source when an override is explicitly configured.
+	return selfSignedCA, nil, nil
 }
 
 func rawAttrsToStruct(in *workloadidentityv1pb.Attrs) (*apievents.Struct, error) {
@@ -1358,16 +1361,16 @@ func verifyCertValidityWithSkew(cert *x509.Certificate, now time.Time) error {
 	return nil
 }
 
-func pemChainToDER(chain [][]byte) ([][]byte, error) {
-	der := make([][]byte, len(chain))
+func certificatesToDER(certs subca.Certificates) ([][]byte, error) {
+	der := make([][]byte, len(certs))
 
-	for i, certPEM := range chain {
-		cert, err := tlsutils.ParseCertificatePEM(certPEM)
-		if err != nil {
-			return nil, trace.Wrap(err)
+	for i, cert := range certs {
+		block, _ := pem.Decode(cert.PEM)
+		if block == nil {
+			return nil, trace.BadParameter("expected PEM-encoded certificate at index %d", i)
 		}
 
-		der[i] = cert.Raw
+		der[i] = block.Bytes
 	}
 
 	return der, nil

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -862,8 +862,8 @@ func (s *IssuanceService) getX509CA(
 		return overrideCA, chain, nil
 	}
 
-	// CA override resource exists but no override matches the selected signing key. Return the self-signed CA
-	// rather than falling back to a different trust source when an override is explicitly configured.
+	// CA override resource exists but no override matches the selected signing key (or all overrides are disabled).
+	// Return the self-signed CA rather than falling back to a different trust source.
 	return selfSignedCA, nil, nil
 }
 

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -1545,7 +1545,7 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			},
 		},
 		{
-			name:               "SVID chains to legacy override when sub-CA override targets a stale key",
+			name:               "SVID chains to self-signed CA when key does not match sub-CA override",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
 			configureOverrides: func(t *testing.T, tp *issuanceTestPack) overrideResult {
@@ -1554,7 +1554,7 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 
 				createSPIFFECAOverrideForKey(t, tp, staleKey.Public(), false)
 
-				return installLegacyOverrideGetter(t, tp)
+				return overrideResult{roots: tp.spiffeX509CAPool, issuer: spiffeCACert(t, tp).Subject}
 			},
 		},
 		{

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -1536,12 +1536,13 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			configureOverrides: installLegacyOverrideGetter, // Active legacy workload override.
 		},
 		{
-			name:               "SVID chains to legacy override when sub-CA override is disabled",
+			name:               "SVID chains to self-signed CA when sub-CA override is disabled",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
 			configureOverrides: func(t *testing.T, tp *issuanceTestPack) overrideResult {
+				installLegacyOverrideGetter(t, tp) // Ignored, the sub-CA override resource takes precedence even when disabled.
 				createSPIFFECAOverrideForKey(t, tp, spiffeCACert(t, tp).PublicKey, true)
-				return installLegacyOverrideGetter(t, tp)
+				return overrideResult{roots: tp.spiffeX509CAPool, issuer: spiffeCACert(t, tp).Subject}
 			},
 		},
 		{

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -1498,17 +1498,15 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 		mods               modules.Modules
 		useIssuerOverrides bool
 
-		// configureOverrides sets up any CA overrides for the test cluster, returning the cert pool containing the full
-		// override chain. Nil means no overrides.
-		configureOverrides func(t *testing.T, tp *issuanceTestPack) *x509.CertPool
+		// configureOverrides sets up any CA overrides for the test cluster, returning the verification roots and
+		// expected SVID issuer. Nil means no overrides are configured.
+		configureOverrides func(t *testing.T, tp *issuanceTestPack) overrideResult
 	}{
 		{
 			name:               "SVID chains to self-signed CA when opted out of overrides",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: false, // Opted out.
-			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
-				return createSPIFFECAOverride(t, tp) // Ignored even though it exists.
-			},
+			configureOverrides: createSPIFFECAOverride,
 		},
 		{
 			name:               "SVID chains to self-signed CA with no overrides configured",
@@ -1526,7 +1524,7 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			name:               "SVID chains to sub-CA override when legacy override is also configured",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
-			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+			configureOverrides: func(t *testing.T, tp *issuanceTestPack) overrideResult {
 				installLegacyOverrideGetter(t, tp) // Ignored, the sub-CA override takes precedence.
 				return createSPIFFECAOverride(t, tp)
 			},
@@ -1541,7 +1539,7 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			name:               "SVID chains to legacy override when sub-CA override is disabled",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
-			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+			configureOverrides: func(t *testing.T, tp *issuanceTestPack) overrideResult {
 				createSPIFFECAOverrideForKey(t, tp, spiffeCACert(t, tp).PublicKey, true)
 				return installLegacyOverrideGetter(t, tp)
 			},
@@ -1550,7 +1548,7 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			name:               "SVID chains to legacy override when sub-CA override targets a stale key",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
-			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+			configureOverrides: func(t *testing.T, tp *issuanceTestPack) overrideResult {
 				staleKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 				require.NoError(t, err)
 
@@ -1563,8 +1561,8 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			name:               "SVID chains to legacy override on OSS build",
 			mods:               modulestest.OSSModules(),
 			useIssuerOverrides: true,
-			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
-				createSPIFFECAOverride(t, tp) // Ignored even though it exists.
+			configureOverrides: func(t *testing.T, tp *issuanceTestPack) overrideResult {
+				createSPIFFECAOverride(t, tp) // Ignored, the legacy override takes precedence.
 				return installLegacyOverrideGetter(t, tp)
 			},
 		},
@@ -1575,14 +1573,10 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			// Overrides are cluster-wide, so each case gets its own cluster.
 			tp := newIssuanceTestPack(t, t.Context(), test.mods)
 
-			var overrideRoots *x509.CertPool
-			if test.configureOverrides != nil {
-				overrideRoots = test.configureOverrides(t, tp)
-			}
-
-			wantRoots := tp.spiffeX509CAPool
-			if test.useIssuerOverrides && overrideRoots != nil {
-				wantRoots = overrideRoots
+			wantRoots, wantIssuer := tp.spiffeX509CAPool, spiffeCACert(t, tp).Subject
+			if test.useIssuerOverrides && test.configureOverrides != nil {
+				r := test.configureOverrides(t, tp)
+				wantRoots, wantIssuer = r.roots, r.issuer
 			}
 
 			client, widName := newWildcardIssuanceClient(t, tp)
@@ -1610,6 +1604,8 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			svidCert, err := x509.ParseCertificate(x509Cred.GetCert())
 			require.NoError(t, err)
 
+			require.Equal(t, wantIssuer, svidCert.Issuer, "issued SVID issuer did not match the expected issuer")
+
 			intermediates := x509.NewCertPool()
 			for _, chainDER := range x509Cred.GetChain() {
 				cert, err := x509.ParseCertificate(chainDER)
@@ -1627,18 +1623,6 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 				},
 			)
 			require.NoError(t, err, "issued SVID did not chain up to the expected CA")
-
-			// When an override is configured but the client opted out, verify the SVID does NOT chain to the override.
-			if overrideRoots != nil && !test.useIssuerOverrides {
-				_, err = svidCert.Verify(
-					x509.VerifyOptions{
-						CurrentTime:   tp.clock.Now(),
-						Roots:         overrideRoots,
-						Intermediates: intermediates,
-					},
-				)
-				require.Error(t, err, "SVID should NOT chain to override CA when opted out")
-			}
 		})
 	}
 }
@@ -5188,22 +5172,28 @@ func newWildcardIssuanceClient(t *testing.T, tp *issuanceTestPack) (workloadiden
 	return client, wid.GetMetadata().GetName()
 }
 
-// createSPIFFECAOverride creates an active cert_authority_override matching the cluster's self-signed SPIFFE CA,
-// returning a pool containing only the external root.
-func createSPIFFECAOverride(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+// overrideResult is the expected outcome of a configured CA override.
+type overrideResult struct {
+	// roots is the external root.
+	roots *x509.CertPool
+	// issuer is the Subject of the CA certificate expected to sign the SVID.
+	issuer pkix.Name
+}
+
+// createSPIFFECAOverride creates an active cert_authority_override matching the cluster's self-signed SPIFFE CA.
+func createSPIFFECAOverride(t *testing.T, tp *issuanceTestPack) overrideResult {
 	t.Helper()
 
 	return createSPIFFECAOverrideForKey(t, tp, spiffeCACert(t, tp).PublicKey, false)
 }
 
-// createSPIFFECAOverrideForKey creates a cert_authority_override whose override certificate is issued over public key,
-// returning a pool containing only the external root.
+// createSPIFFECAOverrideForKey creates a cert_authority_override whose override certificate is issued over pub.
 func createSPIFFECAOverrideForKey(
 	t *testing.T,
 	tp *issuanceTestPack,
 	pub crypto.PublicKey,
 	disabled bool,
-) *x509.CertPool {
+) overrideResult {
 	t.Helper()
 
 	overrideCA, externalRoot := newExternalIntermediateCA(t, tp, pub, spiffeCACert(t, tp).NotAfter)
@@ -5218,7 +5208,7 @@ func createSPIFFECAOverrideForKey(
 		Spec: subcav1.CertAuthorityOverrideSpec_builder{
 			CertificateOverrides: []*subcav1.CertificateOverride{
 				subcav1.CertificateOverride_builder{
-					PublicKey:   "", // Intentially empty, the public key is derived from Certificate.
+					PublicKey:   "", // Intentionally empty, the public key is derived from Certificate.
 					Certificate: string(overrideCA.CertPEM),
 					Disabled:    disabled,
 				}.Build(),
@@ -5232,12 +5222,11 @@ func createSPIFFECAOverrideForKey(
 	overridePool := x509.NewCertPool()
 	overridePool.AddCert(externalRoot)
 
-	return overridePool
+	return overrideResult{roots: overridePool, issuer: overrideCA.Cert.Subject}
 }
 
-// installLegacyOverrideGetter issues a new external intermediate CA, installs it as a workload override CA, and returns
-// the override pool containing the external root CA.
-func installLegacyOverrideGetter(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+// installLegacyOverrideGetter issues a new external intermediate CA and installs it as a workload override CA.
+func installLegacyOverrideGetter(t *testing.T, tp *issuanceTestPack) overrideResult {
 	t.Helper()
 
 	caCert := spiffeCACert(t, tp)
@@ -5254,7 +5243,7 @@ func installLegacyOverrideGetter(t *testing.T, tp *issuanceTestPack) *x509.CertP
 	overridePool := x509.NewCertPool()
 	overridePool.AddCert(externalRoot)
 
-	return overridePool
+	return overrideResult{roots: overridePool, issuer: overrideCA.Cert.Subject}
 }
 
 type fakeX509CAOverrideGetter struct {

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -1503,7 +1503,7 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 		configureOverrides func(t *testing.T, tp *issuanceTestPack) *x509.CertPool
 	}{
 		{
-			name:               "SVID chains to cluster CA when opted out of overrides",
+			name:               "SVID chains to self-signed CA when opted out of overrides",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: false, // Opted out.
 			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
@@ -1511,7 +1511,7 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			},
 		},
 		{
-			name:               "SVID chains to cluster CA with no overrides configured",
+			name:               "SVID chains to self-signed CA with no overrides configured",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
 			configureOverrides: nil, // No overrides configured.
@@ -1523,7 +1523,7 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			configureOverrides: createSPIFFECAOverride, // Active sub-CA override.
 		},
 		{
-			name:               "SVID chains to sub-CA override when legacy getter is also configured",
+			name:               "SVID chains to sub-CA override when legacy override is also configured",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
 			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
@@ -1532,13 +1532,13 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			},
 		},
 		{
-			name:               "SVID chains to legacy getter without sub-CA override",
+			name:               "SVID chains to legacy override when no sub-CA override exists",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
 			configureOverrides: installLegacyOverrideGetter, // Active legacy workload override.
 		},
 		{
-			name:               "SVID chains to legacy getter when sub-CA override is disabled",
+			name:               "SVID chains to legacy override when sub-CA override is disabled",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
 			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
@@ -1547,7 +1547,7 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			},
 		},
 		{
-			name:               "SVID chains to legacy getter when sub-CA override targets a stale key",
+			name:               "SVID chains to legacy override when sub-CA override targets a stale key",
 			mods:               modulestest.EnterpriseModules(),
 			useIssuerOverrides: true,
 			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
@@ -1560,11 +1560,11 @@ func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
 			},
 		},
 		{
-			name:               "SVID chains to legacy getter on OSS build (sub-CA override ignored)",
+			name:               "SVID chains to legacy override on OSS build",
 			mods:               modulestest.OSSModules(),
 			useIssuerOverrides: true,
 			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
-				createSPIFFECAOverride(t, tp)
+				createSPIFFECAOverride(t, tp) // Ignored even though it exists.
 				return installLegacyOverrideGetter(t, tp)
 			},
 		},

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -61,6 +61,7 @@ import (
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	subcav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/subca/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
@@ -81,12 +82,15 @@ import (
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	libjwt "github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/subca"
+	"github.com/gravitational/teleport/lib/subca/testenv"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -98,24 +102,27 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func newTestTLSServer(t testing.TB, opts ...authtest.TestTLSServerOption) (*authtest.TLSServer, *eventstest.MockRecorderEmitter) {
-	return newTestTLSServerWithScopesFeatures(t, scopes.Features{}, opts...)
+type testTLSServerConfig struct {
+	scopesFeatures scopes.Features
+	modules        modules.Modules
 }
 
-func newTestTLSServerWithScopesFeatures(t testing.TB, scopesFeatures scopes.Features, opts ...authtest.TestTLSServerOption) (*authtest.TLSServer, *eventstest.MockRecorderEmitter) {
+func newTestTLSServer(t testing.TB, cfg testTLSServerConfig) (*authtest.TLSServer, *eventstest.MockRecorderEmitter) {
+	t.Helper()
+
 	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		Dir:            t.TempDir(),
 		Clock:          clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
-		ScopesFeatures: scopesFeatures,
+		ScopesFeatures: cfg.scopesFeatures,
+		Modules:        cfg.modules,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, as.Close()) })
 
 	emitter := &eventstest.MockRecorderEmitter{}
-	opts = append(opts, func(config *authtest.TLSServerConfig) {
+	srv, err := as.NewTestTLSServer(func(config *authtest.TLSServerConfig) {
 		config.APIConfig.Emitter = emitter
 	})
-	srv, err := as.NewTestTLSServer(opts...)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -142,11 +149,16 @@ type issuanceTestPack struct {
 	appClientX509CAPool *x509.CertPool
 }
 
-func newIssuanceTestPack(t *testing.T, ctx context.Context) *issuanceTestPack {
+func newIssuanceTestPack(t *testing.T, ctx context.Context, mods modules.Modules) *issuanceTestPack {
+	t.Helper()
+
 	// Scopes are enabled so the issuance RPCs (which authorize via the scoped
 	// authorizer) can serve both unscoped and scoped identities. Unscoped
 	// issuance is unaffected by enabling the feature.
-	srv, eventRecorder := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+	srv, eventRecorder := newTestTLSServer(t, testTLSServerConfig{
+		scopesFeatures: scopes.Features{Enabled: true},
+		modules:        mods,
+	})
 	clock := srv.Auth().GetClock()
 	fakeClock, ok := clock.(*clockwork.FakeClock)
 	require.True(t, ok, "expected to be a clockwork.FakeClock but got %T", clock)
@@ -230,7 +242,7 @@ func TestIssueWorkloadIdentityE2E(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tp := newIssuanceTestPack(t, ctx)
+	tp := newIssuanceTestPack(t, ctx, nil)
 
 	role, err := types.NewRole("my-role", types.RoleSpecV6{
 		Allow: types.RoleConditions{
@@ -419,7 +431,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tp := newIssuanceTestPack(t, ctx)
+	tp := newIssuanceTestPack(t, ctx, nil)
 
 	wildcardAccess, _, err := authtest.CreateUserAndRole(
 		tp.srv.Auth(),
@@ -1478,11 +1490,164 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 	}
 }
 
+func TestIssueWorkloadIdentity_CAOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		mods               modules.Modules
+		useIssuerOverrides bool
+
+		// configureOverrides sets up any CA overrides for the test cluster, returning the cert pool containing the full
+		// override chain. Nil means no overrides.
+		configureOverrides func(t *testing.T, tp *issuanceTestPack) *x509.CertPool
+	}{
+		{
+			name:               "SVID chains to cluster CA when opted out of overrides",
+			mods:               modulestest.EnterpriseModules(),
+			useIssuerOverrides: false, // Opted out.
+			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+				return createSPIFFECAOverride(t, tp) // Ignored even though it exists.
+			},
+		},
+		{
+			name:               "SVID chains to cluster CA with no overrides configured",
+			mods:               modulestest.EnterpriseModules(),
+			useIssuerOverrides: true,
+			configureOverrides: nil, // No overrides configured.
+		},
+		{
+			name:               "SVID chains to sub-CA override when active",
+			mods:               modulestest.EnterpriseModules(),
+			useIssuerOverrides: true,
+			configureOverrides: createSPIFFECAOverride, // Active sub-CA override.
+		},
+		{
+			name:               "SVID chains to sub-CA override when legacy getter is also configured",
+			mods:               modulestest.EnterpriseModules(),
+			useIssuerOverrides: true,
+			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+				installLegacyOverrideGetter(t, tp) // Ignored, the sub-CA override takes precedence.
+				return createSPIFFECAOverride(t, tp)
+			},
+		},
+		{
+			name:               "SVID chains to legacy getter without sub-CA override",
+			mods:               modulestest.EnterpriseModules(),
+			useIssuerOverrides: true,
+			configureOverrides: installLegacyOverrideGetter, // Active legacy workload override.
+		},
+		{
+			name:               "SVID chains to legacy getter when sub-CA override is disabled",
+			mods:               modulestest.EnterpriseModules(),
+			useIssuerOverrides: true,
+			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+				createSPIFFECAOverrideForKey(t, tp, spiffeCACert(t, tp).PublicKey, true)
+				return installLegacyOverrideGetter(t, tp)
+			},
+		},
+		{
+			name:               "SVID chains to legacy getter when sub-CA override targets a stale key",
+			mods:               modulestest.EnterpriseModules(),
+			useIssuerOverrides: true,
+			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+				staleKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+				require.NoError(t, err)
+
+				createSPIFFECAOverrideForKey(t, tp, staleKey.Public(), false)
+
+				return installLegacyOverrideGetter(t, tp)
+			},
+		},
+		{
+			name:               "SVID chains to legacy getter on OSS build (sub-CA override ignored)",
+			mods:               modulestest.OSSModules(),
+			useIssuerOverrides: true,
+			configureOverrides: func(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+				createSPIFFECAOverride(t, tp)
+				return installLegacyOverrideGetter(t, tp)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Overrides are cluster-wide, so each case gets its own cluster.
+			tp := newIssuanceTestPack(t, t.Context(), test.mods)
+
+			var overrideRoots *x509.CertPool
+			if test.configureOverrides != nil {
+				overrideRoots = test.configureOverrides(t, tp)
+			}
+
+			wantRoots := tp.spiffeX509CAPool
+			if test.useIssuerOverrides && overrideRoots != nil {
+				wantRoots = overrideRoots
+			}
+
+			client, widName := newWildcardIssuanceClient(t, tp)
+
+			workloadKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+			require.NoError(t, err)
+
+			workloadKeyPubBytes, err := x509.MarshalPKIXPublicKey(workloadKey.Public())
+			require.NoError(t, err)
+
+			resp, err := client.IssueWorkloadIdentity(
+				t.Context(),
+				workloadidentityv1pb.IssueWorkloadIdentityRequest_builder{
+					Name: widName,
+					X509SvidParams: workloadidentityv1pb.X509SVIDParams_builder{
+						PublicKey:          workloadKeyPubBytes,
+						UseIssuerOverrides: test.useIssuerOverrides,
+					}.Build(),
+				}.Build(),
+			)
+			require.NoError(t, err)
+
+			x509Cred := resp.GetCredential().GetX509Svid()
+
+			svidCert, err := x509.ParseCertificate(x509Cred.GetCert())
+			require.NoError(t, err)
+
+			intermediates := x509.NewCertPool()
+			for _, chainDER := range x509Cred.GetChain() {
+				cert, err := x509.ParseCertificate(chainDER)
+				require.NoError(t, err, "expected DER-encoded chain certificate")
+
+				intermediates.AddCert(cert)
+			}
+
+			// Verify the SVID chains up to the expected CA.
+			_, err = svidCert.Verify(
+				x509.VerifyOptions{
+					CurrentTime:   tp.clock.Now(),
+					Roots:         wantRoots,
+					Intermediates: intermediates,
+				},
+			)
+			require.NoError(t, err, "issued SVID did not chain up to the expected CA")
+
+			// When an override is configured but the client opted out, verify the SVID does NOT chain to the override.
+			if overrideRoots != nil && !test.useIssuerOverrides {
+				_, err = svidCert.Verify(
+					x509.VerifyOptions{
+						CurrentTime:   tp.clock.Now(),
+						Roots:         overrideRoots,
+						Intermediates: intermediates,
+					},
+				)
+				require.Error(t, err, "SVID should NOT chain to override CA when opted out")
+			}
+		})
+	}
+}
+
 func TestIssueWorkloadIdentities(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	tp := newIssuanceTestPack(t, ctx)
+	tp := newIssuanceTestPack(t, ctx, nil)
 
 	user, _, err := authtest.CreateUserAndRole(
 		tp.srv.Auth(),
@@ -1834,7 +1999,7 @@ func TestIssueTeleportWorkloadIdentity(t *testing.T) {
 	const appServiceID = "test-server"
 	const appName = "panel"
 	ctx := t.Context()
-	tp := newIssuanceTestPack(t, ctx)
+	tp := newIssuanceTestPack(t, ctx, nil)
 	clusterName := tp.srv.ClusterName()
 
 	// Register an application.
@@ -2022,7 +2187,7 @@ func TestIssueTeleportWorkloadIdentityRejectsExpiredUserCA(t *testing.T) {
 	const appName = "panel"
 
 	ctx := t.Context()
-	tp := newIssuanceTestPack(t, ctx)
+	tp := newIssuanceTestPack(t, ctx, nil)
 	clusterName := tp.srv.ClusterName()
 
 	app, err := types.NewAppV3(types.Metadata{
@@ -2144,7 +2309,7 @@ func TestIssueTeleportWorkloadIdentityRejectsExpiredUserCA(t *testing.T) {
 
 func TestResourceService_CreateWorkloadIdentity(t *testing.T) {
 	t.Parallel()
-	srv, eventRecorder := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+	srv, eventRecorder := newTestTLSServer(t, testTLSServerConfig{scopesFeatures: scopes.Features{Enabled: true}})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -2390,7 +2555,7 @@ func TestResourceService_CreateWorkloadIdentity(t *testing.T) {
 
 func TestResourceService_DeleteWorkloadIdentity(t *testing.T) {
 	t.Parallel()
-	srv, eventRecorder := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+	srv, eventRecorder := newTestTLSServer(t, testTLSServerConfig{scopesFeatures: scopes.Features{Enabled: true}})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -2571,7 +2736,7 @@ func TestResourceService_DeleteWorkloadIdentity(t *testing.T) {
 
 func TestResourceService_GetWorkloadIdentity(t *testing.T) {
 	t.Parallel()
-	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+	srv, _ := newTestTLSServer(t, testTLSServerConfig{scopesFeatures: scopes.Features{Enabled: true}})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -2767,7 +2932,7 @@ func TestResourceService_GetWorkloadIdentity(t *testing.T) {
 
 func TestResourceService_ListWorkloadIdentities(t *testing.T) {
 	t.Parallel()
-	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+	srv, _ := newTestTLSServer(t, testTLSServerConfig{scopesFeatures: scopes.Features{Enabled: true}})
 	ctx := t.Context()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -2970,7 +3135,7 @@ func TestResourceService_ListWorkloadIdentities(t *testing.T) {
 // test's count assertions depend on only unscoped fixtures existing.
 func TestResourceService_ListWorkloadIdentitiesScopeFilter(t *testing.T) {
 	t.Parallel()
-	srv, _ := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+	srv, _ := newTestTLSServer(t, testTLSServerConfig{scopesFeatures: scopes.Features{Enabled: true}})
 	ctx := t.Context()
 
 	const grantedScope = "/scopes/granted"
@@ -3113,7 +3278,7 @@ func TestResourceService_ListWorkloadIdentitiesScopeFilter(t *testing.T) {
 
 func TestResourceService_UpdateWorkloadIdentity(t *testing.T) {
 	t.Parallel()
-	srv, eventRecorder := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+	srv, eventRecorder := newTestTLSServer(t, testTLSServerConfig{scopesFeatures: scopes.Features{Enabled: true}})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -3347,7 +3512,7 @@ func TestResourceService_UpdateWorkloadIdentity(t *testing.T) {
 
 func TestResourceService_UpsertWorkloadIdentity(t *testing.T) {
 	t.Parallel()
-	srv, eventRecorder := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+	srv, eventRecorder := newTestTLSServer(t, testTLSServerConfig{scopesFeatures: scopes.Features{Enabled: true}})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -3545,7 +3710,7 @@ func TestResourceService_UpsertWorkloadIdentity(t *testing.T) {
 
 func TestResourceService_ScopedWritesRequireScopesFeature(t *testing.T) {
 	t.Parallel()
-	srv, _ := newTestTLSServer(t)
+	srv, _ := newTestTLSServer(t, testTLSServerConfig{})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -3594,7 +3759,7 @@ func TestResourceService_ScopedWritesRequireScopesFeature(t *testing.T) {
 
 func TestRevocationService_CreateWorkloadIdentityX509Revocation(t *testing.T) {
 	t.Parallel()
-	srv, eventRecorder := newTestTLSServer(t)
+	srv, eventRecorder := newTestTLSServer(t, testTLSServerConfig{})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -3787,7 +3952,7 @@ func TestRevocationService_CreateWorkloadIdentityX509Revocation(t *testing.T) {
 
 func TestRevocationService_DeleteWorkloadIdentityX509Revocation(t *testing.T) {
 	t.Parallel()
-	srv, eventRecorder := newTestTLSServer(t)
+	srv, eventRecorder := newTestTLSServer(t, testTLSServerConfig{})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -3924,7 +4089,7 @@ func TestRevocationService_DeleteWorkloadIdentityX509Revocation(t *testing.T) {
 
 func TestRevocationService_GetWorkloadIdentityX509Revocation(t *testing.T) {
 	t.Parallel()
-	srv, _ := newTestTLSServer(t)
+	srv, _ := newTestTLSServer(t, testTLSServerConfig{})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -4040,7 +4205,7 @@ func TestRevocationService_GetWorkloadIdentityX509Revocation(t *testing.T) {
 
 func TestRevocationService_ListWorkloadIdentityX509Revocations(t *testing.T) {
 	t.Parallel()
-	srv, _ := newTestTLSServer(t)
+	srv, _ := newTestTLSServer(t, testTLSServerConfig{})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -4151,7 +4316,7 @@ func TestRevocationService_ListWorkloadIdentityX509Revocations(t *testing.T) {
 
 func TestRevocationService_UpdateWorkloadIdentityX509Revocation(t *testing.T) {
 	t.Parallel()
-	srv, eventRecorder := newTestTLSServer(t)
+	srv, eventRecorder := newTestTLSServer(t, testTLSServerConfig{})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -4341,7 +4506,7 @@ func TestRevocationService_UpdateWorkloadIdentityX509Revocation(t *testing.T) {
 
 func TestRevocationService_UpsertWorkloadIdentityX509Revocation(t *testing.T) {
 	t.Parallel()
-	srv, eventRecorder := newTestTLSServer(t)
+	srv, eventRecorder := newTestTLSServer(t, testTLSServerConfig{})
 	ctx := context.Background()
 
 	authorizedUser, _, err := authtest.CreateUserAndRole(
@@ -4982,4 +5147,171 @@ func newScopedWorkloadIdentityIssuer(
 		scopedaccess.EncodeScopedVerbs(scopedaccess.Read, scopedaccess.List), labels,
 	)
 	return createScopedWorkloadIdentityUser(t, srv, adminClient, username, scope, role)
+}
+
+// newWildcardIssuanceClient creates a workload identity and a user with wildcard access to it, returning an issuance
+// client authenticated as that user along with the workload identity's name.
+func newWildcardIssuanceClient(t *testing.T, tp *issuanceTestPack) (workloadidentityv1pb.WorkloadIdentityIssuanceServiceClient, string) {
+	t.Helper()
+
+	wid, err := tp.srv.Auth().CreateWorkloadIdentity(
+		t.Context(), workloadidentityv1pb.WorkloadIdentity_builder{
+			Kind:     types.KindWorkloadIdentity,
+			Version:  types.V1,
+			Metadata: headerv1.Metadata_builder{Name: "test-wid"}.Build(),
+			Spec: workloadidentityv1pb.WorkloadIdentitySpec_builder{
+				Spiffe: workloadidentityv1pb.WorkloadIdentitySPIFFE_builder{Id: "/test"}.Build(),
+			}.Build(),
+		}.Build(),
+	)
+	require.NoError(t, err)
+
+	wildcardAccess, _, err := authtest.CreateUserAndRole(
+		tp.srv.Auth(),
+		"test-user",
+		[]string{},
+		[]types.Rule{
+			types.NewRule(types.KindWorkloadIdentity, []string{types.VerbRead, types.VerbList}),
+		},
+		authtest.WithRoleMutator(func(role types.Role) {
+			role.SetWorkloadIdentityLabels(types.Allow, types.Labels{types.Wildcard: []string{types.Wildcard}})
+		}),
+	)
+	require.NoError(t, err)
+
+	baseClient, err := tp.srv.NewClient(authtest.TestUser(wildcardAccess.GetName()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = baseClient.Close() })
+
+	client := workloadidentityv1pb.NewWorkloadIdentityIssuanceServiceClient(baseClient.GetConnection())
+
+	return client, wid.GetMetadata().GetName()
+}
+
+// createSPIFFECAOverride creates an active cert_authority_override matching the cluster's self-signed SPIFFE CA,
+// returning a pool containing only the external root.
+func createSPIFFECAOverride(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+	t.Helper()
+
+	return createSPIFFECAOverrideForKey(t, tp, spiffeCACert(t, tp).PublicKey, false)
+}
+
+// createSPIFFECAOverrideForKey creates a cert_authority_override whose override certificate is issued over public key,
+// returning a pool containing only the external root.
+func createSPIFFECAOverrideForKey(
+	t *testing.T,
+	tp *issuanceTestPack,
+	pub crypto.PublicKey,
+	disabled bool,
+) *x509.CertPool {
+	t.Helper()
+
+	overrideCA, externalRoot := newExternalIntermediateCA(t, tp, pub, spiffeCACert(t, tp).NotAfter)
+
+	caOverride := subcav1.CertAuthorityOverride_builder{
+		Kind:    types.KindCertAuthorityOverride,
+		SubKind: subca.SPIFFECAOverrideSubKind,
+		Version: types.V1,
+		Metadata: headerv1.Metadata_builder{
+			Name: tp.srv.ClusterName(),
+		}.Build(),
+		Spec: subcav1.CertAuthorityOverrideSpec_builder{
+			CertificateOverrides: []*subcav1.CertificateOverride{
+				subcav1.CertificateOverride_builder{
+					PublicKey:   "", // Intentially empty, the public key is derived from Certificate.
+					Certificate: string(overrideCA.CertPEM),
+					Disabled:    disabled,
+				}.Build(),
+			},
+		}.Build(),
+	}.Build()
+
+	_, err := tp.srv.Auth().CreateCertAuthorityOverride(t.Context(), caOverride)
+	require.NoError(t, err)
+
+	overridePool := x509.NewCertPool()
+	overridePool.AddCert(externalRoot)
+
+	return overridePool
+}
+
+// installLegacyOverrideGetter issues a new external intermediate CA, installs it as a workload override CA, and returns
+// the override pool containing the external root CA.
+func installLegacyOverrideGetter(t *testing.T, tp *issuanceTestPack) *x509.CertPool {
+	t.Helper()
+
+	caCert := spiffeCACert(t, tp)
+
+	overrideCA, externalRoot := newExternalIntermediateCA(t, tp, caCert.PublicKey, caCert.NotAfter)
+
+	tp.srv.Auth().SetWorkloadIdentityX509CAOverrideGetter(
+		&fakeX509CAOverrideGetter{
+			cert:  overrideCA.Cert,
+			chain: [][]byte{overrideCA.Cert.Raw},
+		},
+	)
+
+	overridePool := x509.NewCertPool()
+	overridePool.AddCert(externalRoot)
+
+	return overridePool
+}
+
+type fakeX509CAOverrideGetter struct {
+	cert  *x509.Certificate
+	chain [][]byte
+}
+
+func (f *fakeX509CAOverrideGetter) GetWorkloadIdentityX509CAOverride(_ context.Context, _ string, ca *tlsca.CertAuthority) (*tlsca.CertAuthority, [][]byte, error) {
+	return &tlsca.CertAuthority{Cert: f.cert, Signer: ca.Signer}, f.chain, nil
+}
+
+// spiffeCACert returns the cluster's self-signed SPIFFE CA certificate.
+func spiffeCACert(t *testing.T, tp *issuanceTestPack) *x509.Certificate {
+	t.Helper()
+
+	spiffeCA, err := tp.srv.Auth().GetCertAuthority(
+		t.Context(),
+		types.CertAuthID{
+			Type:       types.SPIFFECA,
+			DomainName: tp.srv.ClusterName(),
+		},
+		false,
+	)
+	require.NoError(t, err)
+
+	caCert, err := tlsutils.ParseCertificatePEM(spiffeCA.GetActiveKeys().TLS[0].Cert)
+	require.NoError(t, err)
+
+	return caCert
+}
+
+// newExternalIntermediateCA issues an intermediate CA from a fresh external root CA with given public key and returns
+// the intermediate CA and its corresponding root CA certificate.
+func newExternalIntermediateCA(
+	t *testing.T,
+	tp *issuanceTestPack,
+	pub crypto.PublicKey,
+	notAfter time.Time,
+) (*testenv.CA, *x509.Certificate) {
+	t.Helper()
+
+	externalRoot, err := testenv.NewSelfSignedCA(nil)
+	require.NoError(t, err)
+
+	intermediate, err := externalRoot.NewIntermediateCA(
+		&testenv.CAParams{
+			Clock: tp.clock,
+			Pub:   pub,
+			Template: &x509.Certificate{
+				Subject: pkix.Name{
+					Organization: []string{tp.srv.ClusterName()},
+				},
+				NotAfter: notAfter,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	return intermediate, externalRoot.Cert
 }

--- a/lib/subca/ca_override_resolver.go
+++ b/lib/subca/ca_override_resolver.go
@@ -279,8 +279,7 @@ func (c *CAOverrideResolver) calculateOverride(
 	return res, nil
 }
 
-// HasCAOverride reports whether a CA override resource exists and has at least
-// one active (non-disabled) certificate override configured.
+// HasCAOverride reports whether a CA override resource exists for the resolver's target.
 func (c *CAOverrideResolver) HasCAOverride() bool {
-	return c.overridesActive
+	return c.parsed != nil
 }

--- a/lib/subca/ca_override_resolver.go
+++ b/lib/subca/ca_override_resolver.go
@@ -278,3 +278,9 @@ func (c *CAOverrideResolver) calculateOverride(
 
 	return res, nil
 }
+
+// HasCAOverride reports whether a CA override resource exists and has at least
+// one active (non-disabled) certificate override configured.
+func (c *CAOverrideResolver) HasCAOverride() bool {
+	return c.overridesActive
+}


### PR DESCRIPTION
Part of https://github.com/gravitational/core/issues/103.

As of [RFD 0237 - Sub CA support](https://github.com/gravitational/teleport/blob/master/rfd/0237-sub-ca-support.md), overrides configured via [workload overrides](https://github.com/gravitational/teleport/blob/master/rfd/0194-spiffe-x509-override.md) (`workload_identity_x509_issuer_override` resources) are being deprecated in favor of the new  sub-CA overrides (`cert_authority_override` resources).

This change makes it so that just before an SVID is signed, the new sub-CA override resolver is checked first before falling back to the legacy workload override system.

Whether both systems should interoperate and exactly how the migration will happen is still TBD. That being said, this change allows us to continue development on `master`, allowing us to activate both paths for testing, until those decisions have been made. Once they have been decided, this code will likely change, but until then, onward! 😜

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>