### PR TITLE
tctl: Warn on unknown app_resources fields

### DIFF
--- a/api/types/appresources.go
+++ b/api/types/appresources.go
@@ -35,3 +35,20 @@ func (a AppResource) IsAllowAllOnly() bool {
 func AppResourcesAllowAll(allow, deny []AppResource) bool {
 	return len(deny) == 0 && len(allow) == 1 && allow[0].IsAllowAllOnly()
 }
+
+// RoleHasUnknownAppResourcesFields reports whether any app_resources
+// rule on the role, allow or deny, has a proto field this version does
+// not recognize. It looks inside the rules only, so an unrecognized
+// field beside app_resources is not reported.
+func RoleHasUnknownAppResourcesFields(r Role) bool {
+	return appResourcesHaveUnknownFields(r.GetAppResources(Allow)) || appResourcesHaveUnknownFields(r.GetAppResources(Deny))
+}
+
+func appResourcesHaveUnknownFields(rules []AppResource) bool {
+	for _, rule := range rules {
+		if len(rule.XXX_unrecognized) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/api/types/appresources_test.go
+++ b/api/types/appresources_test.go
@@ -121,3 +121,20 @@ func TestAppResourcesAllowAll(t *testing.T) {
 	require.False(t, AppResourcesAllowAll([]AppResource{allowAll, allowAll}, nil))
 	require.False(t, AppResourcesAllowAll([]AppResource{allowAll}, []AppResource{{}}))
 }
+
+func TestRoleHasUnknownAppResourcesFields(t *testing.T) {
+	// Field 10 is not declared in any version.
+	unknown := AppResource{AllowAll: true, XXX_unrecognized: []byte{0x50, 0x01}}
+	role := func(allow, deny []AppResource) Role {
+		return &RoleV6{
+			Metadata: Metadata{Name: "test"},
+			Version:  V9,
+			Spec:     RoleSpecV6{Allow: RoleConditions{AppResources: allow}, Deny: RoleConditions{AppResources: deny}},
+		}
+	}
+	require.False(t, RoleHasUnknownAppResourcesFields(role(nil, nil)))
+	require.False(t, RoleHasUnknownAppResourcesFields(role([]AppResource{{AllowAll: true}, {}}, nil)))
+	require.True(t, RoleHasUnknownAppResourcesFields(role([]AppResource{{AllowAll: true}, unknown}, nil)))
+	// A newer version may write deny rules.
+	require.True(t, RoleHasUnknownAppResourcesFields(role(nil, []AppResource{unknown})))
+}

--- a/tool/tctl/common/resources/role.go
+++ b/tool/tctl/common/resources/role.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -112,6 +113,9 @@ func getRole(ctx context.Context, client *authclient.Client, ref services.Ref, o
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+		for _, role := range roles {
+			warnAboutUnknownAppResourcesFields(os.Stderr, role)
+		}
 		return &roleCollection{roles: roles}, nil
 	}
 	role, err := client.GetRole(ctx, ref.Name)
@@ -119,8 +123,8 @@ func getRole(ctx context.Context, client *authclient.Client, ref services.Ref, o
 		return nil, trace.Wrap(err)
 	}
 	warnAboutDynamicLabelsInDenyRule(ctx, slog.Default(), role)
+	warnAboutUnknownAppResourcesFields(os.Stderr, role)
 	return &roleCollection{roles: []types.Role{role}}, nil
-
 }
 
 func createRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
@@ -139,13 +143,18 @@ func createRole(ctx context.Context, client *authclient.Client, raw services.Unk
 	warnAboutKubernetesResources(ctx, slog.Default(), role)
 
 	roleName := role.GetName()
-	_, err = client.GetRole(ctx, roleName)
+	stored, err := client.GetRole(ctx, roleName)
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
 	roleExists := (err == nil)
-	if roleExists && !opts.Force {
-		return trace.AlreadyExists("role %q already exists", roleName)
+	if roleExists {
+		if !opts.Force {
+			return trace.AlreadyExists("role %q already exists", roleName)
+		}
+		if err := checkUnknownAppResourcesFields(stored); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	if _, err := client.UpsertRole(ctx, role); err != nil {
 		return trace.Wrap(err)
@@ -162,6 +171,14 @@ func updateRole(ctx context.Context, client *authclient.Client, raw services.Unk
 
 	warnAboutKubernetesResources(ctx, slog.Default(), role)
 	warnAboutDynamicLabelsInDenyRule(ctx, slog.Default(), role)
+
+	stored, err := client.GetRole(ctx, role.GetName())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := checkUnknownAppResourcesFields(stored); err != nil {
+		return trace.Wrap(err)
+	}
 
 	if _, err := client.UpdateRole(ctx, role); err != nil {
 		return trace.Wrap(err)
@@ -214,4 +231,22 @@ func warnAboutDynamicLabelsInDenyRule(ctx context.Context, logger *slog.Logger, 
 	} else {
 		logger.WarnContext(ctx, "error checking deny rules labels", "error", err)
 	}
+}
+
+// warnAboutUnknownAppResourcesFields writes a warning when a role has
+// app_resources sub-fields this version of tctl does not recognize.
+func warnAboutUnknownAppResourcesFields(w io.Writer, r types.Role) {
+	if !types.RoleHasUnknownAppResourcesFields(r) {
+		return
+	}
+	fmt.Fprintf(w, "WARNING: role %q has app_resources sub-fields this version of tctl does not recognize. Writing the role back with this version would drop them and can widen app access.\n", r.GetName())
+}
+
+// checkUnknownAppResourcesFields returns an error when a role has
+// app_resources sub-fields this version of tctl does not recognize.
+func checkUnknownAppResourcesFields(r types.Role) error {
+	if types.RoleHasUnknownAppResourcesFields(r) {
+		return trace.BadParameter("role %q has app_resources sub-fields this version of tctl does not recognize. Writing the role back would drop them and can widen app access. Use a tctl version matching the auth server", r.GetName())
+	}
+	return nil
 }

--- a/tool/tctl/common/resources/role_test.go
+++ b/tool/tctl/common/resources/role_test.go
@@ -1,0 +1,65 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func roleWithAppResources(allow, deny []types.AppResource) types.Role {
+	return &types.RoleV6{
+		Metadata: types.Metadata{Name: "test-role"},
+		Version:  types.V9,
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{AppResources: allow},
+			Deny:  types.RoleConditions{AppResources: deny},
+		},
+	}
+}
+
+// unknownField sets field 10, which no version declares.
+var unknownField = types.AppResource{AllowAll: true, XXX_unrecognized: []byte{0x50, 0x01}}
+
+func TestCheckUnknownAppResourcesFields(t *testing.T) {
+	known := types.AppResource{AllowAll: true}
+
+	require.NoError(t, checkUnknownAppResourcesFields(roleWithAppResources(nil, nil)))
+	require.NoError(t, checkUnknownAppResourcesFields(roleWithAppResources([]types.AppResource{known}, nil)))
+
+	err := checkUnknownAppResourcesFields(roleWithAppResources([]types.AppResource{unknownField}, nil))
+	require.ErrorContains(t, err, "does not recognize")
+
+	err = checkUnknownAppResourcesFields(roleWithAppResources(nil, []types.AppResource{unknownField}))
+	require.ErrorContains(t, err, "does not recognize")
+}
+
+func TestWarnAboutUnknownAppResourcesFields(t *testing.T) {
+	var buf strings.Builder
+	warnAboutUnknownAppResourcesFields(&buf, roleWithAppResources([]types.AppResource{{AllowAll: true}}, nil))
+	require.Empty(t, buf.String())
+
+	warnAboutUnknownAppResourcesFields(&buf, roleWithAppResources([]types.AppResource{unknownField}, nil))
+	require.Contains(t, buf.String(), "does not recognize")
+	require.Contains(t, buf.String(), "test-role")
+}


### PR DESCRIPTION
In `tctl`, refuse to write a role whose stored `app_resources` entry has subfields this version does not know, so that later additions to `app_resources` cannot be stripped during version skew, which could silently widen the role's fine-grained HTTP app access.

A future version may add subfields to `app_resources` that this version does not know, for example a filter on a request header. An older `tctl` receives that subfield in the proto field holding whatever the client does not recognize, and drops it when it writes the role out as YAML. A rule stored by a newer auth server as

```yaml
app_resources:
  - paths: ["/api/**"]
    header_filter: "x-env: dev"
```

reaches the user from `tctl get` as

```yaml
app_resources:
  - paths: ["/api/**"]
```

The second rule is valid and grants more than the stored one, because the header filter is gone. Writing it back replaces the stricter rule with the wider one, and the server accepts it, because it cannot tell a dropped subfield from one an admin removed on purpose.

Add `RoleHasUnknownAppResourcesFields` to `api/types`. Warn on stderr when `tctl get` reads a role with unknown subfields in `app_resources`. Return an error from `tctl create -f` and `tctl edit`, which both fetch the stored role before they write. Include the check in 19.0.0, before the first such subfield exists, since the client that strips it is always the older one.

The Web UI role editor round-trips a role through the proxy, which can run a version behind the auth server during an upgrade or after a rollback, so the same drop applies there and needs its own change.

## Manual Test Plan

### Test Environment

Auth-only single-node cluster from this branch, `teleport` and `tctl` built with `make build/teleport build/tctl`. Roles applied with `tctl --config=<config.yaml> create -f <role.yaml>`.

A second build stands in for the newer auth server. It adds `string HeaderFilter = 10` to `AppResource` in the proto and regenerates the stubs. Its `tctl` writes the role. The unmodified `tctl` is the client under test.

### Test Cases

- [x] The newer `tctl` writes a v9 role whose `app_resources` rule sets `allow_all` and `header_filter`, then reads both fields back.
- [x] `tctl get role/NAME` on the client under test prints a warning naming the role to stderr, and the YAML on stdout has no `header_filter`.
- [x] `tctl edit role/NAME` returns an error, and the stored role keeps both `header_filter` and its original labels.
- [x] `tctl create -f --force`, given the YAML that lost the subfield, returns an error, and the stored role keeps `header_filter`.
- [x] `tctl get roles` warns once, for the affected role only.
- [x] A v9 role without `header_filter` produces no warning on `tctl get` and edits normally.
- [x] Deleting the role and recreating it from the YAML that lost the subfield succeeds and loses `header_filter`, since no stored role remains to compare against.

Related-RFD: https://github.com/gravitational/rfd/blob/main/rfd/0303-policy-based-app-access.md
