### PR TITLE
[v18] docs: Slack plugin native Access Request reviews

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -1164,6 +1164,7 @@
     "workloadcluster",
     "wtmp",
     "xample",
+    "xapp",
     "xauth",
     "xclip",
     "xeyes",

--- a/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
+++ b/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
@@ -720,6 +720,35 @@ protected by Teleport, such as deployments and pods.
 Without the ability to preview a resource, reviewers can only see the resource's
 UUID as provided by the Access Request.
 
+## Submitting for other users
+
+You can configure a Teleport role to submit Access Request reviews on behalf of other users.
+This is used by Teleport Access Request plugins to allow users from the connected integration
+to approve and deny Access Requests natively in the integration.
+
+Currently, only the self-hosted Slack plugin supports native Access Request reviews. We highly
+recommend using the preset role `access-plugin-with-review` which provides the plugin with permissions
+to submit for any other user (via the wildcard `*`).
+
+To grant or deny a plugin user the ability to submit reviews on behalf of other users,
+use the `allow.review_requests.submit_for_users` and `deny.review_requests.submit_for_users` fields in the plugin user's roles:
+```yaml
+kind: role
+version: v8
+metadata:
+  name: access-plugin-with-review
+spec:
+  allow:
+    review_requests:
+      submit_for_users:
+        - '*'
+```
+
+When an Access Request review matches a plugin user's role with `submit_for_users`, the review will ignore all other
+`review_requests` conditions. This is because the Teleport Auth Service will perform review permission checks against the
+user that the plugin is submitting on behalf of, instead of the plugin's own review permissions.
+This ensures that RBAC is enforced on the correct user identity and not the plugin's identity.
+
 ## Request annotations
 
 When a user creates an Access Request, the Teleport Auth Service can write

--- a/docs/pages/identity-governance/access-requests/plugins/how-to-build.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/how-to-build.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to Build an Access Request Plugin
-sidebar_position: 11
+sidebar_position: 12
 description: Manage Access Requests using custom workflows with the Teleport API
 tags:
  - access-requests
@@ -500,4 +500,3 @@ the plugin. For production usage, we recommend provisioning short-lived
 credentials via Machine & Workload Identity, which reduces the risk of these credentials becoming
 stolen. View our [Machine & Workload Identity documentation](../../../machine-workload-identity/machine-workload-identity.mdx) to
 learn more.
-

--- a/docs/pages/identity-governance/access-requests/plugins/slack-review.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack-review.mdx
@@ -40,6 +40,8 @@ approve or deny Access Requests directly within Slack without being redirected t
 
 (!docs/pages/includes/machine-id/plugin-prerequisites.mdx!)
 
+- A running Teleport cluster v18.11.0 or later. Teleport Slack plugin v18.11.0 or later.
+
 - Slack admin privileges to create an app and install it to your workspace. Your
   Slack profile must have the "Workspace Owner" or "Workspace Admin" banner
   below your profile picture.

--- a/docs/pages/identity-governance/access-requests/plugins/slack-review.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack-review.mdx
@@ -1,0 +1,552 @@
+---
+title: Run the Slack Access Request Plugin with Native Reviews
+description: How to set up Teleport's Slack plugin to review Access Requests directly within Slack.
+sidebar_label: Slack with Native Reviews
+tags:
+ - access-requests
+ - how-to
+ - identity-governance
+ - privileged-access
+enterprise: Identity Governance
+page_type: how-to
+---
+
+In this guide, you will configure the Teleport Slack plugin to be able to review
+Access Requests directly within Slack.
+
+Currently, only self-hosted plugins support this feature.
+Support for Teleport-hosted plugins will be added in the future.
+
+Security-critical Teleport deployments should follow the [regular Slack plugin guide](slack.mdx),
+which requires reviewers to authenticate to Teleport before approving or denying requests.
+
+<Admonition type="warning">
+Enabling this feature reduces the security of the Teleport cluster.
+Access Request reviews submitted through Slack are bound to a Slack identity rather than
+the reviewer's Teleport identity, and bypass Teleport authentication
+(and MFA for admin actions if enabled on cluster).
+As a result, a compromised Slack account can approve requests from Slack and escalate privileges in Teleport.
+</Admonition>
+
+## How it works
+
+Teleport's Slack integration notifies individuals and channels of
+Access Requests. By enabling the plugin with native Access Request reviews, users can then
+approve or deny Access Requests directly within Slack without being redirected to the Teleport Web UI.
+
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)
+
+(!docs/pages/includes/machine-id/plugin-prerequisites.mdx!)
+
+- Slack admin privileges to create an app and install it to your workspace. Your
+  Slack profile must have the "Workspace Owner" or "Workspace Admin" banner
+  below your profile picture.
+
+- Slack users that are linked to persistent Teleport users in order to review Access Requests from Slack.
+  When using an external Identity Provider, users should be imported using
+  the User Sync feature from the
+  [Teleport Okta integration](../../integrations/okta/user-sync.mdx) or the
+  [Teleport Entra ID integration](../../integrations/entra-id/entra-id.mdx).
+  SSO-only users are represented by temporary users in Teleport and they
+  will be able to submit reviews until their temporary Teleport user expires,
+  after which they must re-login to Teleport again.
+
+- Either a Linux host or Kubernetes cluster where you will run the Teleport Slack plugin.
+
+- A Slack application, Bot OAuth token, and App-level token to use for the plugin.
+
+  <details>
+  <summary>Creating a Slack app</summary>
+
+    1. Visit [https://api.slack.com/apps](https://api.slack.com/apps) to create
+       a new Slack app. Click "Create an App", then "From scratch". Fill in the
+       form as shown below:
+
+       ![Create Slack App](../../../../img/enterprise/plugins/slack/Create-a-Slack-App.png)
+
+       The "App Name" should be "Teleport". Click the "Development Slack
+       Workspace" dropdown and choose the workspace where you would like to see
+       Access Request messages.
+
+    1. Configure your application to authenticate to the Slack API. We will do
+       this by generating an OAuth token that the plugin will present to the
+       Slack API.
+
+       We will restrict the plugin to the narrowest possible permissions by
+       using OAuth scopes. The Slack plugin needs to post messages to your
+       workspace. It also needs to read usernames and email addresses in order
+       to direct Access Request notifications from the Auth Service to the
+       appropriate Teleport users in Slack.
+
+       After creating your app, the Slack website will open a console where you
+       can specify configuration options. 
+
+    1. On the sidebar menu under "Features", click "OAuth & Permissions".
+
+    1. Scroll to the "Scopes" section and click "Add an OAuth Scope" for each of
+       the following scopes:
+
+       - `chat:write`
+       - `incoming-webhook`
+       - `users:read`
+       - `users:read.email`
+
+       The result should look like this:
+
+       ![API Scopes](../../../../img/enterprise/plugins/slack/api-scopes.png)
+
+     1. After you have configured scopes for your plugin, scroll back to the top
+        of the OAuth & Permissions page, find the "OAuth Tokens for Your
+        Workspace" section, and click "Install to Workspace". You will see a
+        summary of the permission you configured for the Slack plugin earlier.
+
+     1. In "Where should Teleport post?", choose "Slackbot" as the default
+        channel the plugin will post to. The plugin will post here when sending
+        direct messages.  Later in this guide, we will configure the plugin to
+        post in other channels as well.
+
+        After submitting this form, you will see an OAuth token in the "OAuth &
+        Permissions" tab under "Tokens for Your Workspace":
+
+        ![OAuth Tokens](../../../../img/enterprise/plugins/slack/OAuth.png)
+
+        You will use this token later when configuring the Slack plugin.
+
+  </details>
+
+(!docs/pages/includes/tctl.mdx!)
+
+## Step 1/7. Configure your Slack app
+
+In this step, you will configure your Slack app to support the native Access Request reviews feature.
+
+### Generate an app-level token
+
+Enter the following URL and select your Slack app to reach your app's settings:
+[`https://api.slack.com/apps`](https://api.slack.com/apps)
+
+In your Slack app's settings, head to the **Basic Information** tab.
+
+Then, under **App-Level Tokens**, click **Generate Token and Scopes**. Set a name
+and add the `connections:write` scope. This will provide the plugin with the necessary permissions
+to receive user interactions from Slack.
+
+Copy the generated app-level token for use in a later step.
+
+<Admonition type="info" title="App-level Token vs. Bot Token">
+
+The Slack app-level token is different from the Slack bot token and must be set up separately.
+
+The bot token `xoxb-...` provides the plugin permissions to read Slack user info and write to channels.
+The app-level token `xapp-...` provides the plugin permissions to receive user interactions from Slack,
+which is necessary for the native Access Request reviews feature.
+
+</Admonition>
+
+### Enable Socket Mode setting
+
+Head to the **Socket Mode** tab and enable Socket Mode. This will allow the Teleport Slack plugin
+to build a WebSocket connection with the Slack server in order to process Access Request reviews from Slack.
+
+![Enable Slack Socket Mode](https://goteleport.com/_uploads/slack_socketmode_4badb28ce0.png)
+
+## Step 2/7. Define requester and reviewer users
+
+For the purpose of this guide, we will define an `access-requester` role that
+can request the built-in `access` role, and an `access-reviewer` role that can
+review requests for the `access` role.
+
+Create a file called `access-request-rbac.yaml` with the following content:
+
+```yaml
+kind: role
+version: v8
+metadata:
+  name: access-reviewer
+spec:
+  allow:
+    review_requests:
+      roles: ['access']
+---
+kind: role
+version: v8
+metadata:
+  name: access-requester
+spec:
+  allow:
+    request:
+      roles: ['access']
+      thresholds:
+        - approve: 1
+          deny: 1
+```
+
+Create the roles you defined:
+
+```code
+$ tctl create -f access-request-rbac.yaml
+role 'access-reviewer' has been created
+role 'access-requester' has been created
+```
+
+(!docs/pages/includes/create-role-using-web.mdx!)
+
+### Set up the requester user
+
+Create a user called `myuser` who has the `access-requester` role:
+
+```code
+$ tctl users add myuser --roles=access-requester
+```
+
+Visit the invitation URL that is printed and login as `myuser` for the first time,
+registering credentials as configured for your Teleport cluster.
+
+Later in this guide, you will have `myuser` request the `access` role so you can
+review the request using the Teleport Slack plugin.
+
+### Set up the reviewer user
+
+Next, we will set up a user that can review Access Requests directly within Slack.
+
+<Admonition type="info">
+All users performing Access Request reviews within Slack must be linked to a persistent Teleport user.
+When using an external Identity Provider, users should be imported using
+the User Sync feature from the
+[Teleport Okta integration](../../integrations/okta/user-sync.mdx) or the
+[Teleport Entra ID integration](../../integrations/entra-id/entra-id.mdx).
+SSO-only users are represented by temporary users in Teleport and they
+will be able to submit reviews until their temporary Teleport user expires,
+after which they must re-login to Teleport again.
+</Admonition>
+
+There are two identity binding models for Slack reviewers:
+- binding based on Teleport username and Slack email
+- binding based on Teleport trait and Slack user ID
+
+The binding based on Teleport trait is stronger, but requires a Teleport user to be given a trait with
+their Slack user ID, often coming from the Identity Provider/SSO connector.
+
+You can set up both types of identity bindings if some users are imported
+from an Identity Provider/SSO connector while others are local Teleport users.
+
+<Tabs>
+<TabItem label="Teleport trait binding">
+
+Create a Teleport user with a username set as <Var name="alice@example.com" />
+and assigned the role `access-reviewer`.
+
+We will assign this reviewer user with a Teleport trait named <Var name="slack_uid" />
+that holds the value of the Slack user's ID: <Var name="U123456789" />.
+The trait name can also be configured in the plugin configuration step.
+
+<Tabs>
+<TabItem label="Local users">
+
+Create a local user:
+
+```code
+$ tctl users add <Var name="alice@example.com" /> --roles=access-reviewer
+```
+
+Visit the invitation URL that is printed and login as <Var name="alice@example.com" /> for the first time,
+registering credentials as configured for your Teleport cluster.
+
+Create a file called `user-traits.yaml` with the following content:
+
+```yaml
+kind: user
+version: v2
+metadata:
+  name: <Var name="alice@example.com" />
+spec:
+  roles: ['access-reviewer']
+  traits:
+    <Var name="slack_uid" />: ['<Var name="U123456789" />']
+```
+
+Update the newly created user:
+
+```code
+$ tctl create -f user-traits.yaml
+```
+
+</TabItem>
+<TabItem label="SSO users">
+
+When using a single sign-on user, the Teleport trait should be configured in the Identity Provider.
+
+To get started integrating your Identity Provider with Teleport, read [Integrate
+your Identity Provider](../../../zero-trust-access/sso/integrate-idp/integrate-idp.mdx).
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+<TabItem label="Teleport username binding">
+
+Prepare a Slack user with an email address.
+Create a Teleport user with a username set to the Slack user's email <Var name="alice@example.com" />
+and assigned the role `access-reviewer`.
+
+```code
+$ tctl users add <Var name="alice@example.com" /> --roles=access-reviewer
+```
+
+Visit the invitation URL that is printed and login as <Var name="alice@example.com" /> for the first time,
+registering credentials as configured for your Teleport cluster.
+
+</TabItem>
+</Tabs>
+
+The Slack user will now be able to review Access Requests for the `access` role within Slack
+once we set up the Teleport Slack plugin.
+
+## Step 3/7. Install the Teleport Slack plugin
+
+(!docs/pages/includes/plugins/install-access-request.mdx name="slack"!)
+
+## Step 4/7. Set up the Teleport Slack plugin
+
+In this section, you will set up the Teleport Slack plugin 
+and generate credentials that the plugin will use for authentication.
+
+### Enable issuing of credentials for the plugin user
+
+The required permissions for the plugin are configured in the preset `access-plugin-with-review`
+role. To generate credentials for the plugin, define either a Machine ID bot user
+or a regular Teleport user.
+
+<Tabs>
+<TabItem label="Machine & Workload Identity">
+(!docs/pages/includes/plugins/rbac-impersonate-machine-id.mdx role="access-plugin-with-review"!)
+</TabItem>
+<TabItem label="Long-lived identity files">
+(!docs/pages/includes/plugins/rbac-impersonate.mdx role="access-plugin-with-review"!)
+</TabItem>
+</Tabs>
+
+### Export an identity file for the plugin user
+
+Give the plugin access to a Teleport identity file. We recommend using Machine
+ID for this in order to produce short-lived identity files that are less
+dangerous if exfiltrated, though in demo deployments, you can generate
+longer-lived identity files with `tctl`:
+
+<Tabs>
+<TabItem label="Machine & Workload Identity">
+(!docs/pages/includes/plugins/tbot-identity.mdx secret="teleport-plugin-slack-identity"!)
+</TabItem>
+<TabItem label="Long-lived identity files">
+(!docs/pages/includes/plugins/identity-export.mdx user="access-plugin-with-review" plugin="slack" secret="teleport-plugin-slack-identity"!)
+</TabItem>
+</Tabs>
+
+## Step 5/7. Run the Teleport Slack plugin
+
+At this point, the Teleport Slack plugin has the credentials it needs to
+communicate with your Teleport cluster and the Slack API. In this step, you will
+configure the Slack plugin to use these credentials. You will also configure the
+plugin to notify the right Slack channels when it receives an Access Request
+update.
+
+Lastly, you will configure the plugin to enable reviews of Access Requests
+directly within Slack.
+
+### Configure the plugin
+
+(!docs/pages/includes/plugins/slack-review-config.mdx!)
+
+### Invite the plugin to your Slack app
+
+Once you have configured the channels that the Slack plugin will notify when it
+receives an Access Request, you will need to ensure that the plugin can post in
+those channels.
+
+You have already configured the plugin to send direct messages as Slackbot. For
+any other channel you mention in your `role_to_recipients` map, you will need
+to invite the plugin to that channel. Navigate to each channel and enter `/invite
+@teleport` in the message box.
+
+<details>
+<summary>Suggested reviewers</summary>
+
+Users can suggest reviewers when they create an Access Request, e.g.:
+
+```code
+$ tsh request create --roles=dbadmin --reviewers=alice@example.com,ivan@example.com
+```
+
+If an Access Request includes suggested reviewers, the Slack plugin will add
+these to the list of channels to notify. If a suggested reviewer is an email
+address, the plugin will look up the direct message channel for that
+address and post a message in that channel.
+
+</details>
+
+### Start the plugin
+
+Start the plugin by following the instructions below.
+
+<Tabs>
+<TabItem label="Executable">
+```code
+$ teleport-slack start --config teleport-slack.toml
+```
+</TabItem>
+<TabItem label="Docker">
+
+```code
+$ docker run \
+  -v $(pwd)/teleport-slack.toml:/etc/teleport-slack.toml \
+  -v <Var name="/var/lib/teleport/plugins/slack" />:<Var name="/var/lib/teleport/plugins/slack" /> \
+  public.ecr.aws/gravitational/teleport-plugin-slack:(=teleport.version=) start
+```
+
+</TabItem>
+<TabItem label="Helm Chart">
+```code
+$ helm upgrade --install teleport-plugin-slack teleport/teleport-plugin-slack --values teleport-plugin-slack-values.yaml
+```
+
+To inspect the plugin's logs, use the following command:
+
+```code
+$ kubectl logs deploy/teleport-plugin-slack
+```
+
+Debug logs can be enabled by setting `log.severity` to `DEBUG` in
+`teleport-plugin-slack-values.yaml` and executing the `helm upgrade ...` command
+above again. Then you can restart the plugin with the following command:
+
+```code
+$ kubectl rollout restart deployment teleport-plugin-slack
+```
+</TabItem>
+</Tabs>
+
+## Step 6/7. Test your Slack app
+
+Once you've created the Slack app and the Teleport Slack plugin is
+running, you can now test the workflow.
+
+### Create an Access Request
+
+(!docs/pages/includes/plugins/create-request.mdx role="access"!)
+
+The user you configured earlier to review the request should receive a direct
+message from "Teleport" in Slack with Access Request details.
+This message will contain “Approve” and “Deny” buttons for the user to either
+approve or deny the request.
+
+![Slack Access Request message with approve and deny buttons](https://goteleport.com/_uploads/slack_review_request_20fcbbb8fe.png)
+
+### Resolve the request
+
+As the Slack user you set as an Access Request reviewer, click the "Approve" button,
+and the plugin will send a reply to the original message with the review response.
+
+Once the request is resolved, the Slack bot will add an emoji reaction of ✅ or
+❌ to the Slack message for the Access Request, depending on whether the request
+was approved or denied.
+
+The Web UI will also reflect the resolved Access Request.
+
+![Access Request reviewed on Web UI](https://goteleport.com/_uploads/slack_approve_request_00532ec851.png)
+
+The Teleport audit log will report the Access Request as submitted by the Teleport Slack plugin identity.
+The `submitted_by` field represents the plugin identity that submitted on behalf of the `reviewer` user.
+
+<details>
+<summary>Audit log</summary>
+
+```json
+{
+  "RequestedResourceAccessIDs": null,
+  "cluster_name": "kevin18.cloud.gravitational.io",
+  "code": "T5002I",
+  "ei": 0,
+  "event": "access_request.review",
+  "expires": "2026-06-18T11:26:07Z",
+  "id": "019ed7ee-e581-7644-81be-dffd1229028c",
+  "max_duration": "2026-06-18T11:26:07Z",
+  "proposed_state": "APPROVED",
+  "reviewer": "kevin.shi@goteleport.com",
+  "state": "APPROVED",
+  "submitted_by": "access-plugin-with-review",
+  "time": "2026-06-17T23:34:06.274Z",
+  "uid": "8912fd42-d1f4-4847-9621-fb7313e0ef08"
+}
+```
+
+</details>
+
+<Admonition type="info" title="Auditing Access Requests">
+
+When the Slack plugin posts an Access Request notification to a channel, anyone
+with access to the channel can view the notification and follow the link. While
+users must be authorized via their Teleport roles to review Access Requests, you
+should still check the Teleport audit log to ensure that the right users are
+reviewing the right requests.
+
+When auditing Access Request reviews, check for events with the type `Access
+Request Reviewed` in the Teleport Web UI.
+
+</Admonition>
+
+## Step 7/7. Set up systemd
+
+This section is only relevant if you are running the Teleport Slack plugin on a
+Linux host.
+
+Copy the `teleport-slack.toml` file to `/etc` on your Linux server:
+
+```code
+$ sudo mv teleport-slack.toml /etc
+```
+
+In production, we recommend starting the Teleport plugin daemon via an init
+system like systemd. Here's the recommended Teleport plugin service unit file
+for systemd:
+
+```ini
+(!examples/systemd/plugins/teleport-slack.service!)
+```
+
+Save this as `teleport-slack.service` in either `/usr/lib/systemd/system/` or
+another [unit file load
+path](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Unit%20File%20Load%20Path)
+supported by systemd.
+
+Enable and start the plugin:
+
+```code
+$ sudo systemctl enable teleport-slack
+$ sudo systemctl start teleport-slack
+```
+
+## Troubleshooting
+
+- Ensure Socket Mode is turned on in your Slack app’s settings.
+- Ensure the Slack app-level token is provided for the plugin configuration field `review.app_token`.
+  This is different from the Slack bot OAuth token.
+- If you receive an Access Request review reply with the following error:
+  `Insufficient permissions to review request`,
+  ensure the Slack reviewer is properly bound with a local Teleport user,
+  and that Teleport user has sufficient review permissions.
+  Also ensure that the Slack plugin is using the preset Teleport role
+  `access-plugin-with-review` which provides proper RBAC permissions for the Slack plugin.
+- A Slack plugin using a long-lived identity file will not work with a Teleport cluster
+  with admin-action MFA enabled. If admin-action MFA is enabled, use a Slack plugin with a Machine ID bot.
+
+## Next steps
+
+- Read our guides to configuring [Resource Access
+    Requests](../resource-requests.mdx) and [Role Access
+    Requests](../role-requests.mdx) so you can get the most out
+    of your Access Request plugins.
+- To see all of the options you can set in the values file for the
+  `teleport-plugin-slack` Helm chart, consult our [reference
+  guide](../../../reference/helm-reference/teleport-plugin-slack.mdx).

--- a/docs/pages/identity-governance/access-requests/plugins/slack.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack.mdx
@@ -13,8 +13,13 @@ enterprise: Identity Governance
 import SlackVideoMp4 from "@version/docs/img/enterprise/plugins/slack/slack.mp4"
 import SlackVideoWebm from "@version/docs/img/enterprise/plugins/slack/slack.webm"
 
-This guide will explain how to set up Slack to receive Access Request messages
-from Teleport. 
+In this guide, you will set up Slack to receive Access Request messages from
+Teleport.
+
+You can opt in to the [native Access Request reviews feature](slack-review.mdx)
+in order to approve or deny Access Requests directly within Slack, avoiding a redirect
+to the Teleport Web UI. Note that this feature reduces the security of the Teleport cluster
+by relying on Slack authentication and bypassing Teleport authentication.
 
 <details>
 <summary>This integration is hosted on Teleport Cloud</summary>
@@ -447,6 +452,8 @@ $ sudo systemctl start teleport-slack
 
 ## Next steps
 
+- Set up the [native Access Request reviews feature](slack-review.mdx)
+    that allows you to approve or deny Access Requests directly within Slack.
 - Read our guides to configuring [Resource Access
     Requests](../resource-requests.mdx) and [Role Access
     Requests](../role-requests.mdx) so you can get the most out

--- a/docs/pages/includes/plugins/create-request.mdx
+++ b/docs/pages/includes/plugins/create-request.mdx
@@ -1,9 +1,11 @@
+{{ role="editor" }}
+
 <Tabs>
 <TabItem label="As an Admin">
   A Teleport admin can create an Access Request for another user with `tctl`:
 
   ```code
-  $ tctl request create myuser --roles=editor
+  $ tctl request create myuser --roles={{ role }}
   ```
 
 </TabItem>
@@ -11,7 +13,7 @@
 
   Users can use `tsh` to create an Access Request and log in with approved roles:
   ```code
-  $ tsh request create --roles=editor
+  $ tsh request create --roles={{ role }}
   Seeking request approval... (id: 8f77d2d1-2bbf-4031-a300-58926237a807)
   ```
 

--- a/docs/pages/includes/plugins/rbac-impersonate-machine-id.mdx
+++ b/docs/pages/includes/plugins/rbac-impersonate-machine-id.mdx
@@ -1,10 +1,12 @@
+{{ role="access-plugin" }}
+
 If you haven't set up a Machine ID bot yet, refer to the
 [deployment guide](../../machine-workload-identity/deployment/deployment.mdx)
 to run the `tbot` binary on your infrastructure.
 
-Next, allow the Machine ID bot to generate credentials for the `access-plugin`
+Next, allow the Machine ID bot to generate credentials for the `{{ role }}`
 role. You can do this using `tctl`, replacing `my-bot` with the name of your bot:
 
 ```code
-$ tctl bots update my-bot --add-roles access-plugin
+$ tctl bots update my-bot --add-roles {{ role }}
 ```

--- a/docs/pages/includes/plugins/rbac-impersonate.mdx
+++ b/docs/pages/includes/plugins/rbac-impersonate.mdx
@@ -1,51 +1,53 @@
+{{ role="access-plugin" }}
+
 As with all Teleport users, the Teleport Auth Service authenticates the
-`access-plugin` user by issuing short-lived TLS credentials. In this case, we
+`{{ role }}` user by issuing short-lived TLS credentials. In this case, we
 will need to request the credentials manually by *impersonating* the
-`access-plugin` role and user.
+`{{ role }}` role and user.
 
 If you are running a self-hosted Teleport Enterprise deployment and are using
 `tctl` from the Auth Service host, you will already have impersonation
 privileges.
 
-To grant your user impersonation privileges for `access-plugin`, define a user
-named `access-plugin` and a role named `access-plugin-impersonator` by adding
-the following YAML document into a file called `access-plugin-impersonator.yaml`:
+To grant your user impersonation privileges for `{{ role }}`, define a user
+named `{{ role }}` and a role named `{{ role }}-impersonator` by adding
+the following YAML document into a file called `{{ role }}-impersonator.yaml`:
 
 ```yaml
 kind: user
 metadata:
-  name: access-plugin
+  name: {{ role }}
 spec:
-  roles: ['access-plugin']
+  roles: ['{{ role }}']
 version: v2
 ---
 kind: role
 version: v7
 metadata:
-  name: access-plugin-impersonator
+  name: {{ role }}-impersonator
 spec:
   allow:
     impersonate:
       roles:
-      - access-plugin
+      - {{ role }}
       users:
-      - access-plugin
+      - {{ role }}
 ```
 
 Create the user and role:
 
 ```code
-$ tctl create -f access-plugin-impersonator.yaml
-user "access-plugin" has been created
-role "access-plugin-impersonator" has been created
+$ tctl create -f {{ role }}-impersonator.yaml
+user "{{ role }}" has been created
+role "{{ role }}-impersonator" has been created
 ```
 
 (!docs/pages/includes/create-role-using-web.mdx!)
 
 Assign this role to the user you plan to use to generate credentials for the
-`access-plugin` role and user:
+`{{ role }}` role and user:
 
-(!docs/pages/includes/add-role-to-user.mdx role="access-plugin-impersonator"!)
+(!docs/pages/includes/add-role-to-user.mdx role="{{ role }}-impersonator"!)
 
-You will now be able to generate signed certificates for the `access-plugin`
+You will now be able to generate signed certificates for the `{{ role }}`
 role and user.

--- a/docs/pages/includes/plugins/slack-review-config.mdx
+++ b/docs/pages/includes/plugins/slack-review-config.mdx
@@ -1,0 +1,143 @@
+<Tabs>
+<TabItem label="Executable">
+
+On your local workstation, create a file called `teleport-slack.toml`
+based on the following example:
+
+```toml
+[teleport]
+# Teleport Proxy/Auth Service address.
+#
+# Should be port 443 or 3080 for Proxy Service and port 3025 for Auth Service.
+# For Teleport Cloud, should be in the form "your-account.teleport.sh:443".
+addr = "<Var name="teleport.example.com:443" />"
+
+# Path to exported identity file.
+#
+# If providing credentials using `tbot` running on a Linux server,
+# set this to `/opt/machine-id/identity`.
+identity = "<Var name="/var/lib/teleport/plugins/slack" />/identity"
+
+# Refresh identity file on a periodic basis.
+refresh_identity = true
+
+[slack]
+# Slack Bot OAuth token.
+#
+# Provides the plugin permissions to read Slack user info and write to channels.
+# Set this up under "OAuth & Permissions" in your Slack app settings:
+# https://api.slack.com/apps
+#
+# You can also use an absolute path to a token file, e.g.,
+# "/var/lib/teleport/plugins/slack/token"
+token = "xoxb-your-bot-token"
+
+[review]
+# Toggles native review feature. Default is false.
+enabled = true
+
+# Slack App-level token.
+#
+# Provides the plugin permissions to receive user interactions from Slack.
+# This is different from the Bot OAuth token, and must be set up separately.
+# Set this up under "Basic Information" in your Slack app settings:
+# https://api.slack.com/apps
+#
+# You can also use an absolute path to a token file, e.g.,
+# "/var/lib/teleport/plugins/slack/app-token"
+app_token = "xapp-your-app-token"
+
+# Allows binding between Teleport username and Slack email.
+#
+# This should only be set to true if `review.slack_user_id_trait` is not configured in Teleport.
+# We recommend configuring a trait for stronger identity binding. Default is false.
+allow_email_username_match = <Var name="slackEmailUsernameBind" initial="false" />
+
+# Name of the Teleport trait to bind Teleport user and Slack user.
+#
+# The trait should hold value of Slack user ID.
+# If no trait is set up in Teleport, this should remain empty.
+slack_user_id_trait = "<Var name="slack_uid" />"
+
+[role_to_recipients]
+# Map roles to recipients.
+#
+# Provide slack user_email/channel recipients for access requests for specific roles. 
+# role.suggested_reviewers will automatically be treated as additional email recipients.
+# "*" must be provided to match non-specified roles.
+"*" = "<Var name="access-requests" />"
+"access" = ["<Var name="alice@example.com" />"]
+
+[log]
+# Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/slack.log"
+output = "stdout"
+
+# Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
+severity = "INFO"
+```
+
+</TabItem>
+<TabItem label="Helm Chart">
+
+On your local workstation, create a file called `teleport-plugin-slack-values.yaml`
+based on the following example:
+
+```yaml
+teleport:
+  # Teleport Proxy/Auth Service address.
+  #
+  # Should be port 443 or 3080 for Proxy Service and port 3025 for Auth Service.
+  # For Teleport Cloud, should be in the form "your-account.teleport.sh:443".
+  address: <Var name="teleport.example.com:443" />
+  # Name of the Kubernetes secret that contains the credentials for the connection
+  # to your Teleport cluster.
+  identitySecretName: teleport-plugin-slack-identity
+  identitySecretPath: identity
+
+slack:
+  # Slack Bot OAuth token.
+  #
+  # Provides the plugin permissions to read Slack user info and write to channels.
+  # Set this up under "OAuth & Permissions" in your Slack app settings:
+  # https://api.slack.com/apps
+  token: "xoxb-your-bot-token"
+
+review:
+  # Toggles native review feature. Default is false.
+  enabled: true
+  # Slack App-level token.
+  #
+  # Provides the plugin permissions to receive user interactions from Slack.
+  # This is different from the Bot OAuth token, and must be set up separately.
+  # Set this up under "Basic Information" in your Slack app settings:
+  # https://api.slack.com/apps
+  appToken: "xapp-your-app-token"
+  # Allows binding between Teleport username and Slack email.
+  #
+  # This should only be set to true if `review.slackUserIdTrait` is not configured in Teleport.
+  # We recommend configuring a trait for stronger identity binding. Default is false.
+  allowEmailUsernameMatch: <Var name="slackEmailUsernameBind" />
+  # Name of the Teleport trait to bind Teleport user and Slack user.
+  #
+  # The trait should hold value of Slack user ID.
+  # If no trait is set up in Teleport, this should remain empty.
+  slackUserIdTrait: <Var name="slack_uid" />
+
+# Map roles to recipients.
+#
+# Provide slack user_email/channel recipients for access requests for specific roles. 
+# role.suggested_reviewers will automatically be treated as additional email recipients.
+# "*" must be provided to match non-specified roles.
+roleToRecipients:
+  "*": "<Var name="access-requests" />"
+  "access": ["<Var name="alice@example.com" />"]
+
+log:
+  # Logger output. Could be "stdout", "stderr" or "/var/lib/teleport/slack.log"
+  output: stdout
+  # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN".
+  severity: INFO
+```
+
+</TabItem>
+</Tabs>

--- a/docs/pages/includes/preset-roles-table.mdx
+++ b/docs/pages/includes/preset-roles-table.mdx
@@ -4,6 +4,7 @@
 | `editor` | Allows editing of cluster configuration settings. |  |
 | `auditor`| Allows reading cluster events, audit logs, and playing back session records. |  |
 | `access-plugin` | Enables self-hosted Access Request plugin features. |  |
+| `access-plugin-with-review` | Enables self-hosted Access Request plugin features including native Access Request reviews. |  |
 | `list-access-request-resources` | Allows reading Access Request resources. |  |
 | `requester`| Allows a user to create Access Requests. | ✔ |
 | `reviewer`| Allows review of Access Requests. | ✔ |

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -382,6 +382,9 @@ spec:
       # the reviewer can preview details about resources accessible by any roles
       # listed in preview_as_roles when reviewing Resource Access Requests
       preview_as_roles: ['dbadmin']
+      # the reviewer can submit reviews on behalf of other users;
+      # only to be used by Access Request plugins (eg. Slack plugin)
+      submit_for_users: ['*']
 
     # request allows a user to request roles matching
     # expressions below

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -721,10 +721,11 @@ Requests, and like `request`, can fall under `allow` or `deny`:
 
 |Role Field|Description|Further Information|
 |---|---|---|
-|`review_requests.roles`|Allows or denies the ability to review requests for particular roles.|[Reviews for specific roles](../../identity-governance/access-requests/access-request-configuration.mdx)|
-|`review_requests.where`|Configures conditions in which a user with the role may review an Access Request|[`where` expressions](../../identity-governance/access-requests/access-request-configuration.mdx)|
-|`review_requests.preview_as_roles`|Allows or denies the ability to list resources that a user with the requested role can access|[Inspecting requested resources](../../identity-governance/access-requests/access-request-configuration.mdx)|
-|`review_requests.claims_to_roles`|Teleport roles that a user can or cannot review requests for based on their traits.|[Reviews for specific roles](../../identity-governance/access-requests/access-request-configuration.mdx)|
+|`review_requests.roles`|Allows or denies the ability to review requests for particular roles.|[Reviews for specific roles](../../identity-governance/access-requests/access-request-configuration.mdx#roles-that-a-reviewer-can-grant-access-to)|
+|`review_requests.where`|Configures conditions in which a user with the role may review an Access Request|[`where` expressions](../../identity-governance/access-requests/access-request-configuration.mdx#where-expressions)|
+|`review_requests.preview_as_roles`|Allows or denies the ability to list resources that a user with the requested role can access|[Inspecting requested resources](../../identity-governance/access-requests/access-request-configuration.mdx#inspecting-requested-resources)|
+|`review_requests.claims_to_roles`|Teleport roles that a user can or cannot review requests for based on their traits.|[Reviews for specific roles](../../identity-governance/access-requests/access-request-configuration.mdx#roles-that-a-reviewer-can-grant-access-to)|
+|`review_requests.submit_for_users`|Allows or denies the ability to submit reviews on behalf of other users. Ignores all other `review_requests` conditions if matched. Only to be used by Teleport Access Request plugins.|[Submitting reviews for other users](../../identity-governance/access-requests/access-request-configuration.mdx#submitting-for-other-users)|
 
 ### Client options
 


### PR DESCRIPTION
Backport to branch/v18:
- https://github.com/gravitational/teleport/pull/67948
- https://github.com/gravitational/teleport/pull/68221

This is the docs PR backport for the Slack plugin native Access Request reviews feature.
Holding until the feature is cut into release.
