### PR TITLE
Mark the Sub CA RFD as implemented

### DIFF
--- a/rfd/0237-sub-ca-support.md
+++ b/rfd/0237-sub-ca-support.md
@@ -1,6 +1,6 @@
 ---
 authors: Alan Parra (alan.parra@goteleport.com)
-state: implemented
+state: implemented (v18.9.0)
 ---
 
 # RFD 0237 - Sub CA support

--- a/rfd/0237-sub-ca-support.md
+++ b/rfd/0237-sub-ca-support.md
@@ -1,6 +1,6 @@
 ---
 authors: Alan Parra (alan.parra@goteleport.com)
-state: draft
+state: implemented
 ---
 
 # RFD 0237 - Sub CA support


### PR DESCRIPTION
The CA override base system is implemented, DB client and Windows overrides are released, and we are working on increasing the number of supported CAs.

There some smaller items we are still to implement (CA expiration and rotation alerts, `tctl get ca` support, Terraform/Operator), but overall I think it's fair to say the RFD is done.

Follow up work is tracked on https://github.com/gravitational/core/issues/102.

https://github.com/gravitational/teleport.e/issues/7675