### PR TITLE
Short circuit Login Hooks on ULS Generator error

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -978,8 +978,6 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		return nil, trace.Wrap(err)
 	}
 
-	as.RegisterLoginHook(as.ULSGenerator.LoginHook(services.UserLoginStates))
-
 	as.pdp, err = decision.NewService(decision.Config{
 		AccessPoint:  as.Cache,
 		ULSGenerator: as.ULSGenerator,
@@ -1679,7 +1677,8 @@ func (a *Server) GetLoginRuleEvaluator() loginrule.Evaluator {
 	return a.loginRuleEvaluator
 }
 
-// RegisterLoginHook will register a login hook with the auth server.
+// RegisterLoginHook will register an additioanl login hook with the auth server to be called after
+// UserLoginState Generator hook.
 func (a *Server) RegisterLoginHook(hook LoginHook) {
 	a.loginHooksMu.Lock()
 	defer a.loginHooksMu.Unlock()
@@ -1687,7 +1686,10 @@ func (a *Server) RegisterLoginHook(hook LoginHook) {
 	a.loginHooks = append(a.loginHooks, hook)
 }
 
-// CallLoginHooks will call the registered login hooks.
+// CallLoginHooks will call the registered login hooks. UserLoginState Generator hook is fixed and
+// is always called before calling the regiesterd hooks, so the registered hooks are always called
+// with a freshly generated ULS. If the Generator hook fails, the other hooks are not called. An
+// aggregated erorr of all registered hook calls is returned.
 func (a *Server) CallLoginHooks(ctx context.Context, user types.User) error {
 	// Make a copy of the login hooks to operate on.
 	a.loginHooksMu.RLock()
@@ -1695,9 +1697,6 @@ func (a *Server) CallLoginHooks(ctx context.Context, user types.User) error {
 	copy(loginHooks, a.loginHooks)
 	a.loginHooksMu.RUnlock()
 
-	if len(loginHooks) == 0 {
-		return nil
-	}
 	// Clone the input user so that hooks never mutate the original object.
 	//
 	// Currently, login hook share state via UserLoginState resources.
@@ -1710,6 +1709,14 @@ func (a *Server) CallLoginHooks(ctx context.Context, user types.User) error {
 	// these attributes in the future, we should first define a single source of
 	// truth and a clear reconciliation strategy.
 	user = user.Clone()
+
+	if err := a.ULSGenerator.LoginHook(ctx, user, a.UserLoginStates); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if len(loginHooks) == 0 {
+		return nil
+	}
 	var errs []error
 	for _, hook := range loginHooks {
 		errs = append(errs, hook(ctx, user))
@@ -1718,7 +1725,8 @@ func (a *Server) CallLoginHooks(ctx context.Context, user types.User) error {
 	return trace.NewAggregate(errs...)
 }
 
-// ResetLoginHooks will clear out the login hooks.
+// ResetLoginHooks will clear out the login hooks. It does not reset UserLoginState Generator
+// hook. Used for testing.
 func (a *Server) ResetLoginHooks() {
 	a.loginHooksMu.Lock()
 	a.loginHooks = nil

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -460,6 +460,12 @@ func preserveSAMLIdentities(dst, src *userloginstate.UserLoginState) {
 	dst.Spec.SAMLIdentities = ids1
 }
 
+// LoginHook will take the user and update the user login state in the backend.
+func (g *Generator) LoginHook(ctx context.Context, user types.User, ulsService services.UserLoginStates) error {
+	_, err := g.Refresh(ctx, user, ulsService)
+	return trace.Wrap(err)
+}
+
 // Refresh will take the user and update the user login state in the backend.
 func (g *Generator) Refresh(ctx context.Context, user types.User, ulsService services.UserLoginStates) (*userloginstate.UserLoginState, error) {
 	uls, err := g.generate(ctx, user, ulsService, false)
@@ -478,14 +484,6 @@ func (g *Generator) Refresh(ctx context.Context, user types.User, ulsService ser
 
 	uls, err = ulsService.UpsertUserLoginState(ctx, uls)
 	return uls, trace.Wrap(err)
-}
-
-// LoginHook creates a login hook from the Generator and the user login state service.
-func (g *Generator) LoginHook(ulsService services.UserLoginStates) func(context.Context, types.User) error {
-	return func(ctx context.Context, user types.User) error {
-		_, err := g.Refresh(ctx, user, ulsService)
-		return trace.Wrap(err)
-	}
 }
 
 // identifyMissingRoles is a helper function which identifies any roles from the provided list that don't exist, and returns nil if they all exist.


### PR DESCRIPTION
Issue https://github.com/gravitational/teleport.e/issues/9281

Requires https://github.com/gravitational/teleport/pull/69408
Test coverage in E: https://github.com/gravitational/teleport.e/pull/9368

Changelog: Fixed a bug where it could happen that Okta assignments could be deleted in Okta on a transient backend error.

## Manual Test Plan

### Test Environment

Teleport cluster with full bidirectional Okta integration.

### Test Cases

 - [ ] Verify assignments push works
    1. Sync Okta user `alice`
    2. Add `alice` to an Access List and verify `alice` was assigned to the corresponding group in Okta
    3. Login as `alice` and verify the assignment is still in Okta.
    4. Remove `alice` from the Access List and check the group assignment is gone in Okta
    5. Add `alice` back to the Access List and verify the assignment is added back in Okta
    6. Log out `alice`
    7. Verify the assignment is still in Okta
    8. Remove `alice` from the Access List and verify the assignment is gone in Okta
