### PR TITLE
fix: allow MFA response reuse during tctl acl create/update

### DIFF
--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -954,10 +954,11 @@ func (c *Command) collectAllReviews(ctx context.Context, client *authclient.Clie
 
 func withReusableAdminActionMFA(ctx context.Context, client *authclient.Client) (context.Context, error) {
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
-	if err == nil {
-		ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
-	} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {
+	if err != nil {
+		if errors.Is(err, &mfa.ErrMFANotRequired) || errors.Is(err, &mfa.ErrMFANotSupported) {
+			return ctx, nil
+		}
 		return nil, trace.Wrap(err)
 	}
-	return ctx, nil
+	return mfa.ContextWithMFAResponse(ctx, mfaResponse), nil
 }

--- a/tool/tctl/common/accesslist/command.go
+++ b/tool/tctl/common/accesslist/command.go
@@ -20,6 +20,7 @@ package accesslist
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -34,6 +35,7 @@ import (
 	"github.com/gravitational/teleport"
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -948,4 +950,14 @@ func (c *Command) collectAllReviews(ctx context.Context, client *authclient.Clie
 				AccessList:      aclName.Name,
 			}.Build())
 		}))
+}
+
+func withReusableAdminActionMFA(ctx context.Context, client *authclient.Client) (context.Context, error) {
+	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
+	if err == nil {
+		ctx = mfa.ContextWithMFAResponse(ctx, mfaResponse)
+	} else if !errors.Is(err, &mfa.ErrMFANotRequired) && !errors.Is(err, &mfa.ErrMFANotSupported) {
+		return nil, trace.Wrap(err)
+	}
+	return ctx, nil
 }

--- a/tool/tctl/common/accesslist/create.go
+++ b/tool/tctl/common/accesslist/create.go
@@ -54,6 +54,11 @@ func (c *Command) Create(ctx context.Context, client *authclient.Client) error {
 		return trace.Wrap(err)
 	}
 
+	ctx, err = withReusableAdminActionMFA(ctx, client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	createResponse, err := c.createAccessList(ctx, client, newAccessList, members)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/accesslist/update.go
+++ b/tool/tctl/common/accesslist/update.go
@@ -89,6 +89,11 @@ func (c *Command) Update(ctx context.Context, client *authclient.Client) error {
 		}
 	}
 
+	ctx, err = withReusableAdminActionMFA(ctx, client)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	var updatedAccessList *accesslist.AccessList
 	var updatedRoles []string
 	var rolesToDelete []string


### PR DESCRIPTION
The commands were failing (see error below) when admin-action is enabled because the API call performed multiple admin-protected writes (access_list and role).

```bash
...
ERROR: access denied
        mfa session data not found
```




<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed `tctl acl create` and `tctl acl update` failures when admin-action MFA is enabled.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
local - my user has both webauthn and otp registered
### Test Cases
with admin-action enabled
- [x] successfully create a custom/jit/standing access list
- [x] successfully update a custom/preset list
- [x] successfully delete both custom and preset list (there is no bug with delete, but double checking)

without admin-action enabled
- [x] successfully create a custom/jit/standing access list
- [x] successfully update a custom/preset list
- [x] successfully delete both custom and preset list
