### PR TITLE
Fix E2E runner linting, add check to `make lint` and CI, fix e2e type check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -219,6 +219,15 @@ jobs:
           working-directory: integrations/event-handler
           skip-cache: true
 
+      - name: golangci-lint (e2e/runner)
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          verify: false
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          working-directory: e2e/runner
+          skip-cache: true
+          args: --config ../../.golangci.yml
+
       - name: Run (non-action) linters
         run: make lint-no-actions
 

--- a/Makefile
+++ b/Makefile
@@ -1332,7 +1332,7 @@ e2e-binaries:
 # changes (or last commit).
 #
 .PHONY: lint
-lint: lint-api lint-go lint-kube-agent-updater lint-tools lint-protos lint-no-actions
+lint: lint-api lint-go lint-kube-agent-updater lint-tools lint-protos lint-no-actions lint-e2e-runner
 
 #
 # Runs linters without dedicated GitHub Actions.
@@ -1413,6 +1413,12 @@ lint-api:
 lint-kube-agent-updater: GO_LINT_API_FLAGS ?=
 lint-kube-agent-updater:
 	cd integrations/kube-agent-updater && golangci-lint run -c ../../.golangci.yml $(GO_LINT_API_FLAGS)
+
+# e2e/runner is its own module, so the root golangci-lint run doesn't reach it.
+.PHONY: lint-e2e-runner
+lint-e2e-runner: GO_LINT_FLAGS ?=
+lint-e2e-runner:
+	cd e2e/runner && golangci-lint run -c ../../.golangci.yml $(GO_LINT_FLAGS)
 
 # TODO(awly): remove the `--exclude` flag after cleaning up existing scripts
 .PHONY: lint-sh

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,7 @@
   "description": "Playwright tests for e2e testing.",
   "scripts": {
     "test": "./run.sh",
-    "type-check": "tsgo --noEmit",
+    "type-check": "tsc --noEmit",
     "test:canonical-key": "tsx scripts/verify-canonical-key.ts",
     "show-report": "playwright show-report --port 0"
   },

--- a/e2e/runner/build.go
+++ b/e2e/runner/build.go
@@ -60,7 +60,7 @@ func build(ctx context.Context, config *e2eConfig) error {
 	// so we ensure JS deps are installed up front before starting concurrent work.
 	needsJSDeps := buildTeleport || buildConnect
 	if needsJSDeps {
-		slog.Info("ensuring JS dependencies are installed")
+		slog.InfoContext(ctx, "ensuring JS dependencies are installed")
 		if err := runMake(ctx, config.repoRoot, "ensure-js-deps"); err != nil {
 			return err
 		}
@@ -71,31 +71,31 @@ func build(ctx context.Context, config *e2eConfig) error {
 	if buildTeleport {
 		buildDir := config.teleportBuildDir
 		g.Go(func() error {
-			slog.Info("building teleport", "dir", buildDir)
+			slog.InfoContext(ctx, "building teleport", "dir", buildDir)
 
 			return runMake(ctx, buildDir, "build/teleport")
 		})
 	} else if config.teleportBuildDir == "" {
-		slog.Debug("teleport binary overridden, skipping build", "path", config.teleportBin)
+		slog.DebugContext(ctx, "teleport binary overridden, skipping build", "path", config.teleportBin)
 	} else if config.noBuild {
-		slog.Debug("skipping teleport build (--no-build)", "path", config.teleportBin)
+		slog.DebugContext(ctx, "skipping teleport build (--no-build)", "path", config.teleportBin)
 	}
 
 	if buildTctl {
 		g.Go(func() error {
-			slog.Info("building tctl")
+			slog.InfoContext(ctx, "building tctl")
 
 			return runMake(ctx, config.repoRoot, "build/tctl")
 		})
 	} else if config.tctlBin != filepath.Join(config.repoRoot, "build", "tctl") {
-		slog.Debug("tctl binary overridden, skipping build", "path", config.tctlBin)
+		slog.DebugContext(ctx, "tctl binary overridden, skipping build", "path", config.tctlBin)
 	} else if config.noBuild {
-		slog.Debug("skipping tctl build (--no-build)", "path", config.tctlBin)
+		slog.DebugContext(ctx, "skipping tctl build (--no-build)", "path", config.tctlBin)
 	}
 
 	if buildNode {
 		g.Go(func() error {
-			slog.Info("cross-compiling teleport for linux (docker node)", "dir", nodeBuildDir)
+			slog.InfoContext(ctx, "cross-compiling teleport for linux (docker node)", "dir", nodeBuildDir)
 
 			output := filepath.Join(nodeBuildDir, "build", "teleport-node")
 			cmd := exec.CommandContext(ctx, "go", "build",
@@ -122,12 +122,12 @@ func build(ctx context.Context, config *e2eConfig) error {
 
 	if !config.isCI {
 		g.Go(func() error {
-			slog.Info("installing e2e dependencies")
+			slog.InfoContext(ctx, "installing e2e dependencies")
 			if err := runInDir(ctx, config.sharedDir, "pnpm", "install"); err != nil {
 				return fmt.Errorf("pnpm install: %w", err)
 			}
 
-			slog.Info("installing playwright browsers")
+			slog.InfoContext(ctx, "installing playwright browsers")
 			args := []string{"exec", "playwright", "install", "--no-shell"}
 			args = append(args, config.browsers...)
 			if err := runInDir(ctx, config.sharedDir, "pnpm", args...); err != nil {
@@ -141,7 +141,7 @@ func build(ctx context.Context, config *e2eConfig) error {
 	if fixtures.Connect.Enabled {
 		if buildConnect {
 			g.Go(func() error {
-				slog.Info("building Teleport Connect")
+				slog.InfoContext(ctx, "building Teleport Connect")
 				if err := runInDir(ctx, config.repoRoot, "pnpm", "--filter=@gravitational/teleterm", "build"); err != nil {
 					return fmt.Errorf("pnpm --filter=@gravitational/teleterm build: %w", err)
 				}
@@ -149,12 +149,12 @@ func build(ctx context.Context, config *e2eConfig) error {
 				return nil
 			})
 		} else if config.noBuild {
-			slog.Debug("skipping Teleport Connect build (--no-build)")
+			slog.DebugContext(ctx, "skipping Teleport Connect build (--no-build)")
 		}
 
 		if buildConnectTsh {
 			g.Go(func() error {
-				slog.Info("building tsh with webauthnmock tag for Teleport Connect e2e")
+				slog.InfoContext(ctx, "building tsh with webauthnmock tag for Teleport Connect e2e")
 				if err := runInDir(ctx, config.repoRoot, "go", "build", "-tags", "webauthnmock", "-o", config.connectTshBinPath, "./tool/tsh"); err != nil {
 					return fmt.Errorf("go build -tags webauthnmock ./tool/tsh: %w", err)
 				}
@@ -162,7 +162,7 @@ func build(ctx context.Context, config *e2eConfig) error {
 				return nil
 			})
 		} else if config.noBuild {
-			slog.Debug("skipping tsh-webauthnmock build (--no-build)", "path", config.connectTshBinPath)
+			slog.DebugContext(ctx, "skipping tsh-webauthnmock build (--no-build)", "path", config.connectTshBinPath)
 		}
 	}
 
@@ -202,9 +202,9 @@ func shouldBuild(path string, noBuild bool) bool {
 
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
-			slog.Info("binary missing, rebuilding", "path", path)
+			slog.InfoContext(context.Background(), "binary missing, rebuilding", "path", path)
 		} else {
-			slog.Warn("error checking binary, rebuilding just in case", "path", path, "error", err)
+			slog.WarnContext(context.Background(), "error checking binary, rebuilding just in case", "path", path, "error", err)
 		}
 
 		return true

--- a/e2e/runner/cmd/gen-ts-fixtures/main.go
+++ b/e2e/runner/cmd/gen-ts-fixtures/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
 	template "github.com/DataDog/datadog-agent/pkg/template/text"
 
 	"github.com/gravitational/teleport/e2e/runner/fixtures"

--- a/e2e/runner/flags.go
+++ b/e2e/runner/flags.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -157,7 +158,7 @@ func parseFlags(repoRoot string) (*e2eFlags, runMode, error) {
 		if len(f.testFiles) > 0 || mode != modeUI {
 			targets, resolveErr := resolveTargetsWithHelpers(e2eDir, f.testFiles)
 			if resolveErr != nil {
-				slog.Warn("scan: error resolving files", "error", resolveErr)
+				slog.WarnContext(context.Background(), "scan: error resolving files", "error", resolveErr)
 			} else {
 				f.scanTargets = targets
 				for _, fix := range scanFixturesFromTargets(targets) {
@@ -174,7 +175,7 @@ func parseFlags(repoRoot string) (*e2eFlags, runMode, error) {
 	}
 
 	if enabled := fixtures.Enabled(); len(enabled) > 0 {
-		slog.Info("enabled fixtures", "fixtures", enabled)
+		slog.InfoContext(context.Background(), "enabled fixtures", "fixtures", enabled)
 	}
 
 	// If every specified test file targets connect, skip browser instances.

--- a/e2e/runner/github.go
+++ b/e2e/runner/github.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -27,8 +28,6 @@ import (
 	"slices"
 	"strings"
 )
-
-const commentMarker = "<!-- e2e-test-results -->"
 
 func writeGitHubReport(resultsPath string) error {
 	data, err := os.ReadFile(resultsPath)
@@ -57,7 +56,7 @@ func writeGitHubReport(resultsPath string) error {
 	emitAnnotations(mergedFailures, mergedFlaky, report.Errors)
 
 	if err := writeJobSummary(report, mergedFailures, mergedFlaky); err != nil {
-		slog.Warn("could not write job summary", "error", err)
+		slog.WarnContext(context.Background(), "could not write job summary", "error", err)
 	}
 
 	return nil
@@ -152,7 +151,7 @@ func emitAnnotations(failures, flaky []mergedFailure, errors []pwError) {
 func writeJobSummary(report pwReport, failures, flaky []mergedFailure) error {
 	summaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
 	if summaryPath == "" {
-		slog.Warn("GITHUB_STEP_SUMMARY not set, skipping job summary")
+		slog.WarnContext(context.Background(), "GITHUB_STEP_SUMMARY not set, skipping job summary")
 
 		return nil
 	}

--- a/e2e/runner/main.go
+++ b/e2e/runner/main.go
@@ -48,9 +48,13 @@ func main() {
 	}))
 	slog.SetDefault(logger)
 
+	// The interruptible context is scoped to run(). The report and summary paths
+	// are short-lived and rely on the default SIGINT behavior.
+	ctx := context.Background()
+
 	e2eDir, err := resolveE2EDir()
 	if err != nil {
-		slog.Error("failed to resolve e2e directory", "error", err)
+		slog.ErrorContext(ctx, "failed to resolve e2e directory", "error", err)
 		os.Exit(1)
 	}
 
@@ -58,13 +62,13 @@ func main() {
 
 	flags, mode, err := parseFlags(filepath.Dir(e2eDir))
 	if err != nil {
-		slog.Error("failed to parse flags", "error", err)
+		slog.ErrorContext(ctx, "failed to parse flags", "error", err)
 		os.Exit(1)
 	}
 
 	if mode == modeGitHubReport {
 		if err := writeGitHubReport(resultsPath); err != nil {
-			slog.Error("failed to write GitHub report", "error", err)
+			slog.ErrorContext(ctx, "failed to write GitHub report", "error", err)
 			os.Exit(1)
 		}
 		return
@@ -86,13 +90,13 @@ func main() {
 
 		var runErr error
 		if mode == modeReport {
-			runErr = runReport(cfg)
+			runErr = runReport(ctx, cfg)
 		} else {
-			runErr = runTestResults(cfg)
+			runErr = runTestResults(ctx, cfg)
 		}
 
 		if runErr != nil {
-			slog.Error("runner exited with error", "error", runErr)
+			slog.ErrorContext(ctx, "runner exited with error", "error", runErr)
 			os.Exit(1)
 		}
 		return
@@ -118,7 +122,7 @@ func main() {
 	}
 
 	if runErr != nil {
-		slog.Error("runner exited with error", "error", runErr)
+		slog.ErrorContext(ctx, "runner exited with error", "error", runErr)
 		os.Exit(1)
 	}
 }
@@ -199,13 +203,13 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		return fmt.Errorf("--%s only supports a single browser, got: %v", mode, config.browsers)
 	}
 
-	slog.Info("running playwright in mode", "mode", mode, "browsers", config.browsers)
+	slog.InfoContext(ctx, "running playwright in mode", "mode", mode, "browsers", config.browsers)
 
-	slog.Debug("using teleport binary", "path", flags.teleportBin)
-	slog.Debug("using tctl binary", "path", flags.tctlBin)
+	slog.DebugContext(ctx, "using teleport binary", "path", flags.teleportBin)
+	slog.DebugContext(ctx, "using tctl binary", "path", flags.tctlBin)
 
 	if config.isCI {
-		slog.Debug("CI environment detected")
+		slog.DebugContext(ctx, "CI environment detected")
 	}
 
 	for _, browser := range config.browsers {
@@ -248,10 +252,10 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 	}
 
 	for _, inst := range config.instances {
-		inst.log.Debug("allocated ports", "proxy", inst.proxyPort, "auth", inst.authPort, "ssh", inst.sshPort)
+		inst.log.DebugContext(ctx, "allocated ports", "proxy", inst.proxyPort, "auth", inst.authPort, "ssh", inst.sshPort)
 	}
 	if ci := config.connectInstance; ci != nil {
-		ci.log.Debug("allocated ports", "proxy", ci.proxyPort, "auth", ci.authPort)
+		ci.log.DebugContext(ctx, "allocated ports", "proxy", ci.proxyPort, "auth", ci.authPort)
 	}
 
 	if err := build(ctx, config); err != nil {
@@ -263,7 +267,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 	case statErr != nil && !os.IsNotExist(statErr):
 		return fmt.Errorf("failed to check certs directory: %w", statErr)
 	case os.IsNotExist(statErr) || config.replaceCerts:
-		slog.Info("generating self-signed TLS certificates", "dir", config.certsDir)
+		slog.InfoContext(ctx, "generating self-signed TLS certificates", "dir", config.certsDir)
 
 		if err := generateSelfSignedCert(config.certsDir); err != nil {
 			return fmt.Errorf("failed to generate TLS certificates: %w", err)
@@ -277,7 +281,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		}
 
 		for _, inst := range allInstances {
-			inst.log.Debug("cleaning data directory", "path", inst.dataDir)
+			inst.log.DebugContext(ctx, "cleaning data directory", "path", inst.dataDir)
 			if err := os.RemoveAll(inst.dataDir); err != nil {
 				return fmt.Errorf("failed to clean data directory for %s: %w", inst.browser, err)
 			}
@@ -296,7 +300,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to scan users: %w", err)
 		}
-		slog.Debug("discovered bootstrap users", "count", len(scannedUsers))
+		slog.DebugContext(ctx, "discovered bootstrap users", "count", len(scannedUsers))
 
 		config.teleportConfigs, config.defaultTestFiles, err = scanTeleportConfigs(targets)
 		if err != nil {
@@ -313,26 +317,26 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 		if err := writeUserMapping(userMappingPath, bootstrap.userMapping); err != nil {
 			return fmt.Errorf("failed to write user mapping: %w", err)
 		}
-		slog.Debug("wrote user mapping", "path", userMappingPath, "users", len(bootstrap.userMapping))
+		slog.DebugContext(ctx, "wrote user mapping", "path", userMappingPath, "users", len(bootstrap.userMapping))
 
 		credsPath := filepath.Join(e2eDir, ".auth", "user-credentials.json")
 		if err := writeCredentialsFile(credsPath, bootstrap.creds); err != nil {
 			return fmt.Errorf("failed to write user credentials: %w", err)
 		}
-		slog.Debug("wrote user credentials", "path", credsPath, "users", len(bootstrap.creds))
+		slog.DebugContext(ctx, "wrote user credentials", "path", credsPath, "users", len(bootstrap.creds))
 
 		recMappingPath := filepath.Join(e2eDir, ".auth", "recording-mapping.json")
 		if err := writeRecordingMapping(recMappingPath, bootstrap.recordingMapping); err != nil {
 			return fmt.Errorf("failed to write recording mapping: %w", err)
 		}
-		slog.Debug("wrote recording mapping", "path", recMappingPath, "users", len(bootstrap.recordingMapping))
+		slog.DebugContext(ctx, "wrote recording mapping", "path", recMappingPath, "users", len(bootstrap.recordingMapping))
 
 		// One shared state file used by all instances.
 		stateFile, err := generateStateFile(config.stateTemplate, bootstrap.state)
 		if err != nil {
 			return fmt.Errorf("failed to generate state file: %w", err)
 		}
-		slog.Debug("generated bootstrap state", "path", stateFile)
+		slog.DebugContext(ctx, "generated bootstrap state", "path", stateFile)
 
 		for _, inst := range allInstances {
 			outPath := filepath.Join(e2eDir, "config", inst.browser+"-teleport.yaml")
@@ -350,7 +354,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 				return fmt.Errorf("failed to generate Teleport config for %s: %w", inst.browser, err)
 			}
 			inst.teleportConfigPath = tcfg
-			inst.log.Debug("generated Teleport config", "path", tcfg)
+			inst.log.DebugContext(ctx, "generated Teleport config", "path", tcfg)
 		}
 
 		// Create teleport instances (started lazily by the playwright runner so that at most 2 run concurrently).
@@ -366,14 +370,14 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 
 			if config.isCI || config.quiet {
 				teleport.logFile = filepath.Join(config.e2eDir, "teleport-"+inst.browser+".log")
-				inst.log.Debug("redirecting Teleport logs to file", "path", teleport.logFile)
+				inst.log.DebugContext(ctx, "redirecting Teleport logs to file", "path", teleport.logFile)
 			}
 
 			inst.teleport = teleport
 		}
 
 		if fixtures.SSHNode.Enabled {
-			slog.Info("running with SSH node fixture enabled")
+			slog.InfoContext(ctx, "running with SSH node fixture enabled")
 
 			nodeBin := config.teleportBin
 			if runtime.GOOS != "linux" {
@@ -399,7 +403,7 @@ func run(flags *e2eFlags, mode runMode, e2eDir string, isCI bool) error {
 				if err != nil {
 					return fmt.Errorf("failed to generate node config for %s: %w", inst.browser, err)
 				}
-				inst.log.Debug("generated Teleport node config", "path", nodeConfigPath)
+				inst.log.DebugContext(ctx, "generated Teleport node config", "path", nodeConfigPath)
 
 				inst.node = &dockerNode{
 					log:                inst.log,
@@ -443,7 +447,7 @@ func applyResources(ctx context.Context, e2eDir, tctlBin, teleportConfig string)
 	sort.Strings(files)
 
 	for _, f := range files {
-		slog.Info("applying resource", "file", filepath.Base(f))
+		slog.InfoContext(ctx, "applying resource", "file", filepath.Base(f))
 		cmd := exec.CommandContext(ctx, tctlBin, "create", "-c", teleportConfig, "-f", f)
 
 		var stderr bytes.Buffer

--- a/e2e/runner/node.go
+++ b/e2e/runner/node.go
@@ -56,7 +56,7 @@ func (d *dockerNode) start(ctx context.Context) error {
 }
 
 func (d *dockerNode) removeStale(ctx context.Context) {
-	cli, err := client.New(client.WithAPIVersionNegotiation())
+	cli, err := client.New()
 	if err != nil {
 		return
 	}
@@ -66,7 +66,7 @@ func (d *dockerNode) removeStale(ctx context.Context) {
 }
 
 func (d *dockerNode) runContainer(ctx context.Context) error {
-	d.log.Info("starting docker SSH node")
+	d.log.InfoContext(ctx, "starting docker SSH node")
 
 	d.removeStale(ctx)
 
@@ -114,7 +114,7 @@ func (d *dockerNode) runContainer(ctx context.Context) error {
 }
 
 func (d *dockerNode) waitJoined(ctx context.Context, timeout time.Duration) error {
-	d.log.Debug("waiting for docker node to join cluster")
+	d.log.DebugContext(ctx, "waiting for docker node to join cluster")
 
 	probe := func(ctx context.Context) (bool, error) {
 		cmd := exec.CommandContext(ctx, d.tctlBin, "nodes", "ls",
@@ -131,7 +131,7 @@ func (d *dockerNode) waitJoined(ctx context.Context, timeout time.Duration) erro
 		return fmt.Errorf("docker node failed to join cluster: %w", err)
 	}
 
-	d.log.Info("docker SSH node is ready")
+	d.log.InfoContext(ctx, "docker SSH node is ready")
 
 	return nil
 }
@@ -145,24 +145,24 @@ func (d *dockerNode) saveLogs(ctx context.Context) {
 
 	logs, err := d.ctr.Logs(ctx)
 	if err != nil {
-		d.log.Warn("could not get docker node logs", "error", err)
+		d.log.WarnContext(ctx, "could not get docker node logs", "error", err)
 		return
 	}
 	defer logs.Close()
 
 	f, err := os.Create(logPath)
 	if err != nil {
-		d.log.Warn("could not create docker node log file", "error", err)
+		d.log.WarnContext(ctx, "could not create docker node log file", "error", err)
 		return
 	}
 	defer f.Close()
 
 	if _, err := io.Copy(f, logs); err != nil {
-		d.log.Warn("could not write docker node logs", "error", err)
+		d.log.WarnContext(ctx, "could not write docker node logs", "error", err)
 		return
 	}
 
-	d.log.Info("saved docker node logs", "path", logPath)
+	d.log.InfoContext(ctx, "saved docker node logs", "path", logPath)
 }
 
 func (d *dockerNode) stop(ctx context.Context) {
@@ -170,16 +170,16 @@ func (d *dockerNode) stop(ctx context.Context) {
 		return
 	}
 
-	d.log.Info("stopping docker SSH node")
+	d.log.InfoContext(ctx, "stopping docker SSH node")
 
 	d.saveLogs(ctx)
 	_ = d.ctr.Terminate(ctx, container.TerminateTimeout(10*time.Second))
 }
 
 func pullImage(ctx context.Context, image string) error {
-	slog.Info("pulling docker image", "image", image)
+	slog.InfoContext(ctx, "pulling docker image", "image", image)
 
-	cli, err := client.New(client.WithAPIVersionNegotiation())
+	cli, err := client.New()
 	if err != nil {
 		return fmt.Errorf("creating docker client: %w", err)
 	}

--- a/e2e/runner/playwright.go
+++ b/e2e/runner/playwright.go
@@ -48,26 +48,6 @@ func (p *playwrightRunner) startURL(inst *testInstance) string {
 	return fmt.Sprintf("https://localhost:%d/web", inst.proxyPort)
 }
 
-// callerRelativePaths returns paths relative to the caller's working directory
-// so that logged paths are cmd+clickable in terminals.
-func (p *playwrightRunner) callerRelativePaths(paths []string) []string {
-	callerDir := os.Getenv("E2E_CALLER_DIR")
-	if callerDir == "" {
-		return paths
-	}
-
-	out := make([]string, len(paths))
-	for i, path := range paths {
-		abs := filepath.Join(p.config.e2eDir, path)
-		if rel, err := filepath.Rel(callerDir, abs); err == nil {
-			out[i] = rel
-		} else {
-			out[i] = path
-		}
-	}
-	return out
-}
-
 func (p *playwrightRunner) run(ctx context.Context, mode runMode) error {
 	switch mode {
 	case modeTest:
@@ -121,12 +101,12 @@ func (p *playwrightRunner) test(ctx context.Context, debug bool) error {
 
 	testErr := g.Wait()
 
-	slog.Info("merging blob reports")
+	slog.InfoContext(ctx, "merging blob reports")
 	mergeArgs := []string{"exec", "playwright", "merge-reports", p.configFlag(), blobBaseDir}
 	mergeEnv := os.Environ()
 	mergeEnv = append(mergeEnv, "FORCE_COLOR=1")
 	if err := p.pnpmQuiet(ctx, mergeArgs, mergeEnv); err != nil {
-		slog.Warn("failed to merge reports", "error", err)
+		slog.WarnContext(ctx, "failed to merge reports", "error", err)
 		if testErr == nil {
 			return err
 		}
@@ -219,9 +199,9 @@ func (p *playwrightRunner) runInstanceTests(ctx context.Context, inst *testInsta
 	args = append(args, files...)
 
 	if len(files) > 0 {
-		inst.log.Info("running e2e tests", "files", files)
+		inst.log.InfoContext(ctx, "running e2e tests", "files", files)
 	} else {
-		inst.log.Info("running e2e tests", "projects", baseProjects)
+		inst.log.InfoContext(ctx, "running e2e tests", "projects", baseProjects)
 	}
 
 	if err := p.pnpm(ctx, args, env); err != nil {
@@ -232,7 +212,7 @@ func (p *playwrightRunner) runInstanceTests(ctx context.Context, inst *testInsta
 
 // runTeleportConfig re-inits the instance's Teleport with a test-declared config.
 func (p *playwrightRunner) runTeleportConfig(ctx context.Context, inst *testInstance, baseConfigPath string, cfg uniqueTeleportConfig, files []string, idx int, blobBaseDir string, debug bool, extraArgs []string) error {
-	inst.log.Info("re-initializing teleport with a test-declared config", "files", files)
+	inst.log.InfoContext(ctx, "re-initializing teleport with a test-declared config", "files", files)
 
 	inst.teleport.stop()
 
@@ -261,7 +241,7 @@ func (p *playwrightRunner) runTeleportConfig(ctx context.Context, inst *testInst
 }
 
 func (p *playwrightRunner) ui(ctx context.Context) error {
-	slog.Info("starting playwright in UI mode")
+	slog.InfoContext(ctx, "starting playwright in UI mode")
 
 	if len(p.config.instances) == 0 {
 		return fmt.Errorf("no test instances configured")
@@ -309,12 +289,12 @@ func (p *playwrightRunner) openWebAuthenticated(ctx context.Context, playwrightC
 		return err
 	}
 
-	slog.Debug("running global setup to generate auth state")
+	slog.DebugContext(ctx, "running global setup to generate auth state")
 	if err := p.pnpm(ctx, []string{"exec", "tsx", filepath.Join(p.config.sharedDir, "global-setup.ts")}, env); err != nil {
 		return err
 	}
 
-	slog.Info("opening playwright " + playwrightCmd + " (with auth and WebAuthn)")
+	slog.InfoContext(ctx, "opening playwright with auth and WebAuthn", "command", playwrightCmd)
 
 	return p.pnpm(ctx, []string{
 		"exec", "tsx", filepath.Join(p.config.sharedDir, "scripts", "open-with-webauthn.ts"),
@@ -339,7 +319,7 @@ func (p *playwrightRunner) openConnectAuthenticated(ctx context.Context) error {
 		return err
 	}
 
-	slog.Info("opening Teleport Connect (with auth)")
+	slog.InfoContext(ctx, "opening Teleport Connect (with auth)")
 
 	return p.pnpm(ctx, []string{"exec", "tsx", filepath.Join(p.config.sharedDir, "scripts", "open-connect.ts")}, env)
 }

--- a/e2e/runner/recordings.go
+++ b/e2e/runner/recordings.go
@@ -173,7 +173,7 @@ func (t *teleportInstance) seedRecordings(ctx context.Context, e2eDir, dataDir s
 		}
 	}
 
-	slog.Info("seeded session recordings", "recordings", len(t.recordingOwners), "instances", len(instances))
+	slog.InfoContext(ctx, "seeded session recordings", "recordings", len(t.recordingOwners), "instances", len(instances))
 
 	return nil
 }

--- a/e2e/runner/report.go
+++ b/e2e/runner/report.go
@@ -44,8 +44,8 @@ type reportConfig struct {
 	tracePath string
 }
 
-func runReport(cfg *reportConfig) error {
-	tmpDir, err := downloadArtifact(cfg, "playwright-report")
+func runReport(ctx context.Context, cfg *reportConfig) error {
+	tmpDir, err := downloadArtifact(ctx, cfg, "playwright-report")
 	if err != nil {
 		return err
 	}
@@ -60,15 +60,15 @@ func runReport(cfg *reportConfig) error {
 	return showCmd.Run()
 }
 
-func runTestResults(cfg *reportConfig) error {
-	tmpDir, err := downloadArtifact(cfg, "test-results")
+func runTestResults(ctx context.Context, cfg *reportConfig) error {
+	tmpDir, err := downloadArtifact(ctx, cfg, "test-results")
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(tmpDir)
 
 	tracePath := filepath.Join(tmpDir, cfg.tracePath)
-	slog.Info("opening trace", "path", tracePath)
+	slog.InfoContext(ctx, "opening trace", "path", tracePath)
 
 	showCmd := exec.Command("pnpm", "exec", "playwright", "show-trace", tracePath)
 	showCmd.Dir = cfg.e2eDir
@@ -96,8 +96,7 @@ func ghClient(ctx context.Context) (*github.Client, error) {
 	return github.NewClient(oauth2.NewClient(ctx, ts)), nil
 }
 
-func downloadArtifact(cfg *reportConfig, artifactName string) (string, error) {
-	ctx := context.Background()
+func downloadArtifact(ctx context.Context, cfg *reportConfig, artifactName string) (string, error) {
 	client, err := ghClient(ctx)
 	if err != nil {
 		return "", err
@@ -114,9 +113,9 @@ func downloadArtifact(cfg *reportConfig, artifactName string) (string, error) {
 		}
 
 		headSHA = pr.GetHead().GetSHA()
-		slog.Debug("resolved PR head SHA", "sha", headSHA)
+		slog.DebugContext(ctx, "resolved PR head SHA", "sha", headSHA)
 	} else {
-		slog.Debug("using provided SHA", "sha", headSHA)
+		slog.DebugContext(ctx, "using provided SHA", "sha", headSHA)
 	}
 
 	opts := &github.ListArtifactsOptions{
@@ -149,7 +148,7 @@ func downloadArtifact(cfg *reportConfig, artifactName string) (string, error) {
 		return "", fmt.Errorf("no artifact %q found for PR head SHA %q", artifactName, headSHA)
 	}
 
-	slog.Debug("found artifact", "id", target.GetID(), "run_id", target.GetWorkflowRun().GetID())
+	slog.DebugContext(ctx, "found artifact", "id", target.GetID(), "run_id", target.GetWorkflowRun().GetID())
 
 	url, _, err := client.Actions.DownloadArtifact(ctx, owner, repoName, target.GetID(), 3)
 	if err != nil {
@@ -178,7 +177,7 @@ func downloadArtifact(cfg *reportConfig, artifactName string) (string, error) {
 		return "", fmt.Errorf("creating temp directory: %w", err)
 	}
 
-	slog.Info("extracting artifact", "artifact", artifactName, "dir", tmpDir)
+	slog.InfoContext(ctx, "extracting artifact", "artifact", artifactName, "dir", tmpDir)
 
 	zr, err := zip.OpenReader(zipFile.Name())
 	if err != nil {

--- a/e2e/runner/scan.go
+++ b/e2e/runner/scan.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -157,19 +158,6 @@ func scanFixturesFromTargets(targets []scanTarget) []*fixtures.Fixture {
 	}
 
 	return result
-}
-
-// scanFixtures wraps resolveTargetsWithHelpers + scanFixturesFromTargets for
-// callers that haven't been split yet.
-func scanFixtures(e2eDir string, testFiles []string) []*fixtures.Fixture {
-	targets, err := resolveTargetsWithHelpers(e2eDir, testFiles)
-	if err != nil {
-		slog.Warn("fixture scan: error resolving files", "error", err)
-
-		return nil
-	}
-
-	return scanFixturesFromTargets(targets)
 }
 
 func resolveFilesToScan(e2eDir string, testFiles []string) ([]scanTarget, error) {
@@ -317,7 +305,7 @@ func scanFile(path string, targetLine int) []*fixtures.Fixture {
 func readCleaned(path string) ([]string, bool) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		slog.Warn("scan: could not read file", "path", path, "error", err)
+		slog.WarnContext(context.Background(), "scan: could not read file", "path", path, "error", err)
 		return nil, false
 	}
 	return stripComments(strings.Split(string(data), "\n")), true
@@ -367,9 +355,10 @@ func findInlineComment(line string) int {
 		ch := line[i]
 
 		if quote != 0 {
-			if ch == '\\' {
+			switch ch {
+			case '\\':
 				i++
-			} else if ch == quote {
+			case quote:
 				quote = 0
 			}
 
@@ -398,9 +387,10 @@ func findBlockCommentOpen(line string) int {
 		ch := line[i]
 
 		if quote != 0 {
-			if ch == '\\' {
+			switch ch {
+			case '\\':
 				i++
-			} else if ch == quote {
+			case quote:
 				quote = 0
 			}
 
@@ -449,9 +439,10 @@ func parseBlocks(lines []string) []blockRange {
 			}
 
 			if quote != 0 {
-				if ch == '\\' {
+				switch ch {
+				case '\\':
 					j++
-				} else if ch == quote {
+				case quote:
 					if quote == '`' {
 						inTemplateLiteral = false
 					}
@@ -512,9 +503,10 @@ func findTestUseCalls(content string) []callRange {
 			ch := content[pos]
 
 			if quote != 0 {
-				if ch == '\\' {
+				switch ch {
+				case '\\':
 					pos++ // skip escaped character
-				} else if ch == quote {
+				case quote:
 					quote = 0
 				}
 
@@ -872,9 +864,10 @@ func scanBalanced(s string, openIdx int, open, close byte) int {
 		ch := s[i]
 
 		if quote != 0 {
-			if ch == '\\' {
+			switch ch {
+			case '\\':
 				i++
-			} else if ch == quote {
+			case quote:
 				quote = 0
 			}
 
@@ -895,23 +888,6 @@ func scanBalanced(s string, openIdx int, open, close byte) int {
 	}
 
 	return -1
-}
-
-// findClosingDelim finds the position after the matching close delimiter
-// for the first open delimiter at or after pos. Returns -1 if not found.
-// Delimiter bytes inside string or template literals are ignored.
-func findClosingDelim(s string, pos int, open, close byte) int {
-	start := strings.IndexByte(s[pos:], open)
-	if start < 0 {
-		return -1
-	}
-
-	end := scanBalanced(s, pos+start, open, close)
-	if end < 0 {
-		return -1
-	}
-
-	return end + 1
 }
 
 // scanTopLevelRecordings extracts recordings: [...] from a test.use() body,
@@ -986,22 +962,6 @@ func parseUserBlock(userBlock string) scannedUser {
 	return user
 }
 
-// extractInner returns the content between the first open delimiter and its
-// matching close, ignoring delimiters inside string/template literals.
-func extractInner(s string, open, close byte) string {
-	start := strings.IndexByte(s, open)
-	if start < 0 {
-		return ""
-	}
-
-	end := scanBalanced(s, start, open, close)
-	if end < 0 {
-		return ""
-	}
-
-	return s[start+1 : end]
-}
-
 // parseTraits parses trait key-value pairs
 // (e.g. `logins: ['root', 'alice'], groups: ['dev']`) into a map.
 func parseTraits(traitsContent string) map[string][]string {
@@ -1049,9 +1009,10 @@ func extractAllOuter(s string, open, close byte) []string {
 		ch := s[i]
 
 		if quote != 0 {
-			if ch == '\\' {
+			switch ch {
+			case '\\':
 				i++
-			} else if ch == quote {
+			case quote:
 				quote = 0
 			}
 
@@ -1088,7 +1049,7 @@ func warnDuplicateRoles(path string, line int, roles []scannedRole) {
 		if roles[i].file != "" {
 			ref = "file:" + roles[i].file
 		}
-		slog.Warn("scan: duplicate role for user", "path", path, "line", line, "role", ref)
+		slog.WarnContext(context.Background(), "scan: duplicate role for user", "path", path, "line", line, "role", ref)
 	}
 }
 

--- a/e2e/runner/summary.go
+++ b/e2e/runner/summary.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -33,13 +34,13 @@ import (
 func printTestSummary(e2eDir, resultsPath string) {
 	data, err := os.ReadFile(resultsPath)
 	if err != nil {
-		slog.Warn("could not read test results", "path", resultsPath, "error", err)
+		slog.WarnContext(context.Background(), "could not read test results", "path", resultsPath, "error", err)
 		return
 	}
 
 	var report pwReport
 	if err := json.Unmarshal(data, &report); err != nil {
-		slog.Warn("could not parse test results", "error", err)
+		slog.WarnContext(context.Background(), "could not parse test results", "error", err)
 		return
 	}
 

--- a/e2e/runner/teleport.go
+++ b/e2e/runner/teleport.go
@@ -31,9 +31,9 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"text/template"
 	"time"
 
+	template "github.com/DataDog/datadog-agent/pkg/template/text"
 	"gopkg.in/yaml.v3"
 )
 
@@ -73,7 +73,7 @@ func (t *teleportInstance) start(ctx context.Context) error {
 
 	t.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	t.log.Info("starting teleport with bootstrap state")
+	t.log.InfoContext(ctx, "starting teleport with bootstrap state")
 	if err := t.cmd.Start(); err != nil {
 		return fmt.Errorf("starting teleport: %w", err)
 	}
@@ -89,7 +89,7 @@ func (t *teleportInstance) start(ctx context.Context) error {
 
 // waitReady polls the proxy's /webapi/ping endpoint until it responds with 200.
 func (t *teleportInstance) waitReady(ctx context.Context, timeout time.Duration) error {
-	t.log.Debug("waiting for teleport to be ready")
+	t.log.DebugContext(ctx, "waiting for teleport to be ready")
 
 	client := &http.Client{
 		Timeout: 2 * time.Second,
@@ -120,7 +120,7 @@ func (t *teleportInstance) waitReady(ctx context.Context, timeout time.Duration)
 		return fmt.Errorf("teleport failed to become ready: %w", err)
 	}
 
-	t.log.Info("teleport is ready")
+	t.log.InfoContext(ctx, "teleport is ready")
 
 	return nil
 }
@@ -130,7 +130,7 @@ func (t *teleportInstance) stop() {
 		return
 	}
 
-	t.log.Info("stopping teleport")
+	t.log.InfoContext(context.Background(), "stopping teleport")
 
 	select {
 	case <-t.waitDone:
@@ -141,7 +141,7 @@ func (t *teleportInstance) stop() {
 		select {
 		case <-t.waitDone:
 		case <-time.After(5 * time.Second):
-			t.log.Warn("teleport did not exit gracefully, sending SIGKILL")
+			t.log.WarnContext(context.Background(), "teleport did not exit gracefully, sending SIGKILL")
 			_ = syscall.Kill(-t.cmd.Process.Pid, syscall.SIGKILL)
 			<-t.waitDone
 		}

--- a/e2e/runner/usercredentials.go
+++ b/e2e/runner/usercredentials.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -64,7 +65,14 @@ func generateUserCredentials() (*credentials, error) {
 		return nil, fmt.Errorf("marshaling private key: %w", err)
 	}
 
-	pubCBOR := encodeEC2PublicKeyCBOR(privateKey.PublicKey.X, privateKey.PublicKey.Y)
+	// Bytes returns the SEC 1 uncompressed point, 0x04 || X || Y, with each
+	// coordinate zero-padded to the 32-byte P-256 field size.
+	pub, err := privateKey.PublicKey.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("encoding public key: %w", err)
+	}
+
+	pubCBOR := encodeEC2PublicKeyCBOR(pub[1:33], pub[33:65])
 
 	credID := make([]byte, 32)
 	if _, err := rand.Read(credID); err != nil {
@@ -79,8 +87,8 @@ func generateUserCredentials() (*credentials, error) {
 		privateKeyPKCS8Base64: base64.StdEncoding.EncodeToString(pkcs8),
 	}
 
-	slog.Debug("generated per-run credentials",
-		"credentialID", creds.credentialIDBase64,
+	slog.DebugContext(context.Background(), "generated per-run credentials",
+		"credential_id", creds.credentialIDBase64,
 	)
 
 	return creds, nil
@@ -88,8 +96,9 @@ func generateUserCredentials() (*credentials, error) {
 
 // encodeEC2PublicKeyCBOR builds the 77-byte COSE key encoding for an
 // EC2 P-256 public key. The structure is fixed so we construct the bytes
-// directly rather than pulling in a CBOR library.
-func encodeEC2PublicKeyCBOR(x, y *big.Int) []byte {
+// directly rather than pulling in a CBOR library. x and y must each be the
+// 32-byte big-endian coordinate.
+func encodeEC2PublicKeyCBOR(x, y []byte) []byte {
 	buf := make([]byte, 0, 77)
 
 	buf = append(buf, 0xa5)       // map(5)
@@ -101,10 +110,10 @@ func encodeEC2PublicKeyCBOR(x, y *big.Int) []byte {
 	buf = append(buf, 0x01)       // value: 1 (P-256)
 	buf = append(buf, 0x21)       // key: -2 (x)
 	buf = append(buf, 0x58, 0x20) // bstr(32)
-	buf = append(buf, x.FillBytes(make([]byte, 32))...)
+	buf = append(buf, x...)
 	buf = append(buf, 0x22)       // key: -3 (y)
 	buf = append(buf, 0x58, 0x20) // bstr(32)
-	buf = append(buf, y.FillBytes(make([]byte, 32))...)
+	buf = append(buf, y...)
 
 	return buf
 }

--- a/e2e/runner/usercredentials.go
+++ b/e2e/runner/usercredentials.go
@@ -65,14 +65,16 @@ func generateUserCredentials() (*credentials, error) {
 		return nil, fmt.Errorf("marshaling private key: %w", err)
 	}
 
-	// Bytes returns the SEC 1 uncompressed point, 0x04 || X || Y, with each
-	// coordinate zero-padded to the 32-byte P-256 field size.
 	pub, err := privateKey.PublicKey.Bytes()
 	if err != nil {
 		return nil, fmt.Errorf("encoding public key: %w", err)
 	}
 
-	pubCBOR := encodeEC2PublicKeyCBOR(pub[1:33], pub[33:65])
+	// The public key is the uncompressed point (0x04 || X || Y), with each
+	// coordinate zero-padded to 32 bytes.
+	x, y := pub[1:33], pub[33:65]
+
+	pubCBOR := encodeEC2PublicKeyCBOR(x, y)
 
 	credID := make([]byte, 32)
 	if _, err := rand.Read(credID); err != nil {

--- a/e2e/runner/util.go
+++ b/e2e/runner/util.go
@@ -27,7 +27,7 @@ import (
 )
 
 // pollUntil calls probe at the given interval until it returns true,
-// the timeout expires, or the context is cancelled.
+// the timeout expires, or the context is canceled.
 func pollUntil(ctx context.Context, timeout, interval time.Duration, probe func(ctx context.Context) (bool, error)) error {
 	deadline := time.After(timeout)
 	tick := time.NewTicker(interval)


### PR DESCRIPTION
Supersedes https://github.com/gravitational/teleport/pull/68955

Adds linting of the `e2e/runner` module to `make lint` (via a separate `make lint-e2e-runner` target) and to the linting CI workflow.

As a result, this also fixes the existing 99 lint issues.

edit: also moves the type check to use `tsc` instead of `tsgo` now that https://github.com/gravitational/teleport/pull/69259 moved us to TypeScript 7

## Manual Test Plan
### Test Environment
Local/CI

### Test Cases
- [x] `make lint-e2e-runner` passes
- [x] CI lint workflow passes
