### PR TITLE
tbot: add scope support for application services

### DIFF
--- a/api/gen/proto/go/teleport/issuance/v1/service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/issuance/v1/service_protohybrid.pb.go
@@ -57,6 +57,7 @@ type IssueScopedBotCertsRequest struct {
 	// Types that are valid to be assigned to Usage:
 	//
 	//	*IssueScopedBotCertsRequest_Identity
+	//	*IssueScopedBotCertsRequest_App
 	Usage         isIssueScopedBotCertsRequest_Usage `protobuf_oneof:"usage"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -124,6 +125,15 @@ func (x *IssueScopedBotCertsRequest) GetIdentity() *UsageIdentity {
 	return nil
 }
 
+func (x *IssueScopedBotCertsRequest) GetApp() *UsageApp {
+	if x != nil {
+		if x, ok := x.Usage.(*IssueScopedBotCertsRequest_App); ok {
+			return x.App
+		}
+	}
+	return nil
+}
+
 func (x *IssueScopedBotCertsRequest) SetSshPublicKey(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -150,6 +160,14 @@ func (x *IssueScopedBotCertsRequest) SetIdentity(v *UsageIdentity) {
 	x.Usage = &IssueScopedBotCertsRequest_Identity{v}
 }
 
+func (x *IssueScopedBotCertsRequest) SetApp(v *UsageApp) {
+	if v == nil {
+		x.Usage = nil
+		return
+	}
+	x.Usage = &IssueScopedBotCertsRequest_App{v}
+}
+
 func (x *IssueScopedBotCertsRequest) HasTtl() bool {
 	if x == nil {
 		return false
@@ -172,6 +190,14 @@ func (x *IssueScopedBotCertsRequest) HasIdentity() bool {
 	return ok
 }
 
+func (x *IssueScopedBotCertsRequest) HasApp() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Usage.(*IssueScopedBotCertsRequest_App)
+	return ok
+}
+
 func (x *IssueScopedBotCertsRequest) ClearTtl() {
 	x.Ttl = nil
 }
@@ -186,8 +212,15 @@ func (x *IssueScopedBotCertsRequest) ClearIdentity() {
 	}
 }
 
+func (x *IssueScopedBotCertsRequest) ClearApp() {
+	if _, ok := x.Usage.(*IssueScopedBotCertsRequest_App); ok {
+		x.Usage = nil
+	}
+}
+
 const IssueScopedBotCertsRequest_Usage_not_set_case case_IssueScopedBotCertsRequest_Usage = 0
 const IssueScopedBotCertsRequest_Identity_case case_IssueScopedBotCertsRequest_Usage = 4
+const IssueScopedBotCertsRequest_App_case case_IssueScopedBotCertsRequest_Usage = 5
 
 func (x *IssueScopedBotCertsRequest) WhichUsage() case_IssueScopedBotCertsRequest_Usage {
 	if x == nil {
@@ -196,6 +229,8 @@ func (x *IssueScopedBotCertsRequest) WhichUsage() case_IssueScopedBotCertsReques
 	switch x.Usage.(type) {
 	case *IssueScopedBotCertsRequest_Identity:
 		return IssueScopedBotCertsRequest_Identity_case
+	case *IssueScopedBotCertsRequest_App:
+		return IssueScopedBotCertsRequest_App_case
 	default:
 		return IssueScopedBotCertsRequest_Usage_not_set_case
 	}
@@ -220,6 +255,7 @@ type IssueScopedBotCertsRequest_builder struct {
 
 	// Fields of oneof Usage:
 	Identity *UsageIdentity
+	App      *UsageApp
 	// -- end of Usage
 }
 
@@ -232,6 +268,9 @@ func (b0 IssueScopedBotCertsRequest_builder) Build() *IssueScopedBotCertsRequest
 	x.Ttl = b.Ttl
 	if b.Identity != nil {
 		x.Usage = &IssueScopedBotCertsRequest_Identity{b.Identity}
+	}
+	if b.App != nil {
+		x.Usage = &IssueScopedBotCertsRequest_App{b.App}
 	}
 	return m0
 }
@@ -254,7 +293,13 @@ type IssueScopedBotCertsRequest_Identity struct {
 	Identity *UsageIdentity `protobuf:"bytes,4,opt,name=identity,proto3,oneof"`
 }
 
+type IssueScopedBotCertsRequest_App struct {
+	App *UsageApp `protobuf:"bytes,5,opt,name=app,proto3,oneof"`
+}
+
 func (*IssueScopedBotCertsRequest_Identity) isIssueScopedBotCertsRequest_Usage() {}
+
+func (*IssueScopedBotCertsRequest_App) isIssueScopedBotCertsRequest_Usage() {}
 
 // The simplest possible usage mode for a certificate, returning certificates
 // appropriate for SSH or API authn.
@@ -301,6 +346,118 @@ func (b0 UsageIdentity_builder) Build() *UsageIdentity {
 	return m0
 }
 
+// UsageApp defines the mode
+type UsageApp struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// name is the name of the application to route to.
+	// Must resolve to an application within the scope to which
+	// the calling bot is pinned.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// public_addr is the application public address.
+	PublicAddr string `protobuf:"bytes,2,opt,name=public_addr,json=publicAddr,proto3" json:"public_addr,omitempty"`
+	// cluster_name is the cluster where the application resides.
+	ClusterName string `protobuf:"bytes,3,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
+	// scope is the scope of the target application.
+	Scope         string `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UsageApp) Reset() {
+	*x = UsageApp{}
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UsageApp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UsageApp) ProtoMessage() {}
+
+func (x *UsageApp) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UsageApp) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *UsageApp) GetPublicAddr() string {
+	if x != nil {
+		return x.PublicAddr
+	}
+	return ""
+}
+
+func (x *UsageApp) GetClusterName() string {
+	if x != nil {
+		return x.ClusterName
+	}
+	return ""
+}
+
+func (x *UsageApp) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *UsageApp) SetName(v string) {
+	x.Name = v
+}
+
+func (x *UsageApp) SetPublicAddr(v string) {
+	x.PublicAddr = v
+}
+
+func (x *UsageApp) SetClusterName(v string) {
+	x.ClusterName = v
+}
+
+func (x *UsageApp) SetScope(v string) {
+	x.Scope = v
+}
+
+type UsageApp_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// name is the name of the application to route to.
+	// Must resolve to an application within the scope to which
+	// the calling bot is pinned.
+	Name string
+	// public_addr is the application public address.
+	PublicAddr string
+	// cluster_name is the cluster where the application resides.
+	ClusterName string
+	// scope is the scope of the target application.
+	Scope string
+}
+
+func (b0 UsageApp_builder) Build() *UsageApp {
+	m0 := &UsageApp{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Name = b.Name
+	x.PublicAddr = b.PublicAddr
+	x.ClusterName = b.ClusterName
+	x.Scope = b.Scope
+	return m0
+}
+
 // Response for IssueScopedBotCerts
 type IssueScopedBotCertsResponse struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -312,7 +469,7 @@ type IssueScopedBotCertsResponse struct {
 
 func (x *IssueScopedBotCertsResponse) Reset() {
 	*x = IssueScopedBotCertsResponse{}
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -324,7 +481,7 @@ func (x *IssueScopedBotCertsResponse) String() string {
 func (*IssueScopedBotCertsResponse) ProtoMessage() {}
 
 func (x *IssueScopedBotCertsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -385,7 +542,7 @@ type Certs struct {
 
 func (x *Certs) Reset() {
 	*x = Certs{}
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -397,7 +554,7 @@ func (x *Certs) String() string {
 func (*Certs) ProtoMessage() {}
 
 func (x *Certs) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -458,14 +615,21 @@ var File_teleport_issuance_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_issuance_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\"teleport/issuance/v1/service.proto\x12\x14teleport.issuance.v1\x1a\x1egoogle/protobuf/duration.proto\"\xe1\x01\n" +
+	"\"teleport/issuance/v1/service.proto\x12\x14teleport.issuance.v1\x1a\x1egoogle/protobuf/duration.proto\"\x95\x02\n" +
 	"\x1aIssueScopedBotCertsRequest\x12$\n" +
 	"\x0essh_public_key\x18\x01 \x01(\fR\fsshPublicKey\x12$\n" +
 	"\x0etls_public_key\x18\x02 \x01(\fR\ftlsPublicKey\x12+\n" +
 	"\x03ttl\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x03ttl\x12A\n" +
-	"\bidentity\x18\x04 \x01(\v2#.teleport.issuance.v1.UsageIdentityH\x00R\bidentityB\a\n" +
+	"\bidentity\x18\x04 \x01(\v2#.teleport.issuance.v1.UsageIdentityH\x00R\bidentity\x122\n" +
+	"\x03app\x18\x05 \x01(\v2\x1e.teleport.issuance.v1.UsageAppH\x00R\x03appB\a\n" +
 	"\x05usage\"\x0f\n" +
-	"\rUsageIdentity\"P\n" +
+	"\rUsageIdentity\"x\n" +
+	"\bUsageApp\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
+	"\vpublic_addr\x18\x02 \x01(\tR\n" +
+	"publicAddr\x12!\n" +
+	"\fcluster_name\x18\x03 \x01(\tR\vclusterName\x12\x14\n" +
+	"\x05scope\x18\x04 \x01(\tR\x05scope\"P\n" +
 	"\x1bIssueScopedBotCertsResponse\x121\n" +
 	"\x05certs\x18\x01 \x01(\v2\x1b.teleport.issuance.v1.CertsR\x05certs\"+\n" +
 	"\x05Certs\x12\x10\n" +
@@ -474,25 +638,27 @@ const file_teleport_issuance_v1_service_proto_rawDesc = "" +
 	"\x0fIssuanceService\x12z\n" +
 	"\x13IssueScopedBotCerts\x120.teleport.issuance.v1.IssueScopedBotCertsRequest\x1a1.teleport.issuance.v1.IssueScopedBotCertsResponseBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1;issuancev1pbb\x06proto3"
 
-var file_teleport_issuance_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_teleport_issuance_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_teleport_issuance_v1_service_proto_goTypes = []any{
 	(*IssueScopedBotCertsRequest)(nil),  // 0: teleport.issuance.v1.IssueScopedBotCertsRequest
 	(*UsageIdentity)(nil),               // 1: teleport.issuance.v1.UsageIdentity
-	(*IssueScopedBotCertsResponse)(nil), // 2: teleport.issuance.v1.IssueScopedBotCertsResponse
-	(*Certs)(nil),                       // 3: teleport.issuance.v1.Certs
-	(*durationpb.Duration)(nil),         // 4: google.protobuf.Duration
+	(*UsageApp)(nil),                    // 2: teleport.issuance.v1.UsageApp
+	(*IssueScopedBotCertsResponse)(nil), // 3: teleport.issuance.v1.IssueScopedBotCertsResponse
+	(*Certs)(nil),                       // 4: teleport.issuance.v1.Certs
+	(*durationpb.Duration)(nil),         // 5: google.protobuf.Duration
 }
 var file_teleport_issuance_v1_service_proto_depIdxs = []int32{
-	4, // 0: teleport.issuance.v1.IssueScopedBotCertsRequest.ttl:type_name -> google.protobuf.Duration
+	5, // 0: teleport.issuance.v1.IssueScopedBotCertsRequest.ttl:type_name -> google.protobuf.Duration
 	1, // 1: teleport.issuance.v1.IssueScopedBotCertsRequest.identity:type_name -> teleport.issuance.v1.UsageIdentity
-	3, // 2: teleport.issuance.v1.IssueScopedBotCertsResponse.certs:type_name -> teleport.issuance.v1.Certs
-	0, // 3: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:input_type -> teleport.issuance.v1.IssueScopedBotCertsRequest
-	2, // 4: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:output_type -> teleport.issuance.v1.IssueScopedBotCertsResponse
-	4, // [4:5] is the sub-list for method output_type
-	3, // [3:4] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	2, // 2: teleport.issuance.v1.IssueScopedBotCertsRequest.app:type_name -> teleport.issuance.v1.UsageApp
+	4, // 3: teleport.issuance.v1.IssueScopedBotCertsResponse.certs:type_name -> teleport.issuance.v1.Certs
+	0, // 4: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:input_type -> teleport.issuance.v1.IssueScopedBotCertsRequest
+	3, // 5: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:output_type -> teleport.issuance.v1.IssueScopedBotCertsResponse
+	5, // [5:6] is the sub-list for method output_type
+	4, // [4:5] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_teleport_issuance_v1_service_proto_init() }
@@ -502,6 +668,7 @@ func file_teleport_issuance_v1_service_proto_init() {
 	}
 	file_teleport_issuance_v1_service_proto_msgTypes[0].OneofWrappers = []any{
 		(*IssueScopedBotCertsRequest_Identity)(nil),
+		(*IssueScopedBotCertsRequest_App)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -509,7 +676,7 @@ func file_teleport_issuance_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_issuance_v1_service_proto_rawDesc), len(file_teleport_issuance_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/issuance/v1/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/issuance/v1/service_protoopaque.pb.go
@@ -103,6 +103,15 @@ func (x *IssueScopedBotCertsRequest) GetIdentity() *UsageIdentity {
 	return nil
 }
 
+func (x *IssueScopedBotCertsRequest) GetApp() *UsageApp {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Usage.(*issueScopedBotCertsRequest_App); ok {
+			return x.App
+		}
+	}
+	return nil
+}
+
 func (x *IssueScopedBotCertsRequest) SetSshPublicKey(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -129,6 +138,14 @@ func (x *IssueScopedBotCertsRequest) SetIdentity(v *UsageIdentity) {
 	x.xxx_hidden_Usage = &issueScopedBotCertsRequest_Identity{v}
 }
 
+func (x *IssueScopedBotCertsRequest) SetApp(v *UsageApp) {
+	if v == nil {
+		x.xxx_hidden_Usage = nil
+		return
+	}
+	x.xxx_hidden_Usage = &issueScopedBotCertsRequest_App{v}
+}
+
 func (x *IssueScopedBotCertsRequest) HasTtl() bool {
 	if x == nil {
 		return false
@@ -151,6 +168,14 @@ func (x *IssueScopedBotCertsRequest) HasIdentity() bool {
 	return ok
 }
 
+func (x *IssueScopedBotCertsRequest) HasApp() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Usage.(*issueScopedBotCertsRequest_App)
+	return ok
+}
+
 func (x *IssueScopedBotCertsRequest) ClearTtl() {
 	x.xxx_hidden_Ttl = nil
 }
@@ -165,8 +190,15 @@ func (x *IssueScopedBotCertsRequest) ClearIdentity() {
 	}
 }
 
+func (x *IssueScopedBotCertsRequest) ClearApp() {
+	if _, ok := x.xxx_hidden_Usage.(*issueScopedBotCertsRequest_App); ok {
+		x.xxx_hidden_Usage = nil
+	}
+}
+
 const IssueScopedBotCertsRequest_Usage_not_set_case case_IssueScopedBotCertsRequest_Usage = 0
 const IssueScopedBotCertsRequest_Identity_case case_IssueScopedBotCertsRequest_Usage = 4
+const IssueScopedBotCertsRequest_App_case case_IssueScopedBotCertsRequest_Usage = 5
 
 func (x *IssueScopedBotCertsRequest) WhichUsage() case_IssueScopedBotCertsRequest_Usage {
 	if x == nil {
@@ -175,6 +207,8 @@ func (x *IssueScopedBotCertsRequest) WhichUsage() case_IssueScopedBotCertsReques
 	switch x.xxx_hidden_Usage.(type) {
 	case *issueScopedBotCertsRequest_Identity:
 		return IssueScopedBotCertsRequest_Identity_case
+	case *issueScopedBotCertsRequest_App:
+		return IssueScopedBotCertsRequest_App_case
 	default:
 		return IssueScopedBotCertsRequest_Usage_not_set_case
 	}
@@ -199,6 +233,7 @@ type IssueScopedBotCertsRequest_builder struct {
 
 	// Fields of oneof xxx_hidden_Usage:
 	Identity *UsageIdentity
+	App      *UsageApp
 	// -- end of xxx_hidden_Usage
 }
 
@@ -211,6 +246,9 @@ func (b0 IssueScopedBotCertsRequest_builder) Build() *IssueScopedBotCertsRequest
 	x.xxx_hidden_Ttl = b.Ttl
 	if b.Identity != nil {
 		x.xxx_hidden_Usage = &issueScopedBotCertsRequest_Identity{b.Identity}
+	}
+	if b.App != nil {
+		x.xxx_hidden_Usage = &issueScopedBotCertsRequest_App{b.App}
 	}
 	return m0
 }
@@ -233,7 +271,13 @@ type issueScopedBotCertsRequest_Identity struct {
 	Identity *UsageIdentity `protobuf:"bytes,4,opt,name=identity,proto3,oneof"`
 }
 
+type issueScopedBotCertsRequest_App struct {
+	App *UsageApp `protobuf:"bytes,5,opt,name=app,proto3,oneof"`
+}
+
 func (*issueScopedBotCertsRequest_Identity) isIssueScopedBotCertsRequest_Usage() {}
+
+func (*issueScopedBotCertsRequest_App) isIssueScopedBotCertsRequest_Usage() {}
 
 // The simplest possible usage mode for a certificate, returning certificates
 // appropriate for SSH or API authn.
@@ -280,6 +324,112 @@ func (b0 UsageIdentity_builder) Build() *UsageIdentity {
 	return m0
 }
 
+// UsageApp defines the mode
+type UsageApp struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name        string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_PublicAddr  string                 `protobuf:"bytes,2,opt,name=public_addr,json=publicAddr,proto3"`
+	xxx_hidden_ClusterName string                 `protobuf:"bytes,3,opt,name=cluster_name,json=clusterName,proto3"`
+	xxx_hidden_Scope       string                 `protobuf:"bytes,4,opt,name=scope,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *UsageApp) Reset() {
+	*x = UsageApp{}
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UsageApp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UsageApp) ProtoMessage() {}
+
+func (x *UsageApp) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UsageApp) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *UsageApp) GetPublicAddr() string {
+	if x != nil {
+		return x.xxx_hidden_PublicAddr
+	}
+	return ""
+}
+
+func (x *UsageApp) GetClusterName() string {
+	if x != nil {
+		return x.xxx_hidden_ClusterName
+	}
+	return ""
+}
+
+func (x *UsageApp) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
+func (x *UsageApp) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *UsageApp) SetPublicAddr(v string) {
+	x.xxx_hidden_PublicAddr = v
+}
+
+func (x *UsageApp) SetClusterName(v string) {
+	x.xxx_hidden_ClusterName = v
+}
+
+func (x *UsageApp) SetScope(v string) {
+	x.xxx_hidden_Scope = v
+}
+
+type UsageApp_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// name is the name of the application to route to.
+	// Must resolve to an application within the scope to which
+	// the calling bot is pinned.
+	Name string
+	// public_addr is the application public address.
+	PublicAddr string
+	// cluster_name is the cluster where the application resides.
+	ClusterName string
+	// scope is the scope of the target application.
+	Scope string
+}
+
+func (b0 UsageApp_builder) Build() *UsageApp {
+	m0 := &UsageApp{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_PublicAddr = b.PublicAddr
+	x.xxx_hidden_ClusterName = b.ClusterName
+	x.xxx_hidden_Scope = b.Scope
+	return m0
+}
+
 // Response for IssueScopedBotCerts
 type IssueScopedBotCertsResponse struct {
 	state            protoimpl.MessageState `protogen:"opaque.v1"`
@@ -290,7 +440,7 @@ type IssueScopedBotCertsResponse struct {
 
 func (x *IssueScopedBotCertsResponse) Reset() {
 	*x = IssueScopedBotCertsResponse{}
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -302,7 +452,7 @@ func (x *IssueScopedBotCertsResponse) String() string {
 func (*IssueScopedBotCertsResponse) ProtoMessage() {}
 
 func (x *IssueScopedBotCertsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -361,7 +511,7 @@ type Certs struct {
 
 func (x *Certs) Reset() {
 	*x = Certs{}
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -373,7 +523,7 @@ func (x *Certs) String() string {
 func (*Certs) ProtoMessage() {}
 
 func (x *Certs) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -434,14 +584,21 @@ var File_teleport_issuance_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_issuance_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\"teleport/issuance/v1/service.proto\x12\x14teleport.issuance.v1\x1a\x1egoogle/protobuf/duration.proto\"\xe1\x01\n" +
+	"\"teleport/issuance/v1/service.proto\x12\x14teleport.issuance.v1\x1a\x1egoogle/protobuf/duration.proto\"\x95\x02\n" +
 	"\x1aIssueScopedBotCertsRequest\x12$\n" +
 	"\x0essh_public_key\x18\x01 \x01(\fR\fsshPublicKey\x12$\n" +
 	"\x0etls_public_key\x18\x02 \x01(\fR\ftlsPublicKey\x12+\n" +
 	"\x03ttl\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x03ttl\x12A\n" +
-	"\bidentity\x18\x04 \x01(\v2#.teleport.issuance.v1.UsageIdentityH\x00R\bidentityB\a\n" +
+	"\bidentity\x18\x04 \x01(\v2#.teleport.issuance.v1.UsageIdentityH\x00R\bidentity\x122\n" +
+	"\x03app\x18\x05 \x01(\v2\x1e.teleport.issuance.v1.UsageAppH\x00R\x03appB\a\n" +
 	"\x05usage\"\x0f\n" +
-	"\rUsageIdentity\"P\n" +
+	"\rUsageIdentity\"x\n" +
+	"\bUsageApp\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
+	"\vpublic_addr\x18\x02 \x01(\tR\n" +
+	"publicAddr\x12!\n" +
+	"\fcluster_name\x18\x03 \x01(\tR\vclusterName\x12\x14\n" +
+	"\x05scope\x18\x04 \x01(\tR\x05scope\"P\n" +
 	"\x1bIssueScopedBotCertsResponse\x121\n" +
 	"\x05certs\x18\x01 \x01(\v2\x1b.teleport.issuance.v1.CertsR\x05certs\"+\n" +
 	"\x05Certs\x12\x10\n" +
@@ -450,25 +607,27 @@ const file_teleport_issuance_v1_service_proto_rawDesc = "" +
 	"\x0fIssuanceService\x12z\n" +
 	"\x13IssueScopedBotCerts\x120.teleport.issuance.v1.IssueScopedBotCertsRequest\x1a1.teleport.issuance.v1.IssueScopedBotCertsResponseBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1;issuancev1pbb\x06proto3"
 
-var file_teleport_issuance_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_teleport_issuance_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_teleport_issuance_v1_service_proto_goTypes = []any{
 	(*IssueScopedBotCertsRequest)(nil),  // 0: teleport.issuance.v1.IssueScopedBotCertsRequest
 	(*UsageIdentity)(nil),               // 1: teleport.issuance.v1.UsageIdentity
-	(*IssueScopedBotCertsResponse)(nil), // 2: teleport.issuance.v1.IssueScopedBotCertsResponse
-	(*Certs)(nil),                       // 3: teleport.issuance.v1.Certs
-	(*durationpb.Duration)(nil),         // 4: google.protobuf.Duration
+	(*UsageApp)(nil),                    // 2: teleport.issuance.v1.UsageApp
+	(*IssueScopedBotCertsResponse)(nil), // 3: teleport.issuance.v1.IssueScopedBotCertsResponse
+	(*Certs)(nil),                       // 4: teleport.issuance.v1.Certs
+	(*durationpb.Duration)(nil),         // 5: google.protobuf.Duration
 }
 var file_teleport_issuance_v1_service_proto_depIdxs = []int32{
-	4, // 0: teleport.issuance.v1.IssueScopedBotCertsRequest.ttl:type_name -> google.protobuf.Duration
+	5, // 0: teleport.issuance.v1.IssueScopedBotCertsRequest.ttl:type_name -> google.protobuf.Duration
 	1, // 1: teleport.issuance.v1.IssueScopedBotCertsRequest.identity:type_name -> teleport.issuance.v1.UsageIdentity
-	3, // 2: teleport.issuance.v1.IssueScopedBotCertsResponse.certs:type_name -> teleport.issuance.v1.Certs
-	0, // 3: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:input_type -> teleport.issuance.v1.IssueScopedBotCertsRequest
-	2, // 4: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:output_type -> teleport.issuance.v1.IssueScopedBotCertsResponse
-	4, // [4:5] is the sub-list for method output_type
-	3, // [3:4] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	2, // 2: teleport.issuance.v1.IssueScopedBotCertsRequest.app:type_name -> teleport.issuance.v1.UsageApp
+	4, // 3: teleport.issuance.v1.IssueScopedBotCertsResponse.certs:type_name -> teleport.issuance.v1.Certs
+	0, // 4: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:input_type -> teleport.issuance.v1.IssueScopedBotCertsRequest
+	3, // 5: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:output_type -> teleport.issuance.v1.IssueScopedBotCertsResponse
+	5, // [5:6] is the sub-list for method output_type
+	4, // [4:5] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_teleport_issuance_v1_service_proto_init() }
@@ -478,6 +637,7 @@ func file_teleport_issuance_v1_service_proto_init() {
 	}
 	file_teleport_issuance_v1_service_proto_msgTypes[0].OneofWrappers = []any{
 		(*issueScopedBotCertsRequest_Identity)(nil),
+		(*issueScopedBotCertsRequest_App)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -485,7 +645,7 @@ func file_teleport_issuance_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_issuance_v1_service_proto_rawDesc), len(file_teleport_issuance_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/issuance/v1/service.proto
+++ b/api/proto/teleport/issuance/v1/service.proto
@@ -65,6 +65,7 @@ message IssueScopedBotCertsRequest {
   // any usage-specific options. At least one of the usage values must be set.
   oneof usage {
     UsageIdentity identity = 4;
+    UsageApp app = 5;
   }
 }
 
@@ -72,6 +73,23 @@ message IssueScopedBotCertsRequest {
 // appropriate for SSH or API authn.
 message UsageIdentity {
   // Reserved for future identity-usage-specific options.
+}
+
+// UsageApp defines the mode
+message UsageApp {
+  // name is the name of the application to route to.
+  // Must resolve to an application within the scope to which
+  // the calling bot is pinned.
+  string name = 1;
+
+  // public_addr is the application public address.
+  string public_addr = 2;
+
+  // cluster_name is the cluster where the application resides.
+  string cluster_name = 3;
+
+  // scope is the scope of the target application.
+  string scope = 4;
 }
 
 // Response for IssueScopedBotCerts

--- a/lib/auth/issuance/v1/service.go
+++ b/lib/auth/issuance/v1/service.go
@@ -20,6 +20,7 @@ package issuancev1
 
 import (
 	"context"
+	"iter"
 
 	"github.com/gravitational/trace"
 
@@ -27,6 +28,7 @@ import (
 	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/internal/cert"
+	sessionreq "github.com/gravitational/teleport/lib/auth/internal/session"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -36,6 +38,8 @@ import (
 type authServer interface {
 	AccessCheckerForScope(ctx context.Context, scope string, userState services.UserState, allowedResourceAccessIDs []types.ResourceAccessID) (*services.ScopedAccessCheckerContext, error)
 	GenerateUserCerts(ctx context.Context, req cert.Request) (*proto.Certs, error)
+	CreateAppSessionFromReq(ctx context.Context, req sessionreq.NewAppSessionRequest) (types.WebSession, error)
+	RangeApplicationServersWithName(ctx context.Context, appName string) iter.Seq2[types.AppServer, error]
 }
 
 // Service implements teleport.issuance.v1.IssuanceService
@@ -128,7 +132,11 @@ func (s *Service) IssueScopedBotCerts(
 
 	switch req.WhichUsage() {
 	case issuancev1pb.IssueScopedBotCertsRequest_Identity_case:
-	// no special handling.
+		// no special handling.
+	case issuancev1pb.IssueScopedBotCertsRequest_App_case:
+		if err := validateUsageApp(req); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	default:
 		return nil, trace.BadParameter(
 			"unsupported or unspecified usage variant",
@@ -202,17 +210,6 @@ func (s *Service) IssueScopedBotCerts(
 		SSHPublicKey:   req.GetSshPublicKey(),
 		TLSPublicKey:   req.GetTlsPublicKey(),
 
-		// Explicitly set BotInternal to false as these certs are intended for
-		// outputs/services and not use by the bot internally. This prevents
-		// using them further issuance.
-		BotInternal: false,
-		// Explicitly reject use for further issuance
-		DisallowReissue: true,
-
-		// We do not pass traits from the Bot user here. This is because we do
-		// not currently support traits for scoped Bots. Users shouldn't be able
-		// to set these due to validation but this acts as a back-stop.
-
 		// Propagate certain attributes from current identity to generated
 		// certificates
 		JoinAttributes: currentIdentity.JoinAttributes,
@@ -225,6 +222,31 @@ func (s *Service) IssueScopedBotCerts(
 		BotScope:  botScope,
 		JoinToken: currentIdentity.JoinToken,
 	}
+
+	// Apply per-usage alterations to the cert request.
+	switch req.WhichUsage() {
+	case issuancev1pb.IssueScopedBotCertsRequest_App_case:
+		// The app session is created with its own scoped access checker, built
+		// internally in CreateAppSessionFromReq from the caller's pin.
+		// That checker authorizes the session certificate stored on
+		// the WebSession, while certReq.CheckerContext authorizes the output certificate
+		// returned to the caller. Both resolve assignments live, so they should
+		// always agree, but they are constructed by separate paths.
+		if err := s.applyUsageApp(ctx, user, botScope, currentIdentity, req.GetApp(), ttl, &certReq); err != nil {
+			return nil, trace.Wrap(err, "configuring App Usage into the certificate request")
+		}
+	}
+
+	// Explicitly set BotInternal to false as these certs are intended for
+	// outputs/services and not use by the bot internally. This prevents
+	// using them further issuance.
+	certReq.BotInternal = false
+	// Explicitly reject use for further issuance
+	certReq.DisallowReissue = true
+	// We do not pass traits from the Bot user here. This is because we do
+	// not currently support traits for scoped Bots. Users shouldn't be able
+	// to set these due to validation but this acts as a back-stop.
+	certReq.Traits = nil
 
 	// nb(strideynet): One day, we'll want to pull more of the logic around
 	// cert generation into this package rather than invoking this via the

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -35,6 +35,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -46,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -80,7 +82,7 @@ func newTestTLSServerWithScopesFeatures(t testing.TB, scopesFeatures scopes.Feat
 	return srv
 }
 
-func TestIssueScopedBotCerts(t *testing.T) {
+func TestIssueScopedBotCerts_UsageIdentity(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -488,6 +490,536 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 			trace.IsAccessDenied(err),
 			"expected access denied, got: %v", err,
 		)
+	})
+}
+
+func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	srv := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+
+	const botScope = "/test-scope"
+
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adminClient.Close() })
+
+	// Create a scoped role with app access.
+	scopedSvc := adminClient.ScopedAccessServiceClient()
+	_, err = scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "bot-role",
+			}.Build(),
+			Scope: botScope,
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{botScope},
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					Labels: []*labelv1.Label{
+						labelv1.Label_builder{
+							Name:   types.Wildcard,
+							Values: []string{types.Wildcard},
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Create a scoped bot.
+	bot, err := adminClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		Bot: machineidv1pb.Bot_builder{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "test-bot",
+			}.Build(),
+			Scope: botScope,
+			Spec:  &machineidv1pb.BotSpec{},
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Create a scoped role assignment for the bot.
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: uuid.NewString(),
+			}.Build(),
+			Scope: botScope,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}.String(),
+				Assignments: []*scopedaccessv1.Assignment{
+					scopedaccessv1.Assignment_builder{Role: botScope + "::bot-role", Scope: botScope}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
+	// Create a scoped app and register it.
+	app, err := types.NewAppV3(types.Metadata{
+		Name: "test-app",
+	}, types.AppSpecV3{
+		URI:        "http://localhost:8080",
+		PublicAddr: scopedapp.ScopedAppPublicAddr(botScope, "test-app", "proxy.example.com"),
+	})
+	require.NoError(t, err)
+	app.Scope = botScope
+	appServer, err := types.NewAppServerV3FromApp(app, "test-app-host", "test-app-hostid")
+	require.NoError(t, err)
+	appServer.Scope = botScope
+	_, err = srv.Auth().UpsertApplicationServer(ctx, appServer)
+	require.NoError(t, err)
+
+	// Create a client with a scoped bot internal identity.
+	botClient, err := srv.NewClient(
+		authtest.TestScopedBot(bot.GetMetadata().GetName(), botScope, true),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = botClient.Close() })
+
+	// Generate a key pair for the request.
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	tlsPubKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	require.NoError(t, err)
+	sshPubKey, err := ssh.NewPublicKey(key.Public())
+	require.NoError(t, err)
+	sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+
+	issuanceClient := issuancev1pb.NewIssuanceServiceClient(botClient.GetConnection())
+	requestedTTL := time.Hour
+
+	t.Run("success", func(t *testing.T) {
+		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			SshPublicKey: sshPubKeyBytes,
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "test-app",
+				PublicAddr:  app.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       botScope,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCerts())
+		require.NotEmpty(t, resp.GetCerts().GetTls())
+
+		// Parse the returned TLS cert and verify app-specific identity properties.
+		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+
+		assert.False(t, identity.BotInternal, "output cert should not be bot-internal")
+		assert.True(t, identity.DisallowReissue, "output cert should disallow reissue")
+		assert.Equal(t, "test-bot", identity.BotName)
+		assert.Equal(t, "test-app", identity.RouteToApp.Name)
+		assert.Equal(t, app.GetPublicAddr(), identity.RouteToApp.PublicAddr)
+		assert.Equal(t, srv.ClusterName(), identity.RouteToApp.ClusterName)
+		assert.NotEmpty(t, identity.RouteToApp.SessionID, "app session should have been created")
+		assert.Equal(t, botScope, identity.RouteToApp.Scope)
+	})
+
+	t.Run("missing app name rejected", func(t *testing.T) {
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Scope: botScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+		require.ErrorContains(t, err, "app.name: is required")
+	})
+
+	t.Run("invalid scope rejected", func(t *testing.T) {
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:  "test-app",
+				Scope: "not-a-scope",
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+		require.ErrorContains(t, err, "app.scope")
+	})
+
+	t.Run("tls public key required for app usage", func(t *testing.T) {
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			SshPublicKey: sshPubKeyBytes,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "test-app",
+				PublicAddr:  app.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       botScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+		require.ErrorContains(t, err, "tls_public_key is required for app usage")
+	})
+
+	t.Run("app scope outside pinned scope rejected", func(t *testing.T) {
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "test-app",
+				PublicAddr:  app.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       "/other-scope",
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+
+	t.Run("app not found in scope rejected", func(t *testing.T) {
+		// Request an app that does not exist at all.
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "nonexistent-app",
+				PublicAddr:  "nonexistent-app.example.com",
+				ClusterName: srv.ClusterName(),
+				Scope:       botScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsNotFound(err), "expected not found, got: %v", err)
+		require.ErrorContains(t, err, "nonexistent-app")
+	})
+
+	t.Run("app exists in sibling child scope rejected by lookup", func(t *testing.T) {
+		// Register an app in /test-scope/team-b (a child scope of the bot's
+		// pin). Then request it claiming scope /test-scope/team-a (a different
+		// child). The scope pin check passes for both (both are descendants
+		// of /test-scope), but the lookup must reject because the app server
+		// is registered in /test-scope/team-b, not /test-scope/team-a.
+		const (
+			actualScope    = "/test-scope/team-b"
+			requestedScope = "/test-scope/team-a"
+		)
+		siblingApp, err := types.NewAppV3(types.Metadata{
+			Name: "team-b-app",
+		}, types.AppSpecV3{
+			URI:        "http://localhost:9090",
+			PublicAddr: scopedapp.ScopedAppPublicAddr(actualScope, "team-b-app", "proxy.example.com"),
+		})
+		require.NoError(t, err)
+		siblingApp.Scope = actualScope
+		siblingAppServer, err := types.NewAppServerV3FromApp(siblingApp, "team-b-host", "team-b-hostid")
+		require.NoError(t, err)
+		siblingAppServer.Scope = actualScope
+		_, err = srv.Auth().UpsertApplicationServer(ctx, siblingAppServer)
+		require.NoError(t, err)
+
+		// Request the app in the wrong sibling scope — scope pin passes
+		// but the app lookup finds no server matching /test-scope/team-a.
+		_, err = issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "team-b-app",
+				PublicAddr:  siblingApp.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       requestedScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsNotFound(err), "expected not found when app is in sibling scope, got: %v", err)
+		require.ErrorContains(t, err, "team-b-app")
+		require.ErrorContains(t, err, requestedScope)
+	})
+
+	t.Run("app in scope but requested with wrong scope rejected", func(t *testing.T) {
+		// The app "test-app" lives in /test-scope. Request it claiming
+		// /test-scope/team-a (a child scope that the app is not in).
+		// The scope pin check passes (child of pinned scope), but the
+		// app lookup must fail because no app server matches that scope.
+		const childScope = "/test-scope/team-a"
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "test-app",
+				PublicAddr:  app.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       childScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsNotFound(err), "expected not found when scope doesn't match app's actual scope, got: %v", err)
+		require.ErrorContains(t, err, "test-app")
+		require.ErrorContains(t, err, childScope)
+	})
+
+	t.Run("identity center account app rejected", func(t *testing.T) {
+		// Register an Identity Center account app in the bot's scope.
+		icApp, err := types.NewAppV3(types.Metadata{
+			Name: "ic-account-app",
+		}, types.AppSpecV3{
+			URI:        "http://localhost:7070",
+			PublicAddr: scopedapp.ScopedAppPublicAddr(botScope, "ic-account-app", "proxy.example.com"),
+		})
+		require.NoError(t, err)
+		icApp.SetSubKind(types.KindIdentityCenterAccount)
+		icApp.Scope = botScope
+		icAppServer, err := types.NewAppServerV3FromApp(icApp, "ic-host", "ic-hostid")
+		require.NoError(t, err)
+		icAppServer.Scope = botScope
+		_, err = srv.Auth().UpsertApplicationServer(ctx, icAppServer)
+		require.NoError(t, err)
+
+		_, err = issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "ic-account-app",
+				PublicAddr:  icApp.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       botScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter for IC account app, got: %v", err)
+		require.ErrorContains(t, err, "Identity Center")
+	})
+}
+
+// TestIssueScopedBotCerts_UsageApp_ScopeHierarchy tests scope matching
+// behavior in detail: exact matches, descendant scopes, and narrower bot
+// scope scenarios.
+func TestIssueScopedBotCerts_UsageApp_ScopeHierarchy(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	srv := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+
+	const (
+		parentScope = "/testing"
+		childScope  = "/testing/team-a"
+	)
+
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adminClient.Close() })
+
+	scopedSvc := adminClient.ScopedAccessServiceClient()
+
+	// Create scoped roles at both levels with wildcard app access.
+	for _, scope := range []string{parentScope, childScope} {
+		_, err = scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+			Role: scopedaccessv1.ScopedRole_builder{
+				Kind:    scopedaccess.KindScopedRole,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: "app-role",
+				}.Build(),
+				Scope: scope,
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{scope},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						Labels: []*labelv1.Label{
+							labelv1.Label_builder{
+								Name:   types.Wildcard,
+								Values: []string{types.Wildcard},
+							}.Build(),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+	}
+
+	// Register apps at both scope levels.
+	parentApp, err := types.NewAppV3(types.Metadata{
+		Name: "parent-app",
+	}, types.AppSpecV3{
+		URI:        "http://localhost:8081",
+		PublicAddr: scopedapp.ScopedAppPublicAddr(parentScope, "parent-app", "proxy.example.com"),
+	})
+	require.NoError(t, err)
+	parentApp.Scope = parentScope
+	parentAppServer, err := types.NewAppServerV3FromApp(parentApp, "parent-host", "parent-hostid")
+	require.NoError(t, err)
+	parentAppServer.Scope = parentScope
+	_, err = srv.Auth().UpsertApplicationServer(ctx, parentAppServer)
+	require.NoError(t, err)
+
+	childApp, err := types.NewAppV3(types.Metadata{
+		Name: "child-app",
+	}, types.AppSpecV3{
+		URI:        "http://localhost:8082",
+		PublicAddr: scopedapp.ScopedAppPublicAddr(childScope, "child-app", "proxy.example.com"),
+	})
+	require.NoError(t, err)
+	childApp.Scope = childScope
+	childAppServer, err := types.NewAppServerV3FromApp(childApp, "child-host", "child-hostid")
+	require.NoError(t, err)
+	childAppServer.Scope = childScope
+	_, err = srv.Auth().UpsertApplicationServer(ctx, childAppServer)
+	require.NoError(t, err)
+
+	// Helper to create a bot+SRA+client pinned to a given scope.
+	setupBot := func(t *testing.T, botName, botScope, roleScope string) issuancev1pb.IssuanceServiceClient {
+		t.Helper()
+
+		bot, err := adminClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+			Bot: machineidv1pb.Bot_builder{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: botName,
+				}.Build(),
+				Scope: botScope,
+				Spec:  &machineidv1pb.BotSpec{},
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+
+		sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+				Kind:    scopedaccess.KindScopedRoleAssignment,
+				SubKind: scopedaccess.SubKindDynamic,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: uuid.NewString(),
+				}.Build(),
+				Scope: botScope,
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					Bot: scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}.String(),
+					Assignments: []*scopedaccessv1.Assignment{
+						scopedaccessv1.Assignment_builder{
+							Role:  scopes.QualifiedName{Scope: roleScope, Name: "app-role"}.String(),
+							Scope: roleScope,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		waitForSRACache(t, srv, sraResp)
+
+		botClient, err := srv.NewClient(
+			authtest.TestScopedBot(bot.GetMetadata().GetName(), botScope, true),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = botClient.Close() })
+
+		return issuancev1pb.NewIssuanceServiceClient(botClient.GetConnection())
+	}
+
+	// Generate a key pair shared across sub-tests.
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	tlsPubKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	require.NoError(t, err)
+	requestedTTL := time.Hour
+
+	t.Run("parent-scoped bot accesses parent-scope app (exact match)", func(t *testing.T) {
+		issuanceClient := setupBot(t, "parent-bot-exact", parentScope, parentScope)
+
+		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "parent-app",
+				PublicAddr:  parentApp.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       parentScope,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCerts())
+		require.NotEmpty(t, resp.GetCerts().GetTls())
+
+		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+		assert.Equal(t, "parent-app", identity.RouteToApp.Name)
+		assert.Equal(t, parentScope, identity.RouteToApp.Scope)
+	})
+
+	t.Run("parent-scoped bot accesses child-scope app (descendant)", func(t *testing.T) {
+		// Bot pinned to /testing can access app in /testing/team-a
+		// because /testing/team-a is a descendant of /testing.
+		issuanceClient := setupBot(t, "parent-bot-child", parentScope, parentScope)
+
+		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "child-app",
+				PublicAddr:  childApp.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       childScope,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCerts())
+		require.NotEmpty(t, resp.GetCerts().GetTls())
+
+		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+		assert.Equal(t, "child-app", identity.RouteToApp.Name)
+		assert.Equal(t, childScope, identity.RouteToApp.Scope)
+	})
+
+	t.Run("child-scoped bot rejected at scope pin for parent-scope app", func(t *testing.T) {
+		// Bot pinned to /testing/team-a requests an app in /testing.
+		// /testing is NOT a descendant of /testing/team-a, so the scope
+		// pin check rejects immediately — the app is never fetched.
+		issuanceClient := setupBot(t, "child-bot-parent", childScope, childScope)
+
+		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "parent-app",
+				PublicAddr:  parentApp.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       parentScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied at scope pin check, got: %v", err)
+	})
+
+	t.Run("child-scoped bot accesses child-scope app (exact match)", func(t *testing.T) {
+		issuanceClient := setupBot(t, "child-bot-exact", childScope, childScope)
+
+		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:        "child-app",
+				PublicAddr:  childApp.GetPublicAddr(),
+				ClusterName: srv.ClusterName(),
+				Scope:       childScope,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCerts())
+		require.NotEmpty(t, resp.GetCerts().GetTls())
+
+		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+		assert.Equal(t, "child-app", identity.RouteToApp.Name)
+		assert.Equal(t, childScope, identity.RouteToApp.Scope)
 	})
 }
 

--- a/lib/auth/issuance/v1/usage_app.go
+++ b/lib/auth/issuance/v1/usage_app.go
@@ -1,0 +1,132 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package issuancev1
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+
+	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/internal/cert"
+	sessionreq "github.com/gravitational/teleport/lib/auth/internal/session"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+// applyUsageApp will create a new scoped session with the application and
+// append to the cert.Request the relevant information.
+func (s *Service) applyUsageApp(
+	ctx context.Context,
+	user types.User,
+	botScope string,
+	currentIdentity tlsca.Identity,
+	usageApp *issuancev1pb.UsageApp,
+	ttl time.Duration,
+	certReq *cert.Request,
+) error {
+	// Ensure the current identity has scope to perform this operation.
+	pinnedScope := currentIdentity.ScopePin.GetScope()
+	if !scopes.ResourceScope(usageApp.GetScope()).IsSubjectToScopeOfEffect(pinnedScope) {
+		return trace.AccessDenied("app scope %q is not equivalent to or descendant of pinned scope %q", usageApp.GetScope(), pinnedScope)
+	}
+
+	// Fetch the application to ensure it exists and that its scope matches.
+	// This is defense-in-depth and UX: it prevents issuing a cert+session
+	// that can never be used, and surfaces a clear error at issuance time
+	// rather than a confusing transport-layer failure later.
+	var app types.Application
+	for server, err := range s.authServer.RangeApplicationServersWithName(ctx, usageApp.GetName()) {
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		// It requires the exact scope match:
+		// If the UsageApp refers to /staging::abc, it should not match /stating/team-1::abc.
+		if server.GetScope() != usageApp.GetScope() {
+			continue
+		}
+		app = server.GetApp()
+		break
+	}
+	if app == nil {
+		return trace.NotFound("application %q in scope %q not found", usageApp.GetName(), usageApp.GetScope())
+	}
+
+	// Reject Identity Center account apps — they have special lifecycle
+	// management and should not be accessed through scoped bot certificates.
+	if app.GetSubKind() == types.KindIdentityCenterAccount {
+		return trace.BadParameter("Identity Center account applications cannot be accessed via scoped bot certificates")
+	}
+
+	// Create a new session.
+	ws, err := s.authServer.CreateAppSessionFromReq(ctx, sessionreq.NewAppSessionRequest{
+		NewWebSessionRequest: sessionreq.NewWebSessionRequest{
+			User:       user.GetName(),
+			LoginIP:    currentIdentity.LoginIP,
+			SessionTTL: ttl,
+			// No Traits, Roles, AccessRequests, or RequestedResourceAccessIDs:
+			// scoped bots have none, and CreateAppSessionFromReq rejects
+			// resource access IDs for scope-pinned identities.
+			AttestWebSession: false,
+		},
+
+		AppName:     usageApp.GetName(),
+		PublicAddr:  usageApp.GetPublicAddr(),
+		ClusterName: usageApp.GetClusterName(),
+		TargetScope: usageApp.GetScope(),
+
+		// Identity drives the scoped access checker context.
+		Identity:      currentIdentity,
+		BotName:       currentIdentity.BotName,
+		BotInstanceID: currentIdentity.BotInstanceID,
+		BotScope:      botScope,
+	})
+	if err != nil {
+		return trace.Wrap(err, "creating app session")
+	}
+
+	// Annotate the certificate with the session information.
+	certReq.Usage = []string{teleport.UsageAppsOnly}
+	certReq.AppSessionID = ws.GetName()
+	certReq.AppName = usageApp.GetName()
+	certReq.AppPublicAddr = usageApp.GetPublicAddr()
+	certReq.AppClusterName = usageApp.GetClusterName()
+	certReq.TargetScope = usageApp.GetScope()
+
+	return nil
+}
+
+func validateUsageApp(req *issuancev1pb.IssueScopedBotCertsRequest) error {
+	app := req.GetApp()
+	if app.GetName() == "" {
+		return trace.BadParameter("app.name: is required")
+	}
+	if err := scopes.StrongValidate(app.GetScope()); err != nil {
+		return trace.Wrap(err, "app.scope")
+	}
+	if len(req.GetTlsPublicKey()) == 0 {
+		return trace.BadParameter("tls_public_key is required for app usage")
+	}
+
+	return nil
+}

--- a/lib/tbot/identity/generator.go
+++ b/lib/tbot/identity/generator.go
@@ -440,16 +440,60 @@ func (g *Generator) generateDelegationCertificates(ctx context.Context, req prot
 	}, nil
 }
 
+// ScopedUsage is used to set the type of usage when issuing
+// scoped bot certificates.
+type ScopedUsage struct {
+	apply func(*issuancev1pb.IssueScopedBotCertsRequest)
+}
+
+// Validate checks that the ScopedUsage is valid for use.
+func (u *ScopedUsage) Validate() error {
+	if u == nil {
+		return trace.BadParameter("usage is undefined")
+	}
+	if u.apply == nil {
+		return trace.BadParameter("usage is incomplete: no apply set")
+	}
+	return nil
+}
+
+// UsageIdentity sets the IssueScopedBotCertsRequest.Usage to be of the UsageIdentity type.
+func UsageIdentity() *ScopedUsage {
+	return &ScopedUsage{
+		apply: func(req *issuancev1pb.IssueScopedBotCertsRequest) {
+			req.SetIdentity(&issuancev1pb.UsageIdentity{})
+		},
+	}
+}
+
+// UsageApp sets the IssueScopedBotCertsRequest.Usage to be of the UsageApp type.
+func UsageApp(route proto.RouteToApp) *ScopedUsage {
+	return &ScopedUsage{
+		apply: func(req *issuancev1pb.IssueScopedBotCertsRequest) {
+			req.SetApp(issuancev1pb.UsageApp_builder{
+				Name:        route.Name,
+				PublicAddr:  route.PublicAddr,
+				ClusterName: route.ClusterName,
+				Scope:       route.Scope,
+			}.Build())
+		},
+	}
+}
+
 // GenerateScoped generates scoped certificates. Bot must already be scoped/
 // hold a scoped identity.
 // TODO(noah): add optional args to this like for Generate.
 func (g *Generator) GenerateScoped(
-	ctx context.Context, ttl, renewalInterval time.Duration,
+	ctx context.Context, ttl, renewalInterval time.Duration, usage *ScopedUsage,
 ) (*Identity, error) {
+	if err := usage.Validate(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	req := issuancev1pb.IssueScopedBotCertsRequest_builder{
-		Ttl:      durationpb.New(ttl),
-		Identity: &issuancev1pb.UsageIdentity{},
+		Ttl: durationpb.New(ttl),
 	}.Build()
+	usage.apply(req)
 
 	keyPurpose := cryptosuites.BotImpersonatedIdentity
 	key, err := cryptosuites.GenerateKey(ctx,
@@ -526,9 +570,9 @@ func (g *Generator) GenerateScoped(
 // GenerateScopedFacade calls GenerateScoped and wraps the resulting Identity
 // in a Facade for easy use in API clients, etc.
 func (g *Generator) GenerateScopedFacade(
-	ctx context.Context, ttl, renewalInterval time.Duration,
+	ctx context.Context, ttl, renewalInterval time.Duration, usage *ScopedUsage,
 ) (*Facade, error) {
-	id, err := g.GenerateScoped(ctx, ttl, renewalInterval)
+	id, err := g.GenerateScoped(ctx, ttl, renewalInterval, usage)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tbot/identity/generator_test.go
+++ b/lib/tbot/identity/generator_test.go
@@ -1,0 +1,103 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package identity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
+)
+
+func TestScopedUsage(t *testing.T) {
+	t.Run("Existing types are valid", func(t *testing.T) {
+		testCases := map[string]*ScopedUsage{
+			"identity": UsageIdentity(),
+			"app":      UsageApp(proto.RouteToApp{}),
+		}
+
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				require.NoError(t, tc.Validate())
+			})
+		}
+	})
+
+	t.Run("Nil usage", func(t *testing.T) {
+		var scopedUsage *ScopedUsage
+
+		err := scopedUsage.Validate()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "usage is undefined")
+	})
+
+	t.Run("Empty usage", func(t *testing.T) {
+		scopedUsage := new(ScopedUsage)
+
+		err := scopedUsage.Validate()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "usage is incomplete")
+	})
+}
+
+func TestScopedUsage_Identity(t *testing.T) {
+	req := issuancev1pb.IssueScopedBotCertsRequest_builder{
+		Ttl: durationpb.New(time.Second),
+	}.Build()
+
+	require.Zero(t, req.WhichUsage())
+	require.Nil(t, req.GetIdentity())
+
+	usage := UsageIdentity()
+	usage.apply(req)
+
+	require.NotNil(t, req.GetIdentity())
+	require.Equal(t, issuancev1pb.IssueScopedBotCertsRequest_Identity_case, req.WhichUsage())
+}
+
+func TestScopedUsage_App(t *testing.T) {
+	req := issuancev1pb.IssueScopedBotCertsRequest_builder{
+		Ttl: durationpb.New(time.Second),
+	}.Build()
+
+	require.Zero(t, req.WhichUsage())
+	require.Nil(t, req.GetApp())
+
+	routeToApp := proto.RouteToApp{
+		Name:        "abc",
+		PublicAddr:  "remotehost",
+		ClusterName: "test-cluster",
+		Scope:       "/testing",
+	}
+	usage := UsageApp(routeToApp)
+	usage.apply(req)
+
+	require.Equal(t, issuancev1pb.IssueScopedBotCertsRequest_App_case, req.WhichUsage())
+	usageApp := req.GetApp()
+	require.NotNil(t, usageApp)
+	assert.Equal(t, routeToApp.Name, usageApp.Name)
+	assert.Equal(t, routeToApp.PublicAddr, usageApp.PublicAddr)
+	assert.Equal(t, routeToApp.ClusterName, usageApp.ClusterName)
+	assert.Equal(t, routeToApp.Scope, usageApp.Scope)
+}

--- a/lib/tbot/services/application/helpers_test.go
+++ b/lib/tbot/services/application/helpers_test.go
@@ -20,6 +20,7 @@ package application
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"net"
 	"os"
@@ -31,10 +32,13 @@ import (
 	"gopkg.in/yaml.v3"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/internal"
@@ -173,4 +177,32 @@ func defaultTestServerOpts(log *slog.Logger) testenv.TestServerOptFunc {
 
 		return nil
 	}
+}
+
+// makeScopedRole creates a scoped role that grants app access with wildcard labels.
+func makeScopedRole(t *testing.T, ctx context.Context, rootClient *authclient.Client, roleName, scopeName string) {
+	t.Helper()
+	scopedSvc := rootClient.ScopedAccessServiceClient()
+	_, err := scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: roleName,
+			}.Build(),
+			Scope: scopeName,
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scopeName},
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					Labels: []*labelv1.Label{
+						labelv1.Label_builder{
+							Name:   "*",
+							Values: []string{"*"},
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
 }

--- a/lib/tbot/services/application/output_config.go
+++ b/lib/tbot/services/application/output_config.go
@@ -65,9 +65,6 @@ func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
 	if err := internal.CheckDeprecatedRoles(o.DeprecatedRoles); err != nil {
 		return trace.Wrap(err)
 	}
-	if scoped {
-		return trace.BadParameter("service type %q is not supported in scoped mode", OutputServiceType)
-	}
 	if o.Destination == nil {
 		return trace.BadParameter("no destination configured for output")
 	}
@@ -76,6 +73,9 @@ func (o *OutputConfig) CheckAndSetDefaults(scoped bool) error {
 	}
 	if o.AppName == "" {
 		return trace.BadParameter("app_name must not be empty")
+	}
+	if scoped && o.DelegationSessionID != "" {
+		return trace.BadParameter("delegation_session_id: not supported with scopes")
 	}
 
 	return nil

--- a/lib/tbot/services/application/output_config_test.go
+++ b/lib/tbot/services/application/output_config_test.go
@@ -102,7 +102,18 @@ func TestApplicationOutput_CheckAndSetDefaults(t *testing.T) {
 					AppName:     "app",
 				}
 			},
-			wantErr: "is not supported in scoped mode",
+		},
+		{
+			name:   "scoped with delegation_session_id set",
+			scoped: true,
+			in: func() *OutputConfig {
+				return &OutputConfig{
+					Destination:         destination.NewMemory(),
+					AppName:             "app",
+					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
+				}
+			},
+			wantErr: "delegation_session_id: not supported with scopes",
 		},
 	}
 	testCheckAndSetDefaults(t, tests)

--- a/lib/tbot/services/application/output_service.go
+++ b/lib/tbot/services/application/output_service.go
@@ -53,6 +53,7 @@ func OutputServiceBuilder(cfg *OutputConfig, defaultCredentialLifetime bot.Crede
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
 			statusReporter:            deps.GetStatusReporter(),
+			scoped:                    deps.Scoped,
 		}
 		return svc, nil
 	}
@@ -72,6 +73,7 @@ type OutputService struct {
 	statusReporter            readyz.Reporter
 	identityGenerator         *identity.Generator
 	clientBuilder             *client.Builder
+	scoped                    bool
 }
 
 func (s *OutputService) String() string {
@@ -120,48 +122,17 @@ func (s *OutputService) generate(ctx context.Context) error {
 		return trace.Wrap(err, "verifying destination")
 	}
 
-	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
-	identityOpts := []identity.GenerateOption{
-		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
-		identity.WithLogger(s.log),
+	var routedIdentity *identity.Identity
+	var err error
+
+	if s.scoped {
+		routedIdentity, err = s.routedIdentityScoped(ctx)
+	} else {
+		routedIdentity, err = s.routedIdentityUnscoped(ctx)
 	}
-	if s.cfg.DelegationSessionID != "" {
-		identityOpts = append(identityOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
-	}
-	id, err := s.identityGenerator.GenerateFacade(ctx, identityOpts...)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer impersonatedClient.Close()
-
-	routeToApp, _, err := getRouteToApp(
-		ctx,
-		s.getBotIdentity(),
-		impersonatedClient,
-		s.cfg.AppName,
-	)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	routedIdentity, err := s.identityGenerator.Generate(ctx, append(identityOpts,
-		identity.WithCurrentIdentityFacade(id),
-		identity.WithRouteToApp(routeToApp),
-	)...)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	s.log.InfoContext(
-		ctx,
-		"Generated identity for app",
-		"app_name", routeToApp.Name,
-	)
 
 	hostCAs, err := s.botAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {
@@ -180,6 +151,91 @@ func (s *OutputService) generate(ctx context.Context) error {
 	}
 
 	return trace.Wrap(s.render(ctx, routedIdentity, hostCAs, userCAs, databaseCAs), "rendering")
+}
+
+func (s *OutputService) routedIdentityUnscoped(ctx context.Context) (*identity.Identity, error) {
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+	identityOpts := []identity.GenerateOption{
+		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
+		identity.WithLogger(s.log),
+	}
+	if s.cfg.DelegationSessionID != "" {
+		identityOpts = append(identityOpts, identity.WithDelegation(s.cfg.DelegationSessionID))
+	}
+	id, err := s.identityGenerator.GenerateFacade(ctx, identityOpts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	impersonatedClient, err := s.clientBuilder.Build(ctx, id)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer impersonatedClient.Close()
+
+	routeToApp, _, err := getRouteToApp(
+		ctx,
+		s.getBotIdentity(),
+		impersonatedClient,
+		s.cfg.AppName,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	routedIdentity, err := s.identityGenerator.Generate(ctx, append(identityOpts,
+		identity.WithCurrentIdentityFacade(id),
+		identity.WithRouteToApp(routeToApp),
+	)...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	s.log.InfoContext(
+		ctx,
+		"Generated identity for app",
+		"app_name", routeToApp.Name,
+	)
+
+	return routedIdentity, nil
+}
+
+func (s *OutputService) routedIdentityScoped(ctx context.Context) (*identity.Identity, error) {
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+
+	// An unrouted scoped identity, used only to look the app up under the bot's own access rights.
+	lookupID, err := s.identityGenerator.GenerateScopedFacade(
+		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval, identity.UsageIdentity(),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err, "generating scoped facade identity")
+	}
+
+	clt, err := s.clientBuilder.Build(ctx, lookupID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer clt.Close()
+
+	routeToApp, _, err := getRouteToApp(ctx, s.getBotIdentity(), clt, s.cfg.AppName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	routedIdentity, err := s.identityGenerator.GenerateScoped(
+		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval, identity.UsageApp(routeToApp),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	s.log.InfoContext(
+		ctx,
+		"Generated scoped identity for app",
+		"app_name", routeToApp.Name,
+	)
+
+	return routedIdentity, nil
 }
 
 func (s *OutputService) render(

--- a/lib/tbot/services/application/proxy_config.go
+++ b/lib/tbot/services/application/proxy_config.go
@@ -89,12 +89,11 @@ func (p *ProxyServiceConfig) UnmarshalYAML(node *yaml.Node) error {
 // CheckAndSetDefaults checks the user-provided configuration against validation
 // rules and sets any default values.
 func (p *ProxyServiceConfig) CheckAndSetDefaults(scoped bool) error {
-	if scoped {
-		return trace.BadParameter("service type %q is not supported in scoped mode", ProxyServiceType)
-	}
 	switch {
 	case p.Listen == "" && p.Listener == nil:
 		return trace.BadParameter("listen: should not be empty")
+	case scoped && p.DelegationSessionID != "":
+		return trace.BadParameter("delegation_session_id: not supported with scopes")
 	}
 
 	if _, err := url.Parse(p.Listen); err != nil {

--- a/lib/tbot/services/application/proxy_config.go
+++ b/lib/tbot/services/application/proxy_config.go
@@ -56,31 +56,31 @@ type ProxyServiceConfig struct {
 }
 
 // GetName returns the user-given name of the service for reporting.
-func (c *ProxyServiceConfig) GetName() string {
-	return c.Name
+func (p *ProxyServiceConfig) GetName() string {
+	return p.Name
 }
 
 // SetName sets the service's name to an automatically generated one.
-func (o *ProxyServiceConfig) SetName(name string) {
-	o.Name = name
+func (p *ProxyServiceConfig) SetName(name string) {
+	p.Name = name
 }
 
 // Type returns the type of the service.
-func (c *ProxyServiceConfig) Type() string {
+func (p *ProxyServiceConfig) Type() string {
 	return ProxyServiceType
 }
 
 // MarshalYAML overrides the YAML representation of the service.
-func (c *ProxyServiceConfig) MarshalYAML() (any, error) {
+func (p *ProxyServiceConfig) MarshalYAML() (any, error) {
 	type raw ProxyServiceConfig
-	return encoding.WithTypeHeader((*raw)(c), ProxyServiceType)
+	return encoding.WithTypeHeader((*raw)(p), ProxyServiceType)
 }
 
 // UnmarshalYAML is used to override the YAML unmarshaling of the service.
-func (c *ProxyServiceConfig) UnmarshalYAML(node *yaml.Node) error {
+func (p *ProxyServiceConfig) UnmarshalYAML(node *yaml.Node) error {
 	// Alias type to remove UnmarshalYAML to avoid recursion
 	type raw ProxyServiceConfig
-	if err := node.Decode((*raw)(c)); err != nil {
+	if err := node.Decode((*raw)(p)); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -88,16 +88,16 @@ func (c *ProxyServiceConfig) UnmarshalYAML(node *yaml.Node) error {
 
 // CheckAndSetDefaults checks the user-provided configuration against validation
 // rules and sets any default values.
-func (c *ProxyServiceConfig) CheckAndSetDefaults(scoped bool) error {
+func (p *ProxyServiceConfig) CheckAndSetDefaults(scoped bool) error {
 	if scoped {
 		return trace.BadParameter("service type %q is not supported in scoped mode", ProxyServiceType)
 	}
 	switch {
-	case c.Listen == "" && c.Listener == nil:
+	case p.Listen == "" && p.Listener == nil:
 		return trace.BadParameter("listen: should not be empty")
 	}
 
-	if _, err := url.Parse(c.Listen); err != nil {
+	if _, err := url.Parse(p.Listen); err != nil {
 		return trace.Wrap(err, "parsing listen")
 	}
 
@@ -105,6 +105,6 @@ func (c *ProxyServiceConfig) CheckAndSetDefaults(scoped bool) error {
 }
 
 // GetCredentialLifetime returns the embedded CredentialLifetime.
-func (c *ProxyServiceConfig) GetCredentialLifetime() bot.CredentialLifetime {
-	return c.CredentialLifetime
+func (p *ProxyServiceConfig) GetCredentialLifetime() bot.CredentialLifetime {
+	return p.CredentialLifetime
 }

--- a/lib/tbot/services/application/proxy_config_test.go
+++ b/lib/tbot/services/application/proxy_config_test.go
@@ -82,7 +82,17 @@ func TestProxyServiceConfig_CheckAndSetDefaults(t *testing.T) {
 					Listen: "tcp://0.0.0.0:3621",
 				}
 			},
-			wantErr: "is not supported in scoped mode",
+		},
+		{
+			name:   "scoped with delegation_session_id set",
+			scoped: true,
+			in: func() *ProxyServiceConfig {
+				return &ProxyServiceConfig{
+					Listen:              "tcp://0.0.0.0:3621",
+					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
+				}
+			},
+			wantErr: "delegation_session_id: not supported with scopes",
 		},
 	}
 	testCheckAndSetDefaults(t, tests)

--- a/lib/tbot/services/application/proxy_service.go
+++ b/lib/tbot/services/application/proxy_service.go
@@ -69,6 +69,7 @@ func ProxyServiceBuilder(
 			alpnUpgradeCache:          alpnUpgradeCache,
 			log:                       deps.Logger,
 			statusReporter:            deps.GetStatusReporter(),
+			scoped:                    deps.Scoped,
 		}
 		return svc, nil
 	}
@@ -95,6 +96,7 @@ type ProxyService struct {
 	cache               *utils.FnCache
 	proxyAddr           string
 	alpnUpgradeRequired bool
+	scoped              bool
 }
 
 // Run runs the service until the context is closed or an error occurs.
@@ -176,7 +178,7 @@ func (s *ProxyService) Run(ctx context.Context) error {
 	})
 	s.log.InfoContext(ctx, "Finished initializing")
 
-	var errCh = make(chan error, 1)
+	errCh := make(chan error, 1)
 	go func() {
 		s.log.DebugContext(ctx, "Starting proxy request handler goroutine")
 		errCh <- httpSrv.Serve(l)
@@ -212,16 +214,30 @@ func (s *ProxyService) issueCert(
 	ctx, span := tracer.Start(ctx, "ProxyService/issueCert")
 	defer span.End()
 
+	var (
+		routedIdent *identity.Identity
+		app         types.Application
+		err         error
+	)
+
+	if s.scoped {
+		routedIdent, app, err = s.routedIdentityScoped(ctx, appName)
+	} else {
+		routedIdent, app, err = s.routedIdentityUnscoped(ctx, appName)
+	}
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return routedIdent.TLSCert, app, nil
+}
+
+func (s *ProxyService) routedIdentityUnscoped(ctx context.Context, appName string) (*identity.Identity, types.Application, error) {
 	// TODO(noah): At a later date, we should consider running a background
 	// goroutine that maintains a role-impersonated client. We should probably
 	// make this a generic helper since we have a few services that do this now.
 	// This will avoid the need to create and destroy a client for each new
 	// upstream.
-
-	// Right now we have to redetermine the route to app each time as the
-	// session ID may need to change. Once v17 hits, this will be automagically
-	// calculated by the auth server on cert generation, and we can fetch the
-	// routeToApp once.
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
 	identityOpts := []identity.GenerateOption{
 		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
@@ -253,14 +269,50 @@ func (s *ProxyService) issueCert(
 		return nil, nil, trace.Wrap(err)
 	}
 
-	routedIdent, err := s.identityGenerator.Generate(
+	routedIdentity, err := s.identityGenerator.Generate(
 		ctx, append(identityOpts, identity.WithRouteToApp(route))...,
 	)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	return routedIdent.TLSCert, app, nil
+	return routedIdentity, app, nil
+}
+
+func (s *ProxyService) routedIdentityScoped(ctx context.Context, appName string) (*identity.Identity, types.Application, error) {
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+
+	// An unrouted scoped identity, used only to look the app up.
+	lookupIdentity, err := s.identityGenerator.GenerateScopedFacade(
+		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval,
+		identity.UsageIdentity(),
+	)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "generating scoped identity")
+	}
+	clt, err := s.clientBuilder.Build(ctx, lookupIdentity)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	defer func() {
+		if err := clt.Close(); err != nil {
+			s.log.ErrorContext(ctx, "Failed to close client.", "error", err)
+		}
+	}()
+
+	route, app, err := getRouteToApp(ctx, s.getBotIdentity(), clt, appName)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	routedIdent, err := s.identityGenerator.GenerateScoped(
+		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval, identity.UsageApp(route),
+	)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return routedIdent, app, nil
 }
 
 // handleProxyRequest handles incoming HTTP requests to the server.

--- a/lib/tbot/services/application/proxy_service_test.go
+++ b/lib/tbot/services/application/proxy_service_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
@@ -287,4 +288,141 @@ func TestE2E_ApplicationProxyService(t *testing.T) {
 	respBody, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "hello from server b", string(respBody))
+}
+
+// TestE2E_ScopedApplicationProxyService tests that the application proxy
+// service works in scoped mode, issuing per-request scoped app certs and
+// routing traffic to the correct backend based on the Host header.
+func TestE2E_ScopedApplicationProxyService(t *testing.T) {
+	if !scopes.FeaturesFromEnv().AgentPinEnabled {
+		t.Skip("test requires TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes")
+	}
+	t.Parallel()
+	ctx := t.Context()
+	log := logtest.NewLogger()
+
+	const (
+		scopeName      = "/test-scope"
+		scopedRoleName = "scoped-app-access"
+		botName        = "scoped-proxy-bot"
+		appName        = "scoped-proxy-app"
+	)
+
+	// Spin up a test HTTP server.
+	wantBody := []byte("hello from scoped proxy")
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(wantBody)
+	}))
+	t.Cleanup(httpSrv.Close)
+
+	// Start the main Teleport process (auth + proxy).
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		defaultTestServerOpts(log),
+		testenv.WithScopesFeatures(scopes.Features{Enabled: true, AgentPinEnabled: true}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+	rootClient, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rootClient.Close() })
+
+	// Create scoped role, bot, SRA, and app agent.
+	makeScopedRole(t, ctx, rootClient, scopedRoleName, scopeName)
+	botOnboarding := makeScopedBot(t, process, rootClient, botName, scopeName, scopedRoleName)
+	makeScopedAppAgent(t, ctx, process, log, scopeName, appName, httpSrv.URL)
+
+	// Wait for the app to be visible.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		servers, err := rootClient.GetApplicationServers(ctx, "default")
+		if !assert.NoError(ct, err) {
+			return
+		}
+		for _, s := range servers {
+			if s.GetApp().GetName() == appName {
+				return
+			}
+		}
+		assert.Fail(ct, "scoped app not yet visible")
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Configure and start the scoped bot with the proxy service.
+	botListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { botListener.Close() })
+
+	proxyAddr, err := process.ProxyWebAddr()
+	require.NoError(t, err)
+	connCfg := connection.Config{
+		Address:     proxyAddr.Addr,
+		AddressKind: connection.AddressKindProxy,
+		Insecure:    true,
+	}
+
+	alpnUpgradeCache := internal.NewALPNUpgradeCache(log)
+	b, err := bot.New(bot.Config{
+		Connection: connCfg,
+		Logger:     log,
+		Onboarding: *botOnboarding,
+		Scoped:     true,
+		Services: []bot.ServiceBuilder{
+			ProxyServiceBuilder(
+				&ProxyServiceConfig{
+					Listen:   "localhost:0",
+					Listener: botListener,
+				},
+				connCfg,
+				bot.DefaultCredentialLifetime,
+				alpnUpgradeCache,
+			),
+		},
+	})
+	require.NoError(t, err)
+
+	// Run bot in background.
+	ctx, cancel := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
+	wg.Go(func() {
+		err := b.Run(ctx)
+		assert.NoError(t, err, "bot should not exit with error")
+		cancel()
+	})
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(&url.URL{
+				Scheme: "http",
+				Host:   botListener.Addr().String(),
+			}),
+		},
+	}
+
+	// Verify the proxy routes traffic to the scoped app.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		req := &http.Request{
+			Method: http.MethodGet,
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   appName,
+				Path:   "/",
+			},
+		}
+		resp, err := httpClient.Do(req)
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, wantBody, body)
+	}, 10*time.Second, 100*time.Millisecond)
 }

--- a/lib/tbot/services/application/tunnel_config.go
+++ b/lib/tbot/services/application/tunnel_config.go
@@ -71,56 +71,56 @@ type TunnelConfig struct {
 }
 
 // GetName returns the user-given name of the service, used for validation purposes.
-func (o *TunnelConfig) GetName() string {
-	return o.Name
+func (t *TunnelConfig) GetName() string {
+	return t.Name
 }
 
 // SetName sets the service's name to an automatically generated one.
-func (o *TunnelConfig) SetName(name string) {
-	o.Name = name
+func (t *TunnelConfig) SetName(name string) {
+	t.Name = name
 }
 
-func (s *TunnelConfig) Type() string {
+func (t *TunnelConfig) Type() string {
 	return TunnelServiceType
 }
 
-func (s *TunnelConfig) MarshalYAML() (any, error) {
+func (t *TunnelConfig) MarshalYAML() (any, error) {
 	type raw TunnelConfig
-	return encoding.WithTypeHeader((*raw)(s), TunnelServiceType)
+	return encoding.WithTypeHeader((*raw)(t), TunnelServiceType)
 }
 
-func (s *TunnelConfig) UnmarshalYAML(node *yaml.Node) error {
+func (t *TunnelConfig) UnmarshalYAML(node *yaml.Node) error {
 	// Alias type to remove UnmarshalYAML to avoid recursion
 	type raw TunnelConfig
-	if err := node.Decode((*raw)(s)); err != nil {
+	if err := node.Decode((*raw)(t)); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-func (s *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
-	if err := internal.CheckDeprecatedRoles(s.DeprecatedRoles); err != nil {
+func (t *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
+	if err := internal.CheckDeprecatedRoles(t.DeprecatedRoles); err != nil {
 		return trace.Wrap(err)
 	}
 	if scoped {
 		return trace.BadParameter("service type %q is not supported in scoped mode", TunnelServiceType)
 	}
 	switch {
-	case s.Listen == "" && s.Listener == nil:
+	case t.Listen == "" && t.Listener == nil:
 		return trace.BadParameter("listen: should not be empty")
-	case s.AppName == "":
+	case t.AppName == "":
 		return trace.BadParameter("app_name: should not be empty")
 	}
-	if _, err := url.Parse(s.Listen); err != nil {
+	if _, err := url.Parse(t.Listen); err != nil {
 		return trace.Wrap(err, "parsing listen")
 	}
-	if s.clock == nil {
-		s.clock = clockwork.NewRealClock()
+	if t.clock == nil {
+		t.clock = clockwork.NewRealClock()
 	}
 
 	return nil
 }
 
-func (o *TunnelConfig) GetCredentialLifetime() bot.CredentialLifetime {
-	return o.CredentialLifetime
+func (t *TunnelConfig) GetCredentialLifetime() bot.CredentialLifetime {
+	return t.CredentialLifetime
 }

--- a/lib/tbot/services/application/tunnel_config.go
+++ b/lib/tbot/services/application/tunnel_config.go
@@ -102,9 +102,6 @@ func (t *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
 	if err := internal.CheckDeprecatedRoles(t.DeprecatedRoles); err != nil {
 		return trace.Wrap(err)
 	}
-	if scoped {
-		return trace.BadParameter("service type %q is not supported in scoped mode", TunnelServiceType)
-	}
 	switch {
 	case t.Listen == "" && t.Listener == nil:
 		return trace.BadParameter("listen: should not be empty")
@@ -116,6 +113,9 @@ func (t *TunnelConfig) CheckAndSetDefaults(scoped bool) error {
 	}
 	if t.clock == nil {
 		t.clock = clockwork.NewRealClock()
+	}
+	if scoped && t.DelegationSessionID != "" {
+		return trace.BadParameter("delegation_session_id: not supported with scopes")
 	}
 
 	return nil

--- a/lib/tbot/services/application/tunnel_config_test.go
+++ b/lib/tbot/services/application/tunnel_config_test.go
@@ -115,9 +115,21 @@ func TestApplicationTunnelService_CheckAndSetDefaults(t *testing.T) {
 				return &TunnelConfig{
 					Listen:  "tcp://0.0.0.0:3621",
 					AppName: "my-app",
+					clock:   clock,
 				}
 			},
-			wantErr: "is not supported in scoped mode",
+		},
+		{
+			name:   "scoped with delegation_session_id set",
+			scoped: true,
+			in: func() *TunnelConfig {
+				return &TunnelConfig{
+					Listen:              "tcp://0.0.0.0:3621",
+					AppName:             "my-app",
+					DelegationSessionID: "8a50ba48-2fad-4c2c-a8ce-f48bc18db9ee",
+				}
+			},
+			wantErr: "delegation_session_id: not supported with scopes",
 		},
 	}
 	testCheckAndSetDefaults(t, tests)

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -66,6 +66,7 @@ func TunnelServiceBuilder(
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
 			statusReporter:            deps.GetStatusReporter(),
+			scoped:                    deps.Scoped,
 		}
 		return svc, nil
 	}
@@ -89,6 +90,7 @@ type TunnelService struct {
 	statusReporter            readyz.Reporter
 	identityGenerator         *identity.Generator
 	clientBuilder             *client.Builder
+	scoped                    bool
 }
 
 func (s *TunnelService) Run(ctx context.Context) error {
@@ -275,10 +277,37 @@ func (s *TunnelService) issueCert(
 	ctx, span := tracer.Start(ctx, "TunnelService/issueCert")
 	defer span.End()
 
-	// Right now we have to redetermine the route to app each time as the
-	// session ID may need to change. Once v17 hits, this will be automagically
-	// calculated by the auth server on cert generation, and we can fetch the
-	// routeToApp once.
+	var (
+		routedIdent *identity.Identity
+		app         types.Application
+		err         error
+	)
+
+	if s.scoped {
+		routedIdent, app, err = s.routedIdentityScoped(ctx)
+	} else {
+		routedIdent, app, err = s.routedIdentityUnscoped(ctx)
+	}
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	s.log.InfoContext(ctx, "Certificate issued for tunnel proxy.")
+
+	// In tests, notify the test that a cert has been issued.
+	if s.cfg.certIssuedHook != nil {
+		s.cfg.certIssuedHook()
+	}
+
+	// The leaf isn't appended by the stdlib, so add it here so we can inspect
+	// the TTL downstream.
+	cert := routedIdent.TLSCert
+	cert.Leaf = routedIdent.X509Cert
+
+	return cert, app, nil
+}
+
+func (s *TunnelService) routedIdentityUnscoped(ctx context.Context) (*identity.Identity, types.Application, error) {
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
 	identityOpts := []identity.GenerateOption{
 		identity.WithLifetime(effectiveLifetime.TTL, effectiveLifetime.RenewalInterval),
@@ -310,19 +339,45 @@ func (s *TunnelService) issueCert(
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	s.log.InfoContext(ctx, "Certificate issued for tunnel proxy.")
 
-	// In tests, notify the test that a cert has been issued.
-	if s.cfg.certIssuedHook != nil {
-		s.cfg.certIssuedHook()
+	return routedIdent, app, nil
+}
+
+func (s *TunnelService) routedIdentityScoped(ctx context.Context) (*identity.Identity, types.Application, error) {
+	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
+
+	// An unrouted scoped identity, used only to look the app up.
+	lookupIdentity, err := s.identityGenerator.GenerateScopedFacade(
+		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval,
+		identity.UsageIdentity(),
+	)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "generating scoped identity")
+	}
+	clt, err := s.clientBuilder.Build(ctx, lookupIdentity)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	defer func() {
+		if err := clt.Close(); err != nil {
+			s.log.ErrorContext(ctx, "Failed to close client.", "error", err)
+		}
+	}()
+
+	route, app, err := getRouteToApp(ctx, s.getBotIdentity(), clt, s.cfg.AppName)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
 	}
 
-	// The leaf isn't appended by the stdlib, so add it here so we can inspect
-	// the TTL downstream.
-	cert := routedIdent.TLSCert
-	cert.Leaf = routedIdent.X509Cert
+	s.log.DebugContext(ctx, "Requesting issuance of certificate for tunnel proxy.")
+	routedIdent, err := s.identityGenerator.GenerateScoped(
+		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval, identity.UsageApp(route),
+	)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 
-	return cert, app, nil
+	return routedIdent, app, nil
 }
 
 // String returns a human-readable string that can uniquely identify the

--- a/lib/tbot/services/application/tunnel_service_test.go
+++ b/lib/tbot/services/application/tunnel_service_test.go
@@ -22,25 +22,41 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	jointoken "github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
@@ -369,4 +385,289 @@ type fakePinger struct {
 
 func (p fakePinger) Ping(_ context.Context) (*connection.ProxyPong, error) {
 	return nil, p.err
+}
+
+// TestE2E_ScopedApplicationTunnelService tests that the application tunnel
+// service works in scoped mode, issuing scoped app certs and proxying
+// traffic through to the backend.
+func TestE2E_ScopedApplicationTunnelService(t *testing.T) {
+	if !scopes.FeaturesFromEnv().AgentPinEnabled {
+		t.Skip("test requires TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes")
+	}
+	t.Parallel()
+	ctx := context.Background()
+	log := logtest.NewLogger()
+
+	const (
+		scopeName      = "/test-scope"
+		scopedRoleName = "scoped-app-access"
+		botName        = "scoped-tunnel-bot"
+		appName        = "scoped-tunnel-app"
+	)
+
+	// Spin up a test HTTP server.
+	wantStatus := http.StatusTeapot
+	wantBody := []byte("hello from scoped tunnel")
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(wantStatus)
+		w.Write(wantBody)
+	}))
+	t.Cleanup(httpSrv.Close)
+
+	// Start the main Teleport process (auth + proxy, no app service).
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		defaultTestServerOpts(log),
+		testenv.WithScopesFeatures(scopes.Features{Enabled: true, AgentPinEnabled: true}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+	rootClient, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rootClient.Close() })
+
+	// Create a scoped role that grants app access.
+	makeScopedRole(t, ctx, rootClient, scopedRoleName, scopeName)
+
+	// Create the scoped bot, token, and role assignment.
+	botOnboarding := makeScopedBot(t, process, rootClient, botName, scopeName, scopedRoleName)
+
+	// Start a scoped app agent.
+	appTokenResp := makeScopedAppAgent(t, ctx, process, log, scopeName, appName, httpSrv.URL)
+	_ = appTokenResp
+
+	// Wait for the app to be visible.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		servers, err := rootClient.GetApplicationServers(ctx, "default")
+		if !assert.NoError(ct, err) {
+			return
+		}
+		for _, s := range servers {
+			if s.GetApp().GetName() == appName {
+				return
+			}
+		}
+		assert.Fail(ct, "scoped app not yet visible")
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Configure and start the scoped bot with the tunnel service.
+	botListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { botListener.Close() })
+
+	proxyAddr, err := process.ProxyWebAddr()
+	require.NoError(t, err)
+	connCfg := connection.Config{
+		Address:     proxyAddr.Addr,
+		AddressKind: connection.AddressKindProxy,
+		Insecure:    true,
+	}
+
+	b, err := bot.New(bot.Config{
+		Connection: connCfg,
+		Logger:     log,
+		Onboarding: *botOnboarding,
+		Scoped:     true,
+		Services: []bot.ServiceBuilder{
+			TunnelServiceBuilder(
+				&TunnelConfig{
+					Listener: botListener,
+					AppName:  appName,
+				},
+				connCfg,
+				bot.DefaultCredentialLifetime,
+				time.Minute,
+			),
+		},
+	})
+	require.NoError(t, err)
+
+	// Run bot in background.
+	ctx, cancel := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
+	wg.Go(func() {
+		err := b.Run(ctx)
+		assert.NoError(t, err, "bot should not exit with error")
+		cancel()
+	})
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	// Verify the tunnel proxies traffic to the backend.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := http.Get("http://" + botListener.Addr().String())
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer resp.Body.Close()
+		assert.Equal(t, wantStatus, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, wantBody, body)
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+// makeScopedBot creates a scoped bot with a bound keypair token and a scoped
+// role assignment, returning the onboarding config for tbot.
+func makeScopedBot(
+	t *testing.T,
+	process *service.TeleportProcess,
+	rootClient *authclient.Client,
+	botName, scopeName, scopedRoleName string,
+) *onboarding.Config {
+	t.Helper()
+	ctx := t.Context()
+
+	_, err := rootClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		Bot: machineidv1pb.Bot_builder{
+			Metadata: headerv1.Metadata_builder{Name: botName}.Build(),
+			Scope:    scopeName,
+			Spec:     &machineidv1pb.BotSpec{},
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	botKey, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	botPublicKey := strings.TrimSpace(string(botKey.MarshalSSHPublicKey()))
+	botKeyPath := filepath.Join(t.TempDir(), "bot_key.pem")
+	require.NoError(t, os.WriteFile(botKeyPath, botKey.PrivateKeyPEM(), 0600))
+
+	botTokenResp, err := process.GetAuthServer().ScopedTokenService.CreateScopedToken(ctx, joiningv1.CreateScopedTokenRequest_builder{
+		Token: joiningv1.ScopedToken_builder{
+			Kind:     types.KindScopedToken,
+			Version:  types.V1,
+			Metadata: headerv1.Metadata_builder{Name: botName + "-token"}.Build(),
+			Scope:    scopeName,
+			Spec: joiningv1.ScopedTokenSpec_builder{
+				Roles:      []string{types.RoleBot.String()},
+				JoinMethod: string(types.JoinMethodBoundKeypair),
+				UsageMode:  jointoken.TokenUsageModeBot,
+				Bot:        scopes.QualifiedName{Scope: scopeName, Name: botName}.String(),
+				BoundKeypair: joiningv1.BoundKeypairSpec_builder{
+					Onboarding: joiningv1.BoundKeypairSpec_OnboardingSpec_builder{
+						InitialPublicKey: botPublicKey,
+					}.Build(),
+					Recovery: joiningv1.BoundKeypairSpec_RecoverySpec_builder{
+						Limit: 10,
+						Mode:  "insecure",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			Status: joiningv1.ScopedTokenStatus_builder{
+				Usage: joiningv1.UsageStatus_builder{
+					BoundKeypair: &joiningv1.BoundKeypairStatus{},
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	sraResp, err := rootClient.ScopedAccessServiceClient().CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:     scopedaccess.KindScopedRoleAssignment,
+			Version:  types.V1,
+			SubKind:  scopedaccess.SubKindDynamic,
+			Metadata: headerv1.Metadata_builder{Name: uuid.NewString()}.Build(),
+			Scope:    scopeName,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: scopes.QualifiedName{Scope: scopeName, Name: botName}.String(),
+				Assignments: []*scopedaccessv1.Assignment{
+					scopedaccessv1.Assignment_builder{
+						Role:  scopes.QualifiedName{Scope: scopeName, Name: scopedRoleName}.String(),
+						Scope: scopeName,
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Wait for the SRA to be visible in the cache.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		_, err := process.GetAuthServer().ScopedAccessCache.GetScopedRoleAssignment(ctx, scopedaccessv1.GetScopedRoleAssignmentRequest_builder{
+			Name:    sraResp.GetAssignment().GetMetadata().GetName(),
+			SubKind: sraResp.GetAssignment().GetSubKind(),
+			Scope:   sraResp.GetAssignment().GetScope(),
+		}.Build())
+		assert.NoError(ct, err)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	return &onboarding.Config{
+		TokenValue: scopes.QualifiedName{Scope: scopeName, Name: botTokenResp.GetToken().GetMetadata().GetName()}.String(),
+		JoinMethod: types.JoinMethodBoundKeypair,
+		BoundKeypair: onboarding.BoundKeypairOnboardingConfig{
+			StaticPrivateKeyPath: botKeyPath,
+		},
+	}
+}
+
+// makeScopedAppAgent starts a Teleport process as an app-only agent, joining
+// with a scoped token so the app is visible to scoped bots.
+func makeScopedAppAgent(
+	t *testing.T,
+	ctx context.Context,
+	process *service.TeleportProcess,
+	log *slog.Logger,
+	scopeName, appName, appURI string,
+) *joiningv1.CreateScopedTokenResponse {
+	t.Helper()
+
+	tokenResp, err := process.GetAuthServer().ScopedTokenService.CreateScopedToken(ctx, joiningv1.CreateScopedTokenRequest_builder{
+		Token: joiningv1.ScopedToken_builder{
+			Kind:     types.KindScopedToken,
+			Version:  types.V1,
+			Metadata: headerv1.Metadata_builder{Name: appName + "-agent-token"}.Build(),
+			Scope:    scopeName,
+			Spec: joiningv1.ScopedTokenSpec_builder{
+				AssignedScope: scopeName,
+				Roles:         []string{types.RoleApp.String()},
+				JoinMethod:    string(types.JoinMethodToken),
+				UsageMode:     string(jointoken.TokenUsageModeUnlimited),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	agentCfg := servicecfg.MakeDefaultConfig()
+	agentCfg.ScopesFeatures = scopes.Features{Enabled: true, AgentPinEnabled: true}
+	agentCfg.Hostname = appName + "-agent"
+	agentCfg.DataDir = t.TempDir()
+	agentCfg.SetToken(scopes.QualifiedName{
+		Scope: scopeName,
+		Name:  jointoken.EncodeScopedToken(tokenResp.GetToken().GetMetadata().GetName(), tokenResp.GetToken().GetStatus().GetSecret()),
+	}.String())
+	agentCfg.SetAuthServerAddress(process.Config.Auth.ListenAddr)
+	agentCfg.Auth.Enabled = false
+	agentCfg.Proxy.Enabled = false
+	agentCfg.SSH.Enabled = false
+	agentCfg.Apps.Enabled = true
+	agentCfg.Apps.Apps = []servicecfg.App{
+		{
+			Name: appName,
+			URI:  appURI,
+		},
+	}
+	agentCfg.CachePolicy.Enabled = false
+	agentCfg.InstanceMetadataClient = nil
+	agentCfg.DebugService.Enabled = false
+	agentCfg.Logger = log
+
+	agentProcess, err := service.NewTeleport(agentCfg)
+	require.NoError(t, err)
+	require.NoError(t, agentProcess.Start())
+	t.Cleanup(func() {
+		require.NoError(t, agentProcess.Close())
+		require.NoError(t, agentProcess.Wait())
+	})
+
+	_, err = agentProcess.WaitForEvent(ctx, service.AppsReady)
+	require.NoError(t, err)
+
+	return tokenResp
 }

--- a/lib/tbot/services/application/tunnel_service_test.go
+++ b/lib/tbot/services/application/tunnel_service_test.go
@@ -634,6 +634,9 @@ func makeScopedAppAgent(
 	}.Build())
 	require.NoError(t, err)
 
+	proxyAddr, err := process.ProxyWebAddr()
+	require.NoError(t, err)
+
 	agentCfg := servicecfg.MakeDefaultConfig()
 	agentCfg.ScopesFeatures = scopes.Features{Enabled: true, AgentPinEnabled: true}
 	agentCfg.Hostname = appName + "-agent"
@@ -642,7 +645,8 @@ func makeScopedAppAgent(
 		Scope: scopeName,
 		Name:  jointoken.EncodeScopedToken(tokenResp.GetToken().GetMetadata().GetName(), tokenResp.GetToken().GetStatus().GetSecret()),
 	}.String())
-	agentCfg.SetAuthServerAddress(process.Config.Auth.ListenAddr)
+	agentCfg.SetAuthServerAddress(*proxyAddr)
+	agentCfg.InsecureMode = true
 	agentCfg.Auth.Enabled = false
 	agentCfg.Proxy.Enabled = false
 	agentCfg.SSH.Enabled = false

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -157,7 +157,7 @@ func (s *Service) generateScoped(ctx context.Context) error {
 	defer span.End()
 	s.log.InfoContext(ctx, "Generating scoped output")
 
-	id, err := s.identityGenerator.GenerateScoped(ctx, s.credentialLifetime.TTL, s.credentialLifetime.RenewalInterval)
+	id, err := s.identityGenerator.GenerateScoped(ctx, s.credentialLifetime.TTL, s.credentialLifetime.RenewalInterval, identity.UsageIdentity())
 	if err != nil {
 		return trace.Wrap(err, "generating scoped identity")
 	}

--- a/lib/tbot/services/identity/output.go
+++ b/lib/tbot/services/identity/output.go
@@ -267,7 +267,7 @@ func (s *OutputService) generateScoped(ctx context.Context) error {
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
 	id, err := s.identityGenerator.GenerateScoped(
-		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval,
+		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval, identity.UsageIdentity(),
 	)
 	if err != nil {
 		return trace.Wrap(err, "generating scoped identity")

--- a/lib/tbot/services/k8s/output_v2.go
+++ b/lib/tbot/services/k8s/output_v2.go
@@ -198,7 +198,7 @@ func (s *OutputV2Service) generateScoped(ctx context.Context) error {
 
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
 	id, err := s.identityGenerator.GenerateScopedFacade(
-		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval,
+		ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval, identity.UsageIdentity(),
 	)
 	if err != nil {
 		return trace.Wrap(err, "generating scoped identity")
@@ -503,7 +503,8 @@ func (o *OutputV2Service) generateKubeConfigV2WithPlugin(ks *kubernetesStatusV2,
 	}
 
 	// Configure primary user/AuthInfo.
-	execArgs := []string{"kube", "credentials",
+	execArgs := []string{
+		"kube", "credentials",
 		fmt.Sprintf("--destination-dir=%s", absDestPath),
 	}
 	config.AuthInfos[ks.teleportClusterName] = &clientcmdapi.AuthInfo{

--- a/lib/tbot/services/workloadidentity/jwt_output.go
+++ b/lib/tbot/services/workloadidentity/jwt_output.go
@@ -177,7 +177,7 @@ func (s *JWTOutputService) generateIdentity(ctx context.Context) (*identity.Faca
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
 	if s.scoped {
 		return s.identityGenerator.GenerateScopedFacade(
-			ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval,
+			ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval, identity.UsageIdentity(),
 		)
 	}
 	return s.identityGenerator.GenerateFacade(ctx,

--- a/lib/tbot/services/workloadidentity/x509_output.go
+++ b/lib/tbot/services/workloadidentity/x509_output.go
@@ -232,7 +232,7 @@ func (s *X509OutputService) generateIdentity(ctx context.Context) (*identity.Fac
 	effectiveLifetime := cmp.Or(s.cfg.CredentialLifetime, s.defaultCredentialLifetime)
 	if s.scoped {
 		return s.identityGenerator.GenerateScopedFacade(
-			ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval,
+			ctx, effectiveLifetime.TTL, effectiveLifetime.RenewalInterval, identity.UsageIdentity(),
 		)
 	}
 	return s.identityGenerator.GenerateFacade(ctx,

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1854,6 +1854,206 @@ func TestScopedBotKubernetes(t *testing.T) {
 	})
 }
 
+// TestScopedBotApp tests that a scoped bot can issue app-routed certificates
+// via the application output service. It verifies:
+//   - The TLS certificate contains a RouteToApp with the correct app name
+//   - The certificate carries the correct scope pin
+//   - Usage is set to apps-only
+//   - DisallowReissue is set
+//   - No roles or traits are encoded
+//   - An out-of-scope app (registered by the unscoped main process) is not visible
+func TestScopedBotApp(t *testing.T) {
+	if !scopes.FeaturesFromEnv().AgentPinEnabled {
+		t.Skip("test requires TELEPORT_UNSTABLE_AGENT_SCOPE_PIN=yes")
+	}
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	log := logtest.NewLogger()
+
+	const (
+		scopeName      = "/test-scope"
+		scopedRoleName = "scoped-app-access"
+		botName        = "scoped-app-bot"
+		scopedAppName  = "scoped-test-app"
+	)
+
+	// Start the main Teleport process (auth + proxy).
+	process, err := testenv.NewTeleportProcess(
+		t.TempDir(),
+		defaultTestServerOpts(log),
+		testenv.WithScopesFeatures(scopes.Features{Enabled: true, AgentPinEnabled: true}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+
+	rootClient, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rootClient.Close() })
+
+	// Create a scoped role that grants app access.
+	scopedSvc := rootClient.ScopedAccessServiceClient()
+	_, err = scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: scopedRoleName,
+			}.Build(),
+			Scope: scopeName,
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scopeName},
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					Labels: []*labelv1.Label{
+						labelv1.Label_builder{
+							Name:   "*",
+							Values: []string{"*"},
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	botOnboarding := createScopedBot(t, process, rootClient, botName, scopeName, scopedRoleName)
+	appTokenResp := createScopedJoinToken(t, process, "app-token", scopeName, types.RoleApp)
+
+	// Start a second Teleport process as an App-only agent, joining with
+	// the scoped token so the app gets scope "/test-scope".
+	appAgentCfg := servicecfg.MakeDefaultConfig()
+	appAgentCfg.ScopesFeatures = scopes.Features{Enabled: true, AgentPinEnabled: true}
+	appAgentCfg.Hostname = "scoped-app-agent"
+	appAgentCfg.DataDir = t.TempDir()
+	appAgentCfg.SetToken(scopes.QualifiedName{
+		Scope: scopeName,
+		Name:  jointoken.EncodeScopedToken(appTokenResp.GetToken().GetMetadata().GetName(), appTokenResp.GetToken().GetStatus().GetSecret()),
+	}.String())
+	appAgentCfg.SetAuthServerAddress(process.Config.Auth.ListenAddr)
+	appAgentCfg.Auth.Enabled = false
+	appAgentCfg.Proxy.Enabled = false
+	appAgentCfg.SSH.Enabled = false
+	appAgentCfg.Apps.Enabled = true
+	appAgentCfg.Apps.Apps = []servicecfg.App{
+		{
+			Name: scopedAppName,
+			URI:  "http://127.0.0.1:0", // No real backend needed for cert issuance test.
+		},
+	}
+	appAgentCfg.CachePolicy.Enabled = false
+	appAgentCfg.InstanceMetadataClient = nil
+	appAgentCfg.DebugService.Enabled = false
+	appAgentCfg.Logger = log
+
+	appAgentProcess, err := service.NewTeleport(appAgentCfg)
+	require.NoError(t, err)
+	require.NoError(t, appAgentProcess.Start())
+	t.Cleanup(func() {
+		require.NoError(t, appAgentProcess.Close())
+		require.NoError(t, appAgentProcess.Wait())
+	})
+
+	// Wait for the app agent to be ready.
+	_, err = appAgentProcess.WaitForEvent(ctx, service.AppsReady)
+	require.NoError(t, err)
+
+	// Wait for the scoped app to be visible.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		servers, err := rootClient.GetApplicationServers(ctx, "default")
+		if !assert.NoError(ct, err) {
+			return
+		}
+		for _, s := range servers {
+			if s.GetApp().GetName() == scopedAppName {
+				return
+			}
+		}
+		assert.Fail(ct, "scoped app not yet visible")
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Configure and run tbot with an application output.
+	appOutput := &application.OutputConfig{
+		Destination: &destination.Memory{},
+		AppName:     scopedAppName,
+	}
+	botConfig := defaultBotConfig(
+		t, process, botOnboarding,
+		config.ServiceConfigs{
+			appOutput,
+		},
+		defaultBotConfigOpts{
+			useAuthServer: true,
+			insecure:      true,
+		},
+	)
+	botConfig.Scoped = true
+	b := New(botConfig, log)
+	require.NoError(t, b.Run(ctx))
+
+	t.Run("app certificate has correct attributes", func(t *testing.T) {
+		tlsIdent := tlsIdentFromDest(ctx, t, appOutput.GetDestination())
+
+		// Verify scope pin is present.
+		require.NotNil(t, tlsIdent.ScopePin, "TLS identity should have a scope pin")
+		require.Equal(t, scopeName, tlsIdent.ScopePin.GetScope())
+
+		// Verify RouteToApp is set correctly.
+		require.Equal(t, scopedAppName, tlsIdent.RouteToApp.Name)
+		require.NotEmpty(t, tlsIdent.RouteToApp.PublicAddr)
+		require.NotEmpty(t, tlsIdent.RouteToApp.SessionID)
+
+		// Verify usage is apps-only.
+		require.Equal(t, []string{"usage:apps"}, tlsIdent.Usage)
+
+		// Verify DisallowReissue.
+		require.True(t, tlsIdent.DisallowReissue, "scoped app cert should have DisallowReissue")
+
+		// Verify no roles or traits are encoded.
+		require.Empty(t, tlsIdent.Groups, "scoped app identity should not have groups/roles")
+		require.Empty(t, tlsIdent.Traits, "scoped app identity should not have traits")
+	})
+
+	t.Run("unscoped app is not visible", func(t *testing.T) {
+		// Register an app on the main (unscoped) process.
+		unscopedApp, err := types.NewAppV3(types.Metadata{
+			Name: "unscoped-app",
+		}, types.AppSpecV3{
+			PublicAddr: "unscoped-app.example.com",
+			URI:        "http://unscoped-app.example.com:1234",
+		})
+		require.NoError(t, err)
+		unscopedAppServer, err := types.NewAppServerV3FromApp(unscopedApp, "unscoped-host", "unscoped-host-id")
+		require.NoError(t, err)
+		_, err = rootClient.UpsertApplicationServer(ctx, unscopedAppServer)
+		require.NoError(t, err)
+
+		// Configure tbot to target the unscoped app — this should fail.
+		unscopedAppOutput := &application.OutputConfig{
+			Destination: &destination.Memory{},
+			AppName:     "unscoped-app",
+		}
+		unscopedBotConfig := defaultBotConfig(
+			t, process, botOnboarding,
+			config.ServiceConfigs{
+				unscopedAppOutput,
+			},
+			defaultBotConfigOpts{
+				useAuthServer: true,
+				insecure:      true,
+			},
+		)
+		unscopedBotConfig.Scoped = true
+		unscopedBot := New(unscopedBotConfig, log)
+		err = unscopedBot.Run(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found")
+	})
+}
+
 // TestScopedBotWorkloadIdentity tests that a scoped bot can issue X.509 and
 // JWT SVIDs for a scoped WorkloadIdentity addressed by a scope-qualified name
 // selector ("<scope>::<name>"), via the x509/jwt file outputs and the SPIFFE

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -1925,6 +1925,9 @@ func TestScopedBotApp(t *testing.T) {
 
 	// Start a second Teleport process as an App-only agent, joining with
 	// the scoped token so the app gets scope "/test-scope".
+	proxyAddr, err := process.ProxyWebAddr()
+	require.NoError(t, err)
+
 	appAgentCfg := servicecfg.MakeDefaultConfig()
 	appAgentCfg.ScopesFeatures = scopes.Features{Enabled: true, AgentPinEnabled: true}
 	appAgentCfg.Hostname = "scoped-app-agent"
@@ -1933,7 +1936,8 @@ func TestScopedBotApp(t *testing.T) {
 		Scope: scopeName,
 		Name:  jointoken.EncodeScopedToken(appTokenResp.GetToken().GetMetadata().GetName(), appTokenResp.GetToken().GetStatus().GetSecret()),
 	}.String())
-	appAgentCfg.SetAuthServerAddress(process.Config.Auth.ListenAddr)
+	appAgentCfg.SetAuthServerAddress(*proxyAddr)
+	appAgentCfg.InsecureMode = true
 	appAgentCfg.Auth.Enabled = false
 	appAgentCfg.Proxy.Enabled = false
 	appAgentCfg.SSH.Enabled = false


### PR DESCRIPTION
closes https://github.com/gravitational/core/issues/57


<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Scoped bots can now issue application-routed certificates through tbot's
`application`, `application-tunnel`, and `application-proxy` services.

<details>
<summary>Request Flow Diagram</summary>
<img width="590" height="2238" alt="scoped-app-access-flow" src="https://github.com/user-attachments/assets/9d2353fd-789f-4547-b0ee-ef8a463e984c" />
</details>

Extends tbot's application services (output, tunnel, proxy) to work in scoped mode by adding a UsageApp variant to the IssueScopedBotCerts RPC.

- Adds UsageApp proto message to issuance/v1/service.proto
- Introduces ScopedUsage type with UsageIdentity() and UsageApp(route) constructors in the tbot identity generator
- Implements applyUsageApp in the issuance service: scope authorization, app lookup with exact scope match, app session creation, and cert annotation
- Enables all three application services (output, tunnel, proxy) in scoped mode -- each calls GenerateScoped(..., UsageApp(route)) instead of the unscoped reissue path
- E2E tests are gated behind `TELEPORT_UNSTABLE_AGENT_SCOPE_PIN`.

I've created https://github.com/gravitational/teleport/issues/69429 as something I stumbled upon during this work.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

local

### Test Cases
- Application Output
  - Run tbot with `scoped: true, oneshot:true` and an application output targeting the scoped app
  - [ ] Verify tbot exits 0 and writes TLS cert to the destination
  - [ ] Inspect cert: OU=usage:apps (apps-only usage)
  - [ ] Inspect cert: scope pin present and matches bot's scope
  - [ ] Inspect cert: RouteToApp contains correct app name, public addr, cluster name
  - [ ] Inspect cert: DisallowReissue=true
  - [ ] Inspect cert: no roles or traits encoded

- Application Tunnel:
  - Run tbot with `scoped: true` and an application-tunnel service pointing at the scoped app
  - [ ] Verify log shows "Listening for proxy connections"
  - [ ] Verify HTTP request with Host: <scoped-app-name> is proxied to the correct backend
  - [ ] Verify request with Host: <non-existent-app> fails (not proxied)

- Application Proxy:
  - Run tbot with scoped: true and an application-proxy service
  - [ ] Verify log shows "Listening for proxy connections"
  - [ ] Verify HTTP request with Host: <scoped-app-name> is proxied to the correct backend
  - [ ] Verify request with Host: <non-existent-app> fails (not proxied)

- Scope Enforcement
  - [ ] Target an unscoped app (registered by the main teleport process) — verify app "X" not found
  - [ ] Target a non-existent app name — verify app "X" not found