### PR TITLE
Refactor ULS generator for LoginHook call fix

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -965,7 +965,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 	}
 
 	// Add in a login hook for generating state during user login.
-	as.ulsGenerator, err = userloginstate.NewGenerator(userloginstate.GeneratorConfig{
+	as.ULSGenerator, err = userloginstate.NewGenerator(userloginstate.GeneratorConfig{
 		Log:         as.logger,
 		AccessLists: as,
 		Access:      as,
@@ -978,11 +978,11 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		return nil, trace.Wrap(err)
 	}
 
-	as.RegisterLoginHook(as.ulsGenerator.LoginHook(services.UserLoginStates))
+	as.RegisterLoginHook(as.ULSGenerator.LoginHook(services.UserLoginStates))
 
 	as.pdp, err = decision.NewService(decision.Config{
 		AccessPoint:  as.Cache,
-		ULSGenerator: as.ulsGenerator,
+		ULSGenerator: as.ULSGenerator,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1534,8 +1534,8 @@ type Server struct {
 	// accessMonitoringEnabled is a flag that indicates whether access monitoring is enabled.
 	accessMonitoringEnabled bool
 
-	// ulsGenerator is the user login state generator.
-	ulsGenerator *userloginstate.Generator
+	// ULSGenerator is the user login state generator.
+	ULSGenerator *userloginstate.Generator
 
 	// createDeviceWebTokenFunc is the CreateDeviceWebToken implementation.
 	// Is nil on OSS clusters.
@@ -2905,7 +2905,7 @@ func (a *Server) regenerateUserLoginState(ctx context.Context, username string) 
 		// See GetUserOrLoginState where IsBot is checked and the user is returned directly.
 		return user, nil
 	}
-	uls, err := a.ulsGenerator.GeneratePureULS(ctx, user)
+	uls, err := a.ULSGenerator.GeneratePureULS(ctx, user)
 	return uls, trace.Wrap(err)
 }
 
@@ -5236,7 +5236,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req authclient.WebSession
 		}
 
 		// Make sure to refresh the user login state.
-		userState, err := a.ulsGenerator.Refresh(ctx, user, a.UserLoginStates)
+		userState, err := a.ULSGenerator.Refresh(ctx, user, a.UserLoginStates)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -968,6 +968,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 	as.ULSGenerator, err = userloginstate.NewGenerator(userloginstate.GeneratorConfig{
 		Log:         as.logger,
 		AccessLists: as,
+		Locks:       as,
 		Access:      as,
 		UsageEvents: as,
 		Clock:       cfg.Clock,

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -199,7 +199,7 @@ func (a *Server) AuthenticateUserLogin(ctx context.Context, req authclient.Authe
 }
 
 func (a *Server) RefreshULS(ctx context.Context, user types.User, ulsService services.UserLoginStates) (*userloginstate.UserLoginState, error) {
-	return a.ulsGenerator.Refresh(ctx, user, ulsService)
+	return a.ULSGenerator.Refresh(ctx, user, ulsService)
 }
 
 func (a *Server) CreateGithubUser(ctx context.Context, p *CreateUserParams, dryRun bool) (types.User, error) {

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -862,7 +862,7 @@ func (a *Server) validateGithubAuthCallbackForAuthenticatedUser(
 	})
 
 	// Instead of updating the user, refresh the user login state.
-	userState, err := a.ulsGenerator.Refresh(ctx, teleportUser, a.UserLoginStates)
+	userState, err := a.ULSGenerator.Refresh(ctx, teleportUser, a.UserLoginStates)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -69,7 +69,7 @@ func (a *Server) ChangeUserAuthentication(ctx context.Context, req *proto.Change
 	// We intentionally do not persist the ULS here (unlike the normal login
 	// path) to avoid leaving stale state if the user's roles are modified
 	// after the reset.
-	userState, err := a.ulsGenerator.GeneratePureULS(ctx, user)
+	userState, err := a.ULSGenerator.GeneratePureULS(ctx, user)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/user_login_state.go
+++ b/lib/auth/user_login_state.go
@@ -26,5 +26,5 @@ import (
 // GeneratePureULS is used to determine login state for the user.
 // It emits no usage events and ignores any existing user login state in the backend.
 func (a *Server) GeneratePureULS(ctx context.Context, user types.User) (*userloginstate.UserLoginState, error) {
-	return a.ulsGenerator.GeneratePureULS(ctx, user)
+	return a.ULSGenerator.GeneratePureULS(ctx, user)
 }

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -44,19 +44,16 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-// AccessListsAndLockGetter is an interface for retrieving access lists and locks.
-type AccessListsAndLockGetter interface {
-	services.AccessListsGetter
-	services.LockGetter
-}
-
 // GeneratorConfig is the configuration for the user login state generator.
 type GeneratorConfig struct {
 	// Log is a logger to use for the generator.
 	Log *slog.Logger
 
-	// AccessLists is a service for retrieving access lists and locks from the backend.
-	AccessLists AccessListsAndLockGetter
+	// AccessLists defines an interface for reading access lists.
+	AccessLists services.AccessListsGetter
+
+	// Locks is a service that gets locks.
+	Locks services.LockGetter
 
 	// Access is a service that will be used for retrieving roles from the backend.
 	Access services.Access
@@ -86,7 +83,11 @@ func (g *GeneratorConfig) CheckAndSetDefaults() error {
 	}
 
 	if g.AccessLists == nil {
-		return trace.BadParameter("missing access lists")
+		return trace.BadParameter("missing access lists service")
+	}
+
+	if g.Locks == nil {
+		return trace.BadParameter("missing locks service")
 	}
 
 	if g.Access == nil {
@@ -219,7 +220,7 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 	locks, err := clientutils.CollectWithFallback(
 		ctx,
 		func(ctx context.Context, limit int, start string) ([]types.Lock, string, error) {
-			return g.Cfg.AccessLists.ListLocks(ctx, limit, start, &types.LockFilter{
+			return g.Cfg.Locks.ListLocks(ctx, limit, start, &types.LockFilter{
 				InForceOnly: true,
 				Targets:     []*types.LockTarget{{User: user.GetName()}},
 			})
@@ -227,7 +228,7 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 		func(ctx context.Context) ([]types.Lock, error) {
 			// TODO(okraport): DELETE IN v21
 			const inForceOnlyTrue = true
-			return g.Cfg.AccessLists.GetLocks(ctx, inForceOnlyTrue, types.LockTarget{
+			return g.Cfg.Locks.GetLocks(ctx, inForceOnlyTrue, types.LockTarget{
 				User: user.GetName(),
 			})
 		},

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -114,12 +114,7 @@ func (g *GeneratorConfig) CheckAndSetDefaults() error {
 
 // Generator will generate a user login state from a user.
 type Generator struct {
-	log         *slog.Logger
-	accessLists AccessListsAndLockGetter
-	access      services.Access
-	usageEvents UsageEventsClient
-	clock       clockwork.Clock
-	emitter     apievents.Emitter
+	Cfg GeneratorConfig
 }
 
 // NewGenerator creates a new user login state generator.
@@ -127,15 +122,7 @@ func NewGenerator(config GeneratorConfig) (*Generator, error) {
 	if err := config.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return &Generator{
-		log:         config.Log,
-		accessLists: config.AccessLists,
-		access:      config.Access,
-		usageEvents: config.UsageEvents,
-		clock:       config.Clock,
-		emitter:     config.Emitter,
-	}, nil
+	return &Generator{config}, nil
 }
 
 // GeneratePureULS is a variant of user login state generation that emits no usage events and ignores any existing user login state
@@ -217,10 +204,10 @@ func (g *Generator) generate(ctx context.Context, user types.User, ulsService se
 		return nil, trace.Wrap(err)
 	}
 
-	if g.usageEvents != nil && !pure {
+	if g.Cfg.UsageEvents != nil && !pure {
 		// Emit the usage event metadata.
 		if err := g.emitUsageEvent(ctx, user, uls, inheritedRoles, inheritedTraits); err != nil {
-			g.log.DebugContext(ctx, "Error emitting usage event during user login state generation, skipping", "error", err)
+			g.Cfg.Log.DebugContext(ctx, "Error emitting usage event during user login state generation, skipping", "error", err)
 		}
 	}
 
@@ -232,7 +219,7 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 	locks, err := clientutils.CollectWithFallback(
 		ctx,
 		func(ctx context.Context, limit int, start string) ([]types.Lock, string, error) {
-			return g.accessLists.ListLocks(ctx, limit, start, &types.LockFilter{
+			return g.Cfg.AccessLists.ListLocks(ctx, limit, start, &types.LockFilter{
 				InForceOnly: true,
 				Targets:     []*types.LockTarget{{User: user.GetName()}},
 			})
@@ -240,7 +227,7 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 		func(ctx context.Context) ([]types.Lock, error) {
 			// TODO(okraport): DELETE IN v21
 			const inForceOnlyTrue = true
-			return g.accessLists.GetLocks(ctx, inForceOnlyTrue, types.LockTarget{
+			return g.Cfg.AccessLists.GetLocks(ctx, inForceOnlyTrue, types.LockTarget{
 				User: user.GetName(),
 			})
 		},
@@ -270,15 +257,15 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 	}
 
 	h, err := accesslists.NewHierarchy(accesslists.HierarchyConfig{
-		AccessListsService: g.accessLists,
-		Clock:              g.clock,
+		AccessListsService: g.Cfg.AccessLists,
+		Clock:              g.Cfg.Clock,
 		IgnoreScoped:       true,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	for acl, err := range clientutils.Resources(ctx, g.accessLists.ListAccessLists) {
+	for acl, err := range clientutils.Resources(ctx, g.Cfg.AccessLists.ListAccessLists) {
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -370,7 +357,7 @@ func (g *Generator) postProcess(ctx context.Context, state *userloginstate.UserL
 
 	// Make sure all the roles exist. If they don't, error out.
 	for _, role := range state.Spec.Roles {
-		if _, err := g.access.GetRole(ctx, role); err != nil {
+		if _, err := g.Cfg.Access.GetRole(ctx, role); err != nil {
 			if trace.IsNotFound(err) {
 				return trace.Wrap(types.ErrNonExistingRoleAssigned)
 			}
@@ -422,7 +409,7 @@ func (g *Generator) emitUsageEvent(ctx context.Context, user types.User, state *
 		CountInheritedTraitsGranted: int32(countInheritedTraitsGranted),
 	}
 
-	if err := g.usageEvents.SubmitUsageEvent(ctx, &proto.SubmitUsageEventRequest{
+	if err := g.Cfg.UsageEvents.SubmitUsageEvent(ctx, &proto.SubmitUsageEventRequest{
 		Event: &usageeventsv1.UsageEventOneOf{
 			Event: &usageeventsv1.UsageEventOneOf_AccessListGrantsToUser{
 				AccessListGrantsToUser: grantsToUser,
@@ -506,7 +493,7 @@ func (g *Generator) identifyMissingRoles(ctx context.Context, roles []string) ([
 	var missingRoles []string
 
 	for _, role := range roles {
-		_, err := g.access.GetRole(ctx, role)
+		_, err := g.Cfg.Access.GetRole(ctx, role)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				missingRoles = append(missingRoles, role)
@@ -526,7 +513,7 @@ func (g *Generator) identifyMissingRoles(ctx context.Context, roles []string) ([
 // emitSkippedAccessListEvent emits an audit log event to indicate that an invalid
 // access list could not be applied during user login.
 func (g *Generator) emitSkippedAccessListEvent(ctx context.Context, accessListName string, missingRoles []string, username string) {
-	if err := g.emitter.EmitAuditEvent(ctx, &apievents.UserLoginAccessListInvalid{
+	if err := g.Cfg.Emitter.EmitAuditEvent(ctx, &apievents.UserLoginAccessListInvalid{
 		Metadata: apievents.Metadata{
 			Type: events.UserLoginAccessListInvalidEvent,
 			Code: events.UserLoginAccessListInvalidCode,
@@ -542,6 +529,6 @@ func (g *Generator) emitSkippedAccessListEvent(ctx context.Context, accessListNa
 			UserMessage: "access list skipped because it references non-existent role(s)",
 		},
 	}); err != nil {
-		g.log.WarnContext(ctx, "Failed to emit access list skipped warning audit event", "error", err)
+		g.Cfg.Log.WarnContext(ctx, "Failed to emit access list skipped warning audit event", "error", err)
 	}
 }

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -768,6 +768,7 @@ func initGeneratorSvc(cloud bool) (*Generator, *svc, error) {
 	generator, err := NewGenerator(GeneratorConfig{
 		Log:         logtest.NewLogger(),
 		AccessLists: svc,
+		Locks:       svc,
 		Access:      svc,
 		UsageEvents: svc,
 		Clock:       clock,


### PR DESCRIPTION
The change is to make UserLoginState Generator's fields public and also make the ULSGenerator field public in the auth server.

This is required so the Generator can be modified for the integration tests (https://github.com/gravitational/teleport.e/pull/9368).

The actual fix will be introduced in the follow up PR https://github.com/gravitational/teleport/pull/69409