### PR TITLE
Preserve existing ProvisionTokenV2 `.status.bound_keypair` on upsert

### DIFF
--- a/lib/auth/bound_keypair_tokens.go
+++ b/lib/auth/bound_keypair_tokens.go
@@ -144,21 +144,29 @@ func (a *Server) UpsertBoundKeypairToken(ctx context.Context, token types.Provis
 	}
 
 	// Implementation note: checkAndSetDefaults() impl for this token type is
-	// called at insertion time as part of `tokenToItem()`
-	return trace.Wrap(a.UpsertToken(ctx, token))
+	// called at insertion time as part of `itemFromProvisionToken()`
+	return trace.Wrap(applyBoundKeypairToken(ctx, a.Services, token))
 }
 
-// applyBoundKeypairToken applies a bound_keypair provision token supplied via
-// --apply-on-startup.
+// applyBoundKeypairToken applies a bound_keypair provision token while ensuring
+// the `.status` field is protected for existing tokens. It is appropriate for
+// all cases where end users are upserting or applying bound keypair tokens,
+// including `tctl create ...` and `teleport start --apply-on-startup`.
 //
-// The join path rejects tokens without an initialized status.bound_keypair, so
-// we initialize it here (the normal admin path does this too, but
+// Since `.status` is unconditionally overwritten with the existing token's
+// status, if `.status` must be modified, the token should be deleted and
+// recreated: the incoming `.status` field is only honored when no matching
+// token exists in the backend.
+//
+// The join path rejects tokens without an initialized `.status.bound_keypair`,
+// so we initialize it here (the normal admin path does this too, but
 // apply-on-startup writes spec-only YAML straight to storage and leaves status
 // nil).
 //
-// apply-on-startup re-runs on every auth restart. If the token already exists,
-// we preserve its status so a restart never resets a bot's join state
-// (recovery counters, bound public key).
+// This preserves `.status` to ensure token updates do not overwrite important
+// status fields, including `.status.bound_keypair.bound_public_key` and the
+// recovery count, making it suitable for upsert RPCs (including for IaC
+// purposes) and repeated use with `--apply-on-startup`.
 func applyBoundKeypairToken(ctx context.Context, service *Services, token types.ProvisionToken) error {
 	tokenV2, ok := token.(*types.ProvisionTokenV2)
 	if !ok {
@@ -200,9 +208,6 @@ func applyBoundKeypairToken(ctx context.Context, service *Services, token types.
 			return trace.Wrap(err)
 		}
 		created := cloned.(*types.ProvisionTokenV2)
-		// Never trust status from config: drop it so a config-supplied
-		// bound_public_key can't bind a key without the join ceremony.
-		created.Status = nil
 		if err := populateRegistrationSecret(created); err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/auth/bound_keypair_tokens.go
+++ b/lib/auth/bound_keypair_tokens.go
@@ -27,16 +27,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// validateBoundKeypairTokenSpec performs some basic validation checks on a
-// bound_keypair-type join token.
-func validateBoundKeypairTokenSpec(spec *types.ProvisionTokenSpecV2BoundKeypair) error {
-	if spec.Recovery == nil {
-		return trace.BadParameter("spec.bound_keypair.recovery: field is required")
-	}
-
-	return nil
-}
-
 // populateRegistrationSecret populates the
 // `status.BoundKeypair.RegistrationSecret` field of a bound keypair token. It
 // should be called as part of any token creation or update to ensure the
@@ -104,10 +94,6 @@ func (a *Server) CreateBoundKeypairToken(ctx context.Context, token types.Provis
 		return trace.BadParameter("bound_keypair token requires non-nil spec.bound_keypair")
 	}
 
-	if err := validateBoundKeypairTokenSpec(spec); err != nil {
-		return trace.Wrap(err)
-	}
-
 	// Not as much to do here - ideally we'd like to prevent users from
 	// tampering with the status field, but we don't have a good mechanism to
 	// stop that that wouldn't also break backup and restore. For now, it's
@@ -133,10 +119,6 @@ func (a *Server) UpsertBoundKeypairToken(ctx context.Context, token types.Provis
 	spec := tokenV2.Spec.BoundKeypair
 	if spec == nil {
 		return trace.BadParameter("bound_keypair token requires non-nil spec.bound_keypair")
-	}
-
-	if err := validateBoundKeypairTokenSpec(spec); err != nil {
-		return trace.Wrap(err)
 	}
 
 	if err := populateRegistrationSecret(tokenV2); err != nil {
@@ -175,9 +157,6 @@ func applyBoundKeypairToken(ctx context.Context, service *Services, token types.
 
 	if tokenV2.Spec.BoundKeypair == nil {
 		return trace.BadParameter("bound_keypair token requires non-nil spec.bound_keypair")
-	}
-	if err := validateBoundKeypairTokenSpec(tokenV2.Spec.BoundKeypair); err != nil {
-		return trace.Wrap(err)
 	}
 
 	// Patch an existing token to keep its status; create it if absent. This

--- a/lib/auth/bound_keypair_tokens_test.go
+++ b/lib/auth/bound_keypair_tokens_test.go
@@ -1,0 +1,254 @@
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertBoundKeypairToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	clock := clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC())
+	as, err := authtest.NewAuthServer(authtest.AuthServerConfig{Dir: t.TempDir(), Clock: clock})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, as.Close()) })
+	authServer := as.AuthServer
+
+	tests := []struct {
+		name string
+
+		pre         *types.ProvisionTokenV2
+		token       *types.ProvisionTokenV2
+		assertError require.ErrorAssertionFunc
+		assertToken func(t *testing.T, token *types.ProvisionTokenV2)
+	}{
+		{
+			name: "minimal create results in valid status",
+			token: &types.ProvisionTokenV2{
+				Kind:    types.KindToken,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: "minimal",
+				},
+				Spec: types.ProvisionTokenSpecV2{
+					JoinMethod:   types.JoinMethodBoundKeypair,
+					Roles:        []types.SystemRole{types.RoleBot},
+					BotName:      "test",
+					BoundKeypair: &types.ProvisionTokenSpecV2BoundKeypair{},
+				},
+			},
+			assertToken: func(t *testing.T, token *types.ProvisionTokenV2) {
+				// Should generate a registration secret but nothing else
+				require.NotEmpty(t, token.Status.BoundKeypair.RegistrationSecret)
+				require.Empty(t, token.Status.BoundKeypair.BoundBotInstanceID)
+				require.Empty(t, token.Status.BoundKeypair.BoundHostID)
+				require.Empty(t, token.Status.BoundKeypair.BoundPublicKey)
+			},
+		},
+		{
+			name: "create with predefined registration secret copies the value",
+			token: &types.ProvisionTokenV2{
+				Kind:    types.KindToken,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: "predefined-secret",
+				},
+				Spec: types.ProvisionTokenSpecV2{
+					JoinMethod: types.JoinMethodBoundKeypair,
+					Roles:      []types.SystemRole{types.RoleBot},
+					BotName:    "test",
+					BoundKeypair: &types.ProvisionTokenSpecV2BoundKeypair{
+						Onboarding: &types.ProvisionTokenSpecV2BoundKeypair_OnboardingSpec{
+							RegistrationSecret: "asdf",
+						},
+					},
+				},
+			},
+			assertToken: func(t *testing.T, token *types.ProvisionTokenV2) {
+				require.Equal(t, "asdf", token.Status.BoundKeypair.RegistrationSecret)
+			},
+		},
+		{
+			name: "create with predefined public key does NOT copy the value",
+			token: &types.ProvisionTokenV2{
+				Kind:    types.KindToken,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: "initial-public-key",
+				},
+				Spec: types.ProvisionTokenSpecV2{
+					JoinMethod: types.JoinMethodBoundKeypair,
+					Roles:      []types.SystemRole{types.RoleBot},
+					BotName:    "test",
+					BoundKeypair: &types.ProvisionTokenSpecV2BoundKeypair{
+						Onboarding: &types.ProvisionTokenSpecV2BoundKeypair_OnboardingSpec{
+							InitialPublicKey: "asdf",
+						},
+					},
+				},
+			},
+			assertToken: func(t *testing.T, token *types.ProvisionTokenV2) {
+				// Keys only become bound at join-time, not at upsert, so it
+				// should remain empty.
+				require.Empty(t, token.Status.BoundKeypair.RegistrationSecret)
+				require.Empty(t, token.Status.BoundKeypair.BoundPublicKey)
+			},
+		},
+		{
+			name: "create with status preserves values",
+			token: &types.ProvisionTokenV2{
+				Kind:    types.KindToken,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: "create-with-status",
+				},
+				Spec: types.ProvisionTokenSpecV2{
+					JoinMethod:   types.JoinMethodBoundKeypair,
+					Roles:        []types.SystemRole{types.RoleBot},
+					BotName:      "test",
+					BoundKeypair: &types.ProvisionTokenSpecV2BoundKeypair{},
+				},
+				Status: &types.ProvisionTokenStatusV2{
+					// It's blatantly invalid to set every field, but we just
+					// want to make sure upsert is not deleting anything.
+					BoundKeypair: &types.ProvisionTokenStatusV2BoundKeypair{
+						RegistrationSecret: "registration-secret",
+						BoundPublicKey:     "bound-public-key",
+						BoundBotInstanceID: "bot-instance-id",
+						BoundHostID:        "host-id",
+						RecoveryCount:      123,
+						LastRecoveredAt:    new(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)),
+						LastRotatedAt:      new(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)),
+					},
+				},
+			},
+			assertToken: func(t *testing.T, token *types.ProvisionTokenV2) {
+				// On create, all fields should be copied.
+				require.Equal(t, &types.ProvisionTokenStatusV2BoundKeypair{
+					RegistrationSecret: "registration-secret",
+					BoundPublicKey:     "bound-public-key",
+					BoundBotInstanceID: "bot-instance-id",
+					BoundHostID:        "host-id",
+					RecoveryCount:      123,
+					LastRecoveredAt:    new(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)),
+					LastRotatedAt:      new(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)),
+				}, token.Status.BoundKeypair)
+			},
+		},
+		{
+			name: "update with status preserves stored values",
+			pre: &types.ProvisionTokenV2{
+				Kind:    types.KindToken,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: "update-with-status",
+				},
+				Spec: types.ProvisionTokenSpecV2{
+					JoinMethod: types.JoinMethodBoundKeypair,
+					Roles:      []types.SystemRole{types.RoleBot},
+					BotName:    "test",
+					BoundKeypair: &types.ProvisionTokenSpecV2BoundKeypair{
+						Recovery: &types.ProvisionTokenSpecV2BoundKeypair_RecoverySpec{
+							Limit: 2,
+							Mode:  "standard",
+						},
+					},
+				},
+				Status: &types.ProvisionTokenStatusV2{
+					// As before, setting every field is invalid (at runtime),
+					// but we want to be sure nothing is overwritten.
+					BoundKeypair: &types.ProvisionTokenStatusV2BoundKeypair{
+						RegistrationSecret: "registration-secret",
+						BoundPublicKey:     "bound-public-key",
+						BoundBotInstanceID: "bot-instance-id",
+						BoundHostID:        "host-id",
+						RecoveryCount:      123,
+						LastRecoveredAt:    new(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)),
+						LastRotatedAt:      new(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)),
+					},
+				},
+			},
+			token: &types.ProvisionTokenV2{
+				Kind:    types.KindToken,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name: "update-with-status",
+				},
+				Spec: types.ProvisionTokenSpecV2{
+					JoinMethod: types.JoinMethodBoundKeypair,
+					Roles:      []types.SystemRole{types.RoleBot},
+					BotName:    "test",
+					BoundKeypair: &types.ProvisionTokenSpecV2BoundKeypair{
+						Recovery: &types.ProvisionTokenSpecV2BoundKeypair_RecoverySpec{
+							Limit: 5,
+							Mode:  "relaxed",
+						},
+					},
+				},
+				Status: &types.ProvisionTokenStatusV2{
+					// Set every field to some other value.
+					BoundKeypair: &types.ProvisionTokenStatusV2BoundKeypair{
+						RegistrationSecret: "other-registration-secret",
+						BoundPublicKey:     "other-bound-public-key",
+						BoundBotInstanceID: "other-bot-instance-id",
+						BoundHostID:        "other-host-id",
+						RecoveryCount:      456,
+						LastRecoveredAt:    new(time.Date(2025, 2, 1, 1, 0, 0, 0, time.UTC)),
+						LastRotatedAt:      new(time.Date(2025, 2, 1, 1, 0, 0, 0, time.UTC)),
+					},
+				},
+			},
+			assertToken: func(t *testing.T, token *types.ProvisionTokenV2) {
+				// All status values should equal the _original_ token, not the
+				// updated one
+				require.Equal(t, &types.ProvisionTokenStatusV2BoundKeypair{
+					RegistrationSecret: "registration-secret",
+					BoundPublicKey:     "bound-public-key",
+					BoundBotInstanceID: "bot-instance-id",
+					BoundHostID:        "host-id",
+					RecoveryCount:      123,
+					LastRecoveredAt:    new(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)),
+					LastRotatedAt:      new(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)),
+				}, token.Status.BoundKeypair)
+
+				// Spec field updates should be honored.
+				require.EqualValues(t, 5, token.Spec.BoundKeypair.Recovery.Limit)
+				require.Equal(t, "relaxed", token.Spec.BoundKeypair.Recovery.Mode)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.pre != nil {
+				require.NoError(t, authServer.UpsertBoundKeypairToken(ctx, tt.pre))
+			}
+
+			err := authServer.UpsertBoundKeypairToken(ctx, tt.token)
+			if tt.assertError != nil {
+				tt.assertError(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if err != nil {
+				return
+			}
+
+			token, err := authServer.GetToken(ctx, tt.token.GetName())
+			require.NoError(t, err)
+
+			ptv2, ok := token.(*types.ProvisionTokenV2)
+			require.True(t, ok)
+
+			tt.assertToken(t, ptv2)
+		})
+	}
+}

--- a/lib/auth/bound_keypair_tokens_test.go
+++ b/lib/auth/bound_keypair_tokens_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package auth_test
 
 import (

--- a/lib/auth/bound_keypair_tokens_test.go
+++ b/lib/auth/bound_keypair_tokens_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 )
 
 func TestUpsertBoundKeypairToken(t *testing.T) {

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -2177,10 +2177,8 @@ func TestInit_ApplyOnStartup_BoundKeypair(t *testing.T) {
 			"apply-on-startup must persist the defaulted recovery limit")
 	})
 
-	t.Run("discards config-supplied status on first apply", func(t *testing.T) {
-		// apply-on-startup config is spec-only and its status is untrusted. A
-		// bound_public_key supplied via config must not bind a key on creation:
-		// that would skip the join ceremony's proof-of-possession.
+	t.Run("honors config-supplied status on first apply", func(t *testing.T) {
+		// status changes are only allowed on initial apply
 		token := resourceFromYAML(t, boundKeypairTokenYAML).(*types.ProvisionTokenV2)
 		token.Status = &types.ProvisionTokenStatusV2{
 			BoundKeypair: &types.ProvisionTokenStatusV2BoundKeypair{
@@ -2199,10 +2197,8 @@ func TestInit_ApplyOnStartup_BoundKeypair(t *testing.T) {
 		require.NoError(t, err)
 		status := stored.GetBoundKeypairStatus()
 		require.NotNil(t, status)
-		require.Empty(t, status.BoundPublicKey,
-			"config-supplied bound_public_key must not be persisted on first apply")
-		require.Zero(t, status.RecoveryCount,
-			"config-supplied recovery count must not be persisted on first apply")
+		require.Equal(t, token.Status.BoundKeypair.BoundPublicKey, status.BoundPublicKey)
+		require.Equal(t, token.Status.BoundKeypair.RecoveryCount, status.RecoveryCount)
 	})
 
 	t.Run("generates a registration secret when no onboarding credential is set", func(t *testing.T) {

--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -111,8 +111,8 @@ func (s *ProvisioningService) AppendDeleteProvisionTokenActions(
 // a revision comparison failure.
 //
 // Unlike CreateToken/UpsertToken, this skips validateProvisionToken admission
-// checks. Safe only while no user-facing RPC reaches it; if one is added,
-// validate here too.
+// checks, it is the caller's responsibility to ensure any necessary checks are
+// still performed.
 func (s *ProvisioningService) PatchToken(
 	ctx context.Context,
 	tokenName string,

--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -147,19 +147,20 @@ func (s *ProvisioningService) PatchToken(
 			return nil, trace.BadParameter("metadata.revision: cannot be patched")
 		}
 
-		item, err := itemFromProvisionToken(updated)
+		// Use AtomicWrite so we can inherit the shared ProvisionToken actions
+		// (vs using ConditionalUpdate())
+		actions, err := s.AppendPutProvisionTokenActions(nil, updated, backend.Revision(existing.GetRevision()))
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		lease, err := s.ConditionalUpdate(ctx, *item)
+		rev, err := s.AtomicWrite(ctx, actions)
 		if trace.IsCompareFailed(err) {
 			continue
 		} else if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		updated.SetRevision(lease.Revision)
+		updated.SetRevision(rev)
 		return updated, nil
 	}
 


### PR DESCRIPTION
When upserting a `bound_keypair`-type provision token, this preserves the status field if an existing token already exists in the backend.

This is necessary to prevent users from accidentally overwriting the status field, which for bound keypair tokens, contains critical information (bound public key, recovery count, etc) that changes on the server over time. If users attempt to update the token using IaC tools that reapply the token with an empty status (e.g. from a template or cached state like Terraform), they would currently overwrite the existing status and deauth their bot or agent.

Given that, the improved strategy is: if the token exists (i.e. update, not create), overwrite the incoming token's status field with the existing value. If users wish to change the status field, they can do so by deleting and recreating the token, as the status is not overwritten on create.

This reuses the recently added `applyBoundKeypairToken()` which was designed for use with `--apply-on-startup`, however, it was designed to solve the exact same problem. However, two changes are made:

- It no longer removes the status on create (it should not have done so)
- The backend token patching mechanism has been updated to use AtomicWrite() instead of ConditionalUpdate() so it properly applies all of the shared token actions, including checks for duplicate scoped tokens, and no longer relies on a _completely_ special insertion mechanism just for bound keypair tokens.

Other small changes:
- Removed `validateBoundKeypairTokenSpec()`, which was useless (`CheckAndSetDefaults()` handles the same thing and it was breaking my unit tests)

Fixes #68211

Changelog: Fixed loss of Bound Keypair token status on update by always preserving the existing token's status, ensuring bots and agents can not have their credentials deleted accidentally

## Breaking change?

This could technically be considered a breaking change. At this time I still intend to backport it to v18:
- No token writes are newly **denied** because of this change.
- [`ProvisionTokenStatusV2` proto docs](https://github.com/gravitational/teleport/blob/2a05d3edfeed9d934acd2d4737626a7983a404a2/api/proto/teleport/legacy/types/types.proto#L2456-L2457) specifically mention:
   > "These fields should not be modified by end users"

   So, while overwriting status has so far been _allowed_, existing documentation has always implied that it wasn't.
- It is still easy to overwrite status if you really want to - just delete the token first.
- All sane use cases continue to work, including:
   - Backup and restore (including status), just ensure the token doesn't exist before restoring (already the case for a fresh cluster)
   - Intentional token modifications, even if they do improperly modify `.status.bound_keypair` (those changes are just silently discarded)
- Meanwhile, without this fix, IaC tools (including Terraform) will happily overwrite status and knock bots offline.

So, I think the potential downsides of the breaking change (such as they are) are outweighed by the benefits.

## Manual Test Plan
### Test Environment

I used my [`teleport-harness` runner](https://github.com/timothyb89/teleport-harness) to create resource with manipulated statuses to confirm the behavior. Full reports can be found here:
* https://gist.github.com/timothyb89/04818455720584b328a247822a48d742 (general bound keypair use)
* https://gist.github.com/timothyb89/160567c88eb68c6f3fa71f0491ae37ba (regression test for my existing `--apply-on-startup` suite)

### Test Cases
- [x] Status is always preserved if a token already exists
- [x] Status on the incoming token is included if the token does not already exist
- [x] `--apply-on-startup` still works as expected
