### PR TITLE
[v18] Fix `application-proxy` service not behaving correctly when ALPN upgrade applied

### DIFF
--- a/api/client/alpn.go
+++ b/api/client/alpn.go
@@ -124,6 +124,9 @@ func (d *ALPNDialer) getTLSConfig(ctx context.Context, addr string) (*tls.Config
 }
 
 // DialContext implements ContextDialer.
+//
+// The returned conn has already completed its TLS handshake. When using it with
+// a http.Transport, wire it in as DialTLSContext not DialContext.
 func (d *ALPNDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	tlsConfig, err := d.getTLSConfig(ctx, addr)
 	if err != nil {

--- a/lib/tbot/services/application/proxy_service.go
+++ b/lib/tbot/services/application/proxy_service.go
@@ -22,6 +22,7 @@ import (
 	"cmp"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"log/slog"
@@ -321,20 +322,19 @@ func (s *ProxyService) handleProxyRequest(w http.ResponseWriter, req *http.Reque
 	// TODO(noah): We could cache the httpClient itself for each upstream, this
 	// would potentially allow performance improvements by caching connections.
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			Certificates:       []tls.Certificate{*appCert},
-			InsecureSkipVerify: s.botClient.Config().InsecureSkipVerify,
-		},
-	}
-	// Inject the ALPN upgrade dialer if required.
-	if s.alpnUpgradeRequired {
-		transport.DialContext = apiclient.NewALPNDialer(apiclient.ALPNDialerConfig{
-			ALPNConnUpgradeRequired: true,
+		// The ALPN dialer's conn has already completed its TLS handshake, so
+		// it is wired in as DialTLSContext rather than DialContext.
+		DialTLSContext: apiclient.NewALPNDialer(apiclient.ALPNDialerConfig{
+			ALPNConnUpgradeRequired: s.alpnUpgradeRequired,
 			TLSConfig: &tls.Config{
+				Certificates:       []tls.Certificate{*appCert},
 				InsecureSkipVerify: s.botClient.Config().InsecureSkipVerify,
 				NextProtos:         []string{string(common.ProtocolHTTP)},
 			},
-		}).DialContext
+			GetClusterCAs: func(context.Context) (*x509.CertPool, error) {
+				return s.getBotIdentity().TLSCAPool, nil
+			},
+		}).DialContext,
 	}
 	httpClient := &http.Client{
 		Transport: transport,

--- a/lib/tbot/services/application/proxy_service_test.go
+++ b/lib/tbot/services/application/proxy_service_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -51,7 +52,16 @@ type proxyReqRes struct {
 }
 
 func TestE2E_ApplicationProxyService(t *testing.T) {
-	t.Parallel()
+	// Not parallel: the ALPN upgrade case relies on t.Setenv.
+	t.Run("direct", func(t *testing.T) {
+		testApplicationProxyService(t, false)
+	})
+	t.Run("alpn conn upgrade", func(t *testing.T) {
+		testApplicationProxyService(t, true)
+	})
+}
+
+func testApplicationProxyService(t *testing.T, forceALPNUpgrade bool) {
 	ctx := t.Context()
 	log := logtest.NewLogger()
 
@@ -150,6 +160,17 @@ func TestE2E_ApplicationProxyService(t *testing.T) {
 
 	proxyAddr, err := process.ProxyWebAddr()
 	require.NoError(t, err)
+
+	if forceALPNUpgrade {
+		// The service probes with the ping-returned web address, which may
+		// name the host differently to proxyAddr, so cover both forms.
+		_, port, err := net.SplitHostPort(proxyAddr.Addr)
+		require.NoError(t, err)
+		t.Setenv(
+			apidefaults.TLSRoutingConnUpgradeEnvVar,
+			"localhost:"+port+"=yes,127.0.0.1:"+port+"=yes",
+		)
+	}
 
 	proxyServiceConfig := &ProxyServiceConfig{
 		Listen:   "localhost:12345",


### PR DESCRIPTION
Backport #69428 to branch/v18

changelog: Fixed "server gave HTTP response to HTTPS client" bug in tbot's `application-proxy` service when a TLS-terminating load-balancer fronts the Teleport Proxy.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Use `application-proxy` to reach a HTTP app service with the proxy fronted by a TLS-terminating load-balancer
- [x] Use `application-proxy` to reach a HTTP app service with the proxy not fronted by a TLS-terminating load-balancer

Agentic test plan: