### PR TITLE
[e2e] Allow e2e tests to declare custom env variables

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -29,7 +29,7 @@ click through to screenshots and anything else from Playwright's test results.
 By default, the runner runs in test mode. Use one of the following flags to change the mode (mutually exclusive):
 
 | Flag               | Description                                                                     |
-| ------------------ | ------------------------------------------------------------------------------- |
+|--------------------|---------------------------------------------------------------------------------|
 | `--ui`             | Open Playwright UI mode                                                         |
 | `--debug`          | Run tests with Playwright inspector (`PWDEBUG=1`)                               |
 | `--codegen`        | Open Playwright codegen against running Teleport. Available only for web tests. |
@@ -39,7 +39,7 @@ By default, the runner runs in test mode. Use one of the following flags to chan
 ### Flags
 
 | Flag                   | Default          | Description                                                                             |
-| ---------------------- | ---------------- | --------------------------------------------------------------------------------------- |
+|------------------------|------------------|-----------------------------------------------------------------------------------------|
 | `-v`                   | `false`          | Enable debug logging                                                                    |
 | `--no-build`           | `false`          | Skip `make` binaries (useful during development)                                        |
 | `--no-resource-setup`  | `false`          | Skip pre-test resource setup                                                            |
@@ -60,11 +60,11 @@ automatically starts the required infrastructure.
 
 Available fixtures:
 
-| Fixture        | Description                                                                |
-| -------------- | -------------------------------------------------------------------------- |
-| `ssh-node`     | Start and connect a Teleport SSH node (runs in Docker)                     |
-| `ssh-node-bpf` | A second node, `docker-node-bpf`, with Enhanced Session Recording enabled. |
-| `connect`      | Build Teleport Connect. Auto-detected from Connect test helpers.           |
+| Fixture        | Description                                                                        |
+|----------------|------------------------------------------------------------------------------------|
+| `ssh-node`     | Start and connect a Teleport SSH node (runs in Docker)                             |
+| `ssh-node-bpf` | A second node, `docker-node-bpf`, with Enhanced Session Recording enabled.         |
+| `connect`      | Build Teleport Connect. Auto-detected from Connect test helpers.                   |
 
 Fixtures can also be enabled manually with `--with-<name>` flags (e.g. `--with-ssh-node`, `--with-connect`),
 which is useful for modes like `--codegen` or `--browse` where auto-detection does not run.
@@ -106,12 +106,9 @@ node and exports `E2E_SKIP_ENHANCED_RECORDING=1`, so running the whole suite loc
 opts into that skip:
 
 ```ts
-import { skipEnhancedRecording } from "@gravitational/e2e/helpers/env";
+import { skipEnhancedRecording } from '@gravitational/e2e/helpers/env';
 
-test.skip(
-  skipEnhancedRecording,
-  "docker daemon's kernel cannot run enhanced session recording",
-);
+test.skip(skipEnhancedRecording, "docker daemon's kernel cannot run enhanced session recording");
 ```
 
 In CI the unsupported kernel is a hard error instead, so the coverage cannot quietly disappear. If the node fails for
@@ -127,7 +124,7 @@ roles or traits can declare them via `test.use()`. Usernames are auto-generated 
 
 ```ts
 test.use({
-  user: { roles: ["access", "editor"] },
+  user: { roles: ['access', 'editor'] },
 });
 ```
 
@@ -139,10 +136,11 @@ For tests that need more than one user (e.g. RBAC tests), use the `users` array.
 have `loginAs: true` to indicate which user the test authenticates as:
 
 ```ts
+
 test.use({
   users: [
-    { roles: ["access", "editor"], loginAs: true },
-    { roles: [{ file: "@gravitational/e2e/roles/viewer.yaml" }] },
+    { roles: ['access', 'editor'], loginAs: true },
+    { roles: [{ file: '@gravitational/e2e/roles/viewer.yaml' }] },
   ],
 });
 ```
@@ -155,8 +153,8 @@ are typed in the `UserTraits` interface, and custom keys are also supported:
 ```ts
 test.use({
   user: {
-    roles: ["access"],
-    traits: { logins: ["root", "alice"], kubernetes_groups: ["dev"] },
+    roles: ['access'],
+    traits: { logins: ['root', 'alice'], kubernetes_groups: ['dev'] },
   },
 });
 ```
@@ -170,7 +168,7 @@ For roles that don't exist as built-in Teleport roles, reference a YAML file in 
 ```ts
 test.use({
   user: {
-    roles: [{ file: "@gravitational/e2e/roles/rbac-read-access.yaml" }],
+    roles: [{ file: '@gravitational/e2e/roles/rbac-read-access.yaml' }],
   },
 });
 ```
@@ -188,10 +186,13 @@ without running the UI login flow, so the switch is near-instant.
 
 ```ts
 test.use({
-  users: [{ roles: ["access"], loginAs: true }, { roles: ["editor"] }],
+  users: [
+    { roles: ['access'], loginAs: true },
+    { roles: ['editor'] },
+  ],
 });
 
-test("switch users", async ({ page, loginAs }) => {
+test('switch users', async ({ page, loginAs }) => {
   // signed in as users[0] at test start
   // ...
   const { name: editorName, recordingIds } = await loginAs(1);
@@ -205,7 +206,6 @@ to limit it to that group, or at the top level of a file to apply to all tests i
 
 **Account isolation:** the runner gives each spec its own bootstrapped account, even when two specs declare
 the same `user`/`users`. Concretely:
-
 - Tests with no `test.use({ user/users })` in a project that needs auth (web `:authenticated` projects and
   the `connect` project) fall through to a single shared `access`/`editor` default user.
 - An explicit `test.use({ user: { roles: [...] } })` always gets a fresh account, distinct from the default
@@ -226,12 +226,12 @@ with `test.use({ teleport: { config: {...} } })` inside a `test.describe()` bloc
 Values are evaluated as a JS object literal, so they must be static (no imports or function calls).
 
 ```ts
-test.describe("custom license", () => {
+test.describe('custom license', () => {
   test.use({
     teleport: {
       config: {
         auth_service: {
-          license_file: "${E2E_DIR}/testdata/licenses/custom-license.pem",
+          license_file: '${E2E_DIR}/testdata/licenses/custom-license.pem',
         },
       },
     },
@@ -247,16 +247,16 @@ A declared config can also set process environment variables scoped to just that
 which avoids a variable meant for one config leaking into unrelated tests:
 
 ```ts
-test.describe("cloud license", () => {
+test.describe('cloud license', () => {
   test.use({
     teleport: {
       config: {
         auth_service: {
-          license_file: "${E2E_DIR}/testdata/licenses/cloud-license.pem",
+          license_file: '${E2E_DIR}/testdata/licenses/cloud-license.pem',
         },
       },
       env: {
-        TELEPORT_CLOUD_HOSTPORT: "api.cloud.gravitational.io",
+        TELEPORT_CLOUD_HOSTPORT: 'api.cloud.gravitational.io',
       },
     },
   });
@@ -268,7 +268,7 @@ test.describe("cloud license", () => {
 Web specs run against every browser by default. A test whose subject is not the browser can opt out:
 
 ```ts
-test.use({ browsers: ["chromium"] });
+test.use({ browsers: ['chromium'] });
 ```
 
 This is worth doing for a test that also declares a Teleport config, since the runner otherwise repeats that config's
@@ -312,11 +312,11 @@ filename) to the seeded session ID for the currently-active user:
 
 ```ts
 test.use({
-  user: { roles: ["access"], recordings: ["ssh-session-1"] },
+  user: { roles: ['access'], recordings: ['ssh-session-1'] },
 });
 
-test("open recording", async ({ page, recordingIds }) => {
-  await page.goto(`/web/recordings/${recordingIds["ssh-session-1"]}`);
+test('open recording', async ({ page, recordingIds }) => {
+  await page.goto(`/web/recordings/${recordingIds['ssh-session-1']}`);
 });
 ```
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -29,7 +29,7 @@ click through to screenshots and anything else from Playwright's test results.
 By default, the runner runs in test mode. Use one of the following flags to change the mode (mutually exclusive):
 
 | Flag               | Description                                                                     |
-|--------------------|---------------------------------------------------------------------------------|
+| ------------------ | ------------------------------------------------------------------------------- |
 | `--ui`             | Open Playwright UI mode                                                         |
 | `--debug`          | Run tests with Playwright inspector (`PWDEBUG=1`)                               |
 | `--codegen`        | Open Playwright codegen against running Teleport. Available only for web tests. |
@@ -39,7 +39,7 @@ By default, the runner runs in test mode. Use one of the following flags to chan
 ### Flags
 
 | Flag                   | Default          | Description                                                                             |
-|------------------------|------------------|-----------------------------------------------------------------------------------------|
+| ---------------------- | ---------------- | --------------------------------------------------------------------------------------- |
 | `-v`                   | `false`          | Enable debug logging                                                                    |
 | `--no-build`           | `false`          | Skip `make` binaries (useful during development)                                        |
 | `--no-resource-setup`  | `false`          | Skip pre-test resource setup                                                            |
@@ -60,11 +60,11 @@ automatically starts the required infrastructure.
 
 Available fixtures:
 
-| Fixture        | Description                                                                        |
-|----------------|------------------------------------------------------------------------------------|
-| `ssh-node`     | Start and connect a Teleport SSH node (runs in Docker)                             |
-| `ssh-node-bpf` | A second node, `docker-node-bpf`, with Enhanced Session Recording enabled.         |
-| `connect`      | Build Teleport Connect. Auto-detected from Connect test helpers.                   |
+| Fixture        | Description                                                                |
+| -------------- | -------------------------------------------------------------------------- |
+| `ssh-node`     | Start and connect a Teleport SSH node (runs in Docker)                     |
+| `ssh-node-bpf` | A second node, `docker-node-bpf`, with Enhanced Session Recording enabled. |
+| `connect`      | Build Teleport Connect. Auto-detected from Connect test helpers.           |
 
 Fixtures can also be enabled manually with `--with-<name>` flags (e.g. `--with-ssh-node`, `--with-connect`),
 which is useful for modes like `--codegen` or `--browse` where auto-detection does not run.
@@ -106,9 +106,12 @@ node and exports `E2E_SKIP_ENHANCED_RECORDING=1`, so running the whole suite loc
 opts into that skip:
 
 ```ts
-import { skipEnhancedRecording } from '@gravitational/e2e/helpers/env';
+import { skipEnhancedRecording } from "@gravitational/e2e/helpers/env";
 
-test.skip(skipEnhancedRecording, "docker daemon's kernel cannot run enhanced session recording");
+test.skip(
+  skipEnhancedRecording,
+  "docker daemon's kernel cannot run enhanced session recording",
+);
 ```
 
 In CI the unsupported kernel is a hard error instead, so the coverage cannot quietly disappear. If the node fails for
@@ -124,7 +127,7 @@ roles or traits can declare them via `test.use()`. Usernames are auto-generated 
 
 ```ts
 test.use({
-  user: { roles: ['access', 'editor'] },
+  user: { roles: ["access", "editor"] },
 });
 ```
 
@@ -136,11 +139,10 @@ For tests that need more than one user (e.g. RBAC tests), use the `users` array.
 have `loginAs: true` to indicate which user the test authenticates as:
 
 ```ts
-
 test.use({
   users: [
-    { roles: ['access', 'editor'], loginAs: true },
-    { roles: [{ file: '@gravitational/e2e/roles/viewer.yaml' }] },
+    { roles: ["access", "editor"], loginAs: true },
+    { roles: [{ file: "@gravitational/e2e/roles/viewer.yaml" }] },
   ],
 });
 ```
@@ -153,8 +155,8 @@ are typed in the `UserTraits` interface, and custom keys are also supported:
 ```ts
 test.use({
   user: {
-    roles: ['access'],
-    traits: { logins: ['root', 'alice'], kubernetes_groups: ['dev'] },
+    roles: ["access"],
+    traits: { logins: ["root", "alice"], kubernetes_groups: ["dev"] },
   },
 });
 ```
@@ -168,7 +170,7 @@ For roles that don't exist as built-in Teleport roles, reference a YAML file in 
 ```ts
 test.use({
   user: {
-    roles: [{ file: '@gravitational/e2e/roles/rbac-read-access.yaml' }],
+    roles: [{ file: "@gravitational/e2e/roles/rbac-read-access.yaml" }],
   },
 });
 ```
@@ -186,13 +188,10 @@ without running the UI login flow, so the switch is near-instant.
 
 ```ts
 test.use({
-  users: [
-    { roles: ['access'], loginAs: true },
-    { roles: ['editor'] },
-  ],
+  users: [{ roles: ["access"], loginAs: true }, { roles: ["editor"] }],
 });
 
-test('switch users', async ({ page, loginAs }) => {
+test("switch users", async ({ page, loginAs }) => {
   // signed in as users[0] at test start
   // ...
   const { name: editorName, recordingIds } = await loginAs(1);
@@ -206,6 +205,7 @@ to limit it to that group, or at the top level of a file to apply to all tests i
 
 **Account isolation:** the runner gives each spec its own bootstrapped account, even when two specs declare
 the same `user`/`users`. Concretely:
+
 - Tests with no `test.use({ user/users })` in a project that needs auth (web `:authenticated` projects and
   the `connect` project) fall through to a single shared `access`/`editor` default user.
 - An explicit `test.use({ user: { roles: [...] } })` always gets a fresh account, distinct from the default
@@ -226,12 +226,12 @@ with `test.use({ teleport: { config: {...} } })` inside a `test.describe()` bloc
 Values are evaluated as a JS object literal, so they must be static (no imports or function calls).
 
 ```ts
-test.describe('custom license', () => {
+test.describe("custom license", () => {
   test.use({
     teleport: {
       config: {
         auth_service: {
-          license_file: '${E2E_DIR}/testdata/licenses/custom-license.pem',
+          license_file: "${E2E_DIR}/testdata/licenses/custom-license.pem",
         },
       },
     },
@@ -242,12 +242,33 @@ test.describe('custom license', () => {
 Note that the e2e runner will only restart Teleport with the different config and not re-initialize it from fresh, so the data directory
 will remains the same for all tests which means the cluster's identity like cluster name, CA, bootstrapped users, and roles will carry over unchanged.
 
+A declared config can also set process environment variables scoped to just that config's Teleport restart via
+`test.use({ teleport: { env: {...} } })`. These are not inherited by the default config or by other declared configs,
+which avoids a variable meant for one config leaking into unrelated tests:
+
+```ts
+test.describe("cloud license", () => {
+  test.use({
+    teleport: {
+      config: {
+        auth_service: {
+          license_file: "${E2E_DIR}/testdata/licenses/cloud-license.pem",
+        },
+      },
+      env: {
+        TELEPORT_CLOUD_HOSTPORT: "api.cloud.gravitational.io",
+      },
+    },
+  });
+});
+```
+
 ### Restricting a spec to certain browsers
 
 Web specs run against every browser by default. A test whose subject is not the browser can opt out:
 
 ```ts
-test.use({ browsers: ['chromium'] });
+test.use({ browsers: ["chromium"] });
 ```
 
 This is worth doing for a test that also declares a Teleport config, since the runner otherwise repeats that config's
@@ -291,11 +312,11 @@ filename) to the seeded session ID for the currently-active user:
 
 ```ts
 test.use({
-  user: { roles: ['access'], recordings: ['ssh-session-1'] },
+  user: { roles: ["access"], recordings: ["ssh-session-1"] },
 });
 
-test('open recording', async ({ page, recordingIds }) => {
-  await page.goto(`/web/recordings/${recordingIds['ssh-session-1']}`);
+test("open recording", async ({ page, recordingIds }) => {
+  await page.goto(`/web/recordings/${recordingIds["ssh-session-1"]}`);
 });
 ```
 

--- a/e2e/helpers/test.ts
+++ b/e2e/helpers/test.ts
@@ -63,6 +63,7 @@ export interface UserDefinition {
  **/
 export interface TeleportOption {
   config: Record<string, unknown>;
+  env?: Record<string, string>;
 }
 
 const e2eDir =

--- a/e2e/runner/env.go
+++ b/e2e/runner/env.go
@@ -1,0 +1,60 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+// envStripKeys is a set of process environment variables cleared before each Teleport
+// instance is started as a safety mechanism to prevent ambient environment variables
+// with known Teleport behavioral changes from accidentally leaking into the default
+// config or other declared configs during restarts. This list can be expanded as needed.
+var envStripKeys = []string{"TELEPORT_CLOUD_HOSTPORT"}
+
+// instanceEnv builds an isolated slice of environment variables for the Teleport instance process.
+// It uses the existing environment variables, removes envStripKeys and any key present in
+// overrides, then applies overrides.
+func instanceEnv(overrides map[string]string) []string {
+	strip := make(map[string]struct{}, len(envStripKeys)+len(overrides))
+	for _, k := range envStripKeys {
+		strip[k] = struct{}{}
+	}
+	for k := range overrides {
+		strip[k] = struct{}{}
+	}
+
+	env := os.Environ()
+	n := 0
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		if _, ok := strip[key]; !ok {
+			env[n] = kv
+			n++
+		}
+	}
+	env = env[:n]
+
+	for k, v := range overrides {
+		env = append(env, k+"="+v)
+	}
+
+	return env
+}

--- a/e2e/runner/env_test.go
+++ b/e2e/runner/env_test.go
@@ -1,0 +1,97 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// envValue returns the value for key in an instanceEnv result, and how many
+// entries for that key were found (so tests can assert there's never more
+// than one).
+func envValue(env []string, key string) (value string, count int) {
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if ok && k == key {
+			value = v
+			count++
+		}
+	}
+	return value, count
+}
+
+func TestInstanceEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		setEnv    map[string]string
+		overrides map[string]string
+		checkKey  string
+		wantCount int
+		wantValue string
+	}{
+		{
+			name:      "strip key with no override is absent entirely",
+			setEnv:    map[string]string{"TELEPORT_CLOUD_HOSTPORT": "ambient.example.com"},
+			checkKey:  "TELEPORT_CLOUD_HOSTPORT",
+			wantCount: 0,
+		},
+		{
+			name:      "override wins over ambient value with no duplicate",
+			setEnv:    map[string]string{"TELEPORT_CLOUD_HOSTPORT": "ambient.example.com"},
+			overrides: map[string]string{"TELEPORT_CLOUD_HOSTPORT": "declared.example.com"},
+			checkKey:  "TELEPORT_CLOUD_HOSTPORT",
+			wantCount: 1,
+			wantValue: "declared.example.com",
+		},
+		{
+			name:      "non-strip var passes through unchanged",
+			setEnv:    map[string]string{"SOME_UNRELATED_VAR": "hello"},
+			checkKey:  "SOME_UNRELATED_VAR",
+			wantCount: 1,
+			wantValue: "hello",
+		},
+		{
+			name:      "override of a non-strip var still dedupes",
+			setEnv:    map[string]string{"SOME_UNRELATED_VAR": "ambient"},
+			overrides: map[string]string{"SOME_UNRELATED_VAR": "overridden"},
+			checkKey:  "SOME_UNRELATED_VAR",
+			wantCount: 1,
+			wantValue: "overridden",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.setEnv {
+				t.Setenv(k, v)
+			}
+
+			env := instanceEnv(tt.overrides)
+
+			value, count := envValue(env, tt.checkKey)
+			require.Equal(t, tt.wantCount, count)
+			if tt.wantCount > 0 {
+				require.Equal(t, tt.wantValue, value)
+			}
+		})
+	}
+}

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -268,6 +268,7 @@ func (p *playwrightRunner) runTeleportConfig(ctx context.Context, inst *testInst
 	}
 	inst.teleport.configPath = mergedPath
 	inst.teleportConfigPath = mergedPath
+	inst.teleport.envOverrides = cfg.env
 
 	if err := inst.teleport.start(ctx); err != nil {
 		return fmt.Errorf("re-initializing teleport for %s: %w", inst.browser, err)

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"unicode"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/gravitational/teleport/e2e/runner/fixtures"
 )
 
@@ -1158,15 +1160,23 @@ func scanBrowserRestrictions(targets []scanTarget) (map[string][]string, error) 
 type uniqueTeleportConfig struct {
 	// raw is the config object's raw JS text.
 	raw string
+	// env holds process environment variable overrides for this config.
+	env map[string]string
 	// files are the test files that declared this config.
 	files []string
+}
+
+// configEnvKey is a dedup key for a declared config
+type configEnvKey struct {
+	config string
+	env    string
 }
 
 // scanTeleportConfigs finds the unique custom Teleport configs declared by tests
 // and the base-config selectors (tests that run without one).
 func scanTeleportConfigs(targets []scanTarget) ([]uniqueTeleportConfig, []string, error) {
-	byKey := make(map[string]*uniqueTeleportConfig)
-	var order []string
+	byKey := make(map[configEnvKey]*uniqueTeleportConfig)
+	var order []configEnvKey
 	var defaults []string
 
 	for _, t := range targets {
@@ -1194,10 +1204,10 @@ func scanTeleportConfigs(targets []scanTarget) ([]uniqueTeleportConfig, []string
 		}
 
 		for _, sc := range configs {
-			key := normalizeConfigText(sc.raw)
+			key := configEnvKey{config: normalizeConfigText(sc.raw), env: normalizeEnvText(sc.env)}
 			u, ok := byKey[key]
 			if !ok {
-				u = &uniqueTeleportConfig{raw: sc.raw}
+				u = &uniqueTeleportConfig{raw: sc.raw, env: sc.env}
 				byKey[key] = u
 				order = append(order, key)
 			}
@@ -1246,6 +1256,7 @@ type scopedTeleportConfig struct {
 	raw                string
 	line               int
 	startByte, endByte int
+	env                map[string]string
 }
 
 // extractTeleportConfigs returns every declared config with the describe it is
@@ -1275,11 +1286,22 @@ func extractTeleportConfigs(content string, blocks []blockRange, path string) ([
 			return nil, fmt.Errorf("%s: a teleport config must be declared inside a named test.describe block", path)
 		}
 
+		var env map[string]string
+		envOpen, envClose := findKeyValueAtDepth(teleportBody, "env", '{', '}', 1)
+		if envOpen >= 0 {
+			parsed, err := parseEnvBlock(teleportBody[envOpen:envClose])
+			if err != nil {
+				return nil, fmt.Errorf("%s: parsing teleport.env: %w", path, err)
+			}
+			env = parsed
+		}
+
 		sc := scopedTeleportConfig{
 			raw:       teleportBody[configOpen:configClose],
 			line:      b.start,
 			startByte: b.startByte,
 			endByte:   b.endByte,
+			env:       env,
 		}
 		for _, existing := range out {
 			if existing.line == sc.line && normalizeConfigText(existing.raw) != normalizeConfigText(sc.raw) {
@@ -1300,6 +1322,36 @@ func describeTitle(content string, blockStart int) string {
 		return ""
 	}
 	return ms[len(ms)-1][1]
+}
+
+// parseEnvBlock parses a declared teleport.env object's raw JS text into a flat string map
+func parseEnvBlock(raw string) (map[string]string, error) {
+	var env map[string]string
+	if err := yaml.Unmarshal([]byte(raw), &env); err != nil {
+		return nil, fmt.Errorf("parsing declared teleport env %q: %w", raw, err)
+	}
+	return env, nil
+}
+
+// normalizeEnvText serializes env into a deterministic string with keys sorted
+func normalizeEnvText(env map[string]string) string {
+	if len(env) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(env[k])
+		b.WriteByte(';')
+	}
+	return b.String()
 }
 
 // normalizeConfigText gets rid of whitespace.

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -1327,8 +1327,8 @@ test.describe('other', () => {
 }
 
 func TestNormalizeEnvText(t *testing.T) {
-	require.Equal(t, "", normalizeEnvText(nil))
-	require.Equal(t, "", normalizeEnvText(map[string]string{}))
+	require.Empty(t, normalizeEnvText(nil))
+	require.Empty(t, normalizeEnvText(map[string]string{}))
 
 	// Same content, different key order, normalizes the same
 	a := normalizeEnvText(map[string]string{"A": "1", "B": "2"})

--- a/e2e/runner/scan_test.go
+++ b/e2e/runner/scan_test.go
@@ -1269,6 +1269,22 @@ test.describe('two', () => {
 			content: `test.use({ teleport: { foo: 1 } });`,
 			wantErr: true,
 		},
+		{
+			name: "env alongside config",
+			content: `test.describe('grp', () => {
+  test.use({ teleport: { config: { a: 1 }, env: { FOO: 'bar' } } });
+});`,
+			want: []scopedTeleportConfig{
+				{raw: `{ a: 1 }`, line: 1, env: map[string]string{"FOO": "bar"}},
+			},
+		},
+		{
+			name: "malformed env errors",
+			content: `test.describe('grp', () => {
+  test.use({ teleport: { config: { a: 1 }, env: { FOO: { nested: 1 } } } });
+});`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1284,6 +1300,7 @@ test.describe('two', () => {
 			for i := range tt.want {
 				require.Equal(t, tt.want[i].raw, got[i].raw)
 				require.Equal(t, tt.want[i].line, got[i].line)
+				require.Equal(t, tt.want[i].env, got[i].env)
 			}
 		})
 	}
@@ -1309,6 +1326,19 @@ test.describe('other', () => {
 	require.Equal(t, []string{"tests/x.spec.ts"}, defaultSelectors("tests/x.spec.ts", content, nil, 0))
 }
 
+func TestNormalizeEnvText(t *testing.T) {
+	require.Equal(t, "", normalizeEnvText(nil))
+	require.Equal(t, "", normalizeEnvText(map[string]string{}))
+
+	// Same content, different key order, normalizes the same
+	a := normalizeEnvText(map[string]string{"A": "1", "B": "2"})
+	b := normalizeEnvText(map[string]string{"B": "2", "A": "1"})
+	require.Equal(t, a, b)
+
+	c := normalizeEnvText(map[string]string{"A": "1", "B": "3"})
+	require.NotEqual(t, a, c)
+}
+
 func TestNormalizeConfigText(t *testing.T) {
 	// Differently-formatted but identical configs normalize the same (so they can be deduped).
 	a := normalizeConfigText("{ auth_service: { license_file: 'x.pem' } }")
@@ -1317,6 +1347,46 @@ func TestNormalizeConfigText(t *testing.T) {
 
 	c := normalizeConfigText("{ auth_service: { license_file: 'y.pem' } }")
 	require.NotEqual(t, a, c)
+}
+
+func TestScanTeleportConfigsDedupesByConfigAndEnv(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.spec.ts", `
+test.describe('grp', () => {
+  test.use({ teleport: { config: { a: 1 }, env: { FOO: 'bar' } } });
+  test('t', () => {});
+});
+`)
+	writeFile(t, dir, "b.spec.ts", `
+test.describe('grp', () => {
+  test.use({ teleport: { config: { a: 1 }, env: { FOO: 'bar' } } });
+  test('t', () => {});
+});
+`)
+	writeFile(t, dir, "c.spec.ts", `
+test.describe('grp', () => {
+  test.use({ teleport: { config: { a: 1 }, env: { FOO: 'different' } } });
+  test('t', () => {});
+});
+`)
+
+	targets := []scanTarget{
+		{path: filepath.Join(dir, "a.spec.ts"), sourceFile: "a.spec.ts"},
+		{path: filepath.Join(dir, "b.spec.ts"), sourceFile: "b.spec.ts"},
+		{path: filepath.Join(dir, "c.spec.ts"), sourceFile: "c.spec.ts"},
+	}
+
+	configs, _, err := scanTeleportConfigs(targets)
+	require.NoError(t, err)
+	require.Len(t, configs, 2, "same config+env should merge into one batch, different env should stay separate")
+
+	byEnv := make(map[string][]string)
+	for _, c := range configs {
+		byEnv[c.env["FOO"]] = c.files
+	}
+
+	require.ElementsMatch(t, []string{"a.spec.ts:2", "b.spec.ts:2"}, byEnv["bar"])
+	require.ElementsMatch(t, []string{"c.spec.ts:2"}, byEnv["different"])
 }
 
 func TestScanTeleportConfigsRejectsHelperConfig(t *testing.T) {

--- a/e2e/runner/teleport.go
+++ b/e2e/runner/teleport.go
@@ -48,6 +48,7 @@ type teleportInstance struct {
 	stateFile       string
 	logFile         string // empty means stdout/stderr
 	recordingOwners recordingOwners
+	envOverrides    map[string]string
 
 	cmd      *exec.Cmd
 	logF     *os.File
@@ -57,6 +58,7 @@ type teleportInstance struct {
 
 func (t *teleportInstance) start(ctx context.Context) error {
 	t.cmd = exec.CommandContext(ctx, t.teleportBin, "start", "-c", t.configPath, "--bootstrap", t.stateFile)
+	t.cmd.Env = instanceEnv(t.envOverrides)
 
 	if t.logFile != "" {
 		f, err := os.Create(t.logFile)


### PR DESCRIPTION
## Summary

This PR adds support for e2e tests to declare their own set of env variables.

This enables us to set env variables like `Teleport_Cloud_Hostport` which change the behavior of Teleport. This builds on top of the work for config in https://github.com/gravitational/teleport/pull/68769

## Context

Contributes to https://github.com/gravitational/cloud/issues/17873

This is the third PR in a chain to add an e2e test to the enterprise repo that asserts the Usage Reporting page can be fetched from the Cloud API and successfully loaded.

<details><summary>PR chain</summary>

<pre>
Chain: Cloud Panel E2E Testing
└── <a href="https://github.com/gravitational/teleport/pull/68865">teleport: Add no-resource-setup flag to e2e runner</a> 
    └── <a href="https://github.com/gravitational/teleport.e/pull/9186">e: Add cloud panel e2e test</a>
        └── <b><a href="https://github.com/gravitational/teleport/pull/69441">teleport: Allow e2e tests to declare custom env variables</a></b> ← current branch
            └── <a href="https://github.com/gravitational/teleport.e/pull/9377">e: Enable Cloud Panel Test in CI</a>

* Note that depending on timing, I may add the last two CI PRs directly to the new monorepo instead.
</pre>

</details>

<!-- Provide a descriptive entry for the changelog of the next release. -->

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local

### Test Cases
- [x] While https://github.com/gravitational/teleport.e/pull/9377 is also checked out, verify that all existing e2e tests pass including tests that declare custom envs
