### PR TITLE
[v18] MWI: Bot Scope Namespacing (#68253)

### DIFF
--- a/api/gen/proto/go/teleport/machineid/v1/bot_service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_service_protohybrid.pb.go
@@ -113,7 +113,9 @@ func (b0 CreateBotRequest_builder) Build() *CreateBotRequest {
 type GetBotRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// The name of the bot to fetch.
-	BotName       string `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
+	BotName string `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
+	// The scope the bot exists in. Empty for an unscoped bot.
+	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -150,8 +152,19 @@ func (x *GetBotRequest) GetBotName() string {
 	return ""
 }
 
+func (x *GetBotRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *GetBotRequest) SetBotName(v string) {
 	x.BotName = v
+}
+
+func (x *GetBotRequest) SetScope(v string) {
+	x.Scope = v
 }
 
 type GetBotRequest_builder struct {
@@ -159,6 +172,8 @@ type GetBotRequest_builder struct {
 
 	// The name of the bot to fetch.
 	BotName string
+	// The scope the bot exists in. Empty for an unscoped bot.
+	Scope string
 }
 
 func (b0 GetBotRequest_builder) Build() *GetBotRequest {
@@ -166,6 +181,7 @@ func (b0 GetBotRequest_builder) Build() *GetBotRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.BotName = b.BotName
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -500,7 +516,9 @@ func (b0 UpsertBotRequest_builder) Build() *UpsertBotRequest {
 type DeleteBotRequest struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// The name of the bot to delete.
-	BotName       string `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
+	BotName string `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3" json:"bot_name,omitempty"`
+	// The scope the bot exists in. Empty for an unscoped bot.
+	Scope         string `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -537,8 +555,19 @@ func (x *DeleteBotRequest) GetBotName() string {
 	return ""
 }
 
+func (x *DeleteBotRequest) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
 func (x *DeleteBotRequest) SetBotName(v string) {
 	x.BotName = v
+}
+
+func (x *DeleteBotRequest) SetScope(v string) {
+	x.Scope = v
 }
 
 type DeleteBotRequest_builder struct {
@@ -546,6 +575,8 @@ type DeleteBotRequest_builder struct {
 
 	// The name of the bot to delete.
 	BotName string
+	// The scope the bot exists in. Empty for an unscoped bot.
+	Scope string
 }
 
 func (b0 DeleteBotRequest_builder) Build() *DeleteBotRequest {
@@ -553,6 +584,7 @@ func (b0 DeleteBotRequest_builder) Build() *DeleteBotRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.BotName = b.BotName
+	x.Scope = b.Scope
 	return m0
 }
 
@@ -562,9 +594,10 @@ const file_teleport_machineid_v1_bot_service_proto_rawDesc = "" +
 	"\n" +
 	"'teleport/machineid/v1/bot_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x1fteleport/machineid/v1/bot.proto\"@\n" +
 	"\x10CreateBotRequest\x12,\n" +
-	"\x03bot\x18\x01 \x01(\v2\x1a.teleport.machineid.v1.BotR\x03bot\"*\n" +
+	"\x03bot\x18\x01 \x01(\v2\x1a.teleport.machineid.v1.BotR\x03bot\"@\n" +
 	"\rGetBotRequest\x12\x19\n" +
-	"\bbot_name\x18\x01 \x01(\tR\abotName\"M\n" +
+	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"M\n" +
 	"\x0fListBotsRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -577,9 +610,10 @@ const file_teleport_machineid_v1_bot_service_proto_rawDesc = "" +
 	"\vupdate_mask\x18\x02 \x01(\v2\x1a.google.protobuf.FieldMaskR\n" +
 	"updateMask\"@\n" +
 	"\x10UpsertBotRequest\x12,\n" +
-	"\x03bot\x18\x01 \x01(\v2\x1a.teleport.machineid.v1.BotR\x03bot\"-\n" +
+	"\x03bot\x18\x01 \x01(\v2\x1a.teleport.machineid.v1.BotR\x03bot\"C\n" +
 	"\x10DeleteBotRequest\x12\x19\n" +
-	"\bbot_name\x18\x01 \x01(\tR\abotName2\xf9\x03\n" +
+	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope2\xf9\x03\n" +
 	"\n" +
 	"BotService\x12J\n" +
 	"\x06GetBot\x12$.teleport.machineid.v1.GetBotRequest\x1a\x1a.teleport.machineid.v1.Bot\x12[\n" +

--- a/api/gen/proto/go/teleport/machineid/v1/bot_service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_service_protoopaque.pb.go
@@ -112,6 +112,7 @@ func (b0 CreateBotRequest_builder) Build() *CreateBotRequest {
 type GetBotRequest struct {
 	state              protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_BotName string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
+	xxx_hidden_Scope   string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -148,8 +149,19 @@ func (x *GetBotRequest) GetBotName() string {
 	return ""
 }
 
+func (x *GetBotRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *GetBotRequest) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
+}
+
+func (x *GetBotRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 type GetBotRequest_builder struct {
@@ -157,6 +169,8 @@ type GetBotRequest_builder struct {
 
 	// The name of the bot to fetch.
 	BotName string
+	// The scope the bot exists in. Empty for an unscoped bot.
+	Scope string
 }
 
 func (b0 GetBotRequest_builder) Build() *GetBotRequest {
@@ -164,6 +178,7 @@ func (b0 GetBotRequest_builder) Build() *GetBotRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_BotName = b.BotName
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -490,6 +505,7 @@ func (b0 UpsertBotRequest_builder) Build() *UpsertBotRequest {
 type DeleteBotRequest struct {
 	state              protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_BotName string                 `protobuf:"bytes,1,opt,name=bot_name,json=botName,proto3"`
+	xxx_hidden_Scope   string                 `protobuf:"bytes,2,opt,name=scope,proto3"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -526,8 +542,19 @@ func (x *DeleteBotRequest) GetBotName() string {
 	return ""
 }
 
+func (x *DeleteBotRequest) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
 func (x *DeleteBotRequest) SetBotName(v string) {
 	x.xxx_hidden_BotName = v
+}
+
+func (x *DeleteBotRequest) SetScope(v string) {
+	x.xxx_hidden_Scope = v
 }
 
 type DeleteBotRequest_builder struct {
@@ -535,6 +562,8 @@ type DeleteBotRequest_builder struct {
 
 	// The name of the bot to delete.
 	BotName string
+	// The scope the bot exists in. Empty for an unscoped bot.
+	Scope string
 }
 
 func (b0 DeleteBotRequest_builder) Build() *DeleteBotRequest {
@@ -542,6 +571,7 @@ func (b0 DeleteBotRequest_builder) Build() *DeleteBotRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_BotName = b.BotName
+	x.xxx_hidden_Scope = b.Scope
 	return m0
 }
 
@@ -551,9 +581,10 @@ const file_teleport_machineid_v1_bot_service_proto_rawDesc = "" +
 	"\n" +
 	"'teleport/machineid/v1/bot_service.proto\x12\x15teleport.machineid.v1\x1a\x1bgoogle/protobuf/empty.proto\x1a google/protobuf/field_mask.proto\x1a\x1fteleport/machineid/v1/bot.proto\"@\n" +
 	"\x10CreateBotRequest\x12,\n" +
-	"\x03bot\x18\x01 \x01(\v2\x1a.teleport.machineid.v1.BotR\x03bot\"*\n" +
+	"\x03bot\x18\x01 \x01(\v2\x1a.teleport.machineid.v1.BotR\x03bot\"@\n" +
 	"\rGetBotRequest\x12\x19\n" +
-	"\bbot_name\x18\x01 \x01(\tR\abotName\"M\n" +
+	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\"M\n" +
 	"\x0fListBotsRequest\x12\x1b\n" +
 	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
@@ -566,9 +597,10 @@ const file_teleport_machineid_v1_bot_service_proto_rawDesc = "" +
 	"\vupdate_mask\x18\x02 \x01(\v2\x1a.google.protobuf.FieldMaskR\n" +
 	"updateMask\"@\n" +
 	"\x10UpsertBotRequest\x12,\n" +
-	"\x03bot\x18\x01 \x01(\v2\x1a.teleport.machineid.v1.BotR\x03bot\"-\n" +
+	"\x03bot\x18\x01 \x01(\v2\x1a.teleport.machineid.v1.BotR\x03bot\"C\n" +
 	"\x10DeleteBotRequest\x12\x19\n" +
-	"\bbot_name\x18\x01 \x01(\tR\abotName2\xf9\x03\n" +
+	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope2\xf9\x03\n" +
 	"\n" +
 	"BotService\x12J\n" +
 	"\x06GetBot\x12$.teleport.machineid.v1.GetBotRequest\x1a\x1a.teleport.machineid.v1.Bot\x12[\n" +

--- a/api/proto/teleport/machineid/v1/bot_service.proto
+++ b/api/proto/teleport/machineid/v1/bot_service.proto
@@ -59,6 +59,8 @@ message CreateBotRequest {
 message GetBotRequest {
   // The name of the bot to fetch.
   string bot_name = 1;
+  // The scope the bot exists in. Empty for an unscoped bot.
+  string scope = 2;
 }
 
 // The request for ListBots.
@@ -98,4 +100,6 @@ message UpsertBotRequest {
 message DeleteBotRequest {
   // The name of the bot to delete.
   string bot_name = 1;
+  // The scope the bot exists in. Empty for an unscoped bot.
+  string scope = 2;
 }

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1211,7 +1211,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|name|*no default* (required)|Name of an existing bot to remove.|
+|name|*no default* (required)|Name of an existing bot to remove. For a scoped bot, provide a scope-qualified name of the form \[scope\]::\[name\].|
 
 ## tctl bots update
 

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -1164,8 +1164,12 @@ func TestBot(botName string, botInternal bool) TestIdentity {
 }
 
 // TestScopedBot returns a TestIdentity for a scoped bot user
-func TestScopedBot(botName string, scope string, botInternal bool) TestIdentity {
-	userName := fmt.Sprintf("bot-%s", botName)
+func TestScopedBot(t *testing.T, botName scopes.QualifiedName, botInternal bool) TestIdentity {
+	// The cert username must match the User name the bot service persists.
+	userName, err := services.BotResourceName(botName)
+	if err != nil {
+		t.Fatalf("TestScopedBot: %s", err.Error())
+	}
 	return TestIdentity{
 		I: authz.LocalUser{
 			Username: userName,
@@ -1176,7 +1180,7 @@ func TestScopedBot(botName string, scope string, botInternal bool) TestIdentity 
 				BotInternal: botInternal,
 			},
 		},
-		Scope: scope,
+		Scope: botName.Scope,
 	}
 }
 

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -7117,7 +7117,7 @@ func TestGenerateUserCertsScopedBot(t *testing.T) {
 				require.NoError(t, err)
 
 				waitForSRACache(t, testServer, sra)
-				ident = authtest.TestScopedBot(c.botName, c.scope, c.internal)
+				ident = authtest.TestScopedBot(t, scopes.QualifiedName{Scope: c.scope, Name: c.botName}, c.internal)
 			}
 
 			client, err := testServer.NewClient(ident)

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -146,7 +146,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 
 	// Create a client with a scoped bot internal identity.
 	botClient, err := srv.NewClient(
-		authtest.TestScopedBot(bot.Metadata.Name, botScope, true),
+		authtest.TestScopedBot(t, scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}, true),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = botClient.Close() })
@@ -459,7 +459,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 
 	t.Run("scoped bot without BotInternal", func(t *testing.T) {
 		botClient, err := srv.NewClient(
-			authtest.TestScopedBot(scopedBot.Metadata.Name, testScope, false),
+			authtest.TestScopedBot(t, scopes.QualifiedName{Scope: testScope, Name: scopedBot.GetMetadata().GetName()}, false),
 		)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = botClient.Close() })
@@ -473,7 +473,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 	})
 
 	t.Run("scoped bot with DisallowReissue", func(t *testing.T) {
-		ident := authtest.TestScopedBot(scopedBot.Metadata.Name, testScope, true)
+		ident := authtest.TestScopedBot(t, scopes.QualifiedName{Scope: testScope, Name: scopedBot.GetMetadata().GetName()}, true)
 		lu := ident.I.(authz.LocalUser)
 		lu.Identity.DisallowReissue = true
 		ident.I = lu

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // checkTokenJoinRequestCommon checks all token join rules that are common to
@@ -361,6 +362,14 @@ func makeBotCertsParams(req *types.RegisterUsingTokenRequest, rawClaims any, att
 	}
 }
 
+// botUserNameFromToken returns the name of the backing User resource for the
+// bot referenced by the given provision token.
+func botUserNameFromToken(token provision.Token) (string, error) {
+	botName, botScope := token.GetBot()
+	username, err := services.BotResourceName(scopes.QualifiedName{Scope: botScope, Name: botName})
+	return username, trace.Wrap(err)
+}
+
 // GenerateBotCertsForJoin generates and returns bot certificates as the result
 // of a cluster join attempt.
 func (a *Server) GenerateBotCertsForJoin(
@@ -427,11 +436,11 @@ func (a *Server) GenerateBotCertsForJoin(
 		a.logger.WarnContext(ctx, "Unable to encode struct value for join metadata", "error", err)
 	}
 
-	// TODO(strideynet): scoped bots are currently looked up by their bare name
-	// and scope-checked via the BotScopeLabel below. Once scoped bots are
-	// namespaced by scope in the backend, the bare name is no longer a unique
-	// identifier and this lookup must key on the scope-qualified name instead.
-	user, err := a.GetUserOrLoginState(ctx, machineidv1.BotResourceName(botName))
+	botUserName, err := botUserNameFromToken(token)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	user, err := a.GetUserOrLoginState(ctx, botUserName)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -471,7 +480,7 @@ func (a *Server) GenerateBotCertsForJoin(
 	certs, botInstanceID, err := a.generateInitialBotCerts(
 		ctx,
 		botName,
-		machineidv1.BotResourceName(botName),
+		botUserName,
 		params.RemoteAddr,
 		params.PublicSSHKey,
 		params.PublicTLSKey,
@@ -568,6 +577,12 @@ func (a *Server) GenerateHostCertsForJoin(
 
 func (a *Server) emitBotJoinEvent(ctx context.Context, token provision.Token, params *join.BotCertsParams, botInstanceID string) {
 	botName, botScope := token.GetBot()
+	botUserName, err := botUserNameFromToken(token)
+	if err != nil {
+		// Best-effort: emit the event with the bare name rather than drop it.
+		a.logger.WarnContext(ctx, "Failed to determine bot user name for join audit event", "error", err)
+		botUserName, _ = services.BotResourceName(scopes.QualifiedName{Name: botName})
+	}
 	joinEvent := &apievents.BotJoin{
 		Metadata: apievents.Metadata{
 			Type: events.BotJoinEvent,
@@ -579,7 +594,7 @@ func (a *Server) emitBotJoinEvent(ctx context.Context, token provision.Token, pa
 		BotName:   botName,
 		Method:    string(token.GetJoinMethod()),
 		TokenName: token.GetSafeName(),
-		UserName:  machineidv1.BotResourceName(botName),
+		UserName:  botUserName,
 		ConnectionMetadata: apievents.ConnectionMetadata{
 			RemoteAddr: params.RemoteAddr,
 		},
@@ -587,7 +602,6 @@ func (a *Server) emitBotJoinEvent(ctx context.Context, token provision.Token, pa
 		BotInstanceID: botInstanceID,
 	}
 
-	var err error
 	joinEvent.Attributes, err = joinutils.RawJoinAttrsToStruct(params.RawJoinClaims)
 	if err != nil {
 		a.logger.WarnContext(

--- a/lib/auth/machineid/machineidv1/bot_service.go
+++ b/lib/auth/machineid/machineidv1/bot_service.go
@@ -68,12 +68,6 @@ var SupportedJoinMethods = []types.JoinMethod{
 	types.JoinMethodBoundKeypair,
 }
 
-// BotResourceName returns the default name for resources associated with the
-// given named bot.
-func BotResourceName(botName string) string {
-	return services.BotResourceName(botName)
-}
-
 // Cache is the subset of the cached resources that the Service queries.
 type Cache interface {
 	// GetUser returns a user by name.
@@ -196,7 +190,7 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 		return nil, trace.BadParameter("bot_name: must be non-empty")
 	}
 
-	bot, err := bs.getBot(ctx, req.BotName)
+	bot, err := bs.getBot(ctx, scopes.QualifiedName{Scope: req.GetScope(), Name: req.GetBotName()})
 	if err != nil {
 		return nil, trace.Wrap(err, "fetching bot")
 	}
@@ -216,14 +210,18 @@ func (bs *BotService) GetBot(ctx context.Context, req *pb.GetBotRequest) (*pb.Bo
 }
 
 func (bs *BotService) getBot(
-	ctx context.Context, botName string,
+	ctx context.Context, name scopes.QualifiedName,
 ) (*pb.Bot, error) {
-	user, err := bs.cache.GetUser(ctx, BotResourceName(botName), false)
+	resourceName, err := services.BotResourceName(name)
+	if err != nil {
+		return nil, trace.Wrap(err, "building bot resource name")
+	}
+	user, err := bs.cache.GetUser(ctx, resourceName, false)
 	if err != nil {
 		return nil, trace.Wrap(err, "fetching bot user")
 	}
 
-	if scope, _ := user.GetLabel(types.BotScopeLabel); scope != "" {
+	if botScope, _ := user.GetLabel(types.BotScopeLabel); botScope != "" {
 		bot, err := scopedBotFromUser(user)
 		if err != nil {
 			return nil, trace.Wrap(err, "converting from resources")
@@ -231,7 +229,8 @@ func (bs *BotService) getBot(
 		return bot, nil
 	}
 
-	role, err := bs.cache.GetRole(ctx, BotResourceName(botName))
+	// An unscoped bot's User and Role share a name.
+	role, err := bs.cache.GetRole(ctx, resourceName)
 	if err != nil {
 		return nil, trace.Wrap(err, "fetching bot role")
 	}
@@ -281,8 +280,9 @@ func (bs *BotService) ListBots(
 		scope, _ := u.GetLabel(types.BotScopeLabel)
 		var bot *pb.Bot
 		if scope == "" {
-			// We only need to fetch the bot role for unscoped bots.
-			role, err := bs.cache.GetRole(ctx, BotResourceName(botName))
+			// We only need to fetch the bot role for unscoped bots, whose Role
+			// shares its name with the User.
+			role, err := bs.cache.GetRole(ctx, u.GetName())
 			if err != nil {
 				bs.logger.WarnContext(
 					ctx,
@@ -382,12 +382,15 @@ func (bs *BotService) CreateBot(
 		}
 	}
 
+	// TODO(strideynet): the usage event carries no scope, so this reports the
+	// unscoped name even for a scoped bot. The unscoped form cannot fail.
+	botUserName, _ := services.BotResourceName(scopes.QualifiedName{Name: bot.GetMetadata().GetName()})
 	bs.reporter.AnonymizeAndSubmit(&usagereporter.BotCreateEvent{
 		UserName:    authz.ClientUsername(ctx),
-		BotUserName: BotResourceName(bot.Metadata.Name),
-		RoleName:    BotResourceName(bot.Metadata.Name),
-		BotName:     bot.Metadata.Name,
-		RoleCount:   int64(len(bot.Spec.Roles)),
+		BotUserName: botUserName,
+		RoleName:    botUserName,
+		BotName:     bot.GetMetadata().GetName(),
+		RoleCount:   int64(len(bot.GetSpec().GetRoles())),
 	})
 	if err := bs.emitter.EmitAuditEvent(ctx, &apievents.BotCreate{
 		Metadata: apievents.Metadata{
@@ -396,7 +399,8 @@ func (bs *BotService) CreateBot(
 		},
 		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
-			Name: bot.Metadata.Name,
+			Name:  bot.GetMetadata().GetName(),
+			Scope: bot.GetScope(),
 		},
 	}); err != nil {
 		bs.logger.WarnContext(
@@ -487,28 +491,31 @@ func UpsertBot(
 		return nil, trace.Wrap(err, "validating bot")
 	}
 
-	// Fetch pre-existing user, we'll use this to preserve generation and
-	// check for scope transitions.
-	existingUser, err := backend.GetUser(
-		ctx, BotResourceName(bot.Metadata.Name), false,
-	)
+	// An upsert under a different scope addresses a different bot rather than
+	// transitioning an existing bot's scope, so there is no scope-transition
+	// guard here.
+	resourceName, err := services.BotResourceName(scopes.QualifiedName{Scope: bot.GetScope(), Name: bot.GetMetadata().GetName()})
+	if err != nil {
+		return nil, trace.Wrap(err, "building bot resource name")
+	}
+
+	// Fetch pre-existing user, we'll use this to preserve generation.
+	existingUser, err := backend.GetUser(ctx, resourceName, false)
 	if err != nil && !trace.IsNotFound(err) {
 		// We'll happily ignore a not-found error, in this case, we have an
 		// upsert for a non-existent bot. If we have any other kind of error,
 		// we want to propagate this up.
 		return nil, trace.Wrap(err, "fetching existing bot user")
 	}
+
+	// An unscoped bot's name can mimic a scoped bot's encoded user name, so
+	// refuse to write through a user that belongs to a different (scope, name)
+	// or to no bot at all.
 	if existingUser != nil {
-		// If the bot already exists, we need to check that the upsert does not
-		// cause a scope transition (i.e change of scope, including from/to
-		// unscoped). This is because our RBAC does not account for this.
-		// This restriction may be loosened in future if we evaluate pre-upsert
-		// and post-upsert scope authz.
-		existingScope, _ := existingUser.GetLabel(types.BotScopeLabel)
-		if existingScope != bot.Scope {
-			return nil, trace.BadParameter(
-				"upserts cannot cause the scope of a bot to change, delete and recreate the bot to change its scope",
-			)
+		existingBotName, _ := existingUser.GetLabel(types.BotLabel)
+		existingBotScope, _ := existingUser.GetLabel(types.BotScopeLabel)
+		if existingBotName != bot.GetMetadata().GetName() || existingBotScope != bot.GetScope() {
+			return nil, trace.AlreadyExists("bot %q: backing user is held by a different bot or user", bot.GetMetadata().GetName())
 		}
 	}
 
@@ -610,12 +617,15 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 		return nil, trace.Wrap(err)
 	}
 
+	// TODO(strideynet): the usage event carries no scope, so this reports the
+	// unscoped name even for a scoped bot. The unscoped form cannot fail.
+	botUserName, _ := services.BotResourceName(scopes.QualifiedName{Name: bot.GetMetadata().GetName()})
 	bs.reporter.AnonymizeAndSubmit(&usagereporter.BotCreateEvent{
 		UserName:    authz.ClientUsername(ctx),
-		BotUserName: BotResourceName(bot.Metadata.Name),
-		RoleName:    BotResourceName(bot.Metadata.Name),
-		BotName:     bot.Metadata.Name,
-		RoleCount:   int64(len(bot.Spec.Roles)),
+		BotUserName: botUserName,
+		RoleName:    botUserName,
+		BotName:     bot.GetMetadata().GetName(),
+		RoleCount:   int64(len(bot.GetSpec().GetRoles())),
 	})
 	if err := bs.emitter.EmitAuditEvent(ctx, &apievents.BotCreate{
 		Metadata: apievents.Metadata{
@@ -624,7 +634,8 @@ func (bs *BotService) UpsertBot(ctx context.Context, req *pb.UpsertBotRequest) (
 		},
 		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
-			Name: bot.Metadata.Name,
+			Name:  bot.GetMetadata().GetName(),
+			Scope: bot.GetScope(),
 		},
 	}); err != nil {
 		bs.logger.WarnContext(
@@ -683,14 +694,25 @@ func (bs *BotService) UpdateBot(
 		return nil, trace.BadParameter("update_mask.paths: must be non-empty")
 	}
 
-	user, err := bs.backend.GetUser(ctx, BotResourceName(req.Bot.Metadata.Name), false)
+	// Scoped bots have no updatable fields: roles, traits and max_session_ttl
+	// cannot be set on them.
+	if req.GetBot().GetScope() != "" {
+		return nil, trace.BadParameter("cannot update scoped bot")
+	}
+
+	// Unscoped by the check above, so the User and Role share this name.
+	resourceName, err := services.BotResourceName(scopes.QualifiedName{Name: req.GetBot().GetMetadata().GetName()})
+	if err != nil {
+		return nil, trace.Wrap(err, "building bot resource name")
+	}
+	user, err := bs.backend.GetUser(ctx, resourceName, false)
 	if err != nil {
 		return nil, trace.Wrap(err, "getting bot user")
 	}
 	if scope := user.GetMetadata().Labels[types.BotScopeLabel]; scope != "" {
 		return nil, trace.BadParameter("cannot update scoped bot")
 	}
-	role, err := bs.backend.GetRole(ctx, BotResourceName(req.Bot.Metadata.Name))
+	role, err := bs.backend.GetRole(ctx, resourceName)
 	if err != nil {
 		return nil, trace.Wrap(err, "getting bot role")
 	}
@@ -747,7 +769,8 @@ func (bs *BotService) UpdateBot(
 		},
 		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
-			Name: req.Bot.Metadata.Name,
+			Name:  req.GetBot().GetMetadata().GetName(),
+			Scope: req.GetBot().GetScope(),
 		},
 	}); err != nil {
 		bs.logger.WarnContext(
@@ -794,7 +817,11 @@ func (bs *BotService) deleteBotUser(
 
 func (bs *BotService) deleteBotRole(ctx context.Context, botName string) error {
 	// Check the role that's being deleted is linked to the bot.
-	role, err := bs.backend.GetRole(ctx, BotResourceName(botName))
+	roleName, err := services.BotResourceName(scopes.QualifiedName{Name: botName})
+	if err != nil {
+		return trace.Wrap(err, "building bot resource name")
+	}
+	role, err := bs.backend.GetRole(ctx, roleName)
 	if err != nil {
 		return trace.Wrap(err, "fetching bot role")
 	}
@@ -844,10 +871,13 @@ func (bs *BotService) DeleteBot(
 		return nil, trace.Wrap(err)
 	}
 
+	resourceName, err := services.BotResourceName(scopes.QualifiedName{Scope: req.GetScope(), Name: req.GetBotName()})
+	if err != nil {
+		return nil, trace.Wrap(err, "building bot resource name")
+	}
+
 	// Fetch user to determine if bot is scoped or unscoped.
-	user, err := bs.backend.GetUser(
-		ctx, BotResourceName(req.BotName), false,
-	)
+	user, err := bs.backend.GetUser(ctx, resourceName, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -888,7 +918,8 @@ func (bs *BotService) DeleteBot(
 		},
 		UserMetadata: authz.ClientUserMetadata(ctx),
 		ResourceMetadata: apievents.ResourceMetadata{
-			Name: req.BotName,
+			Name:  req.GetBotName(),
+			Scope: req.GetScope(),
 		},
 	}); err != nil {
 		bs.logger.WarnContext(
@@ -946,6 +977,10 @@ func StrongValidateBot(b *pb.Bot) error {
 		// Validate scope-specific fields
 		if err := scopes.StrongValidate(b.Scope); err != nil {
 			return trace.Wrap(err, "scope:")
+		}
+
+		if err := scopes.StrongValidateResourceName(b.GetMetadata().GetName()); err != nil {
+			return trace.Wrap(err, "metadata.name:")
 		}
 
 		// Validate unsupported fields aren't set.
@@ -1079,7 +1114,10 @@ func botToUserAndRole(bot *pb.Bot, now time.Time, createdBy string) (types.User,
 	}
 
 	// Setup role
-	resourceName := BotResourceName(bot.Metadata.Name)
+	resourceName, err := services.BotResourceName(scopes.QualifiedName{Name: bot.GetMetadata().GetName()})
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "building bot resource name")
+	}
 
 	// Continue to use the legacy max session TTL (12 hours) as the default, but
 	// allow overrides via the optional bot spec field.
@@ -1167,7 +1205,11 @@ func scopedBotToUser(bot *pb.Bot, now time.Time, createdBy string) (types.User, 
 	}
 
 	// Setup user
-	user, err := types.NewUser(BotResourceName(bot.Metadata.Name))
+	resourceName, err := services.BotResourceName(scopes.QualifiedName{Scope: bot.GetScope(), Name: bot.GetMetadata().GetName()})
+	if err != nil {
+		return nil, trace.Wrap(err, "building bot resource name")
+	}
+	user, err := types.NewUser(resourceName)
 	if err != nil {
 		return nil, trace.Wrap(err, "new user")
 	}

--- a/lib/auth/machineid/machineidv1/machineidv1_test.go
+++ b/lib/auth/machineid/machineidv1/machineidv1_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,6 +49,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
@@ -58,25 +60,13 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 func TestMain(m *testing.M) {
 	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())
-}
-
-func TestBotResourceName(t *testing.T) {
-	require.Equal(
-		t,
-		"bot-name",
-		machineidv1.BotResourceName("name"),
-	)
-	require.Equal(
-		t,
-		"bot-name-with-spaces",
-		machineidv1.BotResourceName("name with spaces"),
-	)
 }
 
 // TestCreateBot is an integration test that uses a real gRPC client/server.
@@ -682,7 +672,7 @@ func TestCreateBot(t *testing.T) {
 				Scope: "/scopes/granted",
 				Spec:  &machineidv1pb.BotSpec{},
 				Status: &machineidv1pb.BotStatus{
-					UserName: "bot-scoped-bot-success",
+					UserName: "bot-++scopes+granted+scoped-bot-success",
 				},
 			},
 		},
@@ -708,7 +698,7 @@ func TestCreateBot(t *testing.T) {
 				Scope: "/scopes/granted",
 				Spec:  &machineidv1pb.BotSpec{},
 				Status: &machineidv1pb.BotStatus{
-					UserName: "bot-scoped-bot-from-unscoped",
+					UserName: "bot-++scopes+granted+scoped-bot-from-unscoped",
 				},
 			},
 		},
@@ -1138,6 +1128,28 @@ func TestUpdateBot(t *testing.T) {
 				require.True(t, trace.IsBadParameter(err), "error should be bad parameter")
 			},
 		},
+		{
+			name: "cannot update scoped bot",
+			user: botUpdaterUser.GetName(),
+			req: machineidv1pb.UpdateBotRequest_builder{
+				Bot: machineidv1pb.Bot_builder{
+					Kind:    types.KindBot,
+					Version: types.V1,
+					Metadata: headerv1.Metadata_builder{
+						Name: preExistingBot.GetMetadata().GetName(),
+					}.Build(),
+					Scope: "/scopes/granted",
+					Spec:  &machineidv1pb.BotSpec{},
+				}.Build(),
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"metadata.description"},
+				},
+			}.Build(),
+			assertError: func(t require.TestingT, err error, i ...any) {
+				require.ErrorContains(t, err, "cannot update scoped bot")
+				require.True(t, trace.IsBadParameter(err), "error should be bad parameter")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1296,16 +1308,6 @@ func TestUpsertBot(t *testing.T) {
 	})
 	require.NoError(t, err)
 	waitForSRACache(t, srv, sraResp)
-
-	// Pre-existing scoped bot for scope-transition tests.
-	_, err = client.BotServiceClient().UpsertBot(ctx, &machineidv1pb.UpsertBotRequest{
-		Bot: &machineidv1pb.Bot{
-			Metadata: &headerv1.Metadata{Name: "scope-change-test"},
-			Scope:    "/scopes/granted",
-			Spec:     &machineidv1pb.BotSpec{},
-		},
-	})
-	require.NoError(t, err)
 
 	tests := []struct {
 		name     string
@@ -1817,7 +1819,7 @@ func TestUpsertBot(t *testing.T) {
 				Scope: "/scopes/granted",
 				Spec:  &machineidv1pb.BotSpec{},
 				Status: &machineidv1pb.BotStatus{
-					UserName: "bot-scoped-upsert-success",
+					UserName: "bot-++scopes+granted+scoped-upsert-success",
 				},
 			},
 		},
@@ -1843,7 +1845,7 @@ func TestUpsertBot(t *testing.T) {
 				Scope: "/scopes/granted",
 				Spec:  &machineidv1pb.BotSpec{},
 				Status: &machineidv1pb.BotStatus{
-					UserName: "bot-scoped-upsert-from-unscoped",
+					UserName: "bot-++scopes+granted+scoped-upsert-from-unscoped",
 				},
 			},
 		},
@@ -1878,47 +1880,6 @@ func TestUpsertBot(t *testing.T) {
 			},
 			assertError: func(t require.TestingT, err error, i ...any) {
 				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
-			},
-		},
-		{
-			name:     "cannot change scope: scoped to unscoped",
-			identity: authtest.TestUser(botCreator.GetName()),
-			req: &machineidv1pb.UpsertBotRequest{
-				Bot: &machineidv1pb.Bot{
-					Metadata: &headerv1.Metadata{Name: "scope-change-test"},
-					Spec:     &machineidv1pb.BotSpec{Roles: []string{testRole.GetName()}},
-				},
-			},
-			assertError: func(t require.TestingT, err error, i ...any) {
-				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
-			},
-		},
-		{
-			name:     "cannot change scope: unscoped to scoped",
-			identity: authtest.TestUser(botCreator.GetName()),
-			req: &machineidv1pb.UpsertBotRequest{
-				Bot: &machineidv1pb.Bot{
-					Metadata: &headerv1.Metadata{Name: "pre-existing"},
-					Scope:    "/scopes/granted",
-					Spec:     &machineidv1pb.BotSpec{},
-				},
-			},
-			assertError: func(t require.TestingT, err error, i ...any) {
-				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
-			},
-		},
-		{
-			name:     "cannot change scope: scoped to different scope",
-			identity: authtest.TestUser(botCreator.GetName()),
-			req: &machineidv1pb.UpsertBotRequest{
-				Bot: &machineidv1pb.Bot{
-					Metadata: &headerv1.Metadata{Name: "scope-change-test"},
-					Scope:    "/scopes/ungranted",
-					Spec:     &machineidv1pb.BotSpec{},
-				},
-			},
-			assertError: func(t require.TestingT, err error, i ...any) {
-				require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
 			},
 		},
 	}
@@ -2183,18 +2144,20 @@ func TestGetBot(t *testing.T) {
 		{
 			name:     "scoped identity gets scoped bot",
 			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
-			req: &machineidv1pb.GetBotRequest{
-				BotName: scopedPreExisting.Metadata.Name,
-			},
+			req: machineidv1pb.GetBotRequest_builder{
+				BotName: scopedPreExisting.GetMetadata().GetName(),
+				Scope:   "/scopes/granted",
+			}.Build(),
 			assertError: require.NoError,
 			want:        scopedPreExisting,
 		},
 		{
 			name:     "unscoped identity gets scoped bot",
 			identity: authtest.TestUser(botGetterUser.GetName()),
-			req: &machineidv1pb.GetBotRequest{
-				BotName: scopedPreExisting.Metadata.Name,
-			},
+			req: machineidv1pb.GetBotRequest_builder{
+				BotName: scopedPreExisting.GetMetadata().GetName(),
+				Scope:   "/scopes/granted",
+			}.Build(),
 			assertError: require.NoError,
 			want:        scopedPreExisting,
 		},
@@ -2203,6 +2166,7 @@ func TestGetBot(t *testing.T) {
 			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
 			req: &machineidv1pb.GetBotRequest{
 				BotName: "scoped-pre-existing-wrong-scope",
+				Scope:   "/scopes/ungranted",
 			},
 			assertError: func(t require.TestingT, err error, i ...any) {
 				// GetBot returns NotFound rather than AccessDenied to avoid leaking existence.
@@ -2794,9 +2758,10 @@ func TestDeleteBot(t *testing.T) {
 		{
 			name:     "scoped identity deletes scoped bot",
 			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
-			req: &machineidv1pb.DeleteBotRequest{
-				BotName: scopedPreExisting.Metadata.Name,
-			},
+			req: machineidv1pb.DeleteBotRequest_builder{
+				BotName: scopedPreExisting.GetMetadata().GetName(),
+				Scope:   "/scopes/granted",
+			}.Build(),
 			assertError:           require.NoError,
 			checkResourcesDeleted: true,
 			scoped:                true,
@@ -2804,9 +2769,10 @@ func TestDeleteBot(t *testing.T) {
 		{
 			name:     "unscoped identity deletes scoped bot",
 			identity: authtest.TestUser(botDeleterUser.GetName()),
-			req: &machineidv1pb.DeleteBotRequest{
-				BotName: scopedPreExistingUnscoped.Metadata.Name,
-			},
+			req: machineidv1pb.DeleteBotRequest_builder{
+				BotName: scopedPreExistingUnscoped.GetMetadata().GetName(),
+				Scope:   "/scopes/granted",
+			}.Build(),
 			assertError:           require.NoError,
 			checkResourcesDeleted: true,
 			scoped:                true,
@@ -2814,9 +2780,10 @@ func TestDeleteBot(t *testing.T) {
 		{
 			name:     "scoped identity wrong scope",
 			identity: authtest.TestScopedUser(scopedUser.GetName(), "/scopes/granted"),
-			req: &machineidv1pb.DeleteBotRequest{
-				BotName: scopedPreExistingWrongScope.Metadata.Name,
-			},
+			req: machineidv1pb.DeleteBotRequest_builder{
+				BotName: scopedPreExistingWrongScope.GetMetadata().GetName(),
+				Scope:   "/scopes/ungranted",
+			}.Build(),
 			assertError: func(t require.TestingT, err error, i ...any) {
 				require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
 			},
@@ -2840,15 +2807,209 @@ func TestDeleteBot(t *testing.T) {
 			_, err = client.BotServiceClient().DeleteBot(ctx, tt.req)
 			tt.assertError(t, err)
 			if tt.checkResourcesDeleted {
-				_, err := srv.Auth().GetUser(ctx, machineidv1.BotResourceName(tt.req.BotName), false)
+				wantUserName, err := services.BotResourceName(scopes.QualifiedName{Scope: tt.req.GetScope(), Name: tt.req.GetBotName()})
+				require.NoError(t, err)
+				_, err = srv.Auth().GetUser(ctx, wantUserName, false)
 				require.True(t, trace.IsNotFound(err), "bot user should be deleted")
 				if !tt.scoped {
-					_, err = srv.Auth().GetRole(ctx, machineidv1.BotResourceName(tt.req.BotName))
+					roleName, err := services.BotResourceName(scopes.QualifiedName{Name: tt.req.GetBotName()})
+					require.NoError(t, err)
+					_, err = srv.Auth().GetRole(ctx, roleName)
 					require.True(t, trace.IsNotFound(err), "bot role should be deleted")
 				}
 			}
 		})
 	}
+}
+
+// TestBotScopeNamespacing is an integration test focused on the scope
+// namespacing of bots: bots sharing a name coexist independently when they
+// live in different scopes (or one is unscoped), because the backing User is
+// keyed on (scope, name). Authorization behavior and per-RPC edge cases are
+// covered by the individual RPC tests, so everything here runs as admin.
+func TestBotScopeNamespacing(t *testing.T) {
+	t.Parallel()
+	srv, emitter := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+	ctx := t.Context()
+
+	client, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	botSvc := client.BotServiceClient()
+
+	const botName = "shared-name"
+
+	newBot := func(name, scope, description string) *machineidv1pb.Bot {
+		return machineidv1pb.Bot_builder{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name:        name,
+				Description: description,
+			}.Build(),
+			Spec:  &machineidv1pb.BotSpec{},
+			Scope: scope,
+		}.Build()
+	}
+	getBot := func(scope string) (*machineidv1pb.Bot, error) {
+		return botSvc.GetBot(ctx, machineidv1pb.GetBotRequest_builder{
+			BotName: botName,
+			Scope:   scope,
+		}.Build())
+	}
+
+	// All four bots share a name but live in distinct namespaces: unscoped,
+	// two sibling scopes, and the siblings' parent scope (whose encoded key
+	// is a prefix of theirs).
+	variants := []struct {
+		scope        string
+		description  string
+		wantUserName string
+	}{
+		{scope: "", description: "unscoped", wantUserName: "bot-shared-name"},
+		{scope: "/scopes", description: "parent", wantUserName: "bot-++scopes+shared-name"},
+		{scope: "/scopes/alpha", description: "alpha", wantUserName: "bot-++scopes+alpha+shared-name"},
+		{scope: "/scopes/beta", description: "beta", wantUserName: "bot-++scopes+beta+shared-name"},
+	}
+
+	// Creating each must succeed despite the shared name, and each must land
+	// on its own backing User.
+	created := map[string]*machineidv1pb.Bot{}
+	for _, v := range variants {
+		bot, err := botSvc.CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+			Bot: newBot(botName, v.scope, v.description),
+		}.Build())
+		require.NoError(t, err, "creating bot in scope %q", v.scope)
+		require.Equal(t, v.wantUserName, bot.GetStatus().GetUserName(), "backing user for scope %q", v.scope)
+		created[v.scope] = bot
+
+		// The scope is the only thing distinguishing these four events.
+		createEvt, ok := emitter.LastEvent().(*apievents.BotCreate)
+		require.True(t, ok, "expected BotCreate event, got %T", emitter.LastEvent())
+		require.Equal(t, botName, createEvt.ResourceMetadata.Name)
+		require.Equal(t, v.scope, createEvt.ResourceMetadata.Scope, "BotCreate scope for scope %q", v.scope)
+	}
+
+	// A duplicate within the same namespace is still rejected.
+	for _, scope := range []string{"", "/scopes/alpha"} {
+		_, err = botSvc.CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+			Bot: newBot(botName, scope, "duplicate"),
+		}.Build())
+		require.True(t, trace.IsAlreadyExists(err), "duplicate in scope %q: expected already exists, got: %v", scope, err)
+	}
+
+	// GetBot with (name, scope) must return exactly the bot of that
+	// namespace.
+	for _, v := range variants {
+		got, err := getBot(v.scope)
+		require.NoError(t, err, "getting bot in scope %q", v.scope)
+		require.Empty(t, cmp.Diff(created[v.scope], got, protocmp.Transform()), "bot in scope %q", v.scope)
+	}
+	// A scope holding no such bot misses, even though the name exists in
+	// other scopes.
+	_, err = getBot("/scopes/gamma")
+	require.True(t, trace.IsNotFound(err), "expected not found, got: %v", err)
+
+	// ListBots returns all four as distinct bots.
+	listResp, err := botSvc.ListBots(ctx, &machineidv1pb.ListBotsRequest{})
+	require.NoError(t, err)
+	gotScopes := []string{}
+	for _, b := range listResp.GetBots() {
+		if b.GetMetadata().GetName() == botName {
+			gotScopes = append(gotScopes, b.GetScope())
+		}
+	}
+	require.ElementsMatch(t, []string{"", "/scopes", "/scopes/alpha", "/scopes/beta"}, gotScopes)
+
+	// Upsert addresses a single namespace: only the alpha bot changes.
+	upserted, err := botSvc.UpsertBot(ctx, machineidv1pb.UpsertBotRequest_builder{
+		Bot: newBot(botName, "/scopes/alpha", "alpha updated"),
+	}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "alpha updated", upserted.GetMetadata().GetDescription())
+	require.Equal(t, "bot-++scopes+alpha+shared-name", upserted.GetStatus().GetUserName())
+	upsertEvt, ok := emitter.LastEvent().(*apievents.BotCreate)
+	require.True(t, ok, "expected BotCreate event, got %T", emitter.LastEvent())
+	require.Equal(t, "/scopes/alpha", upsertEvt.ResourceMetadata.Scope)
+	for _, v := range variants {
+		if v.scope == "/scopes/alpha" {
+			continue
+		}
+		got, err := getBot(v.scope)
+		require.NoError(t, err)
+		require.Equal(t, v.description, got.GetMetadata().GetDescription(),
+			"bot in scope %q must be untouched by the upsert", v.scope)
+	}
+
+	// Deleting one namespace's bot must leave the same-named neighbors
+	// intact.
+	_, err = botSvc.DeleteBot(ctx, machineidv1pb.DeleteBotRequest_builder{
+		BotName: botName,
+		Scope:   "/scopes/alpha",
+	}.Build())
+	require.NoError(t, err)
+	deleteEvt, ok := emitter.LastEvent().(*apievents.BotDelete)
+	require.True(t, ok, "expected BotDelete event, got %T", emitter.LastEvent())
+	require.Equal(t, botName, deleteEvt.ResourceMetadata.Name)
+	require.Equal(t, "/scopes/alpha", deleteEvt.ResourceMetadata.Scope)
+	_, err = srv.Auth().GetUser(ctx, "bot-++scopes+alpha+shared-name", false)
+	require.True(t, trace.IsNotFound(err), "expected backing user to be deleted, got: %v", err)
+	_, err = getBot("/scopes/alpha")
+	require.True(t, trace.IsNotFound(err), "expected not found, got: %v", err)
+	for _, scope := range []string{"", "/scopes", "/scopes/beta"} {
+		_, err := getBot(scope)
+		require.NoError(t, err, "bot in scope %q must survive the delete", scope)
+	}
+
+	// Same story deleting the unscoped bot.
+	_, err = botSvc.DeleteBot(ctx, machineidv1pb.DeleteBotRequest_builder{
+		BotName: botName,
+	}.Build())
+	require.NoError(t, err)
+	unscopedDeleteEvt, ok := emitter.LastEvent().(*apievents.BotDelete)
+	require.True(t, ok, "expected BotDelete event, got %T", emitter.LastEvent())
+	require.Equal(t, botName, unscopedDeleteEvt.ResourceMetadata.Name)
+	require.Empty(t, unscopedDeleteEvt.ResourceMetadata.Scope)
+	_, err = getBot("")
+	require.True(t, trace.IsNotFound(err), "expected not found, got: %v", err)
+	for _, scope := range []string{"/scopes", "/scopes/beta"} {
+		_, err := getBot(scope)
+		require.NoError(t, err, "bot in scope %q must survive the delete", scope)
+	}
+
+	// An unscoped bot's name is not charset validated, so it can mimic a
+	// scoped bot's encoded user name. Upsert must refuse to write through the
+	// collision in either direction rather than clobber the other bot.
+	squatter, err := botSvc.CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		Bot: newBot("++scopes+alpha+victim", "", "unscoped squatter"),
+	}.Build())
+	require.NoError(t, err)
+	require.Equal(t, "bot-++scopes+alpha+victim", squatter.GetStatus().GetUserName())
+	_, err = botSvc.UpsertBot(ctx, machineidv1pb.UpsertBotRequest_builder{
+		Bot: newBot("victim", "/scopes/alpha", "clobber attempt"),
+	}.Build())
+	require.True(t, trace.IsAlreadyExists(err), "expected already exists, got: %v", err)
+	got, err := botSvc.GetBot(ctx, machineidv1pb.GetBotRequest_builder{
+		BotName: "++scopes+alpha+victim",
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(squatter, got, protocmp.Transform()),
+		"unscoped bot must be untouched by the colliding scoped upsert")
+
+	scopedVictim, err := botSvc.CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		Bot: newBot("victim2", "/scopes/alpha", "scoped victim"),
+	}.Build())
+	require.NoError(t, err)
+	_, err = botSvc.UpsertBot(ctx, machineidv1pb.UpsertBotRequest_builder{
+		Bot: newBot("++scopes+alpha+victim2", "", "clobber attempt"),
+	}.Build())
+	require.True(t, trace.IsAlreadyExists(err), "expected already exists, got: %v", err)
+	got, err = botSvc.GetBot(ctx, machineidv1pb.GetBotRequest_builder{
+		BotName: "victim2",
+		Scope:   "/scopes/alpha",
+	}.Build())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(scopedVictim, got, protocmp.Transform()),
+		"scoped bot must be untouched by the colliding unscoped upsert")
 }
 
 func TestStrongValidateBot(t *testing.T) {
@@ -2944,6 +3105,39 @@ func TestStrongValidateBot(t *testing.T) {
 			name:        "scoped bot with invalid scope",
 			bot:         newScopedBot(func(b *machineidv1pb.Bot) { b.Scope = "no-leading-slash" }),
 			assertError: isBadParam,
+		},
+		{
+			name:        "scoped bot with name containing scope-key encoding character",
+			bot:         newScopedBot(func(b *machineidv1pb.Bot) { b.GetMetadata().SetName("test+bot") }),
+			assertError: isBadParam,
+		},
+		{
+			name:        "scoped bot with name containing space",
+			bot:         newScopedBot(func(b *machineidv1pb.Bot) { b.GetMetadata().SetName("test bot") }),
+			assertError: isBadParam,
+		},
+		{
+			name:        "scoped bot with uppercase name",
+			bot:         newScopedBot(func(b *machineidv1pb.Bot) { b.GetMetadata().SetName("Test-Bot") }),
+			assertError: isBadParam,
+		},
+		{
+			name:        "scoped bot with name ending in a separator character",
+			bot:         newScopedBot(func(b *machineidv1pb.Bot) { b.GetMetadata().SetName("test-bot-") }),
+			assertError: isBadParam,
+		},
+		{
+			// Scoped bot names follow scoped resource name rules, which unlike
+			// scope segments permit a single character and impose no maximum
+			// length.
+			name:        "scoped bot with single-character name",
+			bot:         newScopedBot(func(b *machineidv1pb.Bot) { b.GetMetadata().SetName("x") }),
+			assertError: require.NoError,
+		},
+		{
+			name:        "scoped bot with name longer than the max scope segment",
+			bot:         newScopedBot(func(b *machineidv1pb.Bot) { b.GetMetadata().SetName(strings.Repeat("a", 64)) }),
+			assertError: require.NoError,
 		},
 		{
 			name: "scoped bot with roles set",
@@ -3812,7 +4006,7 @@ func TestBotInstanceService_SubmitHeartbeat(t *testing.T) {
 		require.NoError(t, err)
 		waitForSRACache(t, srv, sraResp)
 
-		botClient, instanceID := newBotClient(t, authtest.TestScopedBot(botName, "/scopes/test", true))
+		botClient, instanceID := newBotClient(t, authtest.TestScopedBot(t, scopes.QualifiedName{Scope: "/scopes/test", Name: botName}, true))
 		createBotInstance(t, srv, botName, "/scopes/test", instanceID)
 
 		_, err = botClient.BotInstanceServiceClient().SubmitHeartbeat(ctx, &machineidv1pb.SubmitHeartbeatRequest{

--- a/lib/boundkeypair/join_state.go
+++ b/lib/boundkeypair/join_state.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/join/provision"
 	libjwt "github.com/gravitational/teleport/lib/jwt"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // JoinState is a signed JWT stored on joining clients alongside their usual
@@ -86,13 +87,12 @@ type JoinStateParams struct {
 }
 
 func (p *JoinStateParams) GetSubject() (string, error) {
-	botName, _ := p.Token.GetBot()
+	botName, botScope := p.Token.GetBot()
 	switch {
 	case botName != "":
-		// TODO(strideynet): the bare bot name is only a unique identifier
-		// while bots are globally namespaced. Revisit the subject for scoped
-		// bots once bot users are namespaced by scope.
-		return botName, nil
+		// Bots are namespaced by scope, so only the scope-qualified name
+		// identifies one uniquely. Unscoped bots keep the bare name.
+		return scopes.QualifiedName{Scope: botScope, Name: botName}.String(), nil
 	case p.HostID != "":
 		return p.HostID, nil
 	case p.Token.GetBoundKeypairStatus().BoundHostID != "":

--- a/lib/boundkeypair/join_state_test.go
+++ b/lib/boundkeypair/join_state_test.go
@@ -26,8 +26,12 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 type mockCA struct {
@@ -102,6 +106,43 @@ func TestIssueAndVerifyJoinState(t *testing.T) {
 		}
 
 		return params
+	}
+
+	// makeScopedParams builds params around a scoped token referencing the
+	// bot (scope, botName). Unlike makeParams, mutating the returned params'
+	// token status is not supported: the scoped token wrapper converts its
+	// status on every accessor call.
+	makeScopedParams := func(scope, botName string) *JoinStateParams {
+		scopedToken, err := joining.NewToken(joiningv1.ScopedToken_builder{
+			Kind:    types.KindScopedToken,
+			Version: types.V1,
+			Scope:   scope,
+			Metadata: headerv1.Metadata_builder{
+				Name: "example-token",
+			}.Build(),
+			Spec: joiningv1.ScopedTokenSpec_builder{
+				JoinMethod: string(types.JoinMethodBoundKeypair),
+				Roles:      []string{string(types.RoleBot)},
+				UsageMode:  joining.TokenUsageModeBot,
+				Bot:        scopes.QualifiedName{Scope: scope, Name: botName}.String(),
+				BoundKeypair: joiningv1.BoundKeypairSpec_builder{
+					Onboarding: joiningv1.BoundKeypairSpec_OnboardingSpec_builder{
+						InitialPublicKey: "abcd",
+					}.Build(),
+					Recovery: joiningv1.BoundKeypairSpec_RecoverySpec_builder{
+						Mode:  string(RecoveryModeStandard),
+						Limit: 1,
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+
+		return &JoinStateParams{
+			Clock:       clock,
+			ClusterName: "example.com",
+			Token:       scopedToken,
+		}
 	}
 
 	withRecovery := func(count, limit uint32) func(*JoinStateParams) {
@@ -220,6 +261,38 @@ func TestIssueAndVerifyJoinState(t *testing.T) {
 			},
 		},
 		{
+			name:         "scoped bot success",
+			issue:        makeIssuer(activeSigner, makeScopedParams("/foo", "test")),
+			verifyParams: makeScopedParams("/foo", "test"),
+			assertError:  require.NoError,
+		},
+		{
+			// The subject is the scope-qualified name, so a same-named bot in
+			// another scope is a different subject.
+			name:         "bot scope must match",
+			issue:        makeIssuer(activeSigner, makeScopedParams("/foo", "test")),
+			verifyParams: makeScopedParams("/bar", "test"),
+			assertError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "invalid subject claim")
+			},
+		},
+		{
+			name:         "unscoped join state rejected for scoped bot",
+			issue:        makeIssuer(activeSigner, makeParams(withRecovery(0, 1))),
+			verifyParams: makeScopedParams("/foo", "test"),
+			assertError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "invalid subject claim")
+			},
+		},
+		{
+			name:         "scoped join state rejected for unscoped bot",
+			issue:        makeIssuer(activeSigner, makeScopedParams("/foo", "test")),
+			verifyParams: makeParams(withRecovery(0, 1)),
+			assertError: func(tt require.TestingT, err error, i ...any) {
+				require.ErrorContains(tt, err, "invalid subject claim")
+			},
+		},
+		{
 			name: "informational parameters can be modified",
 			issue: makeIssuer(activeSigner, makeParams(withRecovery(0, 1), func(jsp *JoinStateParams) {
 				jsp.Token.GetBoundKeypair().Recovery.Mode = "relaxed"
@@ -245,4 +318,16 @@ func TestIssueAndVerifyJoinState(t *testing.T) {
 			tt.assertError(t, err)
 		})
 	}
+
+	t.Run("subject", func(t *testing.T) {
+		// An unscoped bot's subject must stay the bare name: changing it would
+		// invalidate every join state already held by an unscoped bot.
+		subject, err := makeParams().GetSubject()
+		require.NoError(t, err)
+		require.Equal(t, "test", subject)
+
+		subject, err = makeScopedParams("/foo", "test").GetSubject()
+		require.NoError(t, err)
+		require.Equal(t, "/foo::test", subject)
+	})
 }

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	libboundkeypair "github.com/gravitational/teleport/lib/auth/join/boundkeypair"
-	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/boundkeypair"
 	"github.com/gravitational/teleport/lib/cryptosuites"
@@ -1864,6 +1863,23 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 
 	CreateScopedBot(t, srv.Auth(), "test-scoped")
 
+	// Also create an *unscoped* bot with the same name as the scoped bot. Bots
+	// are namespaced by scope, so the two coexist; the join below must select
+	// the scoped bot's user, not this one.
+	_, err = adminClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		Bot: machineidv1pb.Bot_builder{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "test-scoped",
+			}.Build(),
+			Spec: machineidv1pb.BotSpec_builder{
+				Roles: []string{"example"},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
 	scopedToken := &joiningv1.ScopedToken{
 		Kind:    types.KindScopedToken,
 		Version: types.V1,
@@ -1913,6 +1929,14 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 	firstInstance, generation := testExtractBotParamsFromCerts(t, joinResult.Certs)
 	require.Equal(t, uint64(1), generation)
 
+	// The issued identity must be backed by the scoped bot's user, not the
+	// same-named unscoped bot's.
+	parsedCert, err := tlsca.ParseCertificatePEM(joinResult.Certs.TLS)
+	require.NoError(t, err)
+	certIdentity, err := tlsca.FromSubject(parsedCert.Subject, parsedCert.NotAfter)
+	require.NoError(t, err)
+	require.Equal(t, "bot-++test+test-scoped", certIdentity.Username)
+
 	// The BotInstance should have the scope set. A bot is identified by
 	// (scope, name), so the read must declare the bot's scope to address the
 	// scoped instance.
@@ -1923,6 +1947,40 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "/test", botInstance.GetScope())
+
+	// Join event should be emitted
+	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
+		evt, err := lastEvent(ctx, srv.Auth(), srv.Auth().GetClock(), events.BotJoinEvent)
+		require.NoError(t, err)
+
+		sqn, err := scopes.ParseQualifiedName(scopedToken.GetSpec().GetBot())
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(
+			&apievents.BotJoin{
+				Metadata: apievents.Metadata{
+					Type: "bot.join",
+					Code: events.BotJoinCode,
+				},
+				Status: apievents.Status{
+					Success: true,
+				},
+				ConnectionMetadata: apievents.ConnectionMetadata{
+					RemoteAddr: "127.0.0.1",
+				},
+				BotInstanceID: firstInstance,
+				TokenName:     scopedToken.GetMetadata().GetName(),
+				Method:        scopedToken.GetSpec().GetJoinMethod(),
+				UserName:      "bot-++test+test-scoped",
+				BotName:       sqn.Name,
+				Scope:         sqn.Scope,
+			},
+			evt,
+			protocmp.Transform(),
+			cmpopts.IgnoreMapEntries(func(key string, val any) bool {
+				return key == "Time" || key == "ID"
+			}),
+		))
+	}, 5*time.Second, 5*time.Millisecond, "expected bot.join success event not found")
 
 	// The recovery event emitted for the first join should carry the bot's
 	// scope.
@@ -1954,39 +2012,6 @@ func TestJoinBoundKeypair_ScopedToken(t *testing.T) {
 			}),
 		))
 	}, 5*time.Second, 5*time.Millisecond, "expected bound keypair recovery event not found")
-
-	// Join event should be emitted
-	require.EventuallyWithT(t, func(collectT *assert.CollectT) {
-		evt, err := lastEvent(ctx, srv.Auth(), srv.Auth().GetClock(), events.BotJoinEvent)
-		require.NoError(t, err)
-		sqn, err := scopes.ParseQualifiedName(scopedToken.GetSpec().GetBot())
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(
-			&apievents.BotJoin{
-				Metadata: apievents.Metadata{
-					Type: "bot.join",
-					Code: events.BotJoinCode,
-				},
-				Status: apievents.Status{
-					Success: true,
-				},
-				ConnectionMetadata: apievents.ConnectionMetadata{
-					RemoteAddr: "127.0.0.1",
-				},
-				BotInstanceID: firstInstance,
-				TokenName:     scopedToken.GetMetadata().GetName(),
-				Method:        scopedToken.GetSpec().GetJoinMethod(),
-				UserName:      machineidv1.BotResourceName(sqn.Name),
-				BotName:       sqn.Name,
-				Scope:         sqn.Scope,
-			},
-			evt,
-			protocmp.Transform(),
-			cmpopts.IgnoreMapEntries(func(key string, val any) bool {
-				return key == "Time" || key == "ID"
-			}),
-		))
-	}, 5*time.Second, 5*time.Millisecond, "expected bot.join success event not found")
 
 	// Status should be updated.
 	token, err := adminClient.GetScopedToken(ctx, "example-token", false)

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -44,7 +44,6 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/keystore"
-	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
@@ -792,7 +791,7 @@ func handleJoinFailure(ctx context.Context, emitter apievents.Emitter, diag *dia
 	}
 
 	log.LogAttrs(ctx, slog.LevelWarn, "Failure to join cluster occurred", slogAttrs...)
-	if err := emitter.EmitAuditEvent(context.WithoutCancel(ctx), makeAuditEvent(diagInfo, attributesStruct)); err != nil {
+	if err := emitter.EmitAuditEvent(context.WithoutCancel(ctx), makeAuditEvent(ctx, diagInfo, attributesStruct)); err != nil {
 		log.WarnContext(ctx, "Failed to emit failed join event", "error", err)
 	}
 }
@@ -806,12 +805,12 @@ func handleJoinSuccess(ctx context.Context, emitter apievents.Emitter, diag *dia
 		log.WarnContext(ctx, "Unable to fetch join attributes from join method", "error", err)
 	}
 
-	if err := emitter.EmitAuditEvent(context.WithoutCancel(ctx), makeAuditEvent(diagInfo, attributesStruct)); err != nil {
+	if err := emitter.EmitAuditEvent(context.WithoutCancel(ctx), makeAuditEvent(ctx, diagInfo, attributesStruct)); err != nil {
 		log.WarnContext(ctx, "Failed to emit join event", "error", err)
 	}
 }
 
-func makeAuditEvent(info diagnostic.Info, attributesStruct *apievents.Struct) apievents.AuditEvent {
+func makeAuditEvent(ctx context.Context, info diagnostic.Info, attributesStruct *apievents.Struct) apievents.AuditEvent {
 	var errorMessage string
 	switch {
 	case errors.Is(info.Error, context.Canceled), status.Code(info.Error) == codes.Canceled:
@@ -833,6 +832,12 @@ func makeAuditEvent(info diagnostic.Info, attributesStruct *apievents.Struct) ap
 		default:
 			code = events.BotJoinCode
 		}
+		botUserName, err := services.BotResourceName(scopes.QualifiedName{Scope: info.BotScope, Name: info.BotName})
+		if err != nil {
+			// Best-effort: emit the event with the bare name rather than drop it.
+			log.WarnContext(ctx, "Failed to determine bot user name for join audit event", "error", err)
+			botUserName, _ = services.BotResourceName(scopes.QualifiedName{Name: info.BotName})
+		}
 		return &apievents.BotJoin{
 			Metadata: apievents.Metadata{
 				Type: events.BotJoinEvent,
@@ -845,7 +850,7 @@ func makeAuditEvent(info diagnostic.Info, attributesStruct *apievents.Struct) ap
 			},
 			Method:        cmp.Or(info.TokenJoinMethod, info.RequestedJoinMethod),
 			TokenName:     info.SafeTokenName,
-			UserName:      machineidv1.BotResourceName(info.BotName),
+			UserName:      botUserName,
 			BotName:       info.BotName,
 			BotInstanceID: info.BotInstanceID,
 			Scope:         info.BotScope,

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -215,8 +215,8 @@ func AdaptRegisterUsingBoundKeypairMethod(
 		i.SafeTokenName = provisionToken.GetSafeName()
 		i.TokenJoinMethod = string(provisionToken.GetJoinMethod())
 		i.TokenExpires = provisionToken.Expiry()
-		// TODO(strideynet): When bots become scope namespaced, ensure this
-		// call site reflects scopedness.
+		// The legacy join service does not support scoped tokens, so the bot
+		// scope here is always empty.
 		i.BotName, _ = provisionToken.GetBot()
 	})
 	if provisionToken.GetJoinMethod() != types.JoinMethodBoundKeypair {

--- a/lib/scopes/qualified.go
+++ b/lib/scopes/qualified.go
@@ -55,11 +55,11 @@ func (q QualifiedName) String() string {
 	return q.Scope + QualifiedNameSeparator + q.Name
 }
 
-// Set sets a possible scope qualified name. If the "::" separator is not present,
-// then the scope qualified name will have an empty scope. This implements
+// Set sets a possible scope qualified name. Input that does not look like an
+// SQN (see [MaybeSQN]) becomes a bare name with an empty scope. This implements
 // the flag/kingping Value interface.
 func (q *QualifiedName) Set(val string) error {
-	if !strings.Contains(val, QualifiedNameSeparator) {
+	if !MaybeSQN(val) {
 		*q = QualifiedName{Name: val}
 		return nil
 	}

--- a/lib/scopes/qualified_test.go
+++ b/lib/scopes/qualified_test.go
@@ -343,6 +343,11 @@ func TestSet(t *testing.T) {
 			val:  "!bad::test",
 			ok:   false,
 		},
+		{
+			name: "scope prefix without separator",
+			val:  "/staging",
+			ok:   false,
+		},
 	}
 
 	for _, tt := range tts {

--- a/lib/services/bot_instance.go
+++ b/lib/services/bot_instance.go
@@ -258,7 +258,22 @@ func (o *ListBotInstancesRequestOptions) GetFilterFn() func(*machineidv1.BotInst
 }
 
 // BotResourceName returns the default name for resources associated with the
-// given named bot.
-func BotResourceName(botName string) string {
-	return BotUserPrefix + strings.ReplaceAll(botName, " ", "-")
+// given bot. An empty Scope refers to an unscoped bot.
+//
+// Bots are namespaced by their scope, so a scoped bot's name encodes the scope
+// as well as the bot name, allowing a name to be reused across scopes. The
+// encoded scope ends in a "+" separator, which cannot appear inside a valid
+// scope, so two different scopes cannot yield the same name. Scoped bots are
+// reconstructed from User labels rather than by parsing this name, so it serves
+// only as an identity key.
+func BotResourceName(bot scopes.QualifiedName) (string, error) {
+	name := bot.Name
+	if bot.Scope != "" {
+		encodedScope, err := scopes.EncodeForKey(bot.Scope)
+		if err != nil {
+			return "", trace.Wrap(err, "encoding scope for bot resource name")
+		}
+		name = encodedScope + bot.Name
+	}
+	return BotUserPrefix + strings.ReplaceAll(name, " ", "-"), nil
 }

--- a/lib/services/bot_instance_test.go
+++ b/lib/services/bot_instance_test.go
@@ -1,0 +1,84 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+func TestBotResourceName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		scope     string
+		botName   string
+		want      string
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name:      "unscoped",
+			botName:   "name",
+			want:      "bot-name",
+			assertErr: require.NoError,
+		},
+		{
+			name:      "unscoped with spaces",
+			botName:   "name with spaces",
+			want:      "bot-name-with-spaces",
+			assertErr: require.NoError,
+		},
+		{
+			name:      "scoped",
+			scope:     "/staging",
+			botName:   "name",
+			want:      "bot-++staging+name",
+			assertErr: require.NoError,
+		},
+		{
+			// A scope is a prefix of its children, so the encoded separator must
+			// keep the two apart.
+			name:      "scoped, child scope",
+			scope:     "/staging/eu",
+			botName:   "name",
+			want:      "bot-++staging+eu+name",
+			assertErr: require.NoError,
+		},
+		{
+			// An empty segment has no encoding that preserves sort order.
+			name:      "unencodable scope",
+			scope:     "/staging//eu",
+			botName:   "name",
+			assertErr: require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BotResourceName(scopes.QualifiedName{Scope: tt.scope, Name: tt.botName})
+			tt.assertErr(t, err)
+			if err != nil {
+				return
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/lib/usagereporter/teleport/aggregating/reporter.go
+++ b/lib/usagereporter/teleport/aggregating/reporter.go
@@ -34,8 +34,9 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	prehogv1 "github.com/gravitational/teleport/gen/proto/go/prehog/v1"
 	prehogv1alpha "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
-	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -565,7 +566,9 @@ Ingest:
 				botInstanceRecord(te.UserName, te.BotInstanceId).SpiffeSvidsIssued++
 			}
 		case *usagereporter.BotJoinEvent:
-			botUserName := machineidv1.BotResourceName(te.BotName)
+			// TODO(strideynet): BotJoinEvent carries no scope, so same-named
+			// bots in different scopes aggregate together.
+			botUserName, _ := services.BotResourceName(scopes.QualifiedName{Name: te.BotName})
 			userRecord(botUserName, prehogv1alpha.UserKind_USER_KIND_BOT).BotJoins++
 			if te.BotInstanceId != "" {
 				botInstanceRecord(botUserName, te.BotInstanceId).BotJoins++

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -51,11 +51,11 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/set"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
@@ -68,7 +68,7 @@ type BotsCommand struct {
 	lockExpires string
 	lockTTL     time.Duration
 
-	botName       string
+	botName       scopes.QualifiedName
 	botRoles      string
 	tokenID       string
 	tokenTTL      time.Duration
@@ -107,7 +107,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	c.botsList.Flag("format", "Output format.").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 
 	c.botsAdd = bots.Command("add", "Add a new certificate renewal bot to the cluster.")
-	c.botsAdd.Arg("name", "A name to uniquely identify this bot in the cluster.").Required().StringVar(&c.botName)
+	c.botsAdd.Arg("name", "A name to uniquely identify this bot in the cluster.").Required().SetValue(&c.botName)
 	c.botsAdd.Flag("roles", "Roles the bot is able to assume.").StringVar(&c.botRoles)
 	c.botsAdd.Flag("ttl", "TTL for the bot join token.").DurationVar(&c.tokenTTL)
 	c.botsAdd.Flag("token", "Name of an existing token to use.").StringVar(&c.tokenID)
@@ -116,16 +116,16 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	c.botsAdd.Flag("max-session-ttl", "Set a max session TTL for the bot's internal identity. 12h default, 168h maximum.").DurationVar(&c.maxSessionTTL)
 
 	c.botsRemove = bots.Command("rm", "Permanently remove a certificate renewal bot from the cluster.")
-	c.botsRemove.Arg("name", "Name of an existing bot to remove.").Required().StringVar(&c.botName)
+	c.botsRemove.Arg("name", "Name of an existing bot to remove. For a scoped bot, provide a scope-qualified name of the form [scope]::[name].").Required().SetValue(&c.botName)
 
 	c.botsLock = bots.Command("lock", "Prevent a bot from renewing its certificates.")
-	c.botsLock.Arg("name", "Name of an existing bot to lock.").Required().StringVar(&c.botName)
+	c.botsLock.Arg("name", "Name of an existing bot to lock. For a scoped bot, provide a scope-qualified name of the form [scope]::[name].").Required().SetValue(&c.botName)
 	c.botsLock.Flag("expires", "Time point (RFC3339) when the lock expires.").StringVar(&c.lockExpires)
 	c.botsLock.Flag("ttl", "Time duration after which the lock expires.").DurationVar(&c.lockTTL)
 	c.botsLock.Hidden()
 
 	c.botsUpdate = bots.Command("update", "Update an existing bot.")
-	c.botsUpdate.Arg("name", "Name of an existing bot to update.").Required().StringVar(&c.botName)
+	c.botsUpdate.Arg("name", "Name of an existing bot to update.").Required().SetValue(&c.botName)
 	c.botsUpdate.Flag("set-roles", "Sets the bot's roles to the given comma-separated list, replacing any existing roles.").StringVar(&c.botRoles)
 	c.botsUpdate.Flag("add-roles", "Adds a comma-separated list of roles to an existing bot.").StringVar(&c.addRoles)
 	c.botsUpdate.Flag("set-logins", "Sets the bot's logins to the given comma-separated list, replacing any existing logins.").StringVar(&c.setLogins)
@@ -138,7 +138,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	c.botsInstancesShow.Arg("id", "The full ID of the bot instance, in the form of [bot name]/[uuid]. For an instance of a scoped bot, prefix the ID with the bot's scope: [scope]::[bot name]/[uuid].").Required().StringVar(&c.instanceID)
 
 	c.botsInstancesList = c.botsInstances.Command("list", "List bot instances.").Alias("ls")
-	c.botsInstancesList.Arg("name", "The name of the bot from which to list instances. For a scoped bot, provide a scope-qualified name of the form [scope]::[name]. If unset, lists instances from all bots.").StringVar(&c.botName)
+	c.botsInstancesList.Arg("name", "The name of the bot from which to list instances. For a scoped bot, provide a scope-qualified name of the form [scope]::[name]. If unset, lists instances from all bots.").SetValue(&c.botName)
 	c.botsInstancesList.Flag("format", "Output format.").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 	c.botsInstancesList.Flag("search", "Fuzzy search query used to filter bot instances").StringVar(&c.search)
 	c.botsInstancesList.Flag("query", "An expression in the Teleport predicate language used to filter bot instances").StringVar(&c.query)
@@ -146,7 +146,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	c.botsInstancesList.Flag("sort-order", "Request sort order, 'ascending' or 'descending'").Default("ascending").StringVar(&c.sortOrder)
 
 	c.botsInstancesAdd = c.botsInstances.Command("add", "Join a new instance onto an existing bot.").Alias("join")
-	c.botsInstancesAdd.Arg("name", "The name of the existing bot for which to add a new instance.").Required().StringVar(&c.botName)
+	c.botsInstancesAdd.Arg("name", "The name of the existing bot for which to add a new instance.").Required().SetValue(&c.botName)
 	c.botsInstancesAdd.Flag("token", "The token to use, if any. If unset, a new one-time-use token will be created.").StringVar(&c.tokenID)
 	c.botsInstancesAdd.Flag("format", "Output format, one of: text, json").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 
@@ -230,8 +230,10 @@ func (c *BotsCommand) ListBots(ctx context.Context, client botsCommandClient) er
 		}
 		t := asciitable.MakeTable([]string{"Bot", "User", "Roles"})
 		for _, u := range bots {
+			// Same-named bots in different scopes would otherwise be identical rows.
+			name := scopes.QualifiedName{Scope: u.GetScope(), Name: u.GetMetadata().GetName()}.String()
 			t.AddRow([]string{
-				u.Metadata.Name, u.Status.UserName, strings.Join(u.Spec.GetRoles(), ","),
+				name, u.Status.UserName, strings.Join(u.Spec.GetRoles(), ","),
 			})
 		}
 		fmt.Fprintln(c.stdout, t.AsBuffer().String())
@@ -291,6 +293,10 @@ Please note:
 
 // AddBot adds a new certificate renewal bot to the cluster.
 func (c *BotsCommand) AddBot(ctx context.Context, client botsCommandClient) error {
+	if c.botName.Scope != "" {
+		return trace.Wrap(errScopedBotTokenUnsupported(c.botName, "creating"))
+	}
+
 	// Prompt for admin action MFA if required, allowing reuse for UpsertToken and CreateBot.
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 	if err == nil {
@@ -317,7 +323,7 @@ func (c *BotsCommand) AddBot(ctx context.Context, client botsCommandClient) erro
 		tokenSpec := types.ProvisionTokenSpecV2{
 			Roles:      types.SystemRoles{types.RoleBot},
 			JoinMethod: types.JoinMethodToken,
-			BotName:    c.botName,
+			BotName:    c.botName.Name,
 		}
 		token, err = types.NewProvisionTokenFromSpec(tokenName, time.Now().Add(ttl), tokenSpec)
 		if err != nil {
@@ -340,11 +346,8 @@ func (c *BotsCommand) AddBot(ctx context.Context, client botsCommandClient) erro
 			return trace.BadParameter("token %q is not valid for role %q",
 				c.tokenID, types.RoleBot)
 		}
-		// TODO(strideynet): When bots become scope namespaced, ensure this
-		// call site reflects scopedness.
-		if tokenBotName, _ := token.GetBot(); tokenBotName != c.botName {
-			return trace.BadParameter("token %q is valid for bot with name %q, not %q",
-				c.tokenID, tokenBotName, c.botName)
+		if err := checkTokenBot(c.tokenID, token, c.botName); err != nil {
+			return trace.Wrap(err)
 		}
 	}
 
@@ -357,7 +360,7 @@ func (c *BotsCommand) AddBot(ctx context.Context, client botsCommandClient) erro
 		Kind:    types.KindBot,
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
-			Name: c.botName,
+			Name: c.botName.Name,
 		},
 		Spec: &machineidv1pb.BotSpec{
 			Roles: roles,
@@ -383,7 +386,8 @@ func (c *BotsCommand) AddBot(ctx context.Context, client botsCommandClient) erro
 
 func (c *BotsCommand) RemoveBot(ctx context.Context, client botsCommandClient) error {
 	_, err := client.BotServiceClient().DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{
-		BotName: c.botName,
+		BotName: c.botName.Name,
+		Scope:   c.botName.Scope,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -400,7 +404,12 @@ func (c *BotsCommand) LockBot(ctx context.Context, client botsCommandClient) err
 		return trace.Wrap(err)
 	}
 
-	user, err := client.GetUser(ctx, machineidv1.BotResourceName(c.botName), false)
+	resourceName, err := services.BotResourceName(c.botName)
+	if err != nil {
+		return trace.Wrap(err, "building bot resource name")
+	}
+
+	user, err := client.GetUser(ctx, resourceName, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -411,8 +420,10 @@ func (c *BotsCommand) LockBot(ctx context.Context, client botsCommandClient) err
 		return trace.BadParameter("User %q is not a bot user; use `tctl lock` directly to lock this user", user.GetName())
 	}
 
-	if botName != c.botName {
-		return trace.BadParameter("User %q is not associated with expected bot %q (expected %q); use `tctl lock` directly to lock this user", user.GetName(), c.botName, botName)
+	// The name label alone is ambiguous now the same name may exist in many scopes.
+	found := scopes.QualifiedName{Scope: meta.Labels[types.BotScopeLabel], Name: botName}
+	if found != c.botName {
+		return trace.BadParameter("User %q is not associated with expected bot %q (expected %q); use `tctl lock` directly to lock this user", user.GetName(), c.botName, found)
 	}
 
 	lock, err := types.NewLock(uuid.New().String(), types.LockSpecV2{
@@ -528,8 +539,17 @@ func (c *BotsCommand) updateBotRoles(ctx context.Context, client botsCommandClie
 
 // UpdateBot performs various updates to existing bot users and roles.
 func (c *BotsCommand) UpdateBot(ctx context.Context, client botsCommandClient) error {
+	if c.botName.Scope != "" {
+		// Nothing this command can set is settable on a scoped bot, so the RPC
+		// would refuse the request anyway.
+		return trace.BadParameter(
+			"cannot update scoped bot %q: scoped bots have no updatable fields "+
+				"(roles are granted with scoped role assignments)", c.botName,
+		)
+	}
+
 	bot, err := client.BotServiceClient().GetBot(ctx, &machineidv1pb.GetBotRequest{
-		BotName: c.botName,
+		BotName: c.botName.Name,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -572,28 +592,14 @@ func (c *BotsCommand) UpdateBot(ctx context.Context, client botsCommandClient) e
 		return trace.Wrap(err)
 	}
 
-	slog.InfoContext(ctx, "Bot has been updated, roles will take effect on its next renewal", "bot", c.botName)
+	slog.InfoContext(ctx, "Bot has been updated, roles will take effect on its next renewal", "bot", c.botName.Name)
 
 	return nil
 }
 
 // ListBotInstances lists bot instances, possibly filtering for a specific bot
 func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandClient) error {
-	// The bot may be given as a scope-qualified name (<scope>::<bot name>) to
-	// list instances of a scoped bot; a bare name lists instances of an
-	// unscoped bot.
-	botName := c.botName
-	var botScope string
-	if scopes.MaybeSQN(botName) {
-		qn, err := scopes.ParseQualifiedName(botName)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if err := qn.StrongValidate(); err != nil {
-			return trace.Wrap(err)
-		}
-		botScope, botName = qn.Scope, qn.Name
-	}
+	botName, botScope := c.botName.Name, c.botName.Scope
 
 	// Exhaustive view, per the scope_filter field docs.
 	var scopeFilter *scopesv1.Filter
@@ -666,7 +672,7 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 	}
 
 	if len(instances) == 0 {
-		if c.botName == "" {
+		if c.botName.Name == "" {
 			fmt.Fprintln(c.stdout, "No bot instances found.")
 		} else {
 			fmt.Fprintf(c.stdout, "No bot instances found with name %q.\n", c.botName)
@@ -744,8 +750,8 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client botsCommandCl
 	executableFileName := filepath.Base(os.Args[0])
 	fmt.Fprintf(c.stdout, "\nTo view more information on a particular instance, run:\n\n> %s bots instances show [id]\n", executableFileName)
 
-	// 'bots instances add' does not support scoped bots yet.
-	if c.botName != "" && botScope == "" {
+	// 'bots instances add' refuses scoped bots, so don't advertise it for one.
+	if c.botName.Name != "" && c.botName.Scope == "" {
 		fmt.Fprintf(c.stdout, "\nTo onboard a new instance for this bot, run:\n\n> %s bots instances add %s\n", executableFileName, c.botName)
 	}
 
@@ -757,9 +763,12 @@ func (c *BotsCommand) AddBotInstance(ctx context.Context, client botsCommandClie
 	// A bit of a misnomer but makes the terminology a bit more consistent. This
 	// doesn't directly create a bot instance, but creates token that allows a
 	// bot to join, which creates a new instance.
+	if c.botName.Scope != "" {
+		return trace.Wrap(errScopedBotTokenUnsupported(c.botName, "onboarding an instance of"))
+	}
 
 	bot, err := client.BotServiceClient().GetBot(ctx, &machineidv1pb.GetBotRequest{
-		BotName: c.botName,
+		BotName: c.botName.Name,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -777,7 +786,7 @@ func (c *BotsCommand) AddBotInstance(ctx context.Context, client botsCommandClie
 		tokenSpec := types.ProvisionTokenSpecV2{
 			Roles:      types.SystemRoles{types.RoleBot},
 			JoinMethod: types.JoinMethodToken,
-			BotName:    c.botName,
+			BotName:    c.botName.Name,
 		}
 		token, err = types.NewProvisionTokenFromSpec(tokenName, time.Now().Add(ttl), tokenSpec)
 		if err != nil {
@@ -807,14 +816,36 @@ func (c *BotsCommand) AddBotInstance(ctx context.Context, client botsCommandClie
 		return trace.BadParameter("token %q is not valid for role %q",
 			c.tokenID, types.RoleBot)
 	}
-	// TODO(strideynet): When bots become scope namespaced, ensure this call
-	// site reflects scopedness.
-	if tokenBotName, _ := token.GetBot(); tokenBotName != c.botName {
-		return trace.BadParameter("token %q is valid for bot with name %q, not %q",
-			c.tokenID, tokenBotName, c.botName)
+	if err := checkTokenBot(c.tokenID, token, c.botName); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return trace.Wrap(outputToken(ctx, c.stdout, c.format, client, bot, token))
+}
+
+// checkTokenBot verifies that the join token references the bot the caller
+// named, scope included.
+func checkTokenBot(tokenID string, token types.ProvisionToken, ref scopes.QualifiedName) error {
+	name, scope := token.GetBot()
+	if tokenBot := (scopes.QualifiedName{Scope: scope, Name: name}); tokenBot != ref {
+		return trace.BadParameter("token %q is valid for bot %q, not %q",
+			tokenID, tokenBot, ref)
+	}
+	return nil
+}
+
+// errScopedBotTokenUnsupported explains that the token-minting `tctl bots`
+// subcommands cannot serve a scoped bot: classic provision tokens can only
+// reference unscoped bots, and this command does not create scoped_tokens.
+func errScopedBotTokenUnsupported(ref scopes.QualifiedName, verb string) error {
+	return trace.BadParameter(
+		"%s a scoped bot is not supported by this command (got %q)\n"+
+			"hint: a scoped bot joins with a scoped token, which this command cannot create.\n"+
+			"  Apply one with 'tctl create -f': a scoped_token in scope %q with spec.bot: %q,\n"+
+			"  spec.usage_mode: bot, spec.roles: [Bot] and spec.join_method: bound_keypair.\n"+
+			"  The bot also needs a scoped role assignment applicable to its scope before it can join.",
+		verb, ref, ref.Scope, ref,
+	)
 }
 
 var showMessageTemplate = template.Must(template.New("show").Funcs(template.FuncMap{

--- a/tool/tctl/common/bots_command_test.go
+++ b/tool/tctl/common/bots_command_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
@@ -131,7 +132,7 @@ func TestUpdateBotLogins(t *testing.T) {
 			require.NoError(t, err)
 
 			cmd := BotsCommand{
-				botName:   botName,
+				botName:   scopes.QualifiedName{Name: botName},
 				addLogins: tt.add,
 				setLogins: tt.set,
 			}
@@ -238,7 +239,7 @@ func TestUpdateBotRoles(t *testing.T) {
 			require.NoError(t, err)
 
 			cmd := BotsCommand{
-				botName:  botName,
+				botName:  scopes.QualifiedName{Name: botName},
 				addRoles: tt.add,
 				botRoles: tt.set,
 			}
@@ -301,7 +302,7 @@ func TestAddAndListBotInstancesJSON(t *testing.T) {
 	cmd := BotsCommand{
 		stdout:  &buf,
 		format:  teleport.JSON,
-		botName: bot.Metadata.Name,
+		botName: scopes.QualifiedName{Name: bot.GetMetadata().GetName()},
 	}
 	require.NoError(t, cmd.AddBotInstance(ctx, client))
 
@@ -501,7 +502,7 @@ func TestListBotInstances(t *testing.T) {
 		cmd := BotsCommand{
 			stdout:  &buf,
 			format:  teleport.JSON,
-			botName: "test-bot-1",
+			botName: scopes.QualifiedName{Name: "test-bot-1"},
 		}
 
 		require.NoError(t, cmd.ListBotInstances(ctx, client))
@@ -632,7 +633,7 @@ func TestBotInstancesScoped(t *testing.T) {
 		cmd := BotsCommand{
 			stdout:  &buf,
 			format:  teleport.JSON,
-			botName: "/staging::test-bot-1",
+			botName: scopes.QualifiedName{Scope: "/staging", Name: "test-bot-1"},
 		}
 
 		require.NoError(t, cmd.ListBotInstances(t.Context(), client))
@@ -649,7 +650,7 @@ func TestBotInstancesScoped(t *testing.T) {
 		cmd := BotsCommand{
 			stdout:  &buf,
 			format:  teleport.JSON,
-			botName: "test-bot-1",
+			botName: scopes.QualifiedName{Name: "test-bot-1"},
 		}
 
 		require.NoError(t, cmd.ListBotInstances(t.Context(), client))
@@ -680,7 +681,7 @@ func TestBotInstancesScoped(t *testing.T) {
 		cmd := BotsCommand{
 			stdout:  &buf,
 			format:  teleport.Text,
-			botName: "/staging::test-bot-1",
+			botName: scopes.QualifiedName{Scope: "/staging", Name: "test-bot-1"},
 		}
 
 		require.NoError(t, cmd.ListBotInstances(t.Context(), client))
@@ -693,7 +694,7 @@ func TestBotInstancesScoped(t *testing.T) {
 		cmd := BotsCommand{
 			stdout:  &buf,
 			format:  teleport.Text,
-			botName: "test-bot-1",
+			botName: scopes.QualifiedName{Name: "test-bot-1"},
 		}
 
 		require.NoError(t, cmd.ListBotInstances(t.Context(), client))
@@ -752,17 +753,6 @@ func TestBotInstancesScoped(t *testing.T) {
 
 		err := cmd.ShowBotInstance(t.Context(), client)
 		require.True(t, trace.IsNotFound(err), "expected NotFound, got: %v", err)
-	})
-
-	t.Run("list filter with scope prefix but no separator is rejected", func(t *testing.T) {
-		cmd := BotsCommand{
-			stdout:  &strings.Builder{},
-			format:  teleport.JSON,
-			botName: "/staging",
-		}
-
-		err := cmd.ListBotInstances(t.Context(), client)
-		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
 	})
 
 	t.Run("show with scope prefix but no separator is rejected", func(t *testing.T) {
@@ -865,7 +855,7 @@ func TestListBotInstancesFallback(t *testing.T) {
 			stdout: ptr(strings.Builder{}),
 			format: teleport.JSON,
 			// The bot scope filter is only available in ListBotInstancesV2.
-			botName: "/staging::test-bot-1",
+			botName: scopes.QualifiedName{Scope: "/staging", Name: "test-bot-1"},
 		}
 
 		err := cmd.ListBotInstances(ctx, authClient)
@@ -911,3 +901,134 @@ func (c *mockBotInstanceListV2ErrorClient) ListBotInstancesV2(ctx context.Contex
 }
 
 func ptr[T any](v T) *T { return &v }
+
+// TestBotsScoped covers the scope-qualified name handling on the `tctl bots`
+// subcommands. Bots are namespaced by scope, so a bare name and an SQN address
+// different bots even when the name component matches.
+func TestBotsScoped(t *testing.T) {
+	t.Parallel()
+
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{DataDir: t.TempDir()},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	process := makeAndRunTestAuthServer(t,
+		withFileConfig(fileConfig),
+		withFileDescriptors(dynAddr.Descriptors),
+		withScopesFeatures(scopes.Features{Enabled: true}),
+	)
+	client, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	makeBot := func(t *testing.T, scope, name string) {
+		t.Helper()
+		_, err := client.BotServiceClient().CreateBot(t.Context(), machineidv1pb.CreateBotRequest_builder{
+			Bot: machineidv1pb.Bot_builder{
+				Kind:     types.KindBot,
+				Version:  types.V1,
+				Scope:    scope,
+				Metadata: headerv1.Metadata_builder{Name: name}.Build(),
+				Spec:     machineidv1pb.BotSpec_builder{}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+	}
+
+	// An unscoped and a scoped bot sharing a name, to prove the subcommands are
+	// scope-strict in both directions.
+	makeBot(t, "", "robot")
+	makeBot(t, "/staging", "robot")
+
+	t.Run("ls renders scoped bots as scope-qualified names", func(t *testing.T) {
+		buf := strings.Builder{}
+		cmd := BotsCommand{stdout: &buf, format: teleport.Text}
+		require.NoError(t, cmd.ListBots(t.Context(), client))
+
+		out := buf.String()
+		require.Contains(t, out, "/staging::robot")
+		// The scoped bot's backing user encodes its scope, which is how the two
+		// same-named bots stay distinct in storage.
+		scopedUser, err := services.BotResourceName(scopes.QualifiedName{Scope: "/staging", Name: "robot"})
+		require.NoError(t, err)
+		require.Contains(t, out, scopedUser)
+		unscopedUser, err := services.BotResourceName(scopes.QualifiedName{Name: "robot"})
+		require.NoError(t, err)
+		require.Contains(t, out, unscopedUser)
+	})
+
+	t.Run("update rejects a scoped bot", func(t *testing.T) {
+		cmd := BotsCommand{stdout: &strings.Builder{}, botName: scopes.QualifiedName{Scope: "/staging", Name: "robot"}, botRoles: "access"}
+		err := cmd.UpdateBot(t.Context(), client)
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+		require.ErrorContains(t, err, "cannot update scoped bot")
+	})
+
+	t.Run("add rejects a scoped bot with a scoped_token hint", func(t *testing.T) {
+		cmd := BotsCommand{stdout: &strings.Builder{}, botName: scopes.QualifiedName{Scope: "/staging", Name: "other"}}
+		err := cmd.AddBot(t.Context(), client)
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+		require.ErrorContains(t, err, "scoped_token")
+		require.ErrorContains(t, err, "spec.usage_mode: bot")
+	})
+
+	t.Run("instances add rejects a scoped bot with a scoped_token hint", func(t *testing.T) {
+		cmd := BotsCommand{stdout: &strings.Builder{}, botName: scopes.QualifiedName{Scope: "/staging", Name: "robot"}}
+		err := cmd.AddBotInstance(t.Context(), client)
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+		require.ErrorContains(t, err, "scoped_token")
+	})
+
+	t.Run("lock targets the scoped bot's backing user", func(t *testing.T) {
+		ctx := t.Context()
+		cmd := BotsCommand{stdout: &strings.Builder{}, botName: scopes.QualifiedName{Scope: "/staging", Name: "robot"}}
+		require.NoError(t, cmd.LockBot(ctx, client))
+
+		scopedUser, err := services.BotResourceName(scopes.QualifiedName{Scope: "/staging", Name: "robot"})
+		require.NoError(t, err)
+		locks, err := client.GetLocks(ctx, false)
+		require.NoError(t, err)
+		require.True(t, slices.ContainsFunc(locks, func(l types.Lock) bool {
+			return l.Target().User == scopedUser
+		}), "expected a lock targeting %q, got %v", scopedUser, locks)
+	})
+
+	t.Run("rm with a bare name deletes only the unscoped bot", func(t *testing.T) {
+		ctx := t.Context()
+		buf := strings.Builder{}
+		cmd := BotsCommand{stdout: &buf, botName: scopes.QualifiedName{Name: "robot"}}
+		require.NoError(t, cmd.RemoveBot(ctx, client))
+		require.Contains(t, buf.String(), `Bot "robot" deleted successfully.`)
+
+		// The scoped bot survives; the unscoped one is gone.
+		_, err := client.BotServiceClient().GetBot(ctx, machineidv1pb.GetBotRequest_builder{
+			BotName: "robot",
+		}.Build())
+		require.True(t, trace.IsNotFound(err), "expected NotFound for the unscoped bot, got: %v", err)
+		_, err = client.BotServiceClient().GetBot(ctx, machineidv1pb.GetBotRequest_builder{
+			BotName: "robot",
+			Scope:   "/staging",
+		}.Build())
+		require.NoError(t, err)
+	})
+
+	t.Run("rm with a scope-qualified name deletes the scoped bot", func(t *testing.T) {
+		ctx := t.Context()
+		buf := strings.Builder{}
+		cmd := BotsCommand{stdout: &buf, botName: scopes.QualifiedName{Scope: "/staging", Name: "robot"}}
+		require.NoError(t, cmd.RemoveBot(ctx, client))
+		require.Contains(t, buf.String(), `Bot "/staging::robot" deleted successfully.`)
+
+		_, err := client.BotServiceClient().GetBot(ctx, machineidv1pb.GetBotRequest_builder{
+			BotName: "robot",
+			Scope:   "/staging",
+		}.Build())
+		require.True(t, trace.IsNotFound(err), "expected NotFound for the scoped bot, got: %v", err)
+	})
+}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1113,30 +1113,6 @@ func (c *samlIdPServiceProviderCollection) WriteText(w io.Writer, verbose bool) 
 	return trace.Wrap(err)
 }
 
-type botCollection struct {
-	bots []*machineidv1pb.Bot
-}
-
-func (c *botCollection) Resources() []types.Resource {
-	resources := make([]types.Resource, len(c.bots))
-	for i, b := range c.bots {
-		resources[i] = types.ProtoResource153ToLegacy(b)
-	}
-	return resources
-}
-
-func (c *botCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"Name", "Roles"})
-	for _, b := range c.bots {
-		t.AddRow([]string{
-			b.Metadata.Name,
-			strings.Join(b.Spec.Roles, ", "),
-		})
-	}
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
 type databaseObjectImportRuleCollection struct {
 	rules []*dbobjectimportrulev1.DatabaseObjectImportRule
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -35,7 +35,6 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/gravitational/trace"
-	"google.golang.org/protobuf/encoding/protojson"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport"
@@ -172,7 +171,6 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindAuditQuery:                         rc.createAuditQuery,
 		types.KindSecurityReport:                     rc.createSecurityReport,
 		types.KindServerInfo:                         rc.createServerInfo,
-		types.KindBot:                                rc.createBot,
 		types.KindDatabaseObjectImportRule:           rc.createDatabaseObjectImportRule,
 		types.KindDatabaseObject:                     rc.createDatabaseObject,
 		types.KindAccessMonitoringRule:               rc.createAccessMonitoringRule,
@@ -760,32 +758,6 @@ func (rc *ResourceCommand) createUser(ctx context.Context, client *authclient.Cl
 		fmt.Printf("user %q has been created\n", userName)
 	}
 
-	return nil
-}
-
-func (rc *ResourceCommand) createBot(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	bot := &machineidv1pb.Bot{}
-	if err := (protojson.UnmarshalOptions{}).Unmarshal(raw.Raw, bot); err != nil {
-		return trace.Wrap(err)
-	}
-	if rc.IsForced() {
-		_, err := client.BotServiceClient().UpsertBot(ctx, &machineidv1pb.UpsertBotRequest{
-			Bot: bot,
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("bot %q has been created\n", bot.Metadata.Name)
-		return nil
-	}
-
-	_, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
-		Bot: bot,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	fmt.Printf("bot %q has been created\n", bot.Metadata.Name)
 	return nil
 }
 
@@ -2193,11 +2165,6 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("Server info %q has been deleted\n", ref.Name)
-	case types.KindBot:
-		if _, err := client.BotServiceClient().DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{BotName: ref.Name}); err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("Bot %q has been deleted\n", ref.Name)
 	case types.KindDatabaseObjectImportRule:
 		if _, err := client.DatabaseObjectImportRuleClient().DeleteDatabaseObjectImportRule(ctx, &dbobjectimportrulev1.DeleteDatabaseObjectImportRuleRequest{Name: ref.Name}); err != nil {
 			return trace.Wrap(err)
@@ -3109,32 +3076,6 @@ func (rc *ResourceCommand) getCollectionByRef(ctx context.Context, client *authc
 		})
 
 		return &deviceCollection{devices: devs}, nil
-	case types.KindBot:
-		remote := client.BotServiceClient()
-		if ref.Name != "" {
-			bot, err := remote.GetBot(ctx, &machineidv1pb.GetBotRequest{
-				BotName: ref.Name,
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			return &botCollection{bots: []*machineidv1pb.Bot{bot}}, nil
-		}
-
-		bots, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]*machineidv1pb.Bot, string, error) {
-			resp, err := remote.ListBots(ctx, &machineidv1pb.ListBotsRequest{
-				PageSize:  int32(limit),
-				PageToken: token,
-			})
-
-			return resp.GetBots(), resp.GetNextPageToken(), trace.Wrap(err)
-		}))
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		return &botCollection{bots: bots}, nil
 	case types.KindDatabaseObjectImportRule:
 		remote := client.DatabaseObjectImportRuleClient()
 		if ref.Name != "" {

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -1308,6 +1308,144 @@ func TestScopedAndUnscopedBotInstanceResource(t *testing.T) {
 	})
 }
 
+// TestScopedAndUnscopedBotResource exercises tctl get/rm on bots, which are
+// double-registered as both a scoped and unscoped resource handler to support a
+// mix of scope-qualified and classic interactions. Bots are namespaced by scope,
+// so the same name may exist unscoped and in several scopes at once; each is
+// addressed by its own scope-qualified name.
+func TestScopedAndUnscopedBotResource(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{DataDir: t.TempDir()},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+	auth := makeAndRunTestAuthServer(t,
+		withFileConfig(fileConfig),
+		withFileDescriptors(dynAddr.Descriptors),
+		withScopesFeatures(scopes.Features{Enabled: true}),
+	)
+	clt, err := testenv.NewDefaultAuthClient(auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	botClient := clt.BotServiceClient()
+	makeBot := func(scope, name string) {
+		t.Helper()
+		bot := machineidv1pb.Bot_builder{
+			Kind:     types.KindBot,
+			Version:  types.V1,
+			Scope:    scope,
+			Metadata: headerv1.Metadata_builder{Name: name}.Build(),
+			Spec:     machineidv1pb.BotSpec_builder{}.Build(),
+		}.Build()
+		if scope == "" {
+			// Roles cannot be set on a scoped bot, but an unscoped bot with no
+			// roles is unremarkable, so keep both fixtures minimal.
+			bot.GetSpec().SetRoles(nil)
+		}
+		_, err := botClient.CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{Bot: bot}.Build())
+		require.NoError(t, err)
+	}
+
+	// The same name in three namespaces: unscoped, /staging and /prod. This is
+	// the invariant scope namespacing exists to provide, seen through tctl.
+	makeBot("", "robot")
+	makeBot("/staging", "robot")
+	makeBot("/prod", "robot")
+
+	// listNames returns the Name column of 'tctl get bot --format=text', which
+	// renders scoped bots as scope-qualified names.
+	listNames := func(t require.TestingT) string {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBot, "--format=text"})
+		require.NoError(t, err)
+		return buf.String()
+	}
+
+	// Wait until all three bots appear via the list (cache propagation).
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		out := listNames(t)
+		require.Contains(t, out, "/staging::robot")
+		require.Contains(t, out, "/prod::robot")
+	}, 30*time.Second, 100*time.Millisecond)
+
+	t.Run("list all shows scope-qualified names for scoped bots", func(t *testing.T) {
+		out := listNames(t)
+		require.Contains(t, out, "/staging::robot")
+		require.Contains(t, out, "/prod::robot")
+		// The unscoped bot keeps its bare name, so the unqualified name appears
+		// on a line of its own.
+		require.Regexp(t, `(?m)^robot\b`, out)
+	})
+
+	t.Run("single-arg unscoped get returns the unscoped bot", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", "bot/robot", "--format=text"})
+		require.NoError(t, err)
+		require.NotContains(t, buf.String(), scopes.QualifiedNameSeparator)
+	})
+
+	t.Run("two-arg unscoped get returns the unscoped bot", func(t *testing.T) {
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBot, "robot", "--format=text"})
+		require.NoError(t, err)
+		require.NotContains(t, buf.String(), scopes.QualifiedNameSeparator)
+	})
+
+	t.Run("scope-qualified get selects the bot in that scope", func(t *testing.T) {
+		for _, scope := range []string{"/staging", "/prod"} {
+			buf, err := runResourceCommand(t, clt, []string{"get", types.KindBot, scope + "::robot", "--format=text"})
+			require.NoError(t, err)
+			require.Contains(t, buf.String(), scope+"::robot")
+		}
+	})
+
+	t.Run("scope-qualified get with scope mismatch", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"get", types.KindBot, "/dev::robot", "--format=text"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound on scope mismatch, got: %v", err)
+	})
+
+	t.Run("sub-kind is rejected with a hint", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"get", types.KindBot + "/staging", "/staging::robot", "--format=text"})
+		require.True(t, trace.IsBadParameter(err), "expected BadParameter, got: %v", err)
+		require.ErrorContains(t, err, "does not support sub-kinds")
+	})
+
+	t.Run("scope-qualified delete removes only that bot", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", types.KindBot, "/staging::robot"})
+		require.NoError(t, err)
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			_, err := runResourceCommand(t, clt, []string{"get", types.KindBot, "/staging::robot", "--format=text"})
+			require.True(t, trace.IsNotFound(err), "expected NotFound waiting for /staging::robot deletion, got: %v", err)
+		}, 30*time.Second, 100*time.Millisecond)
+
+		// The same-named bots in the other two namespaces are untouched.
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBot, "/prod::robot", "--format=text"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "/prod::robot")
+		_, err = runResourceCommand(t, clt, []string{"get", "bot/robot", "--format=text"})
+		require.NoError(t, err)
+	})
+
+	t.Run("unscoped delete leaves the scoped bot intact", func(t *testing.T) {
+		_, err := runResourceCommand(t, clt, []string{"rm", "bot/robot"})
+		require.NoError(t, err)
+
+		_, err = runResourceCommand(t, clt, []string{"get", "bot/robot", "--format=text"})
+		require.True(t, trace.IsNotFound(err), "expected NotFound after unscoped delete, got: %v", err)
+
+		buf, err := runResourceCommand(t, clt, []string{"get", types.KindBot, "/prod::robot", "--format=text"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), "/prod::robot")
+	})
+}
+
 // TestIntegrationResource tests tctl integration commands.
 func TestIntegrationResource(t *testing.T) {
 	dynAddr := helpers.NewDynamicServiceAddr(t)

--- a/tool/tctl/common/resources/bot.go
+++ b/tool/tctl/common/resources/bot.go
@@ -1,0 +1,219 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type botCollection struct {
+	bots []*machineidv1pb.Bot
+}
+
+func (c *botCollection) Resources() []types.Resource {
+	resources := make([]types.Resource, len(c.bots))
+	for i, b := range c.bots {
+		resources[i] = types.ProtoResource153ToLegacy(b)
+	}
+	return resources
+}
+
+func (c *botCollection) WriteText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"Name", "Roles"})
+	for _, b := range c.bots {
+		// Scoped bots are identified by their scope-qualified name; unscoped
+		// bots by their bare name.
+		name := b.GetMetadata().GetName()
+		if scope := b.GetScope(); scope != "" {
+			name = scopes.QualifiedName{Scope: scope, Name: name}.String()
+		}
+		t.AddRow([]string{
+			name,
+			strings.Join(b.GetSpec().GetRoles(), ", "),
+		})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func botHandler() Handler {
+	return Handler{
+		getHandler:    getBot,
+		deleteHandler: deleteBot,
+		createHandler: createBot,
+		singleton:     false,
+		mfaRequired:   true,
+		description:   "Represents the identity of a machine or workload within Teleport.",
+	}
+}
+
+func getBot(
+	ctx context.Context,
+	client *authclient.Client,
+	ref services.Ref,
+	opts GetOpts,
+) (Collection, error) {
+	c := client.BotServiceClient()
+	if ref.Name != "" {
+		bot, err := c.GetBot(ctx, machineidv1pb.GetBotRequest_builder{
+			BotName: ref.Name,
+		}.Build())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &botCollection{bots: []*machineidv1pb.Bot{bot}}, nil
+	}
+
+	bots, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, limit int, token string) ([]*machineidv1pb.Bot, string, error) {
+		resp, err := c.ListBots(ctx, machineidv1pb.ListBotsRequest_builder{
+			PageSize:  int32(limit),
+			PageToken: token,
+		}.Build())
+
+		return resp.GetBots(), resp.GetNextPageToken(), trace.Wrap(err)
+	}))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &botCollection{bots: bots}, nil
+}
+
+// botScopedHandler returns a [ScopedHandler] for bots that are registered with
+// a scope. Bots support both classic (unscoped) and scope-qualified access, so
+// this is registered alongside the classic handler in ScopedHandlers().
+// Create is absent because the classic handler takes precedence for 'tctl
+// create' and already handles a scope on the bot resource.
+func botScopedHandler() ScopedHandler {
+	return ScopedHandler{
+		getHandler:    getBotScoped,
+		deleteHandler: deleteBotScoped,
+		mfaRequired:   true,
+		description:   "Represents the identity of a machine or workload within Teleport.",
+	}
+}
+
+func getBotScoped(
+	ctx context.Context,
+	client *authclient.Client,
+	subKind string,
+	sqn *scopes.QualifiedName,
+	opts GetOpts,
+) (Collection, error) {
+	if subKind != "" {
+		return nil, rejectSubKind(types.KindBot, subKind)
+	}
+	if sqn == nil {
+		// List-all is normally served by the classic handler, which bot is also
+		// registered in; fall back to it for safety.
+		return getBot(ctx, client, services.Ref{Kind: types.KindBot}, opts)
+	}
+
+	bot, err := client.BotServiceClient().GetBot(ctx, machineidv1pb.GetBotRequest_builder{
+		BotName: sqn.Name,
+		Scope:   sqn.Scope,
+	}.Build())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &botCollection{bots: []*machineidv1pb.Bot{bot}}, nil
+}
+
+func deleteBotScoped(
+	ctx context.Context,
+	client *authclient.Client,
+	subKind string,
+	sqn scopes.QualifiedName,
+) error {
+	if subKind != "" {
+		return rejectSubKind(types.KindBot, subKind)
+	}
+
+	_, err := client.BotServiceClient().DeleteBot(ctx, machineidv1pb.DeleteBotRequest_builder{
+		BotName: sqn.Name,
+		Scope:   sqn.Scope,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Bot %q has been deleted\n", sqn.String())
+	return nil
+}
+
+func createBot(
+	ctx context.Context,
+	client *authclient.Client,
+	raw services.UnknownResource,
+	opts CreateOpts,
+) error {
+	bot := &machineidv1pb.Bot{}
+	if err := (protojson.UnmarshalOptions{}).Unmarshal(raw.Raw, bot); err != nil {
+		return trace.Wrap(err)
+	}
+	// String() renders the bare name when the scope is empty.
+	displayName := scopes.QualifiedName{Scope: bot.GetScope(), Name: bot.GetMetadata().GetName()}.String()
+	if opts.Force {
+		_, err := client.BotServiceClient().UpsertBot(ctx, machineidv1pb.UpsertBotRequest_builder{
+			Bot: bot,
+		}.Build())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("Bot %q has been created\n", displayName)
+		return nil
+	}
+
+	_, err := client.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		Bot: bot,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Bot %q has been created\n", displayName)
+	return nil
+}
+
+func deleteBot(
+	ctx context.Context,
+	client *authclient.Client,
+	ref services.Ref,
+) error {
+	_, err := client.BotServiceClient().DeleteBot(ctx, machineidv1pb.DeleteBotRequest_builder{
+		BotName: ref.Name,
+	}.Build())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Bot %q has been deleted\n", ref.Name)
+	return nil
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -38,6 +38,7 @@ func Handlers() map[string]Handler {
 	return map[string]Handler{
 		types.KindBeamsConfig:         beamsConfigHandler(),
 		types.KindAccessList:          accessListHandler(),
+		types.KindBot:                 botHandler(),
 		types.KindBotInstance:         botInstanceHandler(),
 		types.KindClientIPRestriction: clientIPRestrictionHandler(),
 		types.KindIntegration:         integrationHandler(),

--- a/tool/tctl/common/resources/scoped_handler.go
+++ b/tool/tctl/common/resources/scoped_handler.go
@@ -35,6 +35,7 @@ import (
 func ScopedHandlers() map[string]ScopedHandler {
 	return map[string]ScopedHandler{
 		types.KindNode:                        serverScopedHandler(),
+		types.KindBot:                         botScopedHandler(),
 		types.KindWorkloadIdentity:            workloadIdentityScopedHandler(),
 		types.KindBotInstance:                 botInstanceScopedHandler(),
 		scopedaccess.KindScopedRole:           scopedRoleScopedHandler(),

--- a/tool/tctl/common/scoped_ref.go
+++ b/tool/tctl/common/scoped_ref.go
@@ -130,7 +130,7 @@ func ParseScopedRef(ref, id string) (ScopedRef, error) {
 					return ScopedRef{}, trace.BadParameter("scope-qualified name %q has invalid scope: %v", qn, err)
 				}
 				for _, part := range []string{botName, instanceID} {
-					if err := scopes.StrongValidateSegment(part); err != nil {
+					if err := scopes.StrongValidateResourceName(part); err != nil {
 						return ScopedRef{}, trace.BadParameter("scope-qualified name %q has invalid name: %v", qn, err)
 					}
 				}


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport/pull/69316

Backports https://github.com/gravitational/teleport/pull/68253

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Regression:
  - [x] CRUD unscoped bot
  - [x] Join and renew unscoped bot, can SSH into unscoped SSH server
- [x] CRUD Scoped Bot
  - [x] Unscoped user
  - [x] Scoped user
  - [x] Scoped user wrong scope (i.e is RBAC enforced)
- [x] Join and renew scoped bot
- [x] Scoped bot can SSH to scoped SSH node.    


Agentic test plan: https://gist.github.com/strideynet/26e59e2f0527e76347042bd618f0c84a
