### PR TITLE
MWI: issuance: Add UsageApp support to IssueScopedBotCerts

### DIFF
--- a/api/gen/proto/go/teleport/issuance/v1/service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/issuance/v1/service_protohybrid.pb.go
@@ -57,6 +57,7 @@ type IssueScopedBotCertsRequest struct {
 	// Types that are valid to be assigned to Usage:
 	//
 	//	*IssueScopedBotCertsRequest_Identity
+	//	*IssueScopedBotCertsRequest_App
 	Usage         isIssueScopedBotCertsRequest_Usage `protobuf_oneof:"usage"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -124,6 +125,15 @@ func (x *IssueScopedBotCertsRequest) GetIdentity() *UsageIdentity {
 	return nil
 }
 
+func (x *IssueScopedBotCertsRequest) GetApp() *UsageApp {
+	if x != nil {
+		if x, ok := x.Usage.(*IssueScopedBotCertsRequest_App); ok {
+			return x.App
+		}
+	}
+	return nil
+}
+
 func (x *IssueScopedBotCertsRequest) SetSshPublicKey(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -150,6 +160,14 @@ func (x *IssueScopedBotCertsRequest) SetIdentity(v *UsageIdentity) {
 	x.Usage = &IssueScopedBotCertsRequest_Identity{v}
 }
 
+func (x *IssueScopedBotCertsRequest) SetApp(v *UsageApp) {
+	if v == nil {
+		x.Usage = nil
+		return
+	}
+	x.Usage = &IssueScopedBotCertsRequest_App{v}
+}
+
 func (x *IssueScopedBotCertsRequest) HasTtl() bool {
 	if x == nil {
 		return false
@@ -172,6 +190,14 @@ func (x *IssueScopedBotCertsRequest) HasIdentity() bool {
 	return ok
 }
 
+func (x *IssueScopedBotCertsRequest) HasApp() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Usage.(*IssueScopedBotCertsRequest_App)
+	return ok
+}
+
 func (x *IssueScopedBotCertsRequest) ClearTtl() {
 	x.Ttl = nil
 }
@@ -186,8 +212,15 @@ func (x *IssueScopedBotCertsRequest) ClearIdentity() {
 	}
 }
 
+func (x *IssueScopedBotCertsRequest) ClearApp() {
+	if _, ok := x.Usage.(*IssueScopedBotCertsRequest_App); ok {
+		x.Usage = nil
+	}
+}
+
 const IssueScopedBotCertsRequest_Usage_not_set_case case_IssueScopedBotCertsRequest_Usage = 0
 const IssueScopedBotCertsRequest_Identity_case case_IssueScopedBotCertsRequest_Usage = 4
+const IssueScopedBotCertsRequest_App_case case_IssueScopedBotCertsRequest_Usage = 5
 
 func (x *IssueScopedBotCertsRequest) WhichUsage() case_IssueScopedBotCertsRequest_Usage {
 	if x == nil {
@@ -196,6 +229,8 @@ func (x *IssueScopedBotCertsRequest) WhichUsage() case_IssueScopedBotCertsReques
 	switch x.Usage.(type) {
 	case *IssueScopedBotCertsRequest_Identity:
 		return IssueScopedBotCertsRequest_Identity_case
+	case *IssueScopedBotCertsRequest_App:
+		return IssueScopedBotCertsRequest_App_case
 	default:
 		return IssueScopedBotCertsRequest_Usage_not_set_case
 	}
@@ -220,6 +255,7 @@ type IssueScopedBotCertsRequest_builder struct {
 
 	// Fields of oneof Usage:
 	Identity *UsageIdentity
+	App      *UsageApp
 	// -- end of Usage
 }
 
@@ -232,6 +268,9 @@ func (b0 IssueScopedBotCertsRequest_builder) Build() *IssueScopedBotCertsRequest
 	x.Ttl = b.Ttl
 	if b.Identity != nil {
 		x.Usage = &IssueScopedBotCertsRequest_Identity{b.Identity}
+	}
+	if b.App != nil {
+		x.Usage = &IssueScopedBotCertsRequest_App{b.App}
 	}
 	return m0
 }
@@ -254,7 +293,13 @@ type IssueScopedBotCertsRequest_Identity struct {
 	Identity *UsageIdentity `protobuf:"bytes,4,opt,name=identity,proto3,oneof"`
 }
 
+type IssueScopedBotCertsRequest_App struct {
+	App *UsageApp `protobuf:"bytes,5,opt,name=app,proto3,oneof"`
+}
+
 func (*IssueScopedBotCertsRequest_Identity) isIssueScopedBotCertsRequest_Usage() {}
+
+func (*IssueScopedBotCertsRequest_App) isIssueScopedBotCertsRequest_Usage() {}
 
 // The simplest possible usage mode for a certificate, returning certificates
 // appropriate for SSH or API authn.
@@ -301,6 +346,102 @@ func (b0 UsageIdentity_builder) Build() *UsageIdentity {
 	return m0
 }
 
+// UsageApp defines the mode
+type UsageApp struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// name is the name of the application to route to.
+	// Must resolve to an application within the scope to which
+	// the calling bot is pinned.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// public_addr is the application public address.
+	PublicAddr string `protobuf:"bytes,2,opt,name=public_addr,json=publicAddr,proto3" json:"public_addr,omitempty"`
+	// scope is the scope of the target application.
+	Scope         string `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UsageApp) Reset() {
+	*x = UsageApp{}
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UsageApp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UsageApp) ProtoMessage() {}
+
+func (x *UsageApp) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UsageApp) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *UsageApp) GetPublicAddr() string {
+	if x != nil {
+		return x.PublicAddr
+	}
+	return ""
+}
+
+func (x *UsageApp) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *UsageApp) SetName(v string) {
+	x.Name = v
+}
+
+func (x *UsageApp) SetPublicAddr(v string) {
+	x.PublicAddr = v
+}
+
+func (x *UsageApp) SetScope(v string) {
+	x.Scope = v
+}
+
+type UsageApp_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// name is the name of the application to route to.
+	// Must resolve to an application within the scope to which
+	// the calling bot is pinned.
+	Name string
+	// public_addr is the application public address.
+	PublicAddr string
+	// scope is the scope of the target application.
+	Scope string
+}
+
+func (b0 UsageApp_builder) Build() *UsageApp {
+	m0 := &UsageApp{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Name = b.Name
+	x.PublicAddr = b.PublicAddr
+	x.Scope = b.Scope
+	return m0
+}
+
 // Response for IssueScopedBotCerts
 type IssueScopedBotCertsResponse struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
@@ -312,7 +453,7 @@ type IssueScopedBotCertsResponse struct {
 
 func (x *IssueScopedBotCertsResponse) Reset() {
 	*x = IssueScopedBotCertsResponse{}
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -324,7 +465,7 @@ func (x *IssueScopedBotCertsResponse) String() string {
 func (*IssueScopedBotCertsResponse) ProtoMessage() {}
 
 func (x *IssueScopedBotCertsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -385,7 +526,7 @@ type Certs struct {
 
 func (x *Certs) Reset() {
 	*x = Certs{}
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -397,7 +538,7 @@ func (x *Certs) String() string {
 func (*Certs) ProtoMessage() {}
 
 func (x *Certs) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -458,14 +599,20 @@ var File_teleport_issuance_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_issuance_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\"teleport/issuance/v1/service.proto\x12\x14teleport.issuance.v1\x1a\x1egoogle/protobuf/duration.proto\"\xe1\x01\n" +
+	"\"teleport/issuance/v1/service.proto\x12\x14teleport.issuance.v1\x1a\x1egoogle/protobuf/duration.proto\"\x95\x02\n" +
 	"\x1aIssueScopedBotCertsRequest\x12$\n" +
 	"\x0essh_public_key\x18\x01 \x01(\fR\fsshPublicKey\x12$\n" +
 	"\x0etls_public_key\x18\x02 \x01(\fR\ftlsPublicKey\x12+\n" +
 	"\x03ttl\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x03ttl\x12A\n" +
-	"\bidentity\x18\x04 \x01(\v2#.teleport.issuance.v1.UsageIdentityH\x00R\bidentityB\a\n" +
+	"\bidentity\x18\x04 \x01(\v2#.teleport.issuance.v1.UsageIdentityH\x00R\bidentity\x122\n" +
+	"\x03app\x18\x05 \x01(\v2\x1e.teleport.issuance.v1.UsageAppH\x00R\x03appB\a\n" +
 	"\x05usage\"\x0f\n" +
-	"\rUsageIdentity\"P\n" +
+	"\rUsageIdentity\"U\n" +
+	"\bUsageApp\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
+	"\vpublic_addr\x18\x02 \x01(\tR\n" +
+	"publicAddr\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"P\n" +
 	"\x1bIssueScopedBotCertsResponse\x121\n" +
 	"\x05certs\x18\x01 \x01(\v2\x1b.teleport.issuance.v1.CertsR\x05certs\"+\n" +
 	"\x05Certs\x12\x10\n" +
@@ -474,25 +621,27 @@ const file_teleport_issuance_v1_service_proto_rawDesc = "" +
 	"\x0fIssuanceService\x12z\n" +
 	"\x13IssueScopedBotCerts\x120.teleport.issuance.v1.IssueScopedBotCertsRequest\x1a1.teleport.issuance.v1.IssueScopedBotCertsResponseBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1;issuancev1pbb\x06proto3"
 
-var file_teleport_issuance_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_teleport_issuance_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_teleport_issuance_v1_service_proto_goTypes = []any{
 	(*IssueScopedBotCertsRequest)(nil),  // 0: teleport.issuance.v1.IssueScopedBotCertsRequest
 	(*UsageIdentity)(nil),               // 1: teleport.issuance.v1.UsageIdentity
-	(*IssueScopedBotCertsResponse)(nil), // 2: teleport.issuance.v1.IssueScopedBotCertsResponse
-	(*Certs)(nil),                       // 3: teleport.issuance.v1.Certs
-	(*durationpb.Duration)(nil),         // 4: google.protobuf.Duration
+	(*UsageApp)(nil),                    // 2: teleport.issuance.v1.UsageApp
+	(*IssueScopedBotCertsResponse)(nil), // 3: teleport.issuance.v1.IssueScopedBotCertsResponse
+	(*Certs)(nil),                       // 4: teleport.issuance.v1.Certs
+	(*durationpb.Duration)(nil),         // 5: google.protobuf.Duration
 }
 var file_teleport_issuance_v1_service_proto_depIdxs = []int32{
-	4, // 0: teleport.issuance.v1.IssueScopedBotCertsRequest.ttl:type_name -> google.protobuf.Duration
+	5, // 0: teleport.issuance.v1.IssueScopedBotCertsRequest.ttl:type_name -> google.protobuf.Duration
 	1, // 1: teleport.issuance.v1.IssueScopedBotCertsRequest.identity:type_name -> teleport.issuance.v1.UsageIdentity
-	3, // 2: teleport.issuance.v1.IssueScopedBotCertsResponse.certs:type_name -> teleport.issuance.v1.Certs
-	0, // 3: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:input_type -> teleport.issuance.v1.IssueScopedBotCertsRequest
-	2, // 4: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:output_type -> teleport.issuance.v1.IssueScopedBotCertsResponse
-	4, // [4:5] is the sub-list for method output_type
-	3, // [3:4] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	2, // 2: teleport.issuance.v1.IssueScopedBotCertsRequest.app:type_name -> teleport.issuance.v1.UsageApp
+	4, // 3: teleport.issuance.v1.IssueScopedBotCertsResponse.certs:type_name -> teleport.issuance.v1.Certs
+	0, // 4: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:input_type -> teleport.issuance.v1.IssueScopedBotCertsRequest
+	3, // 5: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:output_type -> teleport.issuance.v1.IssueScopedBotCertsResponse
+	5, // [5:6] is the sub-list for method output_type
+	4, // [4:5] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_teleport_issuance_v1_service_proto_init() }
@@ -502,6 +651,7 @@ func file_teleport_issuance_v1_service_proto_init() {
 	}
 	file_teleport_issuance_v1_service_proto_msgTypes[0].OneofWrappers = []any{
 		(*IssueScopedBotCertsRequest_Identity)(nil),
+		(*IssueScopedBotCertsRequest_App)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -509,7 +659,7 @@ func file_teleport_issuance_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_issuance_v1_service_proto_rawDesc), len(file_teleport_issuance_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/issuance/v1/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/issuance/v1/service_protoopaque.pb.go
@@ -103,6 +103,15 @@ func (x *IssueScopedBotCertsRequest) GetIdentity() *UsageIdentity {
 	return nil
 }
 
+func (x *IssueScopedBotCertsRequest) GetApp() *UsageApp {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Usage.(*issueScopedBotCertsRequest_App); ok {
+			return x.App
+		}
+	}
+	return nil
+}
+
 func (x *IssueScopedBotCertsRequest) SetSshPublicKey(v []byte) {
 	if v == nil {
 		v = []byte{}
@@ -129,6 +138,14 @@ func (x *IssueScopedBotCertsRequest) SetIdentity(v *UsageIdentity) {
 	x.xxx_hidden_Usage = &issueScopedBotCertsRequest_Identity{v}
 }
 
+func (x *IssueScopedBotCertsRequest) SetApp(v *UsageApp) {
+	if v == nil {
+		x.xxx_hidden_Usage = nil
+		return
+	}
+	x.xxx_hidden_Usage = &issueScopedBotCertsRequest_App{v}
+}
+
 func (x *IssueScopedBotCertsRequest) HasTtl() bool {
 	if x == nil {
 		return false
@@ -151,6 +168,14 @@ func (x *IssueScopedBotCertsRequest) HasIdentity() bool {
 	return ok
 }
 
+func (x *IssueScopedBotCertsRequest) HasApp() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Usage.(*issueScopedBotCertsRequest_App)
+	return ok
+}
+
 func (x *IssueScopedBotCertsRequest) ClearTtl() {
 	x.xxx_hidden_Ttl = nil
 }
@@ -165,8 +190,15 @@ func (x *IssueScopedBotCertsRequest) ClearIdentity() {
 	}
 }
 
+func (x *IssueScopedBotCertsRequest) ClearApp() {
+	if _, ok := x.xxx_hidden_Usage.(*issueScopedBotCertsRequest_App); ok {
+		x.xxx_hidden_Usage = nil
+	}
+}
+
 const IssueScopedBotCertsRequest_Usage_not_set_case case_IssueScopedBotCertsRequest_Usage = 0
 const IssueScopedBotCertsRequest_Identity_case case_IssueScopedBotCertsRequest_Usage = 4
+const IssueScopedBotCertsRequest_App_case case_IssueScopedBotCertsRequest_Usage = 5
 
 func (x *IssueScopedBotCertsRequest) WhichUsage() case_IssueScopedBotCertsRequest_Usage {
 	if x == nil {
@@ -175,6 +207,8 @@ func (x *IssueScopedBotCertsRequest) WhichUsage() case_IssueScopedBotCertsReques
 	switch x.xxx_hidden_Usage.(type) {
 	case *issueScopedBotCertsRequest_Identity:
 		return IssueScopedBotCertsRequest_Identity_case
+	case *issueScopedBotCertsRequest_App:
+		return IssueScopedBotCertsRequest_App_case
 	default:
 		return IssueScopedBotCertsRequest_Usage_not_set_case
 	}
@@ -199,6 +233,7 @@ type IssueScopedBotCertsRequest_builder struct {
 
 	// Fields of oneof xxx_hidden_Usage:
 	Identity *UsageIdentity
+	App      *UsageApp
 	// -- end of xxx_hidden_Usage
 }
 
@@ -211,6 +246,9 @@ func (b0 IssueScopedBotCertsRequest_builder) Build() *IssueScopedBotCertsRequest
 	x.xxx_hidden_Ttl = b.Ttl
 	if b.Identity != nil {
 		x.xxx_hidden_Usage = &issueScopedBotCertsRequest_Identity{b.Identity}
+	}
+	if b.App != nil {
+		x.xxx_hidden_Usage = &issueScopedBotCertsRequest_App{b.App}
 	}
 	return m0
 }
@@ -233,7 +271,13 @@ type issueScopedBotCertsRequest_Identity struct {
 	Identity *UsageIdentity `protobuf:"bytes,4,opt,name=identity,proto3,oneof"`
 }
 
+type issueScopedBotCertsRequest_App struct {
+	App *UsageApp `protobuf:"bytes,5,opt,name=app,proto3,oneof"`
+}
+
 func (*issueScopedBotCertsRequest_Identity) isIssueScopedBotCertsRequest_Usage() {}
+
+func (*issueScopedBotCertsRequest_App) isIssueScopedBotCertsRequest_Usage() {}
 
 // The simplest possible usage mode for a certificate, returning certificates
 // appropriate for SSH or API authn.
@@ -280,6 +324,97 @@ func (b0 UsageIdentity_builder) Build() *UsageIdentity {
 	return m0
 }
 
+// UsageApp defines the mode
+type UsageApp struct {
+	state                 protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Name       string                 `protobuf:"bytes,1,opt,name=name,proto3"`
+	xxx_hidden_PublicAddr string                 `protobuf:"bytes,2,opt,name=public_addr,json=publicAddr,proto3"`
+	xxx_hidden_Scope      string                 `protobuf:"bytes,3,opt,name=scope,proto3"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *UsageApp) Reset() {
+	*x = UsageApp{}
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UsageApp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UsageApp) ProtoMessage() {}
+
+func (x *UsageApp) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UsageApp) GetName() string {
+	if x != nil {
+		return x.xxx_hidden_Name
+	}
+	return ""
+}
+
+func (x *UsageApp) GetPublicAddr() string {
+	if x != nil {
+		return x.xxx_hidden_PublicAddr
+	}
+	return ""
+}
+
+func (x *UsageApp) GetScope() string {
+	if x != nil {
+		return x.xxx_hidden_Scope
+	}
+	return ""
+}
+
+func (x *UsageApp) SetName(v string) {
+	x.xxx_hidden_Name = v
+}
+
+func (x *UsageApp) SetPublicAddr(v string) {
+	x.xxx_hidden_PublicAddr = v
+}
+
+func (x *UsageApp) SetScope(v string) {
+	x.xxx_hidden_Scope = v
+}
+
+type UsageApp_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// name is the name of the application to route to.
+	// Must resolve to an application within the scope to which
+	// the calling bot is pinned.
+	Name string
+	// public_addr is the application public address.
+	PublicAddr string
+	// scope is the scope of the target application.
+	Scope string
+}
+
+func (b0 UsageApp_builder) Build() *UsageApp {
+	m0 := &UsageApp{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Name = b.Name
+	x.xxx_hidden_PublicAddr = b.PublicAddr
+	x.xxx_hidden_Scope = b.Scope
+	return m0
+}
+
 // Response for IssueScopedBotCerts
 type IssueScopedBotCertsResponse struct {
 	state            protoimpl.MessageState `protogen:"opaque.v1"`
@@ -290,7 +425,7 @@ type IssueScopedBotCertsResponse struct {
 
 func (x *IssueScopedBotCertsResponse) Reset() {
 	*x = IssueScopedBotCertsResponse{}
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -302,7 +437,7 @@ func (x *IssueScopedBotCertsResponse) String() string {
 func (*IssueScopedBotCertsResponse) ProtoMessage() {}
 
 func (x *IssueScopedBotCertsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[2]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -361,7 +496,7 @@ type Certs struct {
 
 func (x *Certs) Reset() {
 	*x = Certs{}
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -373,7 +508,7 @@ func (x *Certs) String() string {
 func (*Certs) ProtoMessage() {}
 
 func (x *Certs) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_issuance_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_issuance_v1_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -434,14 +569,20 @@ var File_teleport_issuance_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_issuance_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\"teleport/issuance/v1/service.proto\x12\x14teleport.issuance.v1\x1a\x1egoogle/protobuf/duration.proto\"\xe1\x01\n" +
+	"\"teleport/issuance/v1/service.proto\x12\x14teleport.issuance.v1\x1a\x1egoogle/protobuf/duration.proto\"\x95\x02\n" +
 	"\x1aIssueScopedBotCertsRequest\x12$\n" +
 	"\x0essh_public_key\x18\x01 \x01(\fR\fsshPublicKey\x12$\n" +
 	"\x0etls_public_key\x18\x02 \x01(\fR\ftlsPublicKey\x12+\n" +
 	"\x03ttl\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x03ttl\x12A\n" +
-	"\bidentity\x18\x04 \x01(\v2#.teleport.issuance.v1.UsageIdentityH\x00R\bidentityB\a\n" +
+	"\bidentity\x18\x04 \x01(\v2#.teleport.issuance.v1.UsageIdentityH\x00R\bidentity\x122\n" +
+	"\x03app\x18\x05 \x01(\v2\x1e.teleport.issuance.v1.UsageAppH\x00R\x03appB\a\n" +
 	"\x05usage\"\x0f\n" +
-	"\rUsageIdentity\"P\n" +
+	"\rUsageIdentity\"U\n" +
+	"\bUsageApp\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
+	"\vpublic_addr\x18\x02 \x01(\tR\n" +
+	"publicAddr\x12\x14\n" +
+	"\x05scope\x18\x03 \x01(\tR\x05scope\"P\n" +
 	"\x1bIssueScopedBotCertsResponse\x121\n" +
 	"\x05certs\x18\x01 \x01(\v2\x1b.teleport.issuance.v1.CertsR\x05certs\"+\n" +
 	"\x05Certs\x12\x10\n" +
@@ -450,25 +591,27 @@ const file_teleport_issuance_v1_service_proto_rawDesc = "" +
 	"\x0fIssuanceService\x12z\n" +
 	"\x13IssueScopedBotCerts\x120.teleport.issuance.v1.IssueScopedBotCertsRequest\x1a1.teleport.issuance.v1.IssueScopedBotCertsResponseBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1;issuancev1pbb\x06proto3"
 
-var file_teleport_issuance_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_teleport_issuance_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_teleport_issuance_v1_service_proto_goTypes = []any{
 	(*IssueScopedBotCertsRequest)(nil),  // 0: teleport.issuance.v1.IssueScopedBotCertsRequest
 	(*UsageIdentity)(nil),               // 1: teleport.issuance.v1.UsageIdentity
-	(*IssueScopedBotCertsResponse)(nil), // 2: teleport.issuance.v1.IssueScopedBotCertsResponse
-	(*Certs)(nil),                       // 3: teleport.issuance.v1.Certs
-	(*durationpb.Duration)(nil),         // 4: google.protobuf.Duration
+	(*UsageApp)(nil),                    // 2: teleport.issuance.v1.UsageApp
+	(*IssueScopedBotCertsResponse)(nil), // 3: teleport.issuance.v1.IssueScopedBotCertsResponse
+	(*Certs)(nil),                       // 4: teleport.issuance.v1.Certs
+	(*durationpb.Duration)(nil),         // 5: google.protobuf.Duration
 }
 var file_teleport_issuance_v1_service_proto_depIdxs = []int32{
-	4, // 0: teleport.issuance.v1.IssueScopedBotCertsRequest.ttl:type_name -> google.protobuf.Duration
+	5, // 0: teleport.issuance.v1.IssueScopedBotCertsRequest.ttl:type_name -> google.protobuf.Duration
 	1, // 1: teleport.issuance.v1.IssueScopedBotCertsRequest.identity:type_name -> teleport.issuance.v1.UsageIdentity
-	3, // 2: teleport.issuance.v1.IssueScopedBotCertsResponse.certs:type_name -> teleport.issuance.v1.Certs
-	0, // 3: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:input_type -> teleport.issuance.v1.IssueScopedBotCertsRequest
-	2, // 4: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:output_type -> teleport.issuance.v1.IssueScopedBotCertsResponse
-	4, // [4:5] is the sub-list for method output_type
-	3, // [3:4] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	2, // 2: teleport.issuance.v1.IssueScopedBotCertsRequest.app:type_name -> teleport.issuance.v1.UsageApp
+	4, // 3: teleport.issuance.v1.IssueScopedBotCertsResponse.certs:type_name -> teleport.issuance.v1.Certs
+	0, // 4: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:input_type -> teleport.issuance.v1.IssueScopedBotCertsRequest
+	3, // 5: teleport.issuance.v1.IssuanceService.IssueScopedBotCerts:output_type -> teleport.issuance.v1.IssueScopedBotCertsResponse
+	5, // [5:6] is the sub-list for method output_type
+	4, // [4:5] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_teleport_issuance_v1_service_proto_init() }
@@ -478,6 +621,7 @@ func file_teleport_issuance_v1_service_proto_init() {
 	}
 	file_teleport_issuance_v1_service_proto_msgTypes[0].OneofWrappers = []any{
 		(*issueScopedBotCertsRequest_Identity)(nil),
+		(*issueScopedBotCertsRequest_App)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -485,7 +629,7 @@ func file_teleport_issuance_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_issuance_v1_service_proto_rawDesc), len(file_teleport_issuance_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/issuance/v1/service.proto
+++ b/api/proto/teleport/issuance/v1/service.proto
@@ -65,6 +65,7 @@ message IssueScopedBotCertsRequest {
   // any usage-specific options. At least one of the usage values must be set.
   oneof usage {
     UsageIdentity identity = 4;
+    UsageApp app = 5;
   }
 }
 
@@ -72,6 +73,20 @@ message IssueScopedBotCertsRequest {
 // appropriate for SSH or API authn.
 message UsageIdentity {
   // Reserved for future identity-usage-specific options.
+}
+
+// UsageApp defines the mode
+message UsageApp {
+  // name is the name of the application to route to.
+  // Must resolve to an application within the scope to which
+  // the calling bot is pinned.
+  string name = 1;
+
+  // public_addr is the application public address.
+  string public_addr = 2;
+
+  // scope is the scope of the target application.
+  string scope = 3;
 }
 
 // Response for IssueScopedBotCerts

--- a/lib/auth/issuance/v1/service.go
+++ b/lib/auth/issuance/v1/service.go
@@ -27,6 +27,7 @@ import (
 	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/internal/cert"
+	sessionreq "github.com/gravitational/teleport/lib/auth/internal/session"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -36,6 +37,8 @@ import (
 type authServer interface {
 	AccessCheckerForScope(ctx context.Context, scope string, userState services.UserState, allowedResourceAccessIDs []types.ResourceAccessID) (*services.ScopedAccessCheckerContext, error)
 	GenerateUserCerts(ctx context.Context, req cert.Request) (*proto.Certs, error)
+	CreateAppSessionFromReq(ctx context.Context, req sessionreq.NewAppSessionRequest) (types.WebSession, error)
+	GetClusterName(ctx context.Context) (types.ClusterName, error)
 }
 
 // Service implements teleport.issuance.v1.IssuanceService
@@ -128,7 +131,11 @@ func (s *Service) IssueScopedBotCerts(
 
 	switch req.WhichUsage() {
 	case issuancev1pb.IssueScopedBotCertsRequest_Identity_case:
-	// no special handling.
+		// no special handling.
+	case issuancev1pb.IssueScopedBotCertsRequest_App_case:
+		if err := validateUsageApp(req); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	default:
 		return nil, trace.BadParameter(
 			"unsupported or unspecified usage variant",
@@ -202,17 +209,6 @@ func (s *Service) IssueScopedBotCerts(
 		SSHPublicKey:   req.GetSshPublicKey(),
 		TLSPublicKey:   req.GetTlsPublicKey(),
 
-		// Explicitly set BotInternal to false as these certs are intended for
-		// outputs/services and not use by the bot internally. This prevents
-		// using them further issuance.
-		BotInternal: false,
-		// Explicitly reject use for further issuance
-		DisallowReissue: true,
-
-		// We do not pass traits from the Bot user here. This is because we do
-		// not currently support traits for scoped Bots. Users shouldn't be able
-		// to set these due to validation but this acts as a back-stop.
-
 		// Propagate certain attributes from current identity to generated
 		// certificates
 		JoinAttributes: currentIdentity.JoinAttributes,
@@ -225,6 +221,25 @@ func (s *Service) IssueScopedBotCerts(
 		BotScope:  botScope,
 		JoinToken: currentIdentity.JoinToken,
 	}
+
+	// Apply per-usage alterations to the cert request.
+	switch req.WhichUsage() {
+	case issuancev1pb.IssueScopedBotCertsRequest_App_case:
+		if err := s.applyUsageApp(ctx, user, botScope, currentIdentity, req.GetApp(), ttl, &certReq); err != nil {
+			return nil, trace.Wrap(err, "configuring App Usage into the certificate request")
+		}
+	}
+
+	// Explicitly set BotInternal to false as these certs are intended for
+	// outputs/services and not use by the bot internally. This prevents
+	// using them further issuance.
+	certReq.BotInternal = false
+	// Explicitly reject use for further issuance
+	certReq.DisallowReissue = true
+	// We do not pass traits from the Bot user here. This is because we do
+	// not currently support traits for scoped Bots. Users shouldn't be able
+	// to set these due to validation but this acts as a back-stop.
+	certReq.Traits = nil
 
 	// nb(strideynet): One day, we'll want to pull more of the logic around
 	// cert generation into this package rather than invoking this via the

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -499,7 +499,10 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 	ctx := t.Context()
 	srv := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
 
-	const botScope = "/test-scope"
+	const (
+		botScope   = "/test-scope"
+		childScope = "/test-scope/child"
+	)
 
 	adminClient, err := srv.NewClient(authtest.TestAdmin())
 	require.NoError(t, err)
@@ -681,40 +684,62 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 		}.Build())
 		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
 	})
-}
 
-// TestIssueScopedBotCerts_UsageApp_ScopeHierarchy tests scope matching
-// behavior in detail: exact matches, descendant scopes, and narrower bot
-// scope scenarios.
-func TestIssueScopedBotCerts_UsageApp_ScopeHierarchy(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	srv := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
-
-	const (
-		parentScope = "/testing"
-		childScope  = "/testing/team-a"
-	)
-
-	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	// Register a child-scope app for hierarchy tests.
+	childApp, err := types.NewAppV3(types.Metadata{
+		Name: "child-app",
+	}, types.AppSpecV3{
+		URI:        "http://localhost:8082",
+		PublicAddr: scopedapp.ScopedAppPublicAddr(childScope, "child-app", "proxy.example.com"),
+	})
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = adminClient.Close() })
+	childApp.Scope = childScope
+	childAppServer, err := types.NewAppServerV3FromApp(childApp, "child-app-host", "child-app-hostid")
+	require.NoError(t, err)
+	childAppServer.Scope = childScope
+	_, err = srv.Auth().UpsertApplicationServer(ctx, childAppServer)
+	require.NoError(t, err)
 
-	scopedSvc := adminClient.ScopedAccessServiceClient()
+	t.Run("parent-scoped bot accesses child-scope app", func(t *testing.T) {
+		// Bot pinned to /test-scope can access app in /test-scope/child
+		// because /test-scope/child is a descendant of /test-scope.
+		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:       "child-app",
+				PublicAddr: childApp.GetPublicAddr(),
+				Scope:      childScope,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCerts())
+		require.NotEmpty(t, resp.GetCerts().GetTls())
 
-	// Create scoped roles at both levels with wildcard app access.
-	for _, scope := range []string{parentScope, childScope} {
-		_, err = scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+		assert.Equal(t, "child-app", identity.RouteToApp.Name)
+		assert.Equal(t, childScope, identity.RouteToApp.Scope)
+	})
+
+	t.Run("child-scoped bot rejected for parent-scope app", func(t *testing.T) {
+		// Bot pinned to /test-scope/child requests an app in /test-scope.
+		// /test-scope is NOT a descendant of /test-scope/child, so the
+		// scope pin check rejects.
+
+		// Create a scoped role at child scope for the child bot.
+		_, err := scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
 			Role: scopedaccessv1.ScopedRole_builder{
 				Kind:    scopedaccess.KindScopedRole,
 				Version: types.V1,
 				Metadata: headerv1.Metadata_builder{
-					Name: "app-role",
+					Name: "child-bot-role",
 				}.Build(),
-				Scope: scope,
+				Scope: childScope,
 				Spec: scopedaccessv1.ScopedRoleSpec_builder{
-					AssignableScopes: []string{scope},
+					AssignableScopes: []string{childScope},
 					App: scopedaccessv1.ScopedRoleApp_builder{
 						Labels: []*labelv1.Label{
 							labelv1.Label_builder{
@@ -727,55 +752,22 @@ func TestIssueScopedBotCerts_UsageApp_ScopeHierarchy(t *testing.T) {
 			}.Build(),
 		}.Build())
 		require.NoError(t, err)
-	}
 
-	// Register apps at both scope levels.
-	parentApp, err := types.NewAppV3(types.Metadata{
-		Name: "parent-app",
-	}, types.AppSpecV3{
-		URI:        "http://localhost:8081",
-		PublicAddr: scopedapp.ScopedAppPublicAddr(parentScope, "parent-app", "proxy.example.com"),
-	})
-	require.NoError(t, err)
-	parentApp.Scope = parentScope
-	parentAppServer, err := types.NewAppServerV3FromApp(parentApp, "parent-host", "parent-hostid")
-	require.NoError(t, err)
-	parentAppServer.Scope = parentScope
-	_, err = srv.Auth().UpsertApplicationServer(ctx, parentAppServer)
-	require.NoError(t, err)
-
-	childApp, err := types.NewAppV3(types.Metadata{
-		Name: "child-app",
-	}, types.AppSpecV3{
-		URI:        "http://localhost:8082",
-		PublicAddr: scopedapp.ScopedAppPublicAddr(childScope, "child-app", "proxy.example.com"),
-	})
-	require.NoError(t, err)
-	childApp.Scope = childScope
-	childAppServer, err := types.NewAppServerV3FromApp(childApp, "child-host", "child-hostid")
-	require.NoError(t, err)
-	childAppServer.Scope = childScope
-	_, err = srv.Auth().UpsertApplicationServer(ctx, childAppServer)
-	require.NoError(t, err)
-
-	// Helper to create a bot+SRA+client pinned to a given scope.
-	setupBot := func(t *testing.T, botName, botScope, roleScope string) issuancev1pb.IssuanceServiceClient {
-		t.Helper()
-
-		bot, err := adminClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		// Create a child-scoped bot.
+		childBot, err := adminClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
 			Bot: machineidv1pb.Bot_builder{
 				Kind:    types.KindBot,
 				Version: types.V1,
 				Metadata: headerv1.Metadata_builder{
-					Name: botName,
+					Name: "child-bot",
 				}.Build(),
-				Scope: botScope,
+				Scope: childScope,
 				Spec:  &machineidv1pb.BotSpec{},
 			}.Build(),
 		}.Build())
 		require.NoError(t, err)
 
-		sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		childSRAResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
 			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    scopedaccess.KindScopedRoleAssignment,
 				SubKind: scopedaccess.SubKindDynamic,
@@ -783,127 +775,38 @@ func TestIssueScopedBotCerts_UsageApp_ScopeHierarchy(t *testing.T) {
 				Metadata: headerv1.Metadata_builder{
 					Name: uuid.NewString(),
 				}.Build(),
-				Scope: botScope,
+				Scope: childScope,
 				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
-					Bot: scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}.String(),
+					Bot: scopes.QualifiedName{Scope: childScope, Name: childBot.GetMetadata().GetName()}.String(),
 					Assignments: []*scopedaccessv1.Assignment{
 						scopedaccessv1.Assignment_builder{
-							Role:  scopes.QualifiedName{Scope: roleScope, Name: "app-role"}.String(),
-							Scope: roleScope,
+							Role:  scopes.QualifiedName{Scope: childScope, Name: "child-bot-role"}.String(),
+							Scope: childScope,
 						}.Build(),
 					},
 				}.Build(),
 			}.Build(),
 		}.Build())
 		require.NoError(t, err)
-		waitForSRACache(t, srv, sraResp)
+		waitForSRACache(t, srv, childSRAResp)
 
-		botClient, err := srv.NewClient(
-			authtest.TestScopedBot(t, scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}, true),
+		childBotClient, err := srv.NewClient(
+			authtest.TestScopedBot(t, scopes.QualifiedName{Scope: childScope, Name: childBot.GetMetadata().GetName()}, true),
 		)
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = botClient.Close() })
+		t.Cleanup(func() { _ = childBotClient.Close() })
 
-		return issuancev1pb.NewIssuanceServiceClient(botClient.GetConnection())
-	}
-
-	// Generate a key pair shared across sub-tests.
-	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
-	require.NoError(t, err)
-	tlsPubKeyPEM, err := keys.MarshalPublicKey(key.Public())
-	require.NoError(t, err)
-	requestedTTL := time.Hour
-
-	t.Run("parent-scoped bot accesses parent-scope app (exact match)", func(t *testing.T) {
-		issuanceClient := setupBot(t, "parent-bot-exact", parentScope, parentScope)
-
-		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+		childIssuanceClient := issuancev1pb.NewIssuanceServiceClient(childBotClient.GetConnection())
+		_, err = childIssuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(requestedTTL),
 			App: issuancev1pb.UsageApp_builder{
-				Name:       "parent-app",
-				PublicAddr: parentApp.GetPublicAddr(),
-				Scope:      parentScope,
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
-		require.NotNil(t, resp.GetCerts())
-		require.NotEmpty(t, resp.GetCerts().GetTls())
-
-		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
-		require.NoError(t, err)
-		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
-		require.NoError(t, err)
-		assert.Equal(t, "parent-app", identity.RouteToApp.Name)
-		assert.Equal(t, parentScope, identity.RouteToApp.Scope)
-	})
-
-	t.Run("parent-scoped bot accesses child-scope app (descendant)", func(t *testing.T) {
-		// Bot pinned to /testing can access app in /testing/team-a
-		// because /testing/team-a is a descendant of /testing.
-		issuanceClient := setupBot(t, "parent-bot-child", parentScope, parentScope)
-
-		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
-			TlsPublicKey: tlsPubKeyPEM,
-			Ttl:          durationpb.New(requestedTTL),
-			App: issuancev1pb.UsageApp_builder{
-				Name:       "child-app",
-				PublicAddr: childApp.GetPublicAddr(),
-				Scope:      childScope,
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
-		require.NotNil(t, resp.GetCerts())
-		require.NotEmpty(t, resp.GetCerts().GetTls())
-
-		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
-		require.NoError(t, err)
-		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
-		require.NoError(t, err)
-		assert.Equal(t, "child-app", identity.RouteToApp.Name)
-		assert.Equal(t, childScope, identity.RouteToApp.Scope)
-	})
-
-	t.Run("child-scoped bot rejected at scope pin for parent-scope app", func(t *testing.T) {
-		// Bot pinned to /testing/team-a requests an app in /testing.
-		// /testing is NOT a descendant of /testing/team-a, so the scope
-		// pin check rejects immediately — the app is never fetched.
-		issuanceClient := setupBot(t, "child-bot-parent", childScope, childScope)
-
-		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
-			TlsPublicKey: tlsPubKeyPEM,
-			Ttl:          durationpb.New(requestedTTL),
-			App: issuancev1pb.UsageApp_builder{
-				Name:       "parent-app",
-				PublicAddr: parentApp.GetPublicAddr(),
-				Scope:      parentScope,
+				Name:       "test-app",
+				PublicAddr: app.GetPublicAddr(),
+				Scope:      botScope,
 			}.Build(),
 		}.Build())
 		require.True(t, trace.IsAccessDenied(err), "expected access denied at scope pin check, got: %v", err)
-	})
-
-	t.Run("child-scoped bot accesses child-scope app (exact match)", func(t *testing.T) {
-		issuanceClient := setupBot(t, "child-bot-exact", childScope, childScope)
-
-		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
-			TlsPublicKey: tlsPubKeyPEM,
-			Ttl:          durationpb.New(requestedTTL),
-			App: issuancev1pb.UsageApp_builder{
-				Name:       "child-app",
-				PublicAddr: childApp.GetPublicAddr(),
-				Scope:      childScope,
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
-		require.NotNil(t, resp.GetCerts())
-		require.NotEmpty(t, resp.GetCerts().GetTls())
-
-		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
-		require.NoError(t, err)
-		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
-		require.NoError(t, err)
-		assert.Equal(t, "child-app", identity.RouteToApp.Name)
-		assert.Equal(t, childScope, identity.RouteToApp.Scope)
 	})
 }
 

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -666,7 +666,7 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 			}.Build(),
 		}.Build())
 		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
-		require.ErrorContains(t, err, "tls_public_key is required for app usage")
+		require.ErrorContains(t, err, "tls_public_key: is required for app usage")
 	})
 
 	t.Run("app scope outside pinned scope rejected", func(t *testing.T) {

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -650,6 +650,18 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 				traceErrCheck: trace.IsBadParameter,
 				errMsg:        "app.name: is required",
 			},
+			"missing scope rejected": {
+				req: issuancev1pb.IssueScopedBotCertsRequest_builder{
+					TlsPublicKey: tlsPubKeyPEM,
+					Ttl:          durationpb.New(requestedTTL),
+					App: issuancev1pb.UsageApp_builder{
+						Name:  "test-app",
+						Scope: "",
+					}.Build(),
+				}.Build(),
+				traceErrCheck: trace.IsBadParameter,
+				errMsg:        "app.scope",
+			},
 			"invalid scope rejected": {
 				req: issuancev1pb.IssueScopedBotCertsRequest_builder{
 					TlsPublicKey: tlsPubKeyPEM,

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -730,7 +730,7 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 		// scope pin check rejects.
 
 		// Create a scoped role at child scope for the child bot.
-		_, err := scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		_, err := scopedSvc.CreateScopedRole(t.Context(), scopedaccessv1.CreateScopedRoleRequest_builder{
 			Role: scopedaccessv1.ScopedRole_builder{
 				Kind:    scopedaccess.KindScopedRole,
 				Version: types.V1,
@@ -754,7 +754,7 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a child-scoped bot.
-		childBot, err := adminClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		childBot, err := adminClient.BotServiceClient().CreateBot(t.Context(), machineidv1pb.CreateBotRequest_builder{
 			Bot: machineidv1pb.Bot_builder{
 				Kind:    types.KindBot,
 				Version: types.V1,
@@ -767,7 +767,7 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 		}.Build())
 		require.NoError(t, err)
 
-		childSRAResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		childSRAResp, err := scopedSvc.CreateScopedRoleAssignment(t.Context(), scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
 			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    scopedaccess.KindScopedRoleAssignment,
 				SubKind: scopedaccess.SubKindDynamic,

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -633,71 +633,85 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 		assert.Equal(t, botScope, identity.RouteToApp.Scope)
 	})
 
-	t.Run("missing app name rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
-			TlsPublicKey: tlsPubKeyPEM,
-			Ttl:          durationpb.New(requestedTTL),
-			App: issuancev1pb.UsageApp_builder{
-				Scope: botScope,
-			}.Build(),
-		}.Build())
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
-		require.ErrorContains(t, err, "app.name: is required")
-	})
+	t.Run("failures", func(t *testing.T) {
+		testCases := map[string]struct {
+			req           *issuancev1pb.IssueScopedBotCertsRequest
+			traceErrCheck func(error) bool
+			errMsg        string
+		}{
+			"missing app name rejected": {
+				req: issuancev1pb.IssueScopedBotCertsRequest_builder{
+					TlsPublicKey: tlsPubKeyPEM,
+					Ttl:          durationpb.New(requestedTTL),
+					App: issuancev1pb.UsageApp_builder{
+						Scope: botScope,
+					}.Build(),
+				}.Build(),
+				traceErrCheck: trace.IsBadParameter,
+				errMsg:        "app.name: is required",
+			},
+			"invalid scope rejected": {
+				req: issuancev1pb.IssueScopedBotCertsRequest_builder{
+					TlsPublicKey: tlsPubKeyPEM,
+					Ttl:          durationpb.New(requestedTTL),
+					App: issuancev1pb.UsageApp_builder{
+						Name:  "test-app",
+						Scope: "not-a-scope",
+					}.Build(),
+				}.Build(),
+				traceErrCheck: trace.IsBadParameter,
+				errMsg:        "app.scope",
+			},
+			"tls public key required for app usage": {
+				req: issuancev1pb.IssueScopedBotCertsRequest_builder{
+					SshPublicKey: sshPubKeyBytes,
+					Ttl:          durationpb.New(requestedTTL),
+					App: issuancev1pb.UsageApp_builder{
+						Name:       "test-app",
+						PublicAddr: app.GetPublicAddr(),
+						Scope:      botScope,
+					}.Build(),
+				}.Build(),
+				traceErrCheck: trace.IsBadParameter,
+				errMsg:        "tls_public_key: is required for app usage",
+			},
+			"public_addr required for app usage": {
+				req: issuancev1pb.IssueScopedBotCertsRequest_builder{
+					SshPublicKey: sshPubKeyBytes,
+					Ttl:          durationpb.New(requestedTTL),
+					TlsPublicKey: tlsPubKeyPEM,
+					App: issuancev1pb.UsageApp_builder{
+						Name:       "test-app",
+						PublicAddr: "",
+						Scope:      botScope,
+					}.Build(),
+				}.Build(),
+				traceErrCheck: trace.IsBadParameter,
+				errMsg:        "app.public_addr: is required",
+			},
+			"app scope outside pinned scope rejected": {
+				req: issuancev1pb.IssueScopedBotCertsRequest_builder{
+					TlsPublicKey: tlsPubKeyPEM,
+					Ttl:          durationpb.New(requestedTTL),
+					App: issuancev1pb.UsageApp_builder{
+						Name:       "test-app",
+						PublicAddr: app.GetPublicAddr(),
+						Scope:      "/other-scope",
+					}.Build(),
+				}.Build(),
+				traceErrCheck: trace.IsAccessDenied,
+				errMsg:        "other scope",
+			},
+		}
 
-	t.Run("invalid scope rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
-			TlsPublicKey: tlsPubKeyPEM,
-			Ttl:          durationpb.New(requestedTTL),
-			App: issuancev1pb.UsageApp_builder{
-				Name:  "test-app",
-				Scope: "not-a-scope",
-			}.Build(),
-		}.Build())
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
-		require.ErrorContains(t, err, "app.scope")
-	})
-
-	t.Run("tls public key required for app usage", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
-			SshPublicKey: sshPubKeyBytes,
-			Ttl:          durationpb.New(requestedTTL),
-			App: issuancev1pb.UsageApp_builder{
-				Name:       "test-app",
-				PublicAddr: app.GetPublicAddr(),
-				Scope:      botScope,
-			}.Build(),
-		}.Build())
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
-		require.ErrorContains(t, err, "tls_public_key: is required for app usage")
-	})
-
-	t.Run("public_addr required for app usage", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
-			SshPublicKey: sshPubKeyBytes,
-			Ttl:          durationpb.New(requestedTTL),
-			TlsPublicKey: tlsPubKeyPEM,
-			App: issuancev1pb.UsageApp_builder{
-				Name:       "test-app",
-				PublicAddr: "",
-				Scope:      botScope,
-			}.Build(),
-		}.Build())
-		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
-		require.ErrorContains(t, err, "app.public_addr: is required")
-	})
-
-	t.Run("app scope outside pinned scope rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
-			TlsPublicKey: tlsPubKeyPEM,
-			Ttl:          durationpb.New(requestedTTL),
-			App: issuancev1pb.UsageApp_builder{
-				Name:       "test-app",
-				PublicAddr: app.GetPublicAddr(),
-				Scope:      "/other-scope",
-			}.Build(),
-		}.Build())
-		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				_, err := issuanceClient.IssueScopedBotCerts(t.Context(), tc.req)
+				require.Error(t, err)
+				require.True(t, tc.traceErrCheck(err), "error is not of the expected type: %v", err)
+				require.ErrorContains(t, err, tc.errMsg)
+			})
+		}
 	})
 
 	// Register a child-scope app for hierarchy tests.

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -35,6 +35,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -46,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/scopes"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedapp "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -80,7 +82,7 @@ func newTestTLSServerWithScopesFeatures(t testing.TB, scopesFeatures scopes.Feat
 	return srv
 }
 
-func TestIssueScopedBotCerts(t *testing.T) {
+func TestIssueScopedBotCerts_UsageIdentity(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -165,7 +167,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	now := srv.Clock().Now()
 
 	t.Run("success", func(t *testing.T) {
-		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(requestedTTL),
@@ -202,7 +204,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("excessive TTL rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(defaults.MaxRenewableCertTTL + time.Hour),
@@ -212,7 +214,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("missing usage rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(time.Hour),
@@ -221,7 +223,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("ssh only", func(t *testing.T) {
-		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			Ttl:          durationpb.New(requestedTTL),
 			Identity:     &issuancev1pb.UsageIdentity{},
@@ -233,7 +235,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("tls only", func(t *testing.T) {
-		resp, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(requestedTTL),
 			Identity:     &issuancev1pb.UsageIdentity{},
@@ -245,7 +247,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("missing keys rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			Ttl:      durationpb.New(requestedTTL),
 			Identity: &issuancev1pb.UsageIdentity{},
 		}.Build())
@@ -254,7 +256,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("zero ttl rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(0),
@@ -265,7 +267,7 @@ func TestIssueScopedBotCerts(t *testing.T) {
 	})
 
 	t.Run("negative ttl rejected", func(t *testing.T) {
-		_, err := issuanceClient.IssueScopedBotCerts(ctx, issuancev1pb.IssueScopedBotCertsRequest_builder{
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			SshPublicKey: sshPubKeyBytes,
 			TlsPublicKey: tlsPubKeyPEM,
 			Ttl:          durationpb.New(-time.Hour),
@@ -382,7 +384,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 	}.Build()
 
 	t.Run("non-bot user without scope", func(t *testing.T) {
-		_, err := adminClient.IssuanceClient().IssueScopedBotCerts(ctx, req)
+		_, err := adminClient.IssuanceClient().IssueScopedBotCerts(t.Context(), req)
 		require.True(
 			t,
 			trace.IsAccessDenied(err),
@@ -392,10 +394,10 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 
 	t.Run("non-bot user with scope", func(t *testing.T) {
 		// Create a regular user with a scoped role assignment.
-		user, err := authtest.CreateUser(ctx, srv.Auth(), "scoped-user")
+		user, err := authtest.CreateUser(t.Context(), srv.Auth(), "scoped-user")
 		require.NoError(t, err)
 
-		userSRAResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		userSRAResp, err := scopedSvc.CreateScopedRoleAssignment(t.Context(), scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
 			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
 				Kind:    scopedaccess.KindScopedRoleAssignment,
 				Version: types.V1,
@@ -421,7 +423,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = scopedUserClient.Close() })
 
-		_, err = scopedUserClient.IssuanceClient().IssueScopedBotCerts(ctx, req)
+		_, err = scopedUserClient.IssuanceClient().IssueScopedBotCerts(t.Context(), req)
 		require.True(
 			t,
 			trace.IsAccessDenied(err),
@@ -431,7 +433,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 
 	t.Run("unscoped bot", func(t *testing.T) {
 		// Create an unscoped bot.
-		unscopedBot, err := adminClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		unscopedBot, err := adminClient.BotServiceClient().CreateBot(t.Context(), machineidv1pb.CreateBotRequest_builder{
 			Bot: machineidv1pb.Bot_builder{
 				Kind:    types.KindBot,
 				Version: types.V1,
@@ -449,7 +451,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = botClient.Close() })
 
-		_, err = botClient.IssuanceClient().IssueScopedBotCerts(ctx, req)
+		_, err = botClient.IssuanceClient().IssueScopedBotCerts(t.Context(), req)
 		require.True(
 			t,
 			trace.IsAccessDenied(err),
@@ -464,7 +466,7 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = botClient.Close() })
 
-		_, err = botClient.IssuanceClient().IssueScopedBotCerts(ctx, req)
+		_, err = botClient.IssuanceClient().IssueScopedBotCerts(t.Context(), req)
 		require.True(
 			t,
 			trace.IsAccessDenied(err),
@@ -482,12 +484,426 @@ func TestIssueScopedBotCerts_Unauthorized(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = botClient.Close() })
 
-		_, err = botClient.IssuanceClient().IssueScopedBotCerts(ctx, req)
+		_, err = botClient.IssuanceClient().IssueScopedBotCerts(t.Context(), req)
 		require.True(
 			t,
 			trace.IsAccessDenied(err),
 			"expected access denied, got: %v", err,
 		)
+	})
+}
+
+func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	srv := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+
+	const botScope = "/test-scope"
+
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adminClient.Close() })
+
+	// Create a scoped role with app access.
+	scopedSvc := adminClient.ScopedAccessServiceClient()
+	_, err = scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+		Role: scopedaccessv1.ScopedRole_builder{
+			Kind:    scopedaccess.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "bot-role",
+			}.Build(),
+			Scope: botScope,
+			Spec: scopedaccessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{botScope},
+				App: scopedaccessv1.ScopedRoleApp_builder{
+					Labels: []*labelv1.Label{
+						labelv1.Label_builder{
+							Name:   types.Wildcard,
+							Values: []string{types.Wildcard},
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Create a scoped bot.
+	bot, err := adminClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+		Bot: machineidv1pb.Bot_builder{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: "test-bot",
+			}.Build(),
+			Scope: botScope,
+			Spec:  &machineidv1pb.BotSpec{},
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	// Create a scoped role assignment for the bot.
+	sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+			Kind:    scopedaccess.KindScopedRoleAssignment,
+			SubKind: scopedaccess.SubKindDynamic,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: uuid.NewString(),
+			}.Build(),
+			Scope: botScope,
+			Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+				Bot: scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}.String(),
+				Assignments: []*scopedaccessv1.Assignment{
+					scopedaccessv1.Assignment_builder{Role: botScope + "::bot-role", Scope: botScope}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	waitForSRACache(t, srv, sraResp)
+
+	// Create a scoped app and register it.
+	app, err := types.NewAppV3(types.Metadata{
+		Name: "test-app",
+	}, types.AppSpecV3{
+		URI:        "http://localhost:8080",
+		PublicAddr: scopedapp.ScopedAppPublicAddr(botScope, "test-app", "proxy.example.com"),
+	})
+	require.NoError(t, err)
+	app.Scope = botScope
+	appServer, err := types.NewAppServerV3FromApp(app, "test-app-host", "test-app-hostid")
+	require.NoError(t, err)
+	appServer.Scope = botScope
+	_, err = srv.Auth().UpsertApplicationServer(ctx, appServer)
+	require.NoError(t, err)
+
+	// Create a client with a scoped bot internal identity.
+	botClient, err := srv.NewClient(
+		authtest.TestScopedBot(t, scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}, true),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = botClient.Close() })
+
+	// Generate a key pair for the request.
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	tlsPubKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	require.NoError(t, err)
+	sshPubKey, err := ssh.NewPublicKey(key.Public())
+	require.NoError(t, err)
+	sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+
+	issuanceClient := issuancev1pb.NewIssuanceServiceClient(botClient.GetConnection())
+	requestedTTL := time.Hour
+
+	t.Run("success", func(t *testing.T) {
+		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			SshPublicKey: sshPubKeyBytes,
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:       "test-app",
+				PublicAddr: app.GetPublicAddr(),
+				Scope:      botScope,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCerts())
+		require.NotEmpty(t, resp.GetCerts().GetTls())
+
+		// Parse the returned TLS cert and verify app-specific identity properties.
+		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+
+		assert.False(t, identity.BotInternal, "output cert should not be bot-internal")
+		assert.True(t, identity.DisallowReissue, "output cert should disallow reissue")
+		assert.Equal(t, "test-bot", identity.BotName)
+		assert.Equal(t, "test-app", identity.RouteToApp.Name)
+		assert.Equal(t, app.GetPublicAddr(), identity.RouteToApp.PublicAddr)
+		assert.Equal(t, srv.ClusterName(), identity.RouteToApp.ClusterName, "ClusterName should be resolved server-side via auth.GetClusterName()")
+		assert.NotEmpty(t, identity.RouteToApp.SessionID, "app session should have been created")
+		assert.Equal(t, botScope, identity.RouteToApp.Scope)
+	})
+
+	t.Run("missing app name rejected", func(t *testing.T) {
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Scope: botScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+		require.ErrorContains(t, err, "app.name: is required")
+	})
+
+	t.Run("invalid scope rejected", func(t *testing.T) {
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:  "test-app",
+				Scope: "not-a-scope",
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+		require.ErrorContains(t, err, "app.scope")
+	})
+
+	t.Run("tls public key required for app usage", func(t *testing.T) {
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			SshPublicKey: sshPubKeyBytes,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:       "test-app",
+				PublicAddr: app.GetPublicAddr(),
+				Scope:      botScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+		require.ErrorContains(t, err, "tls_public_key is required for app usage")
+	})
+
+	t.Run("app scope outside pinned scope rejected", func(t *testing.T) {
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:       "test-app",
+				PublicAddr: app.GetPublicAddr(),
+				Scope:      "/other-scope",
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied, got: %v", err)
+	})
+}
+
+// TestIssueScopedBotCerts_UsageApp_ScopeHierarchy tests scope matching
+// behavior in detail: exact matches, descendant scopes, and narrower bot
+// scope scenarios.
+func TestIssueScopedBotCerts_UsageApp_ScopeHierarchy(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	srv := newTestTLSServerWithScopesFeatures(t, scopes.Features{Enabled: true})
+
+	const (
+		parentScope = "/testing"
+		childScope  = "/testing/team-a"
+	)
+
+	adminClient, err := srv.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = adminClient.Close() })
+
+	scopedSvc := adminClient.ScopedAccessServiceClient()
+
+	// Create scoped roles at both levels with wildcard app access.
+	for _, scope := range []string{parentScope, childScope} {
+		_, err = scopedSvc.CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
+			Role: scopedaccessv1.ScopedRole_builder{
+				Kind:    scopedaccess.KindScopedRole,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: "app-role",
+				}.Build(),
+				Scope: scope,
+				Spec: scopedaccessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{scope},
+					App: scopedaccessv1.ScopedRoleApp_builder{
+						Labels: []*labelv1.Label{
+							labelv1.Label_builder{
+								Name:   types.Wildcard,
+								Values: []string{types.Wildcard},
+							}.Build(),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+	}
+
+	// Register apps at both scope levels.
+	parentApp, err := types.NewAppV3(types.Metadata{
+		Name: "parent-app",
+	}, types.AppSpecV3{
+		URI:        "http://localhost:8081",
+		PublicAddr: scopedapp.ScopedAppPublicAddr(parentScope, "parent-app", "proxy.example.com"),
+	})
+	require.NoError(t, err)
+	parentApp.Scope = parentScope
+	parentAppServer, err := types.NewAppServerV3FromApp(parentApp, "parent-host", "parent-hostid")
+	require.NoError(t, err)
+	parentAppServer.Scope = parentScope
+	_, err = srv.Auth().UpsertApplicationServer(ctx, parentAppServer)
+	require.NoError(t, err)
+
+	childApp, err := types.NewAppV3(types.Metadata{
+		Name: "child-app",
+	}, types.AppSpecV3{
+		URI:        "http://localhost:8082",
+		PublicAddr: scopedapp.ScopedAppPublicAddr(childScope, "child-app", "proxy.example.com"),
+	})
+	require.NoError(t, err)
+	childApp.Scope = childScope
+	childAppServer, err := types.NewAppServerV3FromApp(childApp, "child-host", "child-hostid")
+	require.NoError(t, err)
+	childAppServer.Scope = childScope
+	_, err = srv.Auth().UpsertApplicationServer(ctx, childAppServer)
+	require.NoError(t, err)
+
+	// Helper to create a bot+SRA+client pinned to a given scope.
+	setupBot := func(t *testing.T, botName, botScope, roleScope string) issuancev1pb.IssuanceServiceClient {
+		t.Helper()
+
+		bot, err := adminClient.BotServiceClient().CreateBot(ctx, machineidv1pb.CreateBotRequest_builder{
+			Bot: machineidv1pb.Bot_builder{
+				Kind:    types.KindBot,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: botName,
+				}.Build(),
+				Scope: botScope,
+				Spec:  &machineidv1pb.BotSpec{},
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+
+		sraResp, err := scopedSvc.CreateScopedRoleAssignment(ctx, scopedaccessv1.CreateScopedRoleAssignmentRequest_builder{
+			Assignment: scopedaccessv1.ScopedRoleAssignment_builder{
+				Kind:    scopedaccess.KindScopedRoleAssignment,
+				SubKind: scopedaccess.SubKindDynamic,
+				Version: types.V1,
+				Metadata: headerv1.Metadata_builder{
+					Name: uuid.NewString(),
+				}.Build(),
+				Scope: botScope,
+				Spec: scopedaccessv1.ScopedRoleAssignmentSpec_builder{
+					Bot: scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}.String(),
+					Assignments: []*scopedaccessv1.Assignment{
+						scopedaccessv1.Assignment_builder{
+							Role:  scopes.QualifiedName{Scope: roleScope, Name: "app-role"}.String(),
+							Scope: roleScope,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		waitForSRACache(t, srv, sraResp)
+
+		botClient, err := srv.NewClient(
+			authtest.TestScopedBot(t, scopes.QualifiedName{Scope: botScope, Name: bot.GetMetadata().GetName()}, true),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = botClient.Close() })
+
+		return issuancev1pb.NewIssuanceServiceClient(botClient.GetConnection())
+	}
+
+	// Generate a key pair shared across sub-tests.
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	tlsPubKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	require.NoError(t, err)
+	requestedTTL := time.Hour
+
+	t.Run("parent-scoped bot accesses parent-scope app (exact match)", func(t *testing.T) {
+		issuanceClient := setupBot(t, "parent-bot-exact", parentScope, parentScope)
+
+		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:       "parent-app",
+				PublicAddr: parentApp.GetPublicAddr(),
+				Scope:      parentScope,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCerts())
+		require.NotEmpty(t, resp.GetCerts().GetTls())
+
+		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+		assert.Equal(t, "parent-app", identity.RouteToApp.Name)
+		assert.Equal(t, parentScope, identity.RouteToApp.Scope)
+	})
+
+	t.Run("parent-scoped bot accesses child-scope app (descendant)", func(t *testing.T) {
+		// Bot pinned to /testing can access app in /testing/team-a
+		// because /testing/team-a is a descendant of /testing.
+		issuanceClient := setupBot(t, "parent-bot-child", parentScope, parentScope)
+
+		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:       "child-app",
+				PublicAddr: childApp.GetPublicAddr(),
+				Scope:      childScope,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCerts())
+		require.NotEmpty(t, resp.GetCerts().GetTls())
+
+		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+		assert.Equal(t, "child-app", identity.RouteToApp.Name)
+		assert.Equal(t, childScope, identity.RouteToApp.Scope)
+	})
+
+	t.Run("child-scoped bot rejected at scope pin for parent-scope app", func(t *testing.T) {
+		// Bot pinned to /testing/team-a requests an app in /testing.
+		// /testing is NOT a descendant of /testing/team-a, so the scope
+		// pin check rejects immediately — the app is never fetched.
+		issuanceClient := setupBot(t, "child-bot-parent", childScope, childScope)
+
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:       "parent-app",
+				PublicAddr: parentApp.GetPublicAddr(),
+				Scope:      parentScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsAccessDenied(err), "expected access denied at scope pin check, got: %v", err)
+	})
+
+	t.Run("child-scoped bot accesses child-scope app (exact match)", func(t *testing.T) {
+		issuanceClient := setupBot(t, "child-bot-exact", childScope, childScope)
+
+		resp, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			TlsPublicKey: tlsPubKeyPEM,
+			Ttl:          durationpb.New(requestedTTL),
+			App: issuancev1pb.UsageApp_builder{
+				Name:       "child-app",
+				PublicAddr: childApp.GetPublicAddr(),
+				Scope:      childScope,
+			}.Build(),
+		}.Build())
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetCerts())
+		require.NotEmpty(t, resp.GetCerts().GetTls())
+
+		tlsCert, err := tlsca.ParseCertificatePEM(resp.GetCerts().GetTls())
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		require.NoError(t, err)
+		assert.Equal(t, "child-app", identity.RouteToApp.Name)
+		assert.Equal(t, childScope, identity.RouteToApp.Scope)
 	})
 }
 

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -689,7 +689,7 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 				traceErrCheck: trace.IsBadParameter,
 				errMsg:        "app.public_addr: is required",
 			},
-			"app scope outside pinned scope rejected": {
+			"app scope outside pinned scope rejected by not matching the scoped public addr subdomain": {
 				req: issuancev1pb.IssueScopedBotCertsRequest_builder{
 					TlsPublicKey: tlsPubKeyPEM,
 					Ttl:          durationpb.New(requestedTTL),
@@ -699,8 +699,21 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 						Scope:      "/other-scope",
 					}.Build(),
 				}.Build(),
+				traceErrCheck: trace.IsBadParameter,
+				errMsg:        "app.public_addr: is not valid for given app name and scope",
+			},
+			"app scope outside pinned scope with matching the scoped public addr subdomain gets rejected": {
+				req: issuancev1pb.IssueScopedBotCertsRequest_builder{
+					TlsPublicKey: tlsPubKeyPEM,
+					Ttl:          durationpb.New(requestedTTL),
+					App: issuancev1pb.UsageApp_builder{
+						Name:       "test-app",
+						PublicAddr: scopedapp.ScopedAppPublicAddr("/other-scope", "test-app", "proxy.example.com"),
+						Scope:      "/other-scope",
+					}.Build(),
+				}.Build(),
 				traceErrCheck: trace.IsAccessDenied,
-				errMsg:        "other scope",
+				errMsg:        "other-scope",
 			},
 		}
 

--- a/lib/auth/issuance/v1/service_test.go
+++ b/lib/auth/issuance/v1/service_test.go
@@ -672,6 +672,21 @@ func TestIssueScopedBotCerts_UsageApp(t *testing.T) {
 		require.ErrorContains(t, err, "tls_public_key: is required for app usage")
 	})
 
+	t.Run("public_addr required for app usage", func(t *testing.T) {
+		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
+			SshPublicKey: sshPubKeyBytes,
+			Ttl:          durationpb.New(requestedTTL),
+			TlsPublicKey: tlsPubKeyPEM,
+			App: issuancev1pb.UsageApp_builder{
+				Name:       "test-app",
+				PublicAddr: "",
+				Scope:      botScope,
+			}.Build(),
+		}.Build())
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter, got: %v", err)
+		require.ErrorContains(t, err, "app.public_addr: is required")
+	})
+
 	t.Run("app scope outside pinned scope rejected", func(t *testing.T) {
 		_, err := issuanceClient.IssueScopedBotCerts(t.Context(), issuancev1pb.IssueScopedBotCertsRequest_builder{
 			TlsPublicKey: tlsPubKeyPEM,

--- a/lib/auth/issuance/v1/usage_app.go
+++ b/lib/auth/issuance/v1/usage_app.go
@@ -115,6 +115,9 @@ func validateUsageApp(req *issuancev1pb.IssueScopedBotCertsRequest) error {
 	if len(req.GetTlsPublicKey()) == 0 {
 		return trace.BadParameter("tls_public_key: is required for app usage")
 	}
+	if app.GetPublicAddr() == "" {
+		return trace.BadParameter("app.public_addr: is required")
+	}
 
 	return nil
 }

--- a/lib/auth/issuance/v1/usage_app.go
+++ b/lib/auth/issuance/v1/usage_app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/internal/cert"
 	sessionreq "github.com/gravitational/teleport/lib/auth/internal/session"
 	"github.com/gravitational/teleport/lib/scopes"
+	appscopes "github.com/gravitational/teleport/lib/scopes/app"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -117,6 +118,9 @@ func validateUsageApp(req *issuancev1pb.IssueScopedBotCertsRequest) error {
 	}
 	if app.GetPublicAddr() == "" {
 		return trace.BadParameter("app.public_addr: is required")
+	}
+	if !appscopes.ScopedAppPublicAddrValid(app.GetScope(), app.GetName(), app.GetPublicAddr()) {
+		return trace.BadParameter("app.public_addr: is not valid for given app name and scope")
 	}
 
 	return nil

--- a/lib/auth/issuance/v1/usage_app.go
+++ b/lib/auth/issuance/v1/usage_app.go
@@ -1,0 +1,121 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package issuancev1
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+
+	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/internal/cert"
+	sessionreq "github.com/gravitational/teleport/lib/auth/internal/session"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+// applyUsageApp will create a new scoped session with the application and
+// append to the cert.Request the relevant information.
+func (s *Service) applyUsageApp(
+	ctx context.Context,
+	user types.User,
+	botScope string,
+	currentIdentity tlsca.Identity,
+	usageApp *issuancev1pb.UsageApp,
+	ttl time.Duration,
+	certReq *cert.Request,
+) error {
+	// Ensure the current identity has scope to perform this operation.
+	pinnedScope := currentIdentity.ScopePin.GetScope()
+	if !scopes.ResourceScope(usageApp.GetScope()).IsSubjectToScopeOfEffect(pinnedScope) {
+		return trace.AccessDenied("app scope %q is not equivalent to or descendant of pinned scope %q", usageApp.GetScope(), pinnedScope)
+	}
+
+	cn, err := s.authServer.GetClusterName(ctx)
+	if err != nil {
+		return trace.Wrap(err, "resolving cluster name")
+	}
+
+	// CreateAppSessionFromReq performs some authorization internally, but NOT explicit app-level RBAC.
+	// The explicit app-level authorization (CheckAccessToApp) happens at connection time in the App Service.
+	ws, err := s.authServer.CreateAppSessionFromReq(ctx, sessionreq.NewAppSessionRequest{
+		NewWebSessionRequest: sessionreq.NewWebSessionRequest{
+			User:       user.GetName(),
+			LoginIP:    currentIdentity.LoginIP,
+			SessionTTL: ttl,
+			// No Traits, Roles, AccessRequests, or RequestedResourceAccessIDs:
+			// scoped bots have none, and CreateAppSessionFromReq rejects
+			// resource access IDs for scope-pinned identities.
+
+			// AttestWebSession must be true so that clusters enforcing a
+			// hardware private key policy (e.g. hardware_key_touch) do not
+			// reject this session. The session's private key is generated
+			// and held exclusively by the Auth server — marking it as a
+			// web_session attestation tells GenerateUserCerts that no
+			// physical hardware key is needed to satisfy the policy.
+			// Without this, CreateAppSessionFromReq would fail with a
+			// PrivateKeyPolicyError on any cluster with a non-"none" policy.
+
+			AttestWebSession: true,
+		},
+
+		AppName:     usageApp.GetName(),
+		PublicAddr:  usageApp.GetPublicAddr(),
+		ClusterName: cn.GetClusterName(),
+		TargetScope: usageApp.GetScope(),
+
+		// Identity drives the scoped access checker context.
+		Identity:      currentIdentity,
+		BotName:       currentIdentity.BotName,
+		BotInstanceID: currentIdentity.BotInstanceID,
+		BotScope:      botScope,
+	})
+	if err != nil {
+		return trace.Wrap(err, "creating app session")
+	}
+
+	// Annotate the certificate with the session information.
+	certReq.Usage = []string{teleport.UsageAppsOnly}
+	certReq.AppSessionID = ws.GetName()
+	certReq.AppName = usageApp.GetName()
+	certReq.AppPublicAddr = usageApp.GetPublicAddr()
+	certReq.AppClusterName = cn.GetClusterName()
+	certReq.TargetScope = usageApp.GetScope()
+
+	return nil
+}
+
+func validateUsageApp(req *issuancev1pb.IssueScopedBotCertsRequest) error {
+	app := req.GetApp()
+	if app.GetName() == "" {
+		return trace.BadParameter("app.name: is required")
+	}
+	if err := scopes.StrongValidate(app.GetScope()); err != nil {
+		return trace.Wrap(err, "app.scope")
+	}
+	if len(req.GetTlsPublicKey()) == 0 {
+		return trace.BadParameter("tls_public_key is required for app usage")
+	}
+
+	return nil
+}

--- a/lib/auth/issuance/v1/usage_app.go
+++ b/lib/auth/issuance/v1/usage_app.go
@@ -114,7 +114,7 @@ func validateUsageApp(req *issuancev1pb.IssueScopedBotCertsRequest) error {
 		return trace.Wrap(err, "app.scope")
 	}
 	if len(req.GetTlsPublicKey()) == 0 {
-		return trace.BadParameter("tls_public_key is required for app usage")
+		return trace.BadParameter("tls_public_key: is required for app usage")
 	}
 
 	return nil

--- a/lib/auth/issuance/v1/usage_app.go
+++ b/lib/auth/issuance/v1/usage_app.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-
 	issuancev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/issuance/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/internal/cert"


### PR DESCRIPTION
This is a break down from https://github.com/gravitational/teleport/pull/69422
refs https://github.com/gravitational/core/issues/57

Extracts the internal/server-side plumbing for scoped app access from tscolari/57/scoped-app-access, split out to ease review.

This PR adds UsageApp as a new usage variant for the IssueScopedBotCerts RPC, enabling scoped bots to request application-routed certificates. It spans three layers:

1. Proto — Adds the UsageApp message to IssueScopedBotCertsRequest with fields for name, public_addr, cluster_name, and scope.
2. Issuance service — Implements server-side handling for UsageApp:
- Validates the requested app scope against the caller's scope pin
- Resolves the app via RangeApplicationServersWithName, ensuring it exists in the claimed scope
- Rejects Identity Center account apps (not compatible with scoped cert flow)
- Creates a scoped app session via CreateAppSessionFromReq
- Annotates the output certificate with app routing metadata and session ID

Note: This PR does not yet update tbot to allow scoped apps, it's just the internal plumbing.

## Manual Test Plan
### Test Environment

local

### Test Cases
- [x] Can still create unscoped application tunnel
- [x] Can still create unscoped application output
- [x] Can still create unscoped appliaction proxy 
