### PR TITLE
appresource: Add matcher tree and path.match

### DIFF
--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -137,6 +137,9 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/scopes \
     FuzzValidateQualifiedName fuzz_validate_qualified_name
 
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/appresource \
+    FuzzTokenizeNonASCII fuzz_tokenize_non_ascii
+
 }
 
 build_teleport_api_fuzzers() {

--- a/lib/appresource/match.go
+++ b/lib/appresource/match.go
@@ -1,0 +1,204 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"strings"
+)
+
+// Eval walks tokens against the matcher root. On a match it returns true
+// and the segments bound by capture nodes. On no match it returns false and
+// a nil map. The tokens are the raw output of Tokenize; matching compares
+// their content views, so a token sent with an encoded space or encoded
+// non-ASCII text matches the literal written plain. Evaluation never
+// mutates shared state and never panics.
+func Eval(tokens []string, root *Node) (bool, map[string]string) {
+	caps := map[string]string{}
+	if matchNode(root, tokens, 0, caps) {
+		return true, caps
+	}
+	return false, nil
+}
+
+// matchNode reports whether node matches tokens starting at index i,
+// recursing into children for the following segments. Captures are recorded
+// into caps as the match descends. Because a non-matching branch can still
+// have written a capture before failing, callers must treat caps as
+// meaningful only when the top-level match returns true.
+func matchNode(node *Node, tokens []string, i int, caps map[string]string) bool {
+	switch node.kind {
+	case kindRoot:
+		// Root consumes no token: each child is matched against the same
+		// segment, so the children are alternative roots. The first that
+		// matches wins.
+		for _, child := range node.children {
+			if matchNode(child, tokens, i, caps) {
+				return true
+			}
+		}
+		return false
+	case kindGreedy:
+		// Greedy is terminal and matches the entire remaining suffix,
+		// including zero tokens. It is repeated glob, so the suffix must
+		// carry no encoded separator: a single such segment anywhere in
+		// the tail stops the greedy, which is why a broad `**` never
+		// silently absorbs an encoded slash.
+		for _, tok := range tokens[i:] {
+			if hasEncodedSeparator(tok) {
+				return false
+			}
+		}
+		return true
+	case kindSlash:
+		// A trailing slash is the empty segment that ends the token list.
+		// It is terminal: the empty token must exist and be the last one.
+		return i < len(tokens) && tokens[i] == "" && i+1 == len(tokens)
+	case kindOptional:
+		// The subtree is optional: match either the end of the path, where
+		// it is absent, or one of the children against the remainder. The
+		// end branch binds nothing, which is why a capture inside an
+		// optional is never guaranteed.
+		if i == len(tokens) {
+			return true
+		}
+		for _, child := range node.children {
+			if matchNode(child, tokens, i, caps) {
+				return true
+			}
+		}
+		return false
+	case kindLiteral:
+		// A literal holds decoded content and never contains "%", so a
+		// token carrying the encoded separator keeps its raw "%2F" in the
+		// content view and fails the comparison.
+		if i >= len(tokens) || contentView(tokens[i]) != node.text {
+			return false
+		}
+		return matchChildren(node, tokens, i, caps)
+	case kindGlob:
+		// A glob matches one segment that carries no encoded separator, so
+		// it never spans an encoded slash.
+		if i >= len(tokens) || tokens[i] == "" || hasEncodedSeparator(tokens[i]) {
+			return false
+		}
+		return matchChildren(node, tokens, i, caps)
+	case kindCapture:
+		// Like glob, a capture binds one segment with no encoded
+		// separator. The bound value is the content view, so a where
+		// condition later compares decoded text and never sees an escape.
+		if i >= len(tokens) || tokens[i] == "" || hasEncodedSeparator(tokens[i]) {
+			return false
+		}
+		// Bind before descending so a child predicate can read the capture.
+		caps[node.text] = contentView(tokens[i])
+		return matchChildren(node, tokens, i, caps)
+	default:
+		return false
+	}
+}
+
+// matchChildren handles the continuation after node has consumed tokens[i].
+// A node with no children is terminal and requires the subject to end here.
+// Several children are alternatives: the first that matches wins.
+func matchChildren(node *Node, tokens []string, i int, caps map[string]string) bool {
+	if len(node.children) == 0 {
+		// Terminal: the subject must end exactly at this segment.
+		return i+1 == len(tokens)
+	}
+	for _, child := range node.children {
+		if matchNode(child, tokens, i+1, caps) {
+			return true
+		}
+	}
+	return false
+}
+
+// contentView returns the token with its content escapes decoded: the
+// encoded space %20 and the escapes of non-ASCII bytes become their bytes,
+// while the encoded separator %2F keeps its raw escape. Matching compares
+// content by value, so "My%20Project" and the literal text "My Project" are
+// one segment, while the separator stays a structural question a plain node
+// never answers. The raw token is what the app agent forwards; this view
+// exists only for the comparison.
+func contentView(token string) string {
+	if !strings.ContainsRune(token, '%') {
+		return token
+	}
+	var b strings.Builder
+	b.Grow(len(token))
+	for i := 0; i < len(token); i++ {
+		if token[i] == '%' && i+2 < len(token) && !isEncodedSeparatorAt(token, i) {
+			if v, ok := parseEscape(token, i); ok {
+				b.WriteByte(v)
+				i += 2
+				continue
+			}
+		}
+		b.WriteByte(token[i])
+	}
+	return b.String()
+}
+
+// hasEncodedSeparator reports whether the raw token carries the encoded
+// separator %2F or %2f. It is the one escape a plain glob, capture, or
+// greedy node refuses, because forwarding it upstream can change how many
+// segments the app sees.
+func hasEncodedSeparator(token string) bool {
+	for i := range len(token) {
+		if isEncodedSeparatorAt(token, i) {
+			return true
+		}
+	}
+	return false
+}
+
+// isEncodedSeparatorAt reports whether the escape starting at token[i] is
+// the encoded separator, in either hex case.
+func isEncodedSeparatorAt(token string, i int) bool {
+	return i+2 < len(token) && token[i] == '%' && token[i+1] == '2' &&
+		(token[i+2] == 'F' || token[i+2] == 'f')
+}
+
+// parseEscape reads the two hex digits of the escape starting at token[i]
+// and reports whether they form one of the escapes Tokenize admits.
+func parseEscape(token string, i int) (byte, bool) {
+	hi, ok1 := hexVal(token[i+1])
+	lo, ok2 := hexVal(token[i+2])
+	if !ok1 || !ok2 {
+		return 0, false
+	}
+	b := hi<<4 | lo
+	if !isAllowedEscape(b) {
+		return 0, false
+	}
+	return b, true
+}
+
+// hexVal converts one hex digit, in either case, to its value.
+func hexVal(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}

--- a/lib/appresource/match_test.go
+++ b/lib/appresource/match_test.go
@@ -1,0 +1,257 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// evalPath tokenizes a request path and walks the tree, failing the test on
+// a path Tokenize rejects, so each case states its path in wire form.
+func evalPath(t *testing.T, root *Node, path string) (bool, map[string]string) {
+	t.Helper()
+	tokens, err := Tokenize(path)
+	require.NoError(t, err)
+	return Eval(tokens, root)
+}
+
+func TestEvalLiteralChain(t *testing.T) {
+	tree := Literal("api", Literal("v4"))
+	for path, want := range map[string]bool{
+		"/api/v4":       true,
+		"/api":          false,
+		"/api/v4/extra": false,
+		"/api/v5":       false,
+		"/apix/v4":      false,
+		"/api/v4/":      false,
+	} {
+		matched, _ := evalPath(t, tree, path)
+		require.Equal(t, want, matched, "path %q", path)
+	}
+}
+
+// TestEvalLiteralSplits pins that Literal splits on "/", so the joined and
+// nested spellings build equal trees.
+func TestEvalLiteralSplits(t *testing.T) {
+	require.Equal(t, Literal("a", Literal("b", Literal("c"))), Literal("a/b/c"))
+}
+
+func TestEvalGlob(t *testing.T) {
+	tree := Literal("files", Glob())
+	matched, _ := evalPath(t, tree, "/files/report.pdf")
+	require.True(t, matched)
+	matched, _ = evalPath(t, tree, "/files")
+	require.False(t, matched, "glob requires its one segment")
+	matched, _ = evalPath(t, tree, "/files/a/b")
+	require.False(t, matched, "glob matches exactly one segment")
+	matched, _ = evalPath(t, tree, "/files/")
+	require.False(t, matched, "glob does not match the trailing empty segment")
+	matched, _ = evalPath(t, tree, "/files/group%2Fproject")
+	require.False(t, matched, "glob never matches an encoded separator")
+	matched, _ = evalPath(t, tree, "/files/My%20Report")
+	require.True(t, matched, "an encoded space is content")
+}
+
+func TestEvalCaptureBindsContentView(t *testing.T) {
+	tree := Literal("projects", Capture("project", Greedy()))
+	matched, caps := evalPath(t, tree, "/projects/My%20Project/jobs")
+	require.True(t, matched)
+	require.Equal(t, map[string]string{"project": "My Project"}, caps)
+
+	matched, caps = evalPath(t, tree, "/projects/caf%C3%A9")
+	require.True(t, matched)
+	require.Equal(t, map[string]string{"project": "café"}, caps)
+
+	matched, _ = evalPath(t, tree, "/projects/group%2Fproject")
+	require.False(t, matched, "capture never matches an encoded separator")
+}
+
+func TestEvalGreedy(t *testing.T) {
+	tree := Literal("api", Greedy())
+	for path, want := range map[string]bool{
+		"/api":                 true,
+		"/api/v4":              true,
+		"/api/v4/projects/1":   true,
+		"/api/v4/group%2Fproj": false,
+		"/other":               false,
+	} {
+		matched, _ := evalPath(t, tree, path)
+		require.Equal(t, want, matched, "path %q", path)
+	}
+}
+
+func TestEvalSlash(t *testing.T) {
+	files := Literal("files", Slash())
+	matched, _ := evalPath(t, files, "/files/")
+	require.True(t, matched)
+	matched, _ = evalPath(t, files, "/files")
+	require.False(t, matched)
+
+	matched, _ = evalPath(t, Slash(), "/")
+	require.True(t, matched, "a bare slash node matches the root path")
+}
+
+func TestEvalOptional(t *testing.T) {
+	opt, err := Optional(Slash(), Literal("reports"))
+	require.NoError(t, err)
+	tree := Literal("files", opt)
+	for path, want := range map[string]bool{
+		"/files":         true,
+		"/files/":        true,
+		"/files/reports": true,
+		"/files/other":   false,
+	} {
+		matched, _ := evalPath(t, tree, path)
+		require.Equal(t, want, matched, "path %q", path)
+	}
+
+	_, err = Optional()
+	require.ErrorContains(t, err, "at least one child")
+}
+
+func TestEvalRoot(t *testing.T) {
+	root, err := Root(Literal("api", Greedy()), Literal("health"))
+	require.NoError(t, err)
+	for path, want := range map[string]bool{
+		"/api/v4": true,
+		"/health": true,
+		"/admin":  false,
+	} {
+		matched, _ := evalPath(t, root, path)
+		require.Equal(t, want, matched, "path %q", path)
+	}
+
+	_, err = Root()
+	require.ErrorContains(t, err, "at least one alternative")
+}
+
+func TestEvalLiteralContentView(t *testing.T) {
+	matched, _ := evalPath(t, Literal("My Project"), "/My%20Project")
+	require.True(t, matched, "a literal written plain matches the encoded request form")
+	matched, _ = evalPath(t, Literal("café"), "/caf%C3%A9")
+	require.True(t, matched)
+}
+
+func TestValidateLiteral(t *testing.T) {
+	require.NoError(t, validateLiteral("api/v4/My Project"))
+	require.ErrorContains(t, validateLiteral(""), "cannot be empty")
+	require.ErrorContains(t, validateLiteral("a//b"), "cannot be empty")
+	require.ErrorContains(t, validateLiteral("a%2Fb"), "contains %")
+	require.ErrorContains(t, validateLiteral("secret "), "space")
+	require.ErrorContains(t, validateLiteral("secret."), "dot")
+	require.ErrorContains(t, validateLiteral(".."), `"." or ".."`)
+}
+
+func TestLiteralPanicsOnInvalidSegment(t *testing.T) {
+	require.Panics(t, func() { Literal("") })
+	require.Panics(t, func() { Literal("a%2Fb") })
+}
+
+// compileMatch compiles a predicate that is expected to be valid and
+// evaluates it against a GET request for the given path.
+func compileMatch(t *testing.T, expr, path string) (bool, error) {
+	t.Helper()
+	where, err := CompileWhere(expr)
+	require.NoError(t, err)
+	return where.Evaluate(Env{Request: Request{Method: http.MethodGet, Path: path}})
+}
+
+func TestPathMatchPredicate(t *testing.T) {
+	const expr = `path.match(root(literal("api", greedy()), literal("health", optional(slash()))))`
+	for path, want := range map[string]bool{
+		"/api/v4/projects": true,
+		"/health":          true,
+		"/health/":         true,
+		"/admin":           false,
+	} {
+		matched, err := compileMatch(t, expr, path)
+		require.NoError(t, err, "path %q", path)
+		require.Equal(t, want, matched, "path %q", path)
+	}
+}
+
+// TestPathMatchFailsClosed pins that an unmatchable path is an evaluation
+// error rather than a false, so a negated path.match cannot invert it into
+// an allow.
+func TestPathMatchFailsClosed(t *testing.T) {
+	for _, expr := range []string{
+		`path.match(literal("api"))`,
+		`!path.match(literal("api"))`,
+	} {
+		_, err := compileMatch(t, expr, "/a/../b")
+		require.Error(t, err, "expr %q", expr)
+
+		_, err = compileMatch(t, expr, "/group%2Fproject")
+		require.ErrorContains(t, err, "encoded separator", "expr %q", expr)
+	}
+}
+
+// TestPathMatchCombines pins that path.match composes with the method and
+// identity conditions the where language already has.
+func TestPathMatchCombines(t *testing.T) {
+	where, err := CompileWhere(`path.match(literal("api", greedy())) && request.method == "GET"`)
+	require.NoError(t, err)
+
+	matched, err := where.Evaluate(Env{Request: Request{Method: http.MethodGet, Path: "/api/v4"}})
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	matched, err = where.Evaluate(Env{Request: Request{Method: http.MethodPost, Path: "/api/v4"}})
+	require.NoError(t, err)
+	require.False(t, matched)
+}
+
+// TestPathMatchTypeChecked pins that the constructors type-check at parse
+// time: a string where a *Node belongs is a compile error, not a runtime
+// surprise.
+func TestPathMatchTypeChecked(t *testing.T) {
+	_, err := CompileWhere(`path.match("admin")`)
+	require.Error(t, err)
+}
+
+// TestPredicateLiteralValidates pins that the expression surface holds a
+// literal to the same segment rules as the Literal constructor.
+func TestPredicateLiteralValidates(t *testing.T) {
+	_, err := compileMatch(t, `path.match(literal("a%2Fb"))`, "/api")
+	require.ErrorContains(t, err, "contains %")
+}
+
+func TestContentView(t *testing.T) {
+	for token, want := range map[string]string{
+		"plain":        "plain",
+		"My%20Project": "My Project",
+		"caf%C3%A9":    "café",
+		"group%2Fproj": "group%2Fproj",
+		"group%2fproj": "group%2fproj",
+		"a%20b%2Fc":    "a b%2Fc",
+	} {
+		require.Equal(t, want, contentView(token), "token %q", token)
+	}
+}
+
+func TestHasEncodedSeparator(t *testing.T) {
+	require.True(t, hasEncodedSeparator("group%2Fproj"))
+	require.True(t, hasEncodedSeparator("group%2fproj"))
+	require.False(t, hasEncodedSeparator("My%20Project"))
+	require.False(t, hasEncodedSeparator("plain"))
+	require.False(t, hasEncodedSeparator("caf%C3%A9"))
+}

--- a/lib/appresource/node.go
+++ b/lib/appresource/node.go
@@ -1,0 +1,213 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/text/unicode/norm"
+)
+
+// kind enumerates the matcher node kinds.
+type kind int
+
+const (
+	// kindLiteral matches a token whose content view equals its text.
+	kindLiteral kind = iota
+	// kindGlob matches exactly one non-empty token that carries no encoded
+	// separator, the `*` metacharacter. A `*` therefore never silently
+	// spans an encoded slash.
+	kindGlob
+	// kindCapture matches one token like kindGlob and binds its content
+	// view under the capture name, the `{name}` metacharacter.
+	kindCapture
+	// kindGreedy matches zero or more trailing tokens, the `**`
+	// metacharacter. It is terminal and carries no children. It spans only
+	// tokens with no encoded separator, so a broad `**` never silently
+	// absorbs an encoded slash.
+	kindGreedy
+	// kindRoot is the synthetic top node. It consumes no token and matches
+	// each child against the same segment, so its children are alternative
+	// roots OR-ed together.
+	kindRoot
+	// kindSlash is a terminal node that matches the trailing empty segment a
+	// request path produces after a final "/". It is the named replacement
+	// for an empty literal, so a literal node never carries empty text.
+	kindSlash
+	// kindOptional is a terminal node that matches whether or not its
+	// subtree is present: the path may end here, or one of the node's
+	// children matches the remainder. Several children are alternatives.
+	// The skip branch binds nothing, so a capture inside an optional is
+	// never guaranteed.
+	kindOptional
+)
+
+// Node is one node in a matcher tree. Each node matches exactly one path
+// segment and carries its continuation as zero or more child nodes. Nesting
+// a single child descends to the next segment, so a chain of single children
+// is a sequence. Giving one node several children branches into
+// alternatives, so there is no separate sequence or alternation node. A Node
+// is an ordinary Go value, so a matcher can be constructed and asserted on
+// in tests with no cluster.
+type Node struct {
+	kind kind
+	// text holds the literal text for kindLiteral and the capture name for
+	// kindCapture. It is empty for every other kind.
+	text string
+	// children are the matchers for the next segment. Several children are
+	// alternatives, OR-ed together. A node with no children is terminal:
+	// the subject must end at this segment for the match to succeed.
+	children []*Node
+}
+
+// Literal builds a node that matches one or more fixed segments. The string
+// is split on "/", so Literal("a/b/c", child) is exactly equal to
+// Literal("a", Literal("b", Literal("c", child))). A path segment can never
+// contain a "/" (it is the separator), so splitting here loses nothing and
+// keeps a single canonical internal form. Metacharacters inside the string
+// (`{}`, `*`, `**`) are treated as plain literal text, not as captures or
+// globs; use Capture, Glob, and Greedy for those. The text is the decoded
+// content: a segment that a request sends encoded, such as a space or
+// non-ASCII text, is written plain. Literal panics on a segment that
+// validateLiteral rejects; the predicate literal() validates and returns
+// the error before building a node.
+func Literal(s string, children ...*Node) *Node {
+	segments := strings.Split(s, "/")
+	for _, seg := range segments {
+		if err := validateSegment(seg); err != nil {
+			panic("appresource: " + err.Error())
+		}
+	}
+	// Build from the innermost segment outward so the supplied children
+	// hang off the last segment.
+	node := &Node{kind: kindLiteral, text: segments[len(segments)-1], children: children}
+	for i := len(segments) - 2; i >= 0; i-- {
+		node = &Node{kind: kindLiteral, text: segments[i], children: []*Node{node}}
+	}
+	return node
+}
+
+// Glob builds a node that matches exactly one non-empty segment, the `*`
+// metacharacter.
+func Glob(children ...*Node) *Node {
+	return &Node{kind: kindGlob, children: children}
+}
+
+// Capture builds a node that matches one segment and binds its content view
+// under name, the `{name}` metacharacter.
+func Capture(name string, children ...*Node) *Node {
+	return &Node{kind: kindCapture, text: name, children: children}
+}
+
+// Greedy builds a terminal node that matches zero or more trailing segments,
+// the `**` metacharacter. It takes no children.
+func Greedy() *Node {
+	return &Node{kind: kindGreedy}
+}
+
+// Slash builds a terminal node that matches the trailing empty segment a
+// request path produces after a final "/", so Literal("files", Slash())
+// matches "/files/" but not "/files", and Slash() alone matches the bare
+// root "/".
+func Slash() *Node {
+	return &Node{kind: kindSlash}
+}
+
+// Optional builds a terminal node that makes its subtree optional: the path
+// may end at this node, or one of the children matches the remainder. So
+// Optional(Slash()) matches both "/files" and "/files/", and
+// Optional(Literal("reports")) matches "/files" and "/files/reports" from
+// one tree with no duplicated prefix. Several children are alternatives. An
+// empty Optional is a load error.
+func Optional(children ...*Node) (*Node, error) {
+	if len(children) == 0 {
+		return nil, trace.BadParameter("optional() requires at least one child subtree")
+	}
+	return &Node{kind: kindOptional, children: children}, nil
+}
+
+// Root builds the synthetic top node that matches each child against the
+// same segment, so the children are alternative roots OR-ed together. It is
+// the way to give a tree several first segments, such as
+// Root(Literal("api"), Literal("admin")), which a bare tree cannot express
+// because it has one root node. It consumes no token, so a nested root is a
+// grouping that behaves the same as sibling children in the parent. An
+// empty Root matches nothing and is a load error.
+func Root(children ...*Node) (*Node, error) {
+	if len(children) == 0 {
+		return nil, trace.BadParameter("root() requires at least one alternative")
+	}
+	return &Node{kind: kindRoot, children: children}, nil
+}
+
+// validateSegment rejects a literal segment that no request token's content
+// view can equal. The text must be non-empty, hold no "%" or "/", and pass
+// the same decoded-view checks Tokenize runs on a request segment, so a
+// literal that validates can never be a dead rule. An empty segment is the
+// trailing-slash pun that Slash owns.
+func validateSegment(seg string) error {
+	if seg == "" {
+		return trace.BadParameter("a literal segment cannot be empty; use slash() to match a trailing slash")
+	}
+	// A literal pins the decoded content, so a "%" in it is a dead rule: a
+	// token's content view never contains one unless the raw token carried
+	// the encoded separator, which a plain literal never matches.
+	if strings.ContainsRune(seg, '%') {
+		return trace.BadParameter("literal segment %q contains %%; write the decoded content instead", seg)
+	}
+	if !utf8.ValidString(seg) || !norm.NFKC.IsNormalString(seg) {
+		return trace.BadParameter("literal segment %q is not NFKC-normalized UTF-8", seg)
+	}
+	for _, r := range seg {
+		if r < utf8.RuneSelf && !isLegalPathByte(byte(r)) && r != ' ' {
+			return trace.BadParameter("literal segment %q contains an illegal URL byte %q", seg, string(r))
+		}
+		if !isGraphicRune(r) {
+			return trace.BadParameter("literal segment %q contains the disallowed character %q", seg, string(r))
+		}
+	}
+	if err := rejectDotSegment(seg); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := rejectLeadingMark(seg); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := rejectEdgeSpace(seg); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := rejectTrailingDot(seg); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// validateLiteral validates every segment a literal string splits into on
+// "/". It is the check the predicate literal() builder calls, so an
+// expression-built literal is held to the same rules as the Literal
+// constructor.
+func validateLiteral(s string) error {
+	for _, seg := range strings.Split(s, "/") {
+		if err := validateSegment(seg); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}

--- a/lib/appresource/tokenize.go
+++ b/lib/appresource/tokenize.go
@@ -28,8 +28,6 @@
 //	    - paths:
 //	        - /api/v4/user/{username}
 //	      where: user.name == vars.username
-//
-// The app agent, role validation, and tctl will use this package.
 package appresource
 
 import (
@@ -73,9 +71,10 @@ const legalPathPunct = "-._~!$&'()*+,=:@/%"
 //     consecutive slashes and "." or ".." segments. A ".."
 //     written between encoded slashes ("a%2F..%2Fadmin") is
 //     rejected the same as a raw one.
-//  4. The path body, with the encoded separator kept literal, must
-//     decode to valid, NFKC-stable UTF-8 and contain only graphic
-//     runes. "é" is allowed only as "%C3%A9".
+//  4. Each segment, once its non-ASCII escapes are decoded, must be
+//     valid, NFKC-stable UTF-8 and contain only graphic runes. The
+//     encoded separator %2F is a segment boundary for this check.
+//     "é" is allowed only as "%C3%A9".
 //  5. Split on real "/" only. An encoded slash stays one opaque
 //     token, hex case preserved.
 func Tokenize(path string) ([]string, error) {
@@ -92,9 +91,6 @@ func Tokenize(path string) ([]string, error) {
 		return nil, trace.Wrap(err)
 	}
 	if err := validateDecoded(path); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := validatePathContent(path); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return strings.Split(path[1:], "/"), nil
@@ -152,12 +148,11 @@ func validatePercentEscapes(path string) error {
 	return nil
 }
 
-// validateDecoded rejects "." and ".." segments and consecutive
-// slashes on a view where the encoded separator %2F is decoded
-// to "/". A trailing slash is kept, so "/foo/" tokenizes to
-// ["foo", ""] and does not match "/foo".
+// validateDecoded checks the decoded validation view of the path. It
+// rejects consecutive slashes, "." and ".." segments, and any content
+// that is not NFKC-stable graphic UTF-8.
 func validateDecoded(path string) error {
-	decoded := decodeSeparators(path)
+	decoded := decode(path)
 	if strings.Contains(decoded, "//") {
 		const msg = "path %q has consecutive slashes once the encoded separator %%2F is decoded"
 		return trace.BadParameter(msg, path)
@@ -168,31 +163,13 @@ func validateDecoded(path string) error {
 			return trace.BadParameter(msg, path)
 		}
 	}
-	return nil
-}
-
-// decodeSeparators returns the decode-for-validation view of path.
-// %2F is unescaped to "/", every other byte is left raw. The ".",
-// "..", and "//" checks run on this view, so any of these written
-// with an encoded slash is caught the same as a raw one.
-func decodeSeparators(path string) string {
-	decoded := strings.ReplaceAll(path, "%2F", "/")
-	return strings.ReplaceAll(decoded, "%2f", "/")
-}
-
-// validatePathContent decodes non-ASCII escapes in the path body,
-// keeping the encoded separator literal, and requires valid UTF-8,
-// NFKC stability, and a graphic category for every rune of the
-// resulting string.
-func validatePathContent(path string) error {
-	content := decodeNonASCII(path[1:])
-	if !utf8.ValidString(content) {
+	if !utf8.ValidString(decoded) {
 		return trace.BadParameter("path %q is not valid UTF-8 once decoded", path)
 	}
-	if !norm.NFKC.IsNormalString(content) {
+	if !norm.NFKC.IsNormalString(decoded) {
 		return trace.BadParameter("path %q is not NFKC-normalized", path)
 	}
-	for _, r := range content {
+	for _, r := range decoded {
 		if !isGraphicRune(r) {
 			const msg = "path %q contains the disallowed character %q; only letters, marks, numbers, punctuation, and symbols are allowed"
 			return trace.BadParameter(msg, path, string(r))
@@ -201,11 +178,12 @@ func validatePathContent(path string) error {
 	return nil
 }
 
-// decodeNonASCII returns s with every non-ASCII escape (a "%XX"
-// that decodes to a non-ASCII byte) replaced by its decoded byte.
-// All other bytes, including the encoded separator %2F, are
-// left as is.
-func decodeNonASCII(s string) string {
+// decode returns the validation view of s, resolving every escape that
+// validatePercentEscapes leaves alive: %2F (either case) to "/", and a
+// non-ASCII escape to its byte. Those are the only escapes it can
+// receive, so nothing else needs decoding. The view is used for
+// validation only; the returned tokens keep their raw form.
+func decode(s string) string {
 	if !strings.ContainsRune(s, '%') {
 		return s
 	}
@@ -213,7 +191,7 @@ func decodeNonASCII(s string) string {
 	b.Grow(len(s))
 	for i := 0; i < len(s); i++ {
 		if s[i] == '%' && i+2 < len(s) {
-			if v, err := strconv.ParseUint(s[i+1:i+3], 16, 8); err == nil && byte(v) >= 0x80 {
+			if v, err := strconv.ParseUint(s[i+1:i+3], 16, 8); err == nil && (v == '/' || v >= 0x80) {
 				b.WriteByte(byte(v))
 				i += 2
 				continue

--- a/lib/appresource/tokenize.go
+++ b/lib/appresource/tokenize.go
@@ -1,0 +1,234 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package appresource checks whether an HTTP app request is allowed
+// by a role. Roles carry allow-only rules. A rule can match on
+// request path, HTTP method, and a where predicate over the user
+// identity. Every field is optional.
+//
+// Example role fragment:
+//
+//	allow:
+//	  app_resources:
+//	    - paths:
+//	        - /api/v4/user/{username}
+//	      where: user.name == vars.username
+//
+// The app agent, role validation, and tctl will use this package.
+package appresource
+
+import (
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/text/unicode/norm"
+)
+
+// lengthCap bounds the length of a path Tokenize accepts.
+const lengthCap = 8 << 10 // 8 KiB
+
+// legalPathPunct is the non-alphanumeric bytes allowed in a raw
+// URL path. It is RFC 3986 pchar minus ";", plus "/" and "%".
+//
+// ";" is dropped because matrix parameters and ";jsessionid" may
+// cause the matcher and the upstream app to disagree on where the
+// path ends.
+const legalPathPunct = "-._~!$&'()*+,=:@/%"
+
+// Tokenize validates and splits an HTTP request path into raw segments
+// for matching. The argument is the escaped path as it appears on the
+// wire ([net/url.URL.EscapedPath], never the auto-decoded
+// [net/url.URL.Path]). Tokenize never decodes what it splits or
+// forwards. On any rule violation Tokenize rejects the path and
+// returns an error.
+//
+// The encoded separator is the only ASCII escape allowed.
+// Non-ASCII content is allowed as percent-encoded UTF-8, under
+// checks that prevent fold-to-different-segment bypasses.
+//
+//  1. Reject any raw byte that cannot appear in a URL path,
+//     including bytes at or above 0x80 (raw unicode).
+//  2. Allow only the encoded separator (%2F) and escapes whose
+//     decoded byte is at or above 0x80 (non-ASCII unicode). Reject
+//     every other ASCII percent-encoding.
+//  3. On a decode-for-validation view (%2F to "/"), reject
+//     consecutive slashes and "." or ".." segments. A ".."
+//     written between encoded slashes ("a%2F..%2Fadmin") is
+//     rejected the same as a raw one.
+//  4. The path body, with the encoded separator kept literal, must
+//     decode to valid, NFKC-stable UTF-8 and contain only graphic
+//     runes. "é" is allowed only as "%C3%A9".
+//  5. Split on real "/" only. An encoded slash stays one opaque
+//     token, hex case preserved.
+func Tokenize(path string) ([]string, error) {
+	if len(path) > lengthCap {
+		return nil, trace.BadParameter("path length %d exceeds the %d byte limit", len(path), lengthCap)
+	}
+	if !strings.HasPrefix(path, "/") {
+		return nil, trace.BadParameter("path %q must start with /", path)
+	}
+	if err := validatePathBytes(path); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := validatePercentEscapes(path); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := validateDecoded(path); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := validatePathContent(path); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return strings.Split(path[1:], "/"), nil
+}
+
+// validatePathBytes rejects any byte that cannot appear in a raw URL
+// path under RFC 3986.
+func validatePathBytes(path string) error {
+	for i := range len(path) {
+		if !isLegalPathByte(path[i]) {
+			return trace.BadParameter("path %q contains an illegal URL byte %q", path, string(path[i]))
+		}
+	}
+	return nil
+}
+
+// isLegalPathByte reports whether a given byte may appear in a raw
+// URL path.
+func isLegalPathByte(b byte) bool {
+	switch {
+	case b >= 'A' && b <= 'Z', b >= 'a' && b <= 'z', b >= '0' && b <= '9':
+		return true
+	}
+	return strings.IndexByte(legalPathPunct, b) >= 0
+}
+
+// validatePercentEscapes allows the encoded separator %2F and
+// any escape that decodes to a non-ASCII byte. Every other ASCII
+// escape is rejected, because an upstream could canonicalize it
+// into a structural byte. A "%" without two hex digits is rejected
+// as malformed.
+func validatePercentEscapes(path string) error {
+	for i := 0; i < len(path); i++ {
+		if path[i] != '%' {
+			continue
+		}
+		if i+2 >= len(path) {
+			return trace.BadParameter("path %q has a truncated percent-escape", path)
+		}
+		if path[i+1] == '2' && (path[i+2] == 'F' || path[i+2] == 'f') {
+			i += 2
+			continue
+		}
+		v, err := strconv.ParseUint(path[i+1:i+3], 16, 8)
+		if err != nil {
+			return trace.BadParameter("path %q has a malformed percent-escape %q", path, path[i:i+3])
+		}
+		if byte(v) >= 0x80 {
+			i += 2
+			continue
+		}
+		const msg = "path %q contains the percent-escape %q; only the encoded separator %%2F and non-ASCII content escapes are allowed"
+		return trace.BadParameter(msg, path, path[i:i+3])
+	}
+	return nil
+}
+
+// validateDecoded rejects "." and ".." segments and consecutive
+// slashes on a view where the encoded separator %2F is decoded
+// to "/". A trailing slash is kept, so "/foo/" tokenizes to
+// ["foo", ""] and does not match "/foo".
+func validateDecoded(path string) error {
+	decoded := decodeSeparators(path)
+	if strings.Contains(decoded, "//") {
+		const msg = "path %q has consecutive slashes once the encoded separator %%2F is decoded"
+		return trace.BadParameter(msg, path)
+	}
+	for seg := range strings.SplitSeq(decoded[1:], "/") {
+		if seg == "." || seg == ".." {
+			const msg = `path %q has a "." or ".." segment once the encoded separator %%2F is decoded`
+			return trace.BadParameter(msg, path)
+		}
+	}
+	return nil
+}
+
+// decodeSeparators returns the decode-for-validation view of path.
+// %2F is unescaped to "/", every other byte is left raw. The ".",
+// "..", and "//" checks run on this view, so any of these written
+// with an encoded slash is caught the same as a raw one.
+func decodeSeparators(path string) string {
+	decoded := strings.ReplaceAll(path, "%2F", "/")
+	return strings.ReplaceAll(decoded, "%2f", "/")
+}
+
+// validatePathContent decodes non-ASCII escapes in the path body,
+// keeping the encoded separator literal, and requires valid UTF-8,
+// NFKC stability, and a graphic category for every rune of the
+// resulting string.
+func validatePathContent(path string) error {
+	content := decodeNonASCII(path[1:])
+	if !utf8.ValidString(content) {
+		return trace.BadParameter("path %q is not valid UTF-8 once decoded", path)
+	}
+	if !norm.NFKC.IsNormalString(content) {
+		return trace.BadParameter("path %q is not NFKC-normalized", path)
+	}
+	for _, r := range content {
+		if !isGraphicRune(r) {
+			const msg = "path %q contains the disallowed character %q; only letters, marks, numbers, punctuation, and symbols are allowed"
+			return trace.BadParameter(msg, path, string(r))
+		}
+	}
+	return nil
+}
+
+// decodeNonASCII returns s with every non-ASCII escape (a "%XX"
+// that decodes to a non-ASCII byte) replaced by its decoded byte.
+// All other bytes, including the encoded separator %2F, are
+// left as is.
+func decodeNonASCII(s string) string {
+	if !strings.ContainsRune(s, '%') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '%' && i+2 < len(s) {
+			if v, err := strconv.ParseUint(s[i+1:i+3], 16, 8); err == nil && byte(v) >= 0x80 {
+				b.WriteByte(byte(v))
+				i += 2
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// isGraphicRune reports whether r is a letter, mark, number,
+// punctuation, or symbol. Space and separator categories that
+// unicode.IsGraphic allows are excluded, along with control,
+// format, surrogate, private-use, and unassigned runes.
+func isGraphicRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsMark(r) || unicode.IsNumber(r) ||
+		unicode.IsPunct(r) || unicode.IsSymbol(r)
+}

--- a/lib/appresource/tokenize.go
+++ b/lib/appresource/tokenize.go
@@ -114,7 +114,7 @@ func Tokenize(path string) ([]string, error) {
 func validatePathBytes(path string) error {
 	for i := range len(path) {
 		if !isLegalPathByte(path[i]) {
-			return trace.BadParameter("path %q contains an illegal URL byte %q", clip(path), string(path[i]))
+			return trace.BadParameter("path %q contains an illegal URL byte %q", clip(path), path[i:i+1])
 		}
 	}
 	return nil
@@ -239,18 +239,19 @@ func rejectDotSegment(seg string) error {
 	return nil
 }
 
-// rejectLeadingMark rejects a segment whose first rune is a combining
-// mark. The mark has no base character and renders on the separator
-// before it, so "/a/%CC%87b", where %CC%87 is U+0307 combining dot
-// above, looks like "/a/b". RFC 5891 section 4.2.3.2 bans the same
-// form at the start of a domain label.
+// rejectLeadingMark rejects a segment whose first rune composes onto
+// the character before it, so "/a/%CC%87b", where %CC%87 is U+0307
+// combining dot above, looks like "/a/b". RFC 5891 section 4.2.3.2
+// bans the same form at the start of a domain label. A conjoining
+// Hangul jamo composes the same way without being a mark, so the
+// NFKC boundary property covers what unicode.IsMark misses.
 func rejectLeadingMark(seg string) error {
 	if seg == "" || seg[0] < utf8.RuneSelf {
 		return nil
 	}
 	r, _ := utf8.DecodeRuneInString(seg)
-	if unicode.IsMark(r) {
-		const msg = "segment %q starts with the combining mark %q; a mark must follow a base character"
+	if unicode.IsMark(r) || !norm.NFKC.PropertiesString(seg).BoundaryBefore() {
+		const msg = "segment %q starts with %q, which composes onto the character before it; it must follow a base character"
 		return trace.BadParameter(msg, clip(seg), string(r))
 	}
 	return nil

--- a/lib/appresource/tokenize.go
+++ b/lib/appresource/tokenize.go
@@ -58,24 +58,34 @@ const legalPathPunct = "-._~!$&'()*+,=:@/%"
 // forwards. On any rule violation Tokenize rejects the path and
 // returns an error.
 //
-// The encoded separator is the only ASCII escape allowed.
-// Non-ASCII content is allowed as percent-encoded UTF-8, under
-// checks that prevent fold-to-different-segment bypasses.
+// The encoded separator and the encoded space are the only ASCII
+// escapes allowed. A space has no raw form in a URL path, so %20 is
+// content, like the non-ASCII escapes. Non-ASCII content is allowed
+// as percent-encoded UTF-8, under checks that prevent
+// fold-to-different-segment bypasses.
 //
 //  1. Reject any raw byte that cannot appear in a URL path,
 //     including bytes at or above 0x80 (raw unicode).
-//  2. Allow only the encoded separator (%2F) and escapes whose
-//     decoded byte is at or above 0x80 (non-ASCII unicode). Reject
-//     every other ASCII percent-encoding.
+//  2. Allow only the encoded separator (%2F), the encoded space
+//     (%20), and escapes whose decoded byte is at or above 0x80
+//     (non-ASCII unicode). Reject every other ASCII
+//     percent-encoding.
 //  3. On a decode-for-validation view (%2F to "/"), reject
-//     consecutive slashes and "." or ".." segments. A ".."
-//     written between encoded slashes ("a%2F..%2Fadmin") is
-//     rejected the same as a raw one.
-//  4. Each segment, once its non-ASCII escapes are decoded, must be
-//     valid, NFKC-stable UTF-8 and contain only graphic runes, and
-//     must not start with a combining mark. The encoded separator
-//     %2F is a segment boundary for this check. "é" is allowed only
-//     as the precomposed "%C3%A9", not as the decomposed "e%CC%81".
+//     consecutive slashes and any segment of only dots and spaces,
+//     because an upstream that strips spaces or extra dots would
+//     resolve such a segment as "." or "..". A ".." written between
+//     encoded slashes ("a%2F..%2Fadmin") is rejected the same as a
+//     raw one.
+//  4. Each segment, once its content escapes are decoded, must be
+//     valid, NFKC-stable UTF-8 and contain only graphic runes, must
+//     not start with a combining mark, and must not start or end
+//     with a space, because an upstream that trims the segment
+//     would see a different segment ("..%20" would trim to "..").
+//     U+0020, arriving as %20, is the only space or separator rune
+//     allowed, and only between other characters. The encoded
+//     separator %2F is a segment boundary for these checks. "é" is
+//     allowed only as the precomposed "%C3%A9", not as the
+//     decomposed "e%CC%81".
 //  5. Split on real "/" only. An encoded slash stays one opaque
 //     token, hex case preserved.
 func Tokenize(path string) ([]string, error) {
@@ -118,11 +128,11 @@ func isLegalPathByte(b byte) bool {
 	return strings.IndexByte(legalPathPunct, b) >= 0
 }
 
-// validatePercentEscapes allows the encoded separator %2F and
-// any escape that decodes to a non-ASCII byte. Every other ASCII
-// escape is rejected, because an upstream could canonicalize it
-// into a structural byte. A "%" without two hex digits is rejected
-// as malformed.
+// validatePercentEscapes allows the encoded separator %2F, the
+// encoded space %20, and any escape that decodes to a non-ASCII
+// byte. Every other ASCII escape is rejected, because an upstream
+// could canonicalize it into a structural byte. A "%" without two
+// hex digits is rejected as malformed.
 func validatePercentEscapes(path string) error {
 	for i := 0; i < len(path); i++ {
 		if path[i] != '%' {
@@ -131,7 +141,7 @@ func validatePercentEscapes(path string) error {
 		if i+2 >= len(path) {
 			return trace.BadParameter("path %q has a truncated percent-escape", path)
 		}
-		if path[i+1] == '2' && (path[i+2] == 'F' || path[i+2] == 'f') {
+		if path[i+1] == '2' && (path[i+2] == 'F' || path[i+2] == 'f' || path[i+2] == '0') {
 			i += 2
 			continue
 		}
@@ -143,7 +153,7 @@ func validatePercentEscapes(path string) error {
 			i += 2
 			continue
 		}
-		const msg = "path %q contains the percent-escape %q; only the encoded separator %%2F and non-ASCII content escapes are allowed"
+		const msg = "path %q contains the percent-escape %q; only the encoded separator %%2F, the encoded space %%20, and non-ASCII content escapes are allowed"
 		return trace.BadParameter(msg, path, path[i:i+3])
 	}
 	return nil
@@ -162,11 +172,13 @@ func validateDecoded(path string) error {
 		return trace.BadParameter("path %q is not valid UTF-8 once decoded", path)
 	}
 	for seg := range strings.SplitSeq(decoded[1:], "/") {
-		if seg == "." || seg == ".." {
-			const msg = `path %q has a "." or ".." segment once the encoded separator %%2F is decoded`
-			return trace.BadParameter(msg, path)
+		if err := rejectDotSegment(seg); err != nil {
+			return trace.Wrap(err)
 		}
 		if err := rejectLeadingMark(seg); err != nil {
+			return trace.Wrap(err)
+		}
+		if err := rejectEdgeSpace(seg); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -175,7 +187,7 @@ func validateDecoded(path string) error {
 	}
 	for _, r := range decoded {
 		if !isGraphicRune(r) {
-			const msg = "path %q contains the disallowed character %q; only letters, marks, numbers, punctuation, and symbols are allowed"
+			const msg = "path %q contains the disallowed character %q; only letters, marks, numbers, punctuation, symbols, and the encoded space %%20 are allowed"
 			return trace.BadParameter(msg, path, string(r))
 		}
 	}
@@ -183,10 +195,10 @@ func validateDecoded(path string) error {
 }
 
 // decode returns the validation view of s, resolving every escape that
-// validatePercentEscapes leaves alive: %2F (either case) to "/", and a
-// non-ASCII escape to its byte. Those are the only escapes it can
-// receive, so nothing else needs decoding. The view is used for
-// validation only; the returned tokens keep their raw form.
+// validatePercentEscapes leaves alive: %2F (either case) to "/", %20
+// to a space, and a non-ASCII escape to its byte. Those are the only
+// escapes it can receive, so nothing else needs decoding. The view is
+// used for validation only; the returned tokens keep their raw form.
 func decode(s string) string {
 	if !strings.ContainsRune(s, '%') {
 		return s
@@ -195,7 +207,7 @@ func decode(s string) string {
 	b.Grow(len(s))
 	for i := 0; i < len(s); i++ {
 		if s[i] == '%' && i+2 < len(s) {
-			if v, err := strconv.ParseUint(s[i+1:i+3], 16, 8); err == nil && (v == '/' || v >= 0x80) {
+			if v, err := strconv.ParseUint(s[i+1:i+3], 16, 8); err == nil && (v == '/' || v == ' ' || v >= 0x80) {
 				b.WriteByte(byte(v))
 				i += 2
 				continue
@@ -204,6 +216,18 @@ func decode(s string) string {
 		b.WriteByte(s[i])
 	}
 	return b.String()
+}
+
+// rejectDotSegment rejects a segment made of only dots and spaces
+// that has at least one dot. "." and ".." are traversal segments,
+// and an upstream that strips spaces or extra dots would resolve
+// forms like ". ." or "..." the same way.
+func rejectDotSegment(seg string) error {
+	if strings.Trim(seg, ". ") != "" || !strings.Contains(seg, ".") {
+		return nil
+	}
+	const msg = `segment %q is only dots and spaces; an upstream could resolve it as "." or ".."`
+	return trace.BadParameter(msg, seg)
 }
 
 // rejectLeadingMark rejects a segment whose first rune is a combining
@@ -223,11 +247,26 @@ func rejectLeadingMark(seg string) error {
 	return nil
 }
 
-// isGraphicRune reports whether r is a letter, mark, number,
-// punctuation, or symbol. Space and separator categories that
-// unicode.IsGraphic allows are excluded, along with control,
-// format, surrogate, private-use, and unassigned runes.
+// rejectEdgeSpace rejects a segment whose first or last rune is a
+// space. An upstream that trims the segment would see a different
+// one, so "..%20" would trim to ".." and "secret%20" to "secret".
+func rejectEdgeSpace(seg string) error {
+	if strings.HasPrefix(seg, " ") || strings.HasSuffix(seg, " ") {
+		const msg = "segment %q starts or ends with a space; a space must be between other characters"
+		return trace.BadParameter(msg, seg)
+	}
+	return nil
+}
+
+// isGraphicRune reports whether r is U+0020, a letter, mark, number,
+// punctuation, or symbol. U+0020 is allowed because it only reaches
+// the decoded view as %20, and [rejectEdgeSpace] keeps it off the
+// segment edges. Every other space and separator rune that
+// unicode.IsGraphic allows is excluded, along with control, format,
+// surrogate, private-use, and unassigned runes. The NFKC-stable ones
+// among them, such as U+1680 ogham space mark, are rejected here and
+// nowhere else.
 func isGraphicRune(r rune) bool {
-	return unicode.IsLetter(r) || unicode.IsMark(r) || unicode.IsNumber(r) ||
-		unicode.IsPunct(r) || unicode.IsSymbol(r)
+	return r == ' ' || unicode.IsLetter(r) || unicode.IsMark(r) ||
+		unicode.IsNumber(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)
 }

--- a/lib/appresource/tokenize.go
+++ b/lib/appresource/tokenize.go
@@ -78,9 +78,11 @@ const legalPathPunct = "-._~!$&'()*+,=:@/%"
 //     raw one.
 //  4. Each segment, once its content escapes are decoded, must be
 //     valid, NFKC-stable UTF-8 and contain only graphic runes, must
-//     not start with a combining mark, and must not start or end
-//     with a space, because an upstream that trims the segment
-//     would see a different segment ("..%20" would trim to "..").
+//     not start with a combining mark, must not start or end with a
+//     space, and must not end with dots and spaces, because an
+//     upstream that trims the segment would see a different segment
+//     ("..%20" would trim to ".." and "secret." to "secret"). A
+//     leading dot is allowed, so "/.well-known" stays reachable.
 //     U+0020, arriving as %20, is the only space or separator rune
 //     allowed, and only between other characters. The encoded
 //     separator %2F is a segment boundary for these checks. "é" is
@@ -93,7 +95,7 @@ func Tokenize(path string) ([]string, error) {
 		return nil, trace.BadParameter("path length %d exceeds the %d byte limit", len(path), lengthCap)
 	}
 	if !strings.HasPrefix(path, "/") {
-		return nil, trace.BadParameter("path %q must start with /", path)
+		return nil, trace.BadParameter("path %q must start with /", clip(path))
 	}
 	if err := validatePathBytes(path); err != nil {
 		return nil, trace.Wrap(err)
@@ -112,7 +114,7 @@ func Tokenize(path string) ([]string, error) {
 func validatePathBytes(path string) error {
 	for i := range len(path) {
 		if !isLegalPathByte(path[i]) {
-			return trace.BadParameter("path %q contains an illegal URL byte %q", path, string(path[i]))
+			return trace.BadParameter("path %q contains an illegal URL byte %q", clip(path), string(path[i]))
 		}
 	}
 	return nil
@@ -139,24 +141,28 @@ func validatePercentEscapes(path string) error {
 			continue
 		}
 		if i+2 >= len(path) {
-			return trace.BadParameter("path %q has a truncated percent-escape", path)
-		}
-		if path[i+1] == '2' && (path[i+2] == 'F' || path[i+2] == 'f' || path[i+2] == '0') {
-			i += 2
-			continue
+			return trace.BadParameter("path %q has a truncated percent-escape", clip(path))
 		}
 		v, err := strconv.ParseUint(path[i+1:i+3], 16, 8)
 		if err != nil {
-			return trace.BadParameter("path %q has a malformed percent-escape %q", path, path[i:i+3])
+			return trace.BadParameter("path %q has a malformed percent-escape %q", clip(path), path[i:i+3])
 		}
-		if byte(v) >= 0x80 {
+		if isAllowedEscape(byte(v)) {
 			i += 2
 			continue
 		}
 		const msg = "path %q contains the percent-escape %q; only the encoded separator %%2F, the encoded space %%20, and non-ASCII content escapes are allowed"
-		return trace.BadParameter(msg, path, path[i:i+3])
+		return trace.BadParameter(msg, clip(path), path[i:i+3])
 	}
 	return nil
+}
+
+// isAllowedEscape reports whether a percent-escape decoding to b may
+// appear in a path. [validatePercentEscapes] accepts exactly the
+// escapes [decode] resolves: the separator, the space, and non-ASCII
+// content.
+func isAllowedEscape(b byte) bool {
+	return b == '/' || b == ' ' || b >= 0x80
 }
 
 // validateDecoded checks the decoded validation view of the path. It
@@ -166,10 +172,10 @@ func validateDecoded(path string) error {
 	decoded := decode(path)
 	if strings.Contains(decoded, "//") {
 		const msg = "path %q has consecutive slashes once the encoded separator %%2F is decoded"
-		return trace.BadParameter(msg, path)
+		return trace.BadParameter(msg, clip(path))
 	}
 	if !utf8.ValidString(decoded) {
-		return trace.BadParameter("path %q is not valid UTF-8 once decoded", path)
+		return trace.BadParameter("path %q is not valid UTF-8 once decoded", clip(path))
 	}
 	for seg := range strings.SplitSeq(decoded[1:], "/") {
 		if err := rejectDotSegment(seg); err != nil {
@@ -181,14 +187,17 @@ func validateDecoded(path string) error {
 		if err := rejectEdgeSpace(seg); err != nil {
 			return trace.Wrap(err)
 		}
+		if err := rejectTrailingDot(seg); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	if !norm.NFKC.IsNormalString(decoded) {
-		return trace.BadParameter("path %q is not NFKC-normalized", path)
+		return trace.BadParameter("path %q is not NFKC-normalized", clip(path))
 	}
 	for _, r := range decoded {
 		if !isGraphicRune(r) {
 			const msg = "path %q contains the disallowed character %q; only letters, marks, numbers, punctuation, symbols, and the encoded space %%20 are allowed"
-			return trace.BadParameter(msg, path, string(r))
+			return trace.BadParameter(msg, clip(path), string(r))
 		}
 	}
 	return nil
@@ -207,7 +216,7 @@ func decode(s string) string {
 	b.Grow(len(s))
 	for i := 0; i < len(s); i++ {
 		if s[i] == '%' && i+2 < len(s) {
-			if v, err := strconv.ParseUint(s[i+1:i+3], 16, 8); err == nil && (v == '/' || v == ' ' || v >= 0x80) {
+			if v, err := strconv.ParseUint(s[i+1:i+3], 16, 8); err == nil && isAllowedEscape(byte(v)) {
 				b.WriteByte(byte(v))
 				i += 2
 				continue
@@ -223,11 +232,11 @@ func decode(s string) string {
 // and an upstream that strips spaces or extra dots would resolve
 // forms like ". ." or "..." the same way.
 func rejectDotSegment(seg string) error {
-	if strings.Trim(seg, ". ") != "" || !strings.Contains(seg, ".") {
-		return nil
+	if strings.Trim(seg, ". ") == "" && strings.Contains(seg, ".") {
+		const msg = `segment %q is only dots and spaces; an upstream could resolve it as "." or ".."`
+		return trace.BadParameter(msg, clip(seg))
 	}
-	const msg = `segment %q is only dots and spaces; an upstream could resolve it as "." or ".."`
-	return trace.BadParameter(msg, seg)
+	return nil
 }
 
 // rejectLeadingMark rejects a segment whose first rune is a combining
@@ -242,7 +251,7 @@ func rejectLeadingMark(seg string) error {
 	r, _ := utf8.DecodeRuneInString(seg)
 	if unicode.IsMark(r) {
 		const msg = "segment %q starts with the combining mark %q; a mark must follow a base character"
-		return trace.BadParameter(msg, seg, string(r))
+		return trace.BadParameter(msg, clip(seg), string(r))
 	}
 	return nil
 }
@@ -253,7 +262,21 @@ func rejectLeadingMark(seg string) error {
 func rejectEdgeSpace(seg string) error {
 	if strings.HasPrefix(seg, " ") || strings.HasSuffix(seg, " ") {
 		const msg = "segment %q starts or ends with a space; a space must be between other characters"
-		return trace.BadParameter(msg, seg)
+		return trace.BadParameter(msg, clip(seg))
+	}
+	return nil
+}
+
+// rejectTrailingDot rejects a segment whose trailing run of dots and
+// spaces contains a dot. IIS and Windows trim trailing dots and
+// spaces, so an upstream would resolve "secret." and "secret%20." as
+// "secret", a segment the matcher never saw. A leading dot stays
+// allowed because paths such as "/.well-known" depend on it.
+func rejectTrailingDot(seg string) error {
+	trimmed := strings.TrimRight(seg, ". ")
+	if strings.Contains(seg[len(trimmed):], ".") {
+		const msg = "segment %q ends with dots and spaces; an upstream could trim it to %q"
+		return trace.BadParameter(msg, clip(seg), clip(trimmed))
 	}
 	return nil
 }
@@ -269,4 +292,14 @@ func rejectEdgeSpace(seg string) error {
 func isGraphicRune(r rune) bool {
 	return r == ' ' || unicode.IsLetter(r) || unicode.IsMark(r) ||
 		unicode.IsNumber(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)
+}
+
+// clip shortens s for use in an error message. A rejected path can be
+// kilobytes long, and the message survives into logs and audit events.
+func clip(s string) string {
+	const limit = 256
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit] + "..."
 }

--- a/lib/appresource/tokenize.go
+++ b/lib/appresource/tokenize.go
@@ -40,8 +40,8 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-// lengthCap bounds the length of a path Tokenize accepts.
-const lengthCap = 8 << 10 // 8 KiB
+// maxPathLength bounds the length of a path Tokenize accepts.
+const maxPathLength = 8 << 10 // 8 KiB
 
 // legalPathPunct is the non-alphanumeric bytes allowed in a raw
 // URL path. It is RFC 3986 pchar except for ";", plus "/" and "%".
@@ -51,56 +51,28 @@ const lengthCap = 8 << 10 // 8 KiB
 // path ends.
 const legalPathPunct = "-._~!$&'()*+,=:@/%"
 
-// Tokenize validates and splits an HTTP request path into raw segments
-// for matching. The argument is the escaped path as it appears on the
-// wire ([net/url.URL.EscapedPath], never the auto-decoded
-// [net/url.URL.Path]). Tokenize never decodes what it splits or
-// forwards. On any rule violation Tokenize rejects the path and
-// returns an error.
+// Tokenize validates an HTTP request path and splits it on a real
+// "/" into the encoded segments a role's path rules match against, so
+// an encoded slash stays inside one segment. Pass
+// [net/url.URL.EscapedPath], the encoded path sent to the upstream
+// app, not the already-decoded [net/url.URL.Path].
 //
-// The encoded separator and the encoded space are the only ASCII
-// escapes allowed. A space has no raw form in a URL path, so %20 is
-// content, like the non-ASCII escapes. Non-ASCII content is allowed
-// as percent-encoded UTF-8, under checks that prevent
-// fold-to-different-segment bypasses.
-//
-//  1. Reject any raw byte that cannot appear in a URL path,
-//     including bytes at or above 0x80 (raw unicode).
-//  2. Allow only the encoded separator (%2F), the encoded space
-//     (%20), and escapes whose decoded byte is at or above 0x80
-//     (non-ASCII unicode). Reject every other ASCII
-//     percent-encoding.
-//  3. On a decode-for-validation view (%2F to "/"), reject
-//     consecutive slashes and any segment of only dots and spaces,
-//     because an upstream that strips spaces or extra dots would
-//     resolve such a segment as "." or "..". A ".." written between
-//     encoded slashes ("a%2F..%2Fadmin") is rejected the same as a
-//     raw one.
-//  4. Each segment, once its content escapes are decoded, must be
-//     valid, NFKC-stable UTF-8 and contain only graphic runes, must
-//     not start with a combining mark, must not start or end with a
-//     space, and must not end with dots and spaces, because an
-//     upstream that trims the segment would see a different segment
-//     ("..%20" would trim to ".." and "secret." to "secret"). A
-//     leading dot is allowed, so "/.well-known" stays reachable.
-//     U+0020, arriving as %20, is the only space or separator rune
-//     allowed, and only between other characters. The encoded
-//     separator %2F is a segment boundary for these checks. "é" is
-//     allowed only as the precomposed "%C3%A9", not as the
-//     decomposed "e%CC%81".
-//  5. Split on real "/" only. An encoded slash stays one opaque
-//     token, hex case preserved.
+// Tokenize accepts a path that starts with "/", stays under 8 KiB,
+// and holds only the path characters RFC 3986 allows, except for ";".
+// Anything else has to be sent percent-encoded, and the only escapes
+// allowed are the separator %2F ("/"), the space %20 (" "), and the
+// UTF-8 bytes of non-ASCII text. Tokenize also rejects a path an
+// upstream app could read as a different path than the one a role
+// matched, such as "/a/../b" or "/files/secret." on a server that
+// trims a trailing dot.
 func Tokenize(path string) ([]string, error) {
-	if len(path) > lengthCap {
-		return nil, trace.BadParameter("path length %d exceeds the %d byte limit", len(path), lengthCap)
+	if len(path) > maxPathLength {
+		return nil, trace.BadParameter("path length %d exceeds the %d byte limit", len(path), maxPathLength)
 	}
 	if !strings.HasPrefix(path, "/") {
 		return nil, trace.BadParameter("path %q must start with /", clip(path))
 	}
-	if err := validatePathBytes(path); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := validatePercentEscapes(path); err != nil {
+	if err := validateRawBytes(path); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if err := validateDecoded(path); err != nil {
@@ -109,13 +81,29 @@ func Tokenize(path string) ([]string, error) {
 	return strings.Split(path[1:], "/"), nil
 }
 
-// validatePathBytes rejects any byte that cannot appear in a raw URL
-// path under RFC 3986.
-func validatePathBytes(path string) error {
-	for i := range len(path) {
+// validateRawBytes rejects any byte that cannot appear in a URL path
+// under RFC 3986, any invalid percent-escape, and every escape except
+// %2F ("/"), %20 (" "), or one that decodes to a non-ASCII byte.
+func validateRawBytes(path string) error {
+	for i := 0; i < len(path); i++ {
 		if !isLegalPathByte(path[i]) {
 			return trace.BadParameter("path %q contains an illegal URL byte %q", clip(path), path[i:i+1])
 		}
+		if path[i] != '%' {
+			continue
+		}
+		if i+2 >= len(path) {
+			return trace.BadParameter("path %q has a truncated percent-escape", clip(path))
+		}
+		v, err := strconv.ParseUint(path[i+1:i+3], 16, 8)
+		if err != nil {
+			return trace.BadParameter("path %q has a malformed percent-escape %q", clip(path), path[i:i+3])
+		}
+		if !isAllowedEscape(byte(v)) {
+			const msg = "path %q contains the percent-escape %q; only the encoded separator %%2F, the encoded space %%20, and non-ASCII content escapes are allowed"
+			return trace.BadParameter(msg, clip(path), path[i:i+3])
+		}
+		i += 2
 	}
 	return nil
 }
@@ -130,37 +118,10 @@ func isLegalPathByte(b byte) bool {
 	return strings.IndexByte(legalPathPunct, b) >= 0
 }
 
-// validatePercentEscapes allows the encoded separator %2F, the
-// encoded space %20, and any escape that decodes to a non-ASCII
-// byte. Every other ASCII escape is rejected, because an upstream
-// could canonicalize it into a structural byte. A "%" without two
-// hex digits is rejected as malformed.
-func validatePercentEscapes(path string) error {
-	for i := 0; i < len(path); i++ {
-		if path[i] != '%' {
-			continue
-		}
-		if i+2 >= len(path) {
-			return trace.BadParameter("path %q has a truncated percent-escape", clip(path))
-		}
-		v, err := strconv.ParseUint(path[i+1:i+3], 16, 8)
-		if err != nil {
-			return trace.BadParameter("path %q has a malformed percent-escape %q", clip(path), path[i:i+3])
-		}
-		if isAllowedEscape(byte(v)) {
-			i += 2
-			continue
-		}
-		const msg = "path %q contains the percent-escape %q; only the encoded separator %%2F, the encoded space %%20, and non-ASCII content escapes are allowed"
-		return trace.BadParameter(msg, clip(path), path[i:i+3])
-	}
-	return nil
-}
-
 // isAllowedEscape reports whether a percent-escape decoding to b may
-// appear in a path. [validatePercentEscapes] accepts exactly the
-// escapes [decode] resolves: the separator, the space, and non-ASCII
-// content.
+// appear in a path. [validateRawBytes] accepts exactly the escapes
+// [decode] resolves, which are the separator, the space, and
+// non-ASCII content.
 func isAllowedEscape(b byte) bool {
 	return b == '/' || b == ' ' || b >= 0x80
 }
@@ -203,11 +164,11 @@ func validateDecoded(path string) error {
 	return nil
 }
 
-// decode returns the validation view of s, resolving every escape that
-// validatePercentEscapes leaves alive: %2F (either case) to "/", %20
-// to a space, and a non-ASCII escape to its byte. Those are the only
-// escapes it can receive, so nothing else needs decoding. The view is
-// used for validation only; the returned tokens keep their raw form.
+// decode returns the decoded validation view of path s, resolving
+// only valid escapes. %2F and %2f become "/", %20 a space, and a
+// non-ASCII escape its byte. The view exposes a structural byte
+// written as an escape, so "/x%2F..%2Fadmin" is rejected for the same
+// reason ".." is rejected in "/x/../admin".
 func decode(s string) string {
 	if !strings.ContainsRune(s, '%') {
 		return s
@@ -239,17 +200,16 @@ func rejectDotSegment(seg string) error {
 	return nil
 }
 
-// rejectLeadingMark rejects a segment whose first rune composes onto
-// the character before it, so "/a/%CC%87b", where %CC%87 is U+0307
-// combining dot above, looks like "/a/b". RFC 5891 section 4.2.3.2
-// bans the same form at the start of a domain label. A conjoining
-// Hangul jamo composes the same way without being a mark, so the
-// NFKC boundary property covers what unicode.IsMark misses.
+// rejectLeadingMark rejects a segment whose first character composes
+// onto the character before it, so "/a/%CC%87b", where %CC%87 is
+// U+0307 combining dot above, looks like "/a/b". RFC 5891 bans the
+// same form at the start of a domain label.
 func rejectLeadingMark(seg string) error {
 	if seg == "" || seg[0] < utf8.RuneSelf {
 		return nil
 	}
 	r, _ := utf8.DecodeRuneInString(seg)
+	// Some composing characters are not marks, so both checks are needed.
 	if unicode.IsMark(r) || !norm.NFKC.PropertiesString(seg).BoundaryBefore() {
 		const msg = "segment %q starts with %q, which composes onto the character before it; it must follow a base character"
 		return trace.BadParameter(msg, clip(seg), string(r))
@@ -287,9 +247,9 @@ func rejectTrailingDot(seg string) error {
 // the decoded view as %20, and [rejectEdgeSpace] keeps it off the
 // segment edges. Every other space and separator rune that
 // unicode.IsGraphic allows is excluded, along with control, format,
-// surrogate, private-use, and unassigned runes. The NFKC-stable ones
-// among them, such as U+1680 ogham space mark, are rejected here and
-// nowhere else.
+// surrogate, private-use, and unassigned runes. This is the only
+// check that rejects the NFKC-stable ones among them, such as U+1680
+// ogham space mark.
 func isGraphicRune(r rune) bool {
 	return r == ' ' || unicode.IsLetter(r) || unicode.IsMark(r) ||
 		unicode.IsNumber(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)

--- a/lib/appresource/tokenize.go
+++ b/lib/appresource/tokenize.go
@@ -44,7 +44,7 @@ import (
 const lengthCap = 8 << 10 // 8 KiB
 
 // legalPathPunct is the non-alphanumeric bytes allowed in a raw
-// URL path. It is RFC 3986 pchar minus ";", plus "/" and "%".
+// URL path. It is RFC 3986 pchar except for ";", plus "/" and "%".
 //
 // ";" is dropped because matrix parameters and ";jsessionid" may
 // cause the matcher and the upstream app to disagree on where the
@@ -72,9 +72,10 @@ const legalPathPunct = "-._~!$&'()*+,=:@/%"
 //     written between encoded slashes ("a%2F..%2Fadmin") is
 //     rejected the same as a raw one.
 //  4. Each segment, once its non-ASCII escapes are decoded, must be
-//     valid, NFKC-stable UTF-8 and contain only graphic runes. The
-//     encoded separator %2F is a segment boundary for this check.
-//     "é" is allowed only as "%C3%A9".
+//     valid, NFKC-stable UTF-8 and contain only graphic runes, and
+//     must not start with a combining mark. The encoded separator
+//     %2F is a segment boundary for this check. "é" is allowed only
+//     as the precomposed "%C3%A9", not as the decomposed "e%CC%81".
 //  5. Split on real "/" only. An encoded slash stays one opaque
 //     token, hex case preserved.
 func Tokenize(path string) ([]string, error) {
@@ -157,14 +158,17 @@ func validateDecoded(path string) error {
 		const msg = "path %q has consecutive slashes once the encoded separator %%2F is decoded"
 		return trace.BadParameter(msg, path)
 	}
+	if !utf8.ValidString(decoded) {
+		return trace.BadParameter("path %q is not valid UTF-8 once decoded", path)
+	}
 	for seg := range strings.SplitSeq(decoded[1:], "/") {
 		if seg == "." || seg == ".." {
 			const msg = `path %q has a "." or ".." segment once the encoded separator %%2F is decoded`
 			return trace.BadParameter(msg, path)
 		}
-	}
-	if !utf8.ValidString(decoded) {
-		return trace.BadParameter("path %q is not valid UTF-8 once decoded", path)
+		if err := rejectLeadingMark(seg); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	if !norm.NFKC.IsNormalString(decoded) {
 		return trace.BadParameter("path %q is not NFKC-normalized", path)
@@ -200,6 +204,23 @@ func decode(s string) string {
 		b.WriteByte(s[i])
 	}
 	return b.String()
+}
+
+// rejectLeadingMark rejects a segment whose first rune is a combining
+// mark. The mark has no base character and renders on the separator
+// before it, so "/a/%CC%87b", where %CC%87 is U+0307 combining dot
+// above, looks like "/a/b". RFC 5891 section 4.2.3.2 bans the same
+// form at the start of a domain label.
+func rejectLeadingMark(seg string) error {
+	if seg == "" || seg[0] < utf8.RuneSelf {
+		return nil
+	}
+	r, _ := utf8.DecodeRuneInString(seg)
+	if unicode.IsMark(r) {
+		const msg = "segment %q starts with the combining mark %q; a mark must follow a base character"
+		return trace.BadParameter(msg, seg, string(r))
+	}
+	return nil
 }
 
 // isGraphicRune reports whether r is a letter, mark, number,

--- a/lib/appresource/tokenize_property_test.go
+++ b/lib/appresource/tokenize_property_test.go
@@ -60,7 +60,7 @@ func TestTokenizePropertyAcceptsWireForm(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		path := wirePathGen().Draw(t, "path")
 		_, err := Tokenize(path)
-		require.NoErrorf(t, err, "generated wire path rejected: %q", path)
+		require.NoError(t, err, "generated wire path rejected: %q", path)
 	})
 }
 
@@ -76,7 +76,7 @@ func TestTokenizePropertyAcceptsOnlyEscapedForm(t *testing.T) {
 		_, err := Tokenize(path)
 		require.NoError(t, err)
 		u, err := url.ParseRequestURI(path)
-		require.NoErrorf(t, err, "accepted path does not parse: %q", path)
+		require.NoError(t, err, "accepted path does not parse: %q", path)
 		require.Equal(t, path, u.EscapedPath(), "accepted path is not its own escaped form")
 	})
 }
@@ -107,7 +107,7 @@ func TestTokenizePropertyIgnoresHexCase(t *testing.T) {
 		tokens, err := Tokenize(path)
 		require.NoError(t, err)
 		flippedTokens, err := Tokenize(flipped)
-		require.NoErrorf(t, err, "hex case flip changed the verdict: %q", flipped)
+		require.NoError(t, err, "hex case flip changed the verdict: %q", flipped)
 		require.Equal(t, flipped, "/"+strings.Join(flippedTokens, "/"))
 		require.Len(t, flippedTokens, len(tokens))
 	})
@@ -122,7 +122,7 @@ func TestTokenizePropertyRejectsRawNonASCII(t *testing.T) {
 		b := byte(rapid.IntRange(0x80, 0xff).Draw(t, "byte"))
 		mutated := insertAt(t, path, string(b))
 		_, err := Tokenize(mutated)
-		require.Errorf(t, err, "raw byte %#x not rejected: %q", b, mutated)
+		require.Error(t, err, "raw byte %#x not rejected: %q", b, mutated)
 	})
 }
 
@@ -148,7 +148,7 @@ func TestTokenizePropertyRejectsFoldForms(t *testing.T) {
 				path := wirePathGen().Draw(t, "path")
 				mutated := insertAt(t, path, form)
 				_, err := Tokenize(mutated)
-				require.Errorf(t, err, "%s not rejected: %q", name, mutated)
+				require.Error(t, err, "%s not rejected: %q", name, mutated)
 			})
 		})
 	}
@@ -192,7 +192,7 @@ func TestTokenizePropertyRejectsBadSegments(t *testing.T) {
 				i := slashes[n]
 				mutated := path[:i+1] + segment + "/" + path[i+1:]
 				_, err := Tokenize(mutated)
-				require.Errorf(t, err, "segment %q not rejected: %q", segment, mutated)
+				require.Error(t, err, "segment %q not rejected: %q", segment, mutated)
 			})
 		})
 	}
@@ -212,7 +212,7 @@ func TestTokenizePropertyRejectsEdgeSpaces(t *testing.T) {
 		i := rapid.SampledFrom(bounds).Draw(t, "bound")
 		mutated := path[:i] + "%20" + path[i:]
 		_, err := Tokenize(mutated)
-		require.Errorf(t, err, "edge space not rejected: %q", mutated)
+		require.Error(t, err, "edge space not rejected: %q", mutated)
 	})
 }
 

--- a/lib/appresource/tokenize_property_test.go
+++ b/lib/appresource/tokenize_property_test.go
@@ -133,9 +133,13 @@ func TestTokenizePropertyRejectsFoldForms(t *testing.T) {
 	forms := map[string]string{
 		"%2E (.)":                          "%2E",
 		"%00 (NUL)":                        "%00",
+		"%3F (?)":                          "%3F",
+		"%5C (backslash)":                  "%5C",
 		"%C0%AF (overlong UTF-8 for /)":    "%C0%AF",
 		"%EF%BC%8F (fullwidth solidus)":    "%EF%BC%8F",
 		"%E2%80%8B (zero-width space)":     "%E2%80%8B",
+		"%C2%A0 (no-break space)":          "%C2%A0",
+		"%E1%9A%80 (ogham space mark)":     "%E1%9A%80",
 		"%CC%81 (combining acute on café)": "cafe%CC%81",
 	}
 	for name, form := range forms {
@@ -154,12 +158,21 @@ func TestTokenizePropertyRejectsFoldForms(t *testing.T) {
 // spliced in after any "/" of an accepted path is rejected.
 func TestTokenizePropertyRejectsBadSegments(t *testing.T) {
 	segments := map[string]string{
-		"dot":                     ".",
-		"dot-dot":                 "..",
-		"empty":                   "",
-		"leading mark %CC%87":     "%CC%87x",
-		"leading mark after %2F":  "x%2F%CC%87y",
-		"encoded dot-dot between": "x%2F..%2Fy",
+		"dot":                           ".",
+		"dot-dot":                       "..",
+		"empty":                         "",
+		"leading mark %CC%87":           "%CC%87x",
+		"leading mark after %2F":        "x%2F%CC%87y",
+		"encoded dot-dot between":       "x%2F..%2Fy",
+		"only a space %20":              "%20",
+		"leading space %20":             "%20x",
+		"trailing space %20":            "x%20",
+		"leading space %20 after %2F":   "x%2F%20y",
+		"trailing space %20 before %2F": "x%20%2Fy",
+		"dot space dot":                 ".%20.",
+		"dot-dot space dot":             "..%20.",
+		"only dots":                     "...",
+		"dots and spaces after %2F":     "x%2F.%20.",
 	}
 	for name, segment := range segments {
 		t.Run(name, func(t *testing.T) {
@@ -179,6 +192,24 @@ func TestTokenizePropertyRejectsBadSegments(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestTokenizePropertyRejectsEdgeSpaces asserts that a %20 spliced at
+// the start or end of any part of an accepted path is rejected. An
+// upstream that trims the part would see a different part.
+func TestTokenizePropertyRejectsEdgeSpaces(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		path := wirePathGen().Draw(t, "path")
+		starts, ends := partBounds(path)
+		bounds := starts
+		if rapid.Bool().Draw(t, "trailing") {
+			bounds = ends
+		}
+		i := rapid.SampledFrom(bounds).Draw(t, "bound")
+		mutated := path[:i] + "%20" + path[i:]
+		_, err := Tokenize(mutated)
+		require.Errorf(t, err, "edge space not rejected: %q", mutated)
+	})
 }
 
 // wirePathGen produces a valid wire path, one or more segments with an
@@ -214,13 +245,15 @@ func segmentGen() *rapid.Generator[string] {
 
 // partGen produces the percent-encoded content between two separators.
 // No part starts with a mark and no rune composes with its neighbor.
-// The filter drops "." and "..".
+// A space, emitted as %20, composes with no neighbor under NFKC, so
+// it needs no neighbor rule. The filter drops parts made of only
+// dots and spaces and parts that start or end with a space.
 func partGen() *rapid.Generator[string] {
 	content := rapid.Custom(func(t *rapid.T) string {
 		var b strings.Builder
 		n := rapid.IntRange(1, 5).Draw(t, "rune-count")
 		for range n {
-			switch rapid.IntRange(0, 3).Draw(t, "rune-kind") {
+			switch rapid.IntRange(0, 4).Draw(t, "rune-kind") {
 			case 0:
 				b.WriteByte(alnum[rapid.IntRange(0, len(alnum)-1).Draw(t, "alnum")])
 			case 1:
@@ -229,6 +262,8 @@ func partGen() *rapid.Generator[string] {
 				b.WriteRune(safeRuneGen().Draw(t, "non-ascii"))
 			case 3:
 				b.WriteString(rapid.SampledFrom(stableMarkPairs).Draw(t, "mark-pair"))
+			case 4:
+				b.WriteByte(' ')
 			}
 			if rapid.Bool().Draw(t, "trailing-mark") {
 				b.WriteRune(freeMarkGen().Draw(t, "mark"))
@@ -236,7 +271,8 @@ func partGen() *rapid.Generator[string] {
 		}
 		return b.String()
 	}).Filter(func(s string) bool {
-		return s != "." && s != ".."
+		return strings.Trim(s, ". ") != "" &&
+			!strings.HasPrefix(s, " ") && !strings.HasSuffix(s, " ")
 	})
 	return rapid.Custom(func(t *rapid.T) string {
 		return encodeNonASCII(t, content.Draw(t, "content"))
@@ -273,7 +309,8 @@ func freeRuneGen() *rapid.Generator[rune] {
 }
 
 // encodeNonASCII percent-encodes the bytes of s at or above 0x80 and
-// leaves its ASCII bytes raw, in the hex case the generator picks.
+// the space, which has no raw form in a path, and leaves the other
+// ASCII bytes raw, in the hex case the generator picks.
 func encodeNonASCII(t *rapid.T, s string) string {
 	format := "%%%02x"
 	if rapid.Bool().Draw(t, "upper-hex") {
@@ -281,13 +318,33 @@ func encodeNonASCII(t *rapid.T, s string) string {
 	}
 	var b strings.Builder
 	for i := range len(s) {
-		if s[i] < 0x80 {
+		if s[i] < 0x80 && s[i] != ' ' {
 			b.WriteByte(s[i])
 			continue
 		}
 		fmt.Fprintf(&b, format, s[i])
 	}
 	return b.String()
+}
+
+// partBounds returns the offsets where a part starts and ends. A part
+// is bounded by a raw slash, an encoded separator, or the end of the
+// path.
+func partBounds(path string) (starts, ends []int) {
+	for i := range len(path) {
+		switch {
+		case path[i] == '/':
+			starts = append(starts, i+1)
+			if i > 0 {
+				ends = append(ends, i)
+			}
+		case path[i] == '%' && i+2 < len(path) && path[i+1] == '2' && (path[i+2] == 'F' || path[i+2] == 'f'):
+			starts = append(starts, i+3)
+			ends = append(ends, i)
+		}
+	}
+	ends = append(ends, len(path))
+	return starts, ends
 }
 
 // insertAt splices s into path at a generated offset after the leading

--- a/lib/appresource/tokenize_property_test.go
+++ b/lib/appresource/tokenize_property_test.go
@@ -1,0 +1,323 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/unicode/norm"
+	"pgregory.net/rapid"
+)
+
+// stableMarkPairs are base characters followed by a combining mark
+// that has no pre-composed form with them, so each pair survives NFKC
+// and gives the generator a mark where a mark is allowed.
+var stableMarkPairs = []string{
+	"q̇",           // U+0071 U+0307, latin q, combining dot above
+	"v́",           // U+0076 U+0301, latin v, combining acute
+	"j̣",           // U+006A U+0323, latin j, combining dot below
+	"α̈",           // U+03B1 U+0308, greek alpha, combining diaeresis
+	"б́",           // U+0431 U+0301, cyrillic be, combining acute
+	"का",           // U+0915 U+093E, devanagari ka, vowel sign aa, a spacing mark
+	"ก่",           // U+0E01 U+0E48, thai ko kai, mai ek
+	"あ゙",           // U+3042 U+3099, hiragana a, combining voiced sound mark
+	"\u05d0\u05b7", // U+05D0 U+05B7, hebrew alef, point patah, escaped because RTL reorders the line
+	"\u0627\u064e", // U+0627 U+064E, arabic alef, fatha, escaped because RTL reorders the line
+}
+
+// safePunct is legalPathPunct without the two bytes the generator
+// places itself, "/" as the segment boundary and "%" as the start of
+// an escape.
+var safePunct = strings.NewReplacer("/", "", "%", "").Replace(legalPathPunct)
+
+const alnum = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// TestTokenizePropertyAcceptsWireForm asserts that every path the wire
+// generator produces is accepted. It pins over-rejection, which the
+// reject-only properties below cannot see.
+func TestTokenizePropertyAcceptsWireForm(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		path := wirePathGen().Draw(t, "path")
+		_, err := Tokenize(path)
+		require.NoErrorf(t, err, "generated wire path rejected: %q", path)
+	})
+}
+
+// TestTokenizePropertyAcceptsOnlyEscapedForm asserts that an accepted
+// path is what net/url emits for it. The reverse proxy forwards
+// EscapedPath, so a path Go would re-encode reaches the app as bytes
+// the matcher never saw. net/url decides here, not the generator, so
+// widening a byte rule without widening what net/url preserves fails
+// this property.
+func TestTokenizePropertyAcceptsOnlyEscapedForm(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		path := wirePathGen().Draw(t, "path")
+		_, err := Tokenize(path)
+		require.NoError(t, err)
+		u, err := url.ParseRequestURI(path)
+		require.NoErrorf(t, err, "accepted path does not parse: %q", path)
+		require.Equal(t, path, u.EscapedPath(), "accepted path is not its own escaped form")
+	})
+}
+
+// TestTokenizePropertyPreservesStructure asserts that tokens are the
+// input split on raw "/" and nothing else. Rejoining them reproduces
+// the input byte for byte, so no token was decoded or rewritten.
+func TestTokenizePropertyPreservesStructure(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		path := wirePathGen().Draw(t, "path")
+		tokens, err := Tokenize(path)
+		require.NoError(t, err)
+		require.Equal(t, path, "/"+strings.Join(tokens, "/"))
+		require.Len(t, tokens, strings.Count(path, "/"))
+		for _, tok := range tokens {
+			require.NotContains(t, tok, "/")
+		}
+	})
+}
+
+// TestTokenizePropertyIgnoresHexCase asserts that the hex case of an
+// escape never changes the verdict, and that the tokens keep the case
+// they arrived in.
+func TestTokenizePropertyIgnoresHexCase(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		path := wirePathGen().Draw(t, "path")
+		flipped := flipHexCase(path)
+		tokens, err := Tokenize(path)
+		require.NoError(t, err)
+		flippedTokens, err := Tokenize(flipped)
+		require.NoErrorf(t, err, "hex case flip changed the verdict: %q", flipped)
+		require.Equal(t, flipped, "/"+strings.Join(flippedTokens, "/"))
+		require.Len(t, flippedTokens, len(tokens))
+	})
+}
+
+// TestTokenizePropertyRejectsRawNonASCII asserts that a raw byte at or
+// above 0x80 anywhere in an accepted path is rejected. Unicode must
+// arrive percent-encoded.
+func TestTokenizePropertyRejectsRawNonASCII(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		path := wirePathGen().Draw(t, "path")
+		b := byte(rapid.IntRange(0x80, 0xff).Draw(t, "byte"))
+		mutated := insertAt(t, path, string(b))
+		_, err := Tokenize(mutated)
+		require.Errorf(t, err, "raw byte %#x not rejected: %q", b, mutated)
+	})
+}
+
+// TestTokenizePropertyRejectsFoldForms asserts that a known fold or
+// canonicalization form inserted anywhere in an accepted path is
+// rejected.
+func TestTokenizePropertyRejectsFoldForms(t *testing.T) {
+	forms := map[string]string{
+		"%2E (.)":                          "%2E",
+		"%00 (NUL)":                        "%00",
+		"%C0%AF (overlong UTF-8 for /)":    "%C0%AF",
+		"%EF%BC%8F (fullwidth solidus)":    "%EF%BC%8F",
+		"%E2%80%8B (zero-width space)":     "%E2%80%8B",
+		"%CC%81 (combining acute on café)": "cafe%CC%81",
+	}
+	for name, form := range forms {
+		t.Run(name, func(t *testing.T) {
+			rapid.Check(t, func(t *rapid.T) {
+				path := wirePathGen().Draw(t, "path")
+				mutated := insertAt(t, path, form)
+				_, err := Tokenize(mutated)
+				require.Errorf(t, err, "%s not rejected: %q", name, mutated)
+			})
+		})
+	}
+}
+
+// TestTokenizePropertyRejectsBadSegments asserts that a bad segment
+// spliced in after any "/" of an accepted path is rejected.
+func TestTokenizePropertyRejectsBadSegments(t *testing.T) {
+	segments := map[string]string{
+		"dot":                     ".",
+		"dot-dot":                 "..",
+		"empty":                   "",
+		"leading mark %CC%87":     "%CC%87x",
+		"leading mark after %2F":  "x%2F%CC%87y",
+		"encoded dot-dot between": "x%2F..%2Fy",
+	}
+	for name, segment := range segments {
+		t.Run(name, func(t *testing.T) {
+			rapid.Check(t, func(t *rapid.T) {
+				path := wirePathGen().Draw(t, "path")
+				var slashes []int
+				for i := range len(path) {
+					if path[i] == '/' {
+						slashes = append(slashes, i)
+					}
+				}
+				n := rapid.IntRange(0, len(slashes)-1).Draw(t, "slash")
+				i := slashes[n]
+				mutated := path[:i+1] + segment + "/" + path[i+1:]
+				_, err := Tokenize(mutated)
+				require.Errorf(t, err, "segment %q not rejected: %q", segment, mutated)
+			})
+		})
+	}
+}
+
+// wirePathGen produces a valid wire path, one or more segments with an
+// optional trailing slash.
+func wirePathGen() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		n := rapid.IntRange(1, 4).Draw(t, "segment-count")
+		segments := make([]string, n)
+		for i := range segments {
+			segments[i] = segmentGen().Draw(t, "segment")
+		}
+		path := "/" + strings.Join(segments, "/")
+		if rapid.Bool().Draw(t, "trailing-slash") {
+			path += "/"
+		}
+		return path
+	})
+}
+
+// segmentGen joins one or more parts with the encoded separator, %2F
+// or %2f.
+func segmentGen() *rapid.Generator[string] {
+	return rapid.Custom(func(t *rapid.T) string {
+		n := rapid.IntRange(1, 3).Draw(t, "part-count")
+		parts := make([]string, n)
+		for i := range parts {
+			parts[i] = partGen().Draw(t, "part")
+		}
+		sep := rapid.SampledFrom([]string{"%2F", "%2f"}).Draw(t, "encoded-separator")
+		return strings.Join(parts, sep)
+	})
+}
+
+// partGen produces the percent-encoded content between two separators.
+// No part starts with a mark and no rune composes with its neighbor.
+// The filter drops "." and "..".
+func partGen() *rapid.Generator[string] {
+	content := rapid.Custom(func(t *rapid.T) string {
+		var b strings.Builder
+		n := rapid.IntRange(1, 5).Draw(t, "rune-count")
+		for range n {
+			switch rapid.IntRange(0, 3).Draw(t, "rune-kind") {
+			case 0:
+				b.WriteByte(alnum[rapid.IntRange(0, len(alnum)-1).Draw(t, "alnum")])
+			case 1:
+				b.WriteByte(safePunct[rapid.IntRange(0, len(safePunct)-1).Draw(t, "punct")])
+			case 2:
+				b.WriteRune(safeRuneGen().Draw(t, "non-ascii"))
+			case 3:
+				b.WriteString(rapid.SampledFrom(stableMarkPairs).Draw(t, "mark-pair"))
+			}
+			if rapid.Bool().Draw(t, "trailing-mark") {
+				b.WriteRune(freeMarkGen().Draw(t, "mark"))
+			}
+		}
+		return b.String()
+	}).Filter(func(s string) bool {
+		return s != "." && s != ".."
+	})
+	return rapid.Custom(func(t *rapid.T) string {
+		return encodeNonASCII(t, content.Draw(t, "content"))
+	})
+}
+
+// safeRuneGen produces a non-ASCII rune that is legal anywhere in a
+// part, including first, so it excludes the marks.
+func safeRuneGen() *rapid.Generator[rune] {
+	return freeRuneGen().Filter(func(r rune) bool { return !unicode.IsMark(r) })
+}
+
+// freeMarkGen produces a mark that stands on its own, so it is legal
+// anywhere except as the first rune of a part.
+func freeMarkGen() *rapid.Generator[rune] {
+	return freeRuneGen().Filter(unicode.IsMark)
+}
+
+// freeRuneGen produces a non-ASCII rune that NFKC puts a boundary
+// before, so it never combines with whatever the generator wrote
+// previously. That covers the combining marks with a non-zero class
+// and the trailing Hangul jamo without naming either. The filter reads
+// the stdlib category tables and the normalization properties rather
+// than isGraphicRune, so the generator does not inherit the
+// validator's own view of what is allowed.
+func freeRuneGen() *rapid.Generator[rune] {
+	return rapid.Rune().Filter(func(r rune) bool {
+		if r < 0x80 || !unicode.IsGraphic(r) || unicode.IsSpace(r) {
+			return false
+		}
+		return norm.NFKC.PropertiesString(string(r)).BoundaryBefore() &&
+			norm.NFKC.IsNormalString(string(r))
+	})
+}
+
+// encodeNonASCII percent-encodes the bytes of s at or above 0x80 and
+// leaves its ASCII bytes raw, in the hex case the generator picks.
+func encodeNonASCII(t *rapid.T, s string) string {
+	format := "%%%02x"
+	if rapid.Bool().Draw(t, "upper-hex") {
+		format = "%%%02X"
+	}
+	var b strings.Builder
+	for i := range len(s) {
+		if s[i] < 0x80 {
+			b.WriteByte(s[i])
+			continue
+		}
+		fmt.Fprintf(&b, format, s[i])
+	}
+	return b.String()
+}
+
+// insertAt splices s into path at a generated offset after the leading
+// slash.
+func insertAt(t *rapid.T, path, s string) string {
+	i := rapid.IntRange(1, len(path)).Draw(t, "offset")
+	return path[:i] + s + path[i:]
+}
+
+// flipHexCase swaps the case of the hex digits of every escape in
+// path.
+func flipHexCase(path string) string {
+	out := []byte(path)
+	for i := 0; i+2 < len(out); i++ {
+		if out[i] != '%' {
+			continue
+		}
+		out[i+1] = flipByteCase(out[i+1])
+		out[i+2] = flipByteCase(out[i+2])
+	}
+	return string(out)
+}
+
+// flipByteCase swaps the case of an ASCII letter.
+func flipByteCase(b byte) byte {
+	switch {
+	case b >= 'a' && b <= 'z':
+		return b - 'a' + 'A'
+	case b >= 'A' && b <= 'Z':
+		return b - 'A' + 'a'
+	}
+	return b
+}

--- a/lib/appresource/tokenize_property_test.go
+++ b/lib/appresource/tokenize_property_test.go
@@ -173,6 +173,10 @@ func TestTokenizePropertyRejectsBadSegments(t *testing.T) {
 		"dot-dot space dot":             "..%20.",
 		"only dots":                     "...",
 		"dots and spaces after %2F":     "x%2F.%20.",
+		"trailing dot":                  "x.",
+		"trailing dots":                 "x..",
+		"trailing space dot":            "x%20.",
+		"trailing dot before %2F":       "x.%2Fy",
 	}
 	for name, segment := range segments {
 		t.Run(name, func(t *testing.T) {
@@ -247,7 +251,8 @@ func segmentGen() *rapid.Generator[string] {
 // No part starts with a mark and no rune composes with its neighbor.
 // A space, emitted as %20, composes with no neighbor under NFKC, so
 // it needs no neighbor rule. The filter drops parts made of only
-// dots and spaces and parts that start or end with a space.
+// dots and spaces, parts that start or end with a space, and parts
+// whose trailing run of dots and spaces contains a dot.
 func partGen() *rapid.Generator[string] {
 	content := rapid.Custom(func(t *rapid.T) string {
 		var b strings.Builder
@@ -272,7 +277,8 @@ func partGen() *rapid.Generator[string] {
 		return b.String()
 	}).Filter(func(s string) bool {
 		return strings.Trim(s, ". ") != "" &&
-			!strings.HasPrefix(s, " ") && !strings.HasSuffix(s, " ")
+			!strings.HasPrefix(s, " ") && !strings.HasSuffix(s, " ") &&
+			!strings.Contains(s[len(strings.TrimRight(s, ". ")):], ".")
 	})
 	return rapid.Custom(func(t *rapid.T) string {
 		return encodeNonASCII(t, content.Draw(t, "content"))

--- a/lib/appresource/tokenize_test.go
+++ b/lib/appresource/tokenize_test.go
@@ -78,6 +78,19 @@ func TestTokenize(t *testing.T) {
 			want: []string{"files", "caf%C3%A9.md"},
 		},
 		{
+			// %2F decodes to a real "/" before the NFKC check, so a
+			// combining mark after it has no "F" to fold with and
+			// accepts just like the real-slash form below.
+			name: "combining mark after an encoded slash is allowed",
+			path: "/p/a%2F%CC%87x",
+			want: []string{"p", "a%2F%CC%87x"},
+		},
+		{
+			name: "combining mark after a real slash is allowed",
+			path: "/p/a/%CC%87x",
+			want: []string{"p", "a", "%CC%87x"},
+		},
+		{
 			name:    "path over the length cap is rejected",
 			path:    "/" + strings.Repeat("a", lengthCap),
 			wantErr: true,
@@ -217,24 +230,32 @@ func TestNonASCIIFold(t *testing.T) {
 		})
 	}
 
-	reject := map[string]string{
-		"raw non-ASCII byte":           "/files/caf\xc3\xa9",
-		"overlong UTF-8 of slash":      "/p/a%C0%AFb",
-		"lone continuation byte":       "/p/%A9",
-		"truncated two-byte sequence":  "/p/%C3",
-		"fullwidth solidus folds to /": "/p/a%EF%BC%8Fb",
-		"fullwidth A folds to A":       "/p/%EF%BC%A1dmin",
-		"fullwidth lowercase a":        "/p/%EF%BD%81dmin",
-		"zero-width space is format":   "/p/a%E2%80%8Bb",
-		"bidi override is format":      "/p/a%E2%80%AEb",
-		"decomposed e plus accent":     "/p/cafe%CC%81",
-		"ligature fi folds to fi":      "/p/o%EF%AC%81ce",
-		"non-breaking space folds":     "/p/a%C2%A0b",
+	reject := map[string]struct {
+		path string
+		// errContains pins which rule must reject inputs that more
+		// than one layer would catch. When empty, any error passes.
+		errContains string
+	}{
+		"raw non-ASCII byte":           {path: "/files/caf\xc3\xa9"},
+		"overlong UTF-8 of slash":      {path: "/p/a%C0%AFb"},
+		"lone continuation byte":       {path: "/p/%A9"},
+		"truncated two-byte sequence":  {path: "/p/%C3"},
+		"fullwidth solidus folds to /": {path: "/p/a%EF%BC%8Fb"},
+		"fullwidth A folds to A":       {path: "/p/%EF%BC%A1dmin"},
+		"fullwidth lowercase a":        {path: "/p/%EF%BD%81dmin"},
+		"zero-width space is format":   {path: "/p/a%E2%80%8Bb"},
+		"bidi override is format":      {path: "/p/a%E2%80%AEb"},
+		"decomposed e plus accent":     {path: "/p/cafe%CC%81"},
+		"ligature fi folds to fi":      {path: "/p/o%EF%AC%81ce"},
+		"non-breaking space folds":     {path: "/p/a%C2%A0b", errContains: "not NFKC-normalized"},
 	}
-	for name, path := range reject {
+	for name, tt := range reject {
 		t.Run("reject "+name, func(t *testing.T) {
-			_, err := Tokenize(path)
+			_, err := Tokenize(tt.path)
 			require.Error(t, err)
+			if tt.errContains != "" {
+				require.ErrorContains(t, err, tt.errContains)
+			}
 		})
 	}
 }
@@ -255,7 +276,7 @@ func FuzzTokenizeNonASCII(f *testing.F) {
 			return
 		}
 		for _, tok := range tokens {
-			content := decodeNonASCII(decodeSeparators(tok))
+			content := decode(tok)
 			valid := utf8.ValidString(content)
 			require.True(t, valid, "accepted token %q decodes to invalid UTF-8", tok)
 			normal := norm.NFKC.IsNormalString(content)

--- a/lib/appresource/tokenize_test.go
+++ b/lib/appresource/tokenize_test.go
@@ -1,0 +1,273 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package appresource
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/unicode/norm"
+)
+
+// TestTokenize pins the tokenizer's accept and reject cases, including
+// the opaque encoded separator and the decode-for-validation view.
+func TestTokenize(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "plain path splits on real slashes",
+			path: "/api/v4/projects",
+			want: []string{"api", "v4", "projects"},
+		},
+		{
+			name: "bare root yields a single empty token",
+			path: "/",
+			want: []string{""},
+		},
+		{
+			name: "path at the length cap is allowed",
+			path: "/" + strings.Repeat("a", lengthCap-1),
+			want: []string{strings.Repeat("a", lengthCap-1)},
+		},
+		{
+			name: "encoded slash stays one opaque token",
+			path: "/files/a%2Fb",
+			want: []string{"files", "a%2Fb"},
+		},
+		{
+			name: "lowercase encoded slash stays one raw token",
+			path: "/files/a%2fb",
+			want: []string{"files", "a%2fb"},
+		},
+		{
+			name: "trailing slash yields a trailing empty token",
+			path: "/files/",
+			want: []string{"files", ""},
+		},
+		{
+			name: "trailing encoded slash is allowed raw",
+			path: "/files/a%2F",
+			want: []string{"files", "a%2F"},
+		},
+		{
+			// é arrives percent-encoded and stays raw in the token.
+			name: "percent-encoded UTF-8 content is allowed raw",
+			path: "/files/caf%C3%A9.md",
+			want: []string{"files", "caf%C3%A9.md"},
+		},
+		{
+			name:    "path over the length cap is rejected",
+			path:    "/" + strings.Repeat("a", lengthCap),
+			wantErr: true,
+		},
+		{
+			name:    "double-encoded slash is rejected because %25 decodes to %",
+			path:    "/files/a%252Fb",
+			wantErr: true,
+		},
+		{
+			name:    "an ASCII escape %40 (@) is rejected",
+			path:    "/files/a%40b",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded dot %2E (.) is rejected",
+			path:    "/files/a%2Eb",
+			wantErr: true,
+		},
+		{
+			name:    "a truncated escape is rejected",
+			path:    "/files/a%2",
+			wantErr: true,
+		},
+		{
+			name:    "a malformed escape with non-hex digits is rejected",
+			path:    "/files/a%G1b",
+			wantErr: true,
+		},
+		{
+			name:    "a lone percent is rejected",
+			path:    "/files/a%",
+			wantErr: true,
+		},
+		{
+			name:    "a dot-dot between encoded slashes is rejected",
+			path:    "/a%2F..%2Fadmin",
+			wantErr: true,
+		},
+		{
+			name:    "an empty inner part in encoded slashes is rejected",
+			path:    "/a%2F%2Fb",
+			wantErr: true,
+		},
+		{
+			name:    "a raw dot-dot segment is rejected",
+			path:    "/api/v4/../secret",
+			wantErr: true,
+		},
+		{
+			name:    "a raw single-dot segment is rejected",
+			path:    "/api/./v4",
+			wantErr: true,
+		},
+		{
+			name:    "consecutive slashes are rejected",
+			path:    "/api//v4",
+			wantErr: true,
+		},
+		{
+			name:    "a path without a leading slash is rejected",
+			path:    "api/v4",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Tokenize(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestTokenizeByteRules pins the RFC 3986 path-character rules.
+// Pchar except for ";", plus "/" and "%", are allowed. Anything else
+// in the raw path is rejected.
+func TestTokenizeByteRules(t *testing.T) {
+	allow := []string{
+		"/api/v4/projects",
+		"/api/@@@",                        // "@" is a pchar
+		"/api/(group)/sub.tree",           // sub-delims and unreserved
+		"/api/a:b/c,d/e=f/gh",             // ":" and sub-delims
+		"/api/a-b_c~d!$&'()*+,=",          // the unreserved and sub-delim set, except for ";"
+		"/api/v4/projects/group%2Frepo/x", // the encoded separator, allowed
+	}
+	for _, p := range allow {
+		t.Run("allow "+p, func(t *testing.T) {
+			_, err := Tokenize(p)
+			require.NoError(t, err)
+		})
+	}
+
+	reject := []string{
+		"/api/a b",   // space
+		"/api/a\"b",  // double quote
+		"/api/a<b",   // angle bracket
+		"/api/a>b",   // angle bracket
+		"/api/a{b}",  // braces
+		"/api/a|b",   // pipe
+		"/api/a^b",   // caret
+		"/api/a`b",   // backtick
+		"/api/a\\b",  // backslash
+		"/api/a[b]",  // square brackets
+		"/api/a#b",   // fragment delimiter
+		"/api/a?b",   // query delimiter
+		"/api/café",  // raw non-ASCII, must be percent-encoded
+		"/api/a;b/c", // semicolon, the matrix-parameter / jsessionid vector
+	}
+	for _, p := range reject {
+		t.Run("reject "+p, func(t *testing.T) {
+			_, err := Tokenize(p)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestNonASCIIFold pins the fold and homoglyph cases for the
+// non-ASCII path pipeline. Rejected entries are forms that could
+// resolve to a different segment once an upstream normalizes them.
+func TestNonASCIIFold(t *testing.T) {
+	allow := map[string]string{
+		"precomposed accent (café.md)": "/files/caf%C3%A9.md",
+		"CJK han character":            "/files/%E6%97%A5.txt",
+		"cyrillic letter":              "/u/%D0%B4",
+		"emoji is a symbol":            "/r/%F0%9F%98%80",
+		"accent next to encoded slash": "/p/caf%C3%A9%2Fx",
+	}
+	for name, path := range allow {
+		t.Run("allow "+name, func(t *testing.T) {
+			_, err := Tokenize(path)
+			require.NoError(t, err)
+		})
+	}
+
+	reject := map[string]string{
+		"raw non-ASCII byte":           "/files/caf\xc3\xa9",
+		"overlong UTF-8 of slash":      "/p/a%C0%AFb",
+		"lone continuation byte":       "/p/%A9",
+		"truncated two-byte sequence":  "/p/%C3",
+		"fullwidth solidus folds to /": "/p/a%EF%BC%8Fb",
+		"fullwidth A folds to A":       "/p/%EF%BC%A1dmin",
+		"fullwidth lowercase a":        "/p/%EF%BD%81dmin",
+		"zero-width space is format":   "/p/a%E2%80%8Bb",
+		"bidi override is format":      "/p/a%E2%80%AEb",
+		"decomposed e plus accent":     "/p/cafe%CC%81",
+		"ligature fi folds to fi":      "/p/o%EF%AC%81ce",
+		"non-breaking space folds":     "/p/a%C2%A0b",
+	}
+	for name, path := range reject {
+		t.Run("reject "+name, func(t *testing.T) {
+			_, err := Tokenize(path)
+			require.Error(t, err)
+		})
+	}
+}
+
+// FuzzTokenizeNonASCII checks that every accepted path decodes per
+// segment to valid, NFKC-stable UTF-8. Corpus seeds cover the known
+// fold and homoglyph bypasses. The fuzzer explores around them.
+func FuzzTokenizeNonASCII(f *testing.F) {
+	for _, seed := range []string{
+		"/files/caf%C3%A9.md", "/p/a%EF%BC%8Fb", "/p/%EF%BC%A1dmin",
+		"/p/a%C0%AFb", "/p/a%E2%80%8Bb", "/p/cafe%CC%81", "/api/v4/x%2Fy",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, path string) {
+		tokens, err := Tokenize(path)
+		if err != nil {
+			return
+		}
+		for _, tok := range tokens {
+			content := decodeNonASCII(decodeSeparators(tok))
+			valid := utf8.ValidString(content)
+			require.True(t, valid, "accepted token %q decodes to invalid UTF-8", tok)
+			normal := norm.NFKC.IsNormalString(content)
+			require.True(t, normal, "accepted token %q is not NFKC-stable; a fold bypass slipped through", tok)
+		}
+		// An accepted token contains no raw non-ASCII bytes.
+		for _, tok := range tokens {
+			for i := range len(tok) {
+				require.Less(t, tok[i], byte(0x80), "accepted token %q has a raw non-ASCII byte", tok)
+			}
+		}
+		// Rejoining path segments roundtrips cleanly.
+		require.Equal(t, path, "/"+strings.Join(tokens, "/"))
+	})
+}

--- a/lib/appresource/tokenize_test.go
+++ b/lib/appresource/tokenize_test.go
@@ -19,8 +19,10 @@
 package appresource
 
 import (
+	"net/url"
 	"strings"
 	"testing"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
@@ -78,17 +80,9 @@ func TestTokenize(t *testing.T) {
 			want: []string{"files", "caf%C3%A9.md"},
 		},
 		{
-			// %2F decodes to a real "/" before the NFKC check, so a
-			// combining mark after it has no "F" to fold with and
-			// accepts just like the real-slash form below.
-			name: "combining mark after an encoded slash is allowed",
-			path: "/p/a%2F%CC%87x",
-			want: []string{"p", "a%2F%CC%87x"},
-		},
-		{
-			name: "combining mark after a real slash is allowed",
-			path: "/p/a/%CC%87x",
-			want: []string{"p", "a", "%CC%87x"},
+			name: "combining mark %CC%87 (U+0307) on a base character is allowed",
+			path: "/p/q%CC%87x",
+			want: []string{"p", "q%CC%87x"},
 		},
 		{
 			name:    "path over the length cap is rejected",
@@ -108,6 +102,11 @@ func TestTokenize(t *testing.T) {
 		{
 			name:    "an encoded dot %2E (.) is rejected",
 			path:    "/files/a%2Eb",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded hash %23 (#) is rejected",
+			path:    "/files/a%23b",
 			wantErr: true,
 		},
 		{
@@ -143,6 +142,16 @@ func TestTokenize(t *testing.T) {
 		{
 			name:    "a raw single-dot segment is rejected",
 			path:    "/api/./v4",
+			wantErr: true,
+		},
+		{
+			name:    "a segment starting with the combining mark %CC%87 is rejected",
+			path:    "/p/%CC%87x",
+			wantErr: true,
+		},
+		{
+			name:    "a combining mark after an encoded slash %2F is rejected",
+			path:    "/p/a%2F%CC%87x",
 			wantErr: true,
 		},
 		{
@@ -281,6 +290,13 @@ func FuzzTokenizeNonASCII(f *testing.F) {
 			require.True(t, valid, "accepted token %q decodes to invalid UTF-8", tok)
 			normal := norm.NFKC.IsNormalString(content)
 			require.True(t, normal, "accepted token %q is not NFKC-stable; a fold bypass slipped through", tok)
+			for _, part := range strings.Split(content, "/") {
+				if part == "" {
+					continue
+				}
+				r, _ := utf8.DecodeRuneInString(part)
+				require.False(t, unicode.IsMark(r), "accepted token %q has a part starting with the combining mark %q", tok, string(r))
+			}
 		}
 		// An accepted token contains no raw non-ASCII bytes.
 		for _, tok := range tokens {
@@ -290,5 +306,9 @@ func FuzzTokenizeNonASCII(f *testing.F) {
 		}
 		// Rejoining path segments roundtrips cleanly.
 		require.Equal(t, path, "/"+strings.Join(tokens, "/"))
+		// An accepted path is its own escaped form.
+		u, err := url.ParseRequestURI(path)
+		require.NoError(t, err, "accepted path does not parse: %q", path)
+		require.Equal(t, path, u.EscapedPath(), "accepted path is not its own escaped form")
 	})
 }

--- a/lib/appresource/tokenize_test.go
+++ b/lib/appresource/tokenize_test.go
@@ -80,6 +80,51 @@ func TestTokenize(t *testing.T) {
 			want: []string{"files", "caf%C3%A9.md"},
 		},
 		{
+			name: "encoded space %20 stays raw in the token",
+			path: "/job/My%20Job/lastBuild",
+			want: []string{"job", "My%20Job", "lastBuild"},
+		},
+		{
+			name: "encoded space %20 in the first segment",
+			path: "/My%20Jobs/config",
+			want: []string{"My%20Jobs", "config"},
+		},
+		{
+			name: "encoded space %20 in the last segment",
+			path: "/job/last%20build",
+			want: []string{"job", "last%20build"},
+		},
+		{
+			name: "several encoded spaces %20 in one segment",
+			path: "/job/a%20b%20c",
+			want: []string{"job", "a%20b%20c"},
+		},
+		{
+			name: "consecutive encoded spaces %20%20 are allowed",
+			path: "/job/a%20%20b",
+			want: []string{"job", "a%20%20b"},
+		},
+		{
+			name: "encoded spaces %20 in several segments are allowed",
+			path: "/sites/Team%20Site/Shared%20Documents/x",
+			want: []string{"sites", "Team%20Site", "Shared%20Documents", "x"},
+		},
+		{
+			name: "interior encoded space %20 next to the encoded separator %2F",
+			path: "/files/a%20b%2Fc",
+			want: []string{"files", "a%20b%2Fc"},
+		},
+		{
+			name: "encoded space %20 next to a non-ASCII escape",
+			path: "/files/caf%C3%A9%20menu",
+			want: []string{"files", "caf%C3%A9%20menu"},
+		},
+		{
+			name: "dots and an encoded space %20 among other characters are allowed",
+			path: "/a/a.%20.b/c",
+			want: []string{"a", "a.%20.b", "c"},
+		},
+		{
 			name: "combining mark %CC%87 (U+0307) on a base character is allowed",
 			path: "/p/q%CC%87x",
 			want: []string{"p", "q%CC%87x"},
@@ -107,6 +152,157 @@ func TestTokenize(t *testing.T) {
 		{
 			name:    "an encoded hash %23 (#) is rejected",
 			path:    "/files/a%23b",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded percent %25 (%) is rejected",
+			path:    "/files/a%25b",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded question mark %3F (?) is rejected",
+			path:    "/files/a%3Fb",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded NUL %00 is rejected",
+			path:    "/files/a%00b",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded double quote %22 (\") is rejected",
+			path:    "/files/a%22b",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded less-than %3C (<) is rejected",
+			path:    "/files/a%3Cb",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded greater-than %3E (>) is rejected",
+			path:    "/files/a%3Eb",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded opening bracket %5B ([) is rejected",
+			path:    "/files/a%5Bb",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded closing bracket %5D (]) is rejected",
+			path:    "/files/a%5Db",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded backslash %5C (\\) is rejected",
+			path:    "/files/a%5Cb",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded caret %5E (^) is rejected",
+			path:    "/files/a%5Eb",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded backtick %60 (`) is rejected",
+			path:    "/files/a%60b",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded opening brace %7B ({) is rejected",
+			path:    "/files/a%7Bb",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded pipe %7C (|) is rejected",
+			path:    "/files/a%7Cb",
+			wantErr: true,
+		},
+		{
+			name:    "an encoded closing brace %7D (}) is rejected",
+			path:    "/files/a%7Db",
+			wantErr: true,
+		},
+		{
+			name:    "a segment of only the encoded space %20 is rejected",
+			path:    "/a/%20/b",
+			wantErr: true,
+		},
+		{
+			name:    "a leading encoded space %20 in a segment is rejected",
+			path:    "/a/%20x",
+			wantErr: true,
+		},
+		{
+			name:    "a trailing encoded space %20 in a segment is rejected",
+			path:    "/a/x%20",
+			wantErr: true,
+		},
+		{
+			// The segment decodes to ".. ", which trims to "..".
+			name:    "a dot-dot with a trailing encoded space %20 is rejected",
+			path:    "/a/..%20/b",
+			wantErr: true,
+		},
+		{
+			// The segment decodes to ". ", which trims to ".".
+			name:    "a dot with a trailing encoded space %20 is rejected",
+			path:    "/a/.%20/b",
+			wantErr: true,
+		},
+		{
+			name:    "a dot-dot with a leading encoded space %20 is rejected",
+			path:    "/a/%20../b",
+			wantErr: true,
+		},
+		{
+			name:    "a leading encoded space %20 after an encoded slash %2F is rejected",
+			path:    "/p/a%2F%20b/c",
+			wantErr: true,
+		},
+		{
+			name:    "a trailing encoded space %20 before an encoded slash %2F is rejected",
+			path:    "/p/b%20%2Fc/d",
+			wantErr: true,
+		},
+		{
+			// The segment starts with a space that carries the mark.
+			name:    "a combining mark %CC%81 (U+0301) on a leading encoded space %20 is rejected",
+			path:    "/p/%20%CC%81x",
+			wantErr: true,
+		},
+		{
+			// The segment decodes to ". .", stripped of spaces "..".
+			name:    "an encoded space %20 between dots is rejected",
+			path:    "/a/.%20./b",
+			wantErr: true,
+		},
+		{
+			// The dot-segment rule fires; the segment also violates
+			// the edge-space rule.
+			name:    "a segment of alternating %20 and dots is rejected",
+			path:    "/a/%20.%20.%20/b",
+			wantErr: true,
+		},
+		{
+			name:    "a dot-dot with %20 and a trailing dot is rejected",
+			path:    "/a/..%20./b",
+			wantErr: true,
+		},
+		{
+			name:    "dots separated by encoded spaces %20 are rejected",
+			path:    "/a/.%20.%20./b",
+			wantErr: true,
+		},
+		{
+			name:    "dots and %20 between encoded slashes %2F are rejected",
+			path:    "/p/a%2F.%20.%2Fb",
+			wantErr: true,
+		},
+		{
+			name:    "a segment of only dots is rejected",
+			path:    "/a/.../b",
 			wantErr: true,
 		},
 		{
@@ -198,7 +394,7 @@ func TestTokenizeByteRules(t *testing.T) {
 	}
 
 	reject := []string{
-		"/api/a b",   // space
+		"/api/a b",   // raw space, allowed only encoded as %20
 		"/api/a\"b",  // double quote
 		"/api/a<b",   // angle bracket
 		"/api/a>b",   // angle bracket
@@ -245,18 +441,22 @@ func TestNonASCIIFold(t *testing.T) {
 		// than one layer would catch. When empty, any error passes.
 		errContains string
 	}{
-		"raw non-ASCII byte":           {path: "/files/caf\xc3\xa9"},
-		"overlong UTF-8 of slash":      {path: "/p/a%C0%AFb"},
-		"lone continuation byte":       {path: "/p/%A9"},
-		"truncated two-byte sequence":  {path: "/p/%C3"},
-		"fullwidth solidus folds to /": {path: "/p/a%EF%BC%8Fb"},
-		"fullwidth A folds to A":       {path: "/p/%EF%BC%A1dmin"},
-		"fullwidth lowercase a":        {path: "/p/%EF%BD%81dmin"},
-		"zero-width space is format":   {path: "/p/a%E2%80%8Bb"},
-		"bidi override is format":      {path: "/p/a%E2%80%AEb"},
-		"decomposed e plus accent":     {path: "/p/cafe%CC%81"},
-		"ligature fi folds to fi":      {path: "/p/o%EF%AC%81ce"},
-		"non-breaking space folds":     {path: "/p/a%C2%A0b", errContains: "not NFKC-normalized"},
+		"raw non-ASCII byte":                                 {path: "/files/caf\xc3\xa9"},
+		"overlong UTF-8 of slash":                            {path: "/p/a%C0%AFb"},
+		"lone continuation byte":                             {path: "/p/%A9"},
+		"truncated two-byte sequence":                        {path: "/p/%C3"},
+		"fullwidth solidus folds to /":                       {path: "/p/a%EF%BC%8Fb"},
+		"fullwidth A folds to A":                             {path: "/p/%EF%BC%A1dmin"},
+		"fullwidth lowercase a":                              {path: "/p/%EF%BD%81dmin"},
+		"zero-width space is format":                         {path: "/p/a%E2%80%8Bb"},
+		"bidi override is format":                            {path: "/p/a%E2%80%AEb"},
+		"decomposed e plus accent":                           {path: "/p/cafe%CC%81"},
+		"ligature fi folds to fi":                            {path: "/p/o%EF%AC%81ce"},
+		"non-breaking space folds":                           {path: "/p/a%C2%A0b", errContains: "not NFKC-normalized"},
+		"en quad %E2%80%80 (U+2000) folds to space":          {path: "/p/a%E2%80%80b", errContains: "not NFKC-normalized"},
+		"ideographic space %E3%80%80 (U+3000) folds":         {path: "/p/a%E3%80%80b", errContains: "not NFKC-normalized"},
+		"ogham space mark %E1%9A%80 (U+1680) is a separator": {path: "/p/a%E1%9A%80b", errContains: "disallowed character"},
+		"line separator %E2%80%A8 (U+2028) is a separator":   {path: "/p/a%E2%80%A8b", errContains: "disallowed character"},
 	}
 	for name, tt := range reject {
 		t.Run("reject "+name, func(t *testing.T) {
@@ -276,6 +476,8 @@ func FuzzTokenizeNonASCII(f *testing.F) {
 	for _, seed := range []string{
 		"/files/caf%C3%A9.md", "/p/a%EF%BC%8Fb", "/p/%EF%BC%A1dmin",
 		"/p/a%C0%AFb", "/p/a%E2%80%8Bb", "/p/cafe%CC%81", "/api/v4/x%2Fy",
+		"/job/My%20Job/lastBuild", "/p/%20%CC%81x", "/p/a%C2%A0b",
+		"/a/..%20/b", "/a/%20/b", "/a/.%20./b", "/a/.../b",
 	} {
 		f.Add(seed)
 	}
@@ -296,6 +498,10 @@ func FuzzTokenizeNonASCII(f *testing.F) {
 				}
 				r, _ := utf8.DecodeRuneInString(part)
 				require.False(t, unicode.IsMark(r), "accepted token %q has a part starting with the combining mark %q", tok, string(r))
+				require.False(t, strings.HasPrefix(part, " "), "accepted token %q has a part starting with a space", tok)
+				require.False(t, strings.HasSuffix(part, " "), "accepted token %q has a part ending with a space", tok)
+				dotSpaces := strings.Trim(part, ". ") == "" && strings.Contains(part, ".")
+				require.False(t, dotSpaces, "accepted token %q has a part of only dots and spaces", tok)
 			}
 		}
 		// An accepted token contains no raw non-ASCII bytes.

--- a/lib/appresource/tokenize_test.go
+++ b/lib/appresource/tokenize_test.go
@@ -130,6 +130,23 @@ func TestTokenize(t *testing.T) {
 			want: []string{"p", "q%CC%87x"},
 		},
 		{
+			name: "interior dots in a segment are allowed",
+			path: "/a/1.2.3/b",
+			want: []string{"a", "1.2.3", "b"},
+		},
+		{
+			name: "a leading dot in a segment is allowed",
+			path: "/.well-known/openid-configuration",
+			want: []string{".well-known", "openid-configuration"},
+		},
+		{
+			// The segment ends with the mark riding the space, not
+			// with a space byte, so no upstream trim fires on it.
+			name: "a combining mark %CC%81 on a trailing interior space %20 is allowed",
+			path: "/p/x%20%CC%81",
+			want: []string{"p", "x%20%CC%81"},
+		},
+		{
 			name:    "path over the length cap is rejected",
 			path:    "/" + strings.Repeat("a", lengthCap),
 			wantErr: true,
@@ -306,6 +323,26 @@ func TestTokenize(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "a trailing dot in a segment is rejected",
+			path:    "/files/secret./x",
+			wantErr: true,
+		},
+		{
+			name:    "trailing dots in a segment are rejected",
+			path:    "/files/secret../x",
+			wantErr: true,
+		},
+		{
+			name:    "a trailing encoded space %20 and dot in a segment are rejected",
+			path:    "/files/secret%20./x",
+			wantErr: true,
+		},
+		{
+			name:    "a trailing dot before an encoded slash %2F is rejected",
+			path:    "/p/a.%2Fb",
+			wantErr: true,
+		},
+		{
 			name:    "a truncated escape is rejected",
 			path:    "/files/a%2",
 			wantErr: true,
@@ -478,6 +515,7 @@ func FuzzTokenizeNonASCII(f *testing.F) {
 		"/p/a%C0%AFb", "/p/a%E2%80%8Bb", "/p/cafe%CC%81", "/api/v4/x%2Fy",
 		"/job/My%20Job/lastBuild", "/p/%20%CC%81x", "/p/a%C2%A0b",
 		"/a/..%20/b", "/a/%20/b", "/a/.%20./b", "/a/.../b",
+		"/files/secret./x", "/files/secret%20./x",
 	} {
 		f.Add(seed)
 	}
@@ -502,6 +540,8 @@ func FuzzTokenizeNonASCII(f *testing.F) {
 				require.False(t, strings.HasSuffix(part, " "), "accepted token %q has a part ending with a space", tok)
 				dotSpaces := strings.Trim(part, ". ") == "" && strings.Contains(part, ".")
 				require.False(t, dotSpaces, "accepted token %q has a part of only dots and spaces", tok)
+				tail := part[len(strings.TrimRight(part, ". ")):]
+				require.NotContains(t, tail, ".", "accepted token %q has a part ending with dots and spaces", tok)
 			}
 		}
 		// An accepted token contains no raw non-ASCII bytes.

--- a/lib/appresource/tokenize_test.go
+++ b/lib/appresource/tokenize_test.go
@@ -378,6 +378,11 @@ func TestTokenize(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "a segment starting with the conjoining jamo %E1%86%A8 (U+11A8) is rejected",
+			path:    "/%EA%B0%80/%E1%86%A8",
+			wantErr: true,
+		},
+		{
 			name:    "a segment starting with the combining mark %CC%87 is rejected",
 			path:    "/p/%CC%87x",
 			wantErr: true,
@@ -494,6 +499,8 @@ func TestNonASCIIFold(t *testing.T) {
 		"ideographic space %E3%80%80 (U+3000) folds":         {path: "/p/a%E3%80%80b", errContains: "not NFKC-normalized"},
 		"ogham space mark %E1%9A%80 (U+1680) is a separator": {path: "/p/a%E1%9A%80b", errContains: "disallowed character"},
 		"line separator %E2%80%A8 (U+2028) is a separator":   {path: "/p/a%E2%80%A8b", errContains: "disallowed character"},
+		"conjoining jamo %E1%86%A8 (U+11A8) composes":        {path: "/p/%EA%B0%80%E1%86%A8", errContains: "not NFKC-normalized"},
+		"conjoining jamo starting a segment":                 {path: "/%EA%B0%80/%E1%86%A8", errContains: "composes onto the character before it"},
 	}
 	for name, tt := range reject {
 		t.Run("reject "+name, func(t *testing.T) {
@@ -515,6 +522,7 @@ func FuzzTokenizeNonASCII(f *testing.F) {
 		"/p/a%C0%AFb", "/p/a%E2%80%8Bb", "/p/cafe%CC%81", "/api/v4/x%2Fy",
 		"/job/My%20Job/lastBuild", "/p/%20%CC%81x", "/p/a%C2%A0b",
 		"/a/..%20/b", "/a/%20/b", "/a/.%20./b", "/a/.../b",
+		"/%EA%B0%80/%E1%86%A8",
 		"/files/secret./x", "/files/secret%20./x",
 	} {
 		f.Add(seed)

--- a/lib/appresource/tokenize_test.go
+++ b/lib/appresource/tokenize_test.go
@@ -50,8 +50,8 @@ func TestTokenize(t *testing.T) {
 		},
 		{
 			name: "path at the length cap is allowed",
-			path: "/" + strings.Repeat("a", lengthCap-1),
-			want: []string{strings.Repeat("a", lengthCap-1)},
+			path: "/" + strings.Repeat("a", maxPathLength-1),
+			want: []string{strings.Repeat("a", maxPathLength-1)},
 		},
 		{
 			name: "encoded slash stays one opaque token",
@@ -148,7 +148,7 @@ func TestTokenize(t *testing.T) {
 		},
 		{
 			name:    "path over the length cap is rejected",
-			path:    "/" + strings.Repeat("a", lengthCap),
+			path:    "/" + strings.Repeat("a", maxPathLength),
 			wantErr: true,
 		},
 		{

--- a/lib/appresource/where.go
+++ b/lib/appresource/where.go
@@ -44,9 +44,13 @@ var validMethods = []string{
 var whereParser = mustNewWhereParser()
 
 // Request encodes the elements of the HTTP request a where clause is
-// evaluated against.
+// evaluated against. Path is the encoded request path as sent to the
+// upstream app, [net/url.URL.EscapedPath]. NewEnv does not validate it;
+// the first path.match call in an evaluation tokenizes it and returns an
+// error when Tokenize rejects it, and the caller denies on error.
 type Request struct {
 	Method string
+	Path   string
 }
 
 // Identity is the caller a where clause is evaluated against.
@@ -144,6 +148,62 @@ func mustNewWhereParser() *typical.CachedParser[Env, bool] {
 			}),
 		},
 		Functions: map[string]typical.Function{
+			// path.match walks the matcher tree against the tokenized
+			// request path and reports whether it matched. A path that
+			// Tokenize rejects is an evaluation error, and a path carrying
+			// the encoded separator %2F is too, because no node in this
+			// version admits one. An error, not false, keeps a negated
+			// path.match from turning an unmatchable path into an allow:
+			// the error aborts the evaluation and the caller denies.
+			"path.match": typical.UnaryFunctionWithEnv(func(e Env, root *Node) (bool, error) {
+				tokens, err := Tokenize(e.Request.Path)
+				if err != nil {
+					return false, trace.Wrap(err)
+				}
+				for _, tok := range tokens {
+					if hasEncodedSeparator(tok) {
+						return false, trace.BadParameter("path %q carries the encoded separator %%2F, which no rule in this version admits", e.Request.Path)
+					}
+				}
+				matched, _ := Eval(tokens, root)
+				return matched, nil
+			}),
+			// Matcher constructors. Each returns one Node, so they nest
+			// and type-check at parse time: every child argument must
+			// itself evaluate to a *Node.
+			"literal": typical.BinaryVariadicFunction[Env](func(s string, children ...*Node) (*Node, error) {
+				if err := validateLiteral(s); err != nil {
+					return nil, trace.Wrap(err)
+				}
+				return Literal(s, children...), nil
+			}),
+			"capture": typical.BinaryVariadicFunction[Env](func(name string, children ...*Node) (*Node, error) {
+				return Capture(name, children...), nil
+			}),
+			"glob": typical.UnaryVariadicFunction[Env](func(children ...*Node) (*Node, error) {
+				return Glob(children...), nil
+			}),
+			"greedy": typical.NullaryFunction[Env](func() (*Node, error) {
+				return Greedy(), nil
+			}),
+			// slash() matches the empty segment a final "/" produces, so a
+			// literal never carries empty text.
+			"slash": typical.NullaryFunction[Env](func() (*Node, error) {
+				return Slash(), nil
+			}),
+			// optional() makes a trailing subtree optional: the path may
+			// end at this node, or one of the children matches the
+			// remainder. So optional(slash()) matches "/foo" and "/foo/"
+			// alike from one tree with no duplicated prefix.
+			"optional": typical.UnaryVariadicFunction[Env](func(children ...*Node) (*Node, error) {
+				return Optional(children...)
+			}),
+			// root gives a tree several first segments. It consumes no
+			// token and OR-s its children, so it folds several root paths
+			// into one path.match call.
+			"root": typical.UnaryVariadicFunction[Env](func(children ...*Node) (*Node, error) {
+				return Root(children...)
+			}),
 			// set and contains are named after the functions in the role
 			// where-clause language, services.NewWhereParser.
 			"set": typical.UnaryVariadicFunction[Env](func(args ...string) ([]string, error) {


### PR DESCRIPTION
Add the path matcher tree for fine-grained HTTP app access: the node constructors (`literal`, `glob`, `capture`, `greedy`, `slash`, `optional`, `root`), the tree evaluator, and the `path.match` function on the where-clause parser. This is the desugared authoring surface; the `paths:` string sugar follows in a later PR and lowers to these same nodes.

The matcher is a tree. Each node matches exactly one path segment and carries its continuation as child nodes, several children are alternatives, and there is no regular-expression matching. `path.match` tokenizes the request path with `Tokenize` from [#68795](https://github.com/gravitational/teleport/pull/68795) and walks the tree:

```
path.match(root(literal("api", greedy()), literal("health", optional(slash()))))
```

Two decisions to look at.

The tokenizer admits the encoded space `%20` and encoded non-ASCII text as content, so the matcher treats them as content too: literals and captures compare and bind a decoded view, and a pattern written plain (`literal("My Project")`, `literal("café")`) matches the encoded form the wire carries. Only the encoded separator `%2F` stays refused, by globs, captures, and greedy alike, because forwarding it changes how many segments the upstream sees. The raw token is what the agent forwards; the decoded view exists only for the comparison.

A path the tokenizer rejects, or one carrying `%2F`, makes the evaluation error rather than report a no-match. `Where.Evaluate` callers deny on error, so a negated `path.match` cannot invert an unreadable path into an allow.

Capture bindings are recorded by the evaluator but not yet readable in a `where` clause; the `vars.` namespace arrives with the path sugar.

Stacks on [#68795](https://github.com/gravitational/teleport/pull/68795) (the first two commits are its tokenizer, plus a merge of master for the where-clause parser); only the last commit is this PR. There is no test plan because nothing is user-facing yet; this is prep work for later wiring.

Related-RFD: https://github.com/gravitational/rfd/blob/main/rfd/0303-policy-based-app-access.md