### PR TITLE
Switch `tsgo` to `tsc`

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,7 +5,7 @@
   "description": "Playwright tests for e2e testing.",
   "scripts": {
     "test": "./run.sh",
-    "type-check": "tsgo --noEmit",
+    "type-check": "tsc --noEmit",
     "test:canonical-key": "tsx scripts/verify-canonical-key.ts",
     "show-report": "playwright show-report --port 0"
   },


### PR DESCRIPTION
A follow up to https://github.com/gravitational/teleport/pull/69258.

I missed that we use `tsgo` in `e2e` which is no longer provided by TypeScript 7.0.
