### PR TITLE
Make LDAP CA cert optional for DB access

### DIFF
--- a/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/self-hosted/sql-server-ad-pkinit.mdx
@@ -237,7 +237,7 @@ database section below as appropriate:
 - `domain`: The Active Directory domain (Kerberos realm) DNS/Address to which SQL Server is joined.
 - `spn`: Service Principal Name (SPN) for SQL Server to fetch Kerberos tickets.
 - `kdc_host_name`: SPN of the domain controller responsible for providing the LDAP CA.
-- `ldap_cert`: The contents of the LDAP CA previously exported.
+- `ldap_cert`: Optional. The contents of the LDAP CA previously exported. If omitted, Teleport uses the host's system certificate pool to verify the LDAP server.
 - `ldap_service_account_name`: Name of the service account Teleport uses to query LDAP for user SIDs.
 - `ldap_service_account_sid`: SID corresponding to the specified `ldap_service_account_name`.
 

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -200,10 +200,7 @@ func ValidateDatabase(db types.Database) error {
 		if db.GetAD().SPN == "" {
 			return trace.BadParameter("missing service principal name for database %q", db.GetName())
 		}
-		if db.GetAD().KDCHostName != "" {
-			if db.GetAD().LDAPCert == "" {
-				return trace.BadParameter("missing LDAP certificate for x509 authentication for database %q", db.GetName())
-			}
+		if db.GetAD().KDCHostName != "" && db.GetAD().LDAPCert != "" {
 			if _, err := tlsca.ParseCertificatePEM([]byte(db.GetAD().LDAPCert)); err != nil {
 				return trace.BadParameter("provided database %q LDAP certificate doesn't appear to be valid: %v", db.GetName(), err)
 			}

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -354,7 +354,7 @@ func TestValidateDatabase(t *testing.T) {
 			expectError: false,
 		},
 		{
-			inputName: "invalid-mssql-kerberos-kdchostname-without-ldapcert",
+			inputName: "valid-mssql-kerberos-kdchostname-with-system-cert-pool",
 			inputSpec: types.DatabaseSpecV3{
 				Protocol: defaults.ProtocolSQLServer,
 				URI:      "sqlserver.goteleport.com:1433",
@@ -365,7 +365,7 @@ func TestValidateDatabase(t *testing.T) {
 					SPN:         "MSSQLSvc/sqlserver.goteleport.com:1433",
 				},
 			},
-			expectError: true,
+			expectError: false,
 		},
 		{
 			inputName: "valid-mssql-azure-kerberos",

--- a/lib/srv/db/common/kerberos/client.go
+++ b/lib/srv/db/common/kerberos/client.go
@@ -75,7 +75,7 @@ func (c *clientProvider) GetKerberosClient(ctx context.Context, ad types.AD, use
 		}
 		return kt, nil
 	}
-	return nil, trace.BadParameter("configuration must have either keytab_file or kdc_host_name and ldap_cert")
+	return nil, trace.BadParameter("configuration must have either keytab_file or kdc_host_name")
 }
 
 // keytabClient returns a kerberos client using a keytab file
@@ -115,8 +115,10 @@ func (c *clientProvider) keytabClient(ad types.AD, username string) (*client.Cli
 
 // kinitClient returns a kerberos client using a kinit ccache
 func (c *clientProvider) kinitClient(ctx context.Context, ad types.AD, username string, auth winpki.AuthInterface) (*client.Client, error) {
-	if _, err := tlsutils.ParseCertificatePEM([]byte(ad.LDAPCert)); err != nil {
-		return nil, trace.Wrap(err, "invalid certificate was provided via AD configuration")
+	if ad.LDAPCert != "" {
+		if _, err := tlsutils.ParseCertificatePEM([]byte(ad.LDAPCert)); err != nil {
+			return nil, trace.Wrap(err, "invalid certificate was provided via AD configuration")
+		}
 	}
 
 	if c.providerFun == nil {

--- a/lib/srv/db/common/kerberos/client_test.go
+++ b/lib/srv/db/common/kerberos/client_test.go
@@ -181,13 +181,26 @@ func TestConnectorKInitClient(t *testing.T) {
 			},
 		},
 		{
+			name: "kinit using system certificate pool",
+			databaseSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver:1443",
+				AD: types.AD{
+					KDCHostName: "kdc.example.com",
+				},
+			},
+			validateClient: func(t *testing.T, clt *client.Client) {
+				require.NotNil(t, clt)
+			},
+		},
+		{
 			name: "invalid AD config",
 			databaseSpec: types.DatabaseSpecV3{
 				Protocol: defaults.ProtocolSQLServer,
 				URI:      "sqlserver:1443",
 				AD:       types.AD{},
 			},
-			errorMessage: "configuration must have either keytab_file or kdc_host_name and ldap_cert",
+			errorMessage: "configuration must have either keytab_file or kdc_host_name",
 		},
 		{
 			name: "kinit invalid certificate",

--- a/lib/srv/db/common/kerberos/kinit/ldap.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap.go
@@ -70,9 +70,13 @@ func newLDAPConnector(logger *slog.Logger, authClient winpki.AuthInterface, adCo
 		return nil, trace.BadParameter("missing KDC host name / LDAP address")
 	}
 
-	ldapCert, err := tlsca.ParseCertificatePEM([]byte(adConfig.LDAPCert))
-	if err != nil {
-		return nil, trace.Wrap(err, "cannot find valid LDAP certificate block in AD configuration")
+	var ldapCert *x509.Certificate
+	if adConfig.LDAPCert != "" {
+		var err error
+		ldapCert, err = tlsca.ParseCertificatePEM([]byte(adConfig.LDAPCert))
+		if err != nil {
+			return nil, trace.Wrap(err, "cannot find valid LDAP certificate block in AD configuration")
+		}
 	}
 
 	cfg := ldapConnectionConfig{

--- a/lib/srv/db/common/kerberos/kinit/ldap_test.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap_test.go
@@ -120,4 +120,14 @@ func TestTLSConfigForLDAP(t *testing.T) {
 	require.Equal(t, "ldap.example.com", tlsConfig.ServerName)
 	require.NotEmpty(t, tlsConfig.Certificates)
 	require.NotNil(t, tlsConfig.RootCAs)
+
+	// Leaving LDAPCert unset leaves RootCAs nil, which makes crypto/tls use the
+	// host's system certificate pool.
+	adConfig.LDAPCert = ""
+	connector, err = newLDAPConnector(slog.Default(), auth, adConfig)
+	require.NoError(t, err)
+
+	tlsConfig, err = connector.tlsConfigForLDAP(ctx, "test-cluster")
+	require.NoError(t, err)
+	require.Nil(t, tlsConfig.RootCAs)
 }


### PR DESCRIPTION
When not specified, Teleport will fall back to using the system cert pool for validation.

Closes #69464

Changelog: The `ldap_cert` configuration is no longer required for MS SQL access. Leave it empty to use the system cert pool for server certificate validation.

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
