### PR TITLE
Mark RFD for SSH in-band MFA as implemented.

### DIFF
--- a/rfd/0234-in-band-mfa-ssh-sessions.md
+++ b/rfd/0234-in-band-mfa-ssh-sessions.md
@@ -1,6 +1,6 @@
 ---
 authors: Chris Thach (chris.thach@goteleport.com)
-state: draft
+state: implemented
 ---
 
 # RFD 0234 - In-Band MFA for SSH Sessions

--- a/rfd/0234-in-band-mfa-ssh-sessions.md
+++ b/rfd/0234-in-band-mfa-ssh-sessions.md
@@ -1,6 +1,6 @@
 ---
 authors: Chris Thach (chris.thach@goteleport.com)
-state: implemented
+state: implemented (v19.0.0)
 ---
 
 # RFD 0234 - In-Band MFA for SSH Sessions


### PR DESCRIPTION
This feature is on track for delivery in the v19 release.

There is one known implementation bug, https://github.com/gravitational/core/issues/146, but otherwise can be marked as implemented.

