### PR TITLE
Show Kubernetes cluster descriptions

### DIFF
--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -173,6 +173,8 @@ type KubeCluster struct {
 	Kind string `json:"kind"`
 	// Name is the name of the kube cluster.
 	Name string `json:"name"`
+	// Description is the kube cluster description.
+	Description string `json:"description"`
 	// Labels is a map of static and dynamic labels associated with an kube cluster.
 	Labels []ui.Label `json:"labels"`
 	// KubeUsers is the list of allowed Kubernetes RBAC users that the user can impersonate.
@@ -199,6 +201,7 @@ func MakeKubeCluster(cluster types.KubeCluster, accessChecker services.AccessChe
 	return KubeCluster{
 		Kind:            cluster.GetKind(),
 		Name:            cluster.GetName(),
+		Description:     cluster.GetDescription(),
 		Labels:          uiLabels,
 		KubeUsers:       kubeUsers,
 		RequiresRequest: requiresRequest,
@@ -234,10 +237,11 @@ func MakeKubeClusters(clusters []types.KubeCluster, accessChecker services.Acces
 		kubeUsers, kubeGroups := getAllowedKubeUsersAndGroupsForCluster(accessChecker, cluster)
 
 		uiKubeClusters = append(uiKubeClusters, KubeCluster{
-			Name:       cluster.GetName(),
-			Labels:     uiLabels,
-			KubeUsers:  kubeUsers,
-			KubeGroups: kubeGroups,
+			Name:        cluster.GetName(),
+			Description: cluster.GetDescription(),
+			Labels:      uiLabels,
+			KubeUsers:   kubeUsers,
+			KubeGroups:  kubeGroups,
 		})
 	}
 

--- a/lib/web/ui/server_test.go
+++ b/lib/web/ui/server_test.go
@@ -341,6 +341,33 @@ func makeTestKubeCluster(t *testing.T, labels map[string]string) types.KubeClust
 	return s
 }
 
+func TestMakeKubeClusterDescription(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name        string
+		description string
+	}{
+		{name: "with description", description: "Production cluster for the payments team"},
+		{name: "without description"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cluster, err := types.NewKubernetesClusterV3(
+				types.Metadata{
+					Name:        "production-us-east",
+					Description: test.description,
+				},
+				types.KubernetesClusterSpecV3{},
+			)
+			require.NoError(t, err)
+
+			accessChecker := services.NewAccessCheckerWithRoleSet(&services.AccessInfo{}, "clusterName", nil)
+			require.Equal(t, test.description, MakeKubeCluster(cluster, accessChecker, false).Description)
+			require.Equal(t, test.description, MakeKubeClusters([]types.KubeCluster{cluster}, accessChecker)[0].Description)
+		})
+	}
+}
+
 func TestMakeClusterHiddenLabels(t *testing.T) {
 	type testCase struct {
 		name           string

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.test.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { mockResizeObserver } from 'jsdom-testing-mocks';
+
+import { render, screen } from 'design/utils/testing';
+
+import { makeUnifiedResourceViewItemKube } from '../shared/viewItemsFactory';
+import { PinningSupport, UnifiedResourceKube } from '../types';
+import { ResourceCard } from './ResourceCard';
+
+mockResizeObserver();
+
+test('renders a Kubernetes cluster description as a subtitle', () => {
+  const viewItem = setupKubeCard('Production cluster for the payments team');
+
+  expect(
+    screen.getByText('Production cluster for the payments team')
+  ).toBeInTheDocument();
+  expect(viewItem.listViewProps.description).toBe(
+    'Production cluster for the payments team'
+  );
+});
+
+test('preserves the existing subtitle when a Kubernetes cluster has no description', () => {
+  setupKubeCard();
+
+  expect(screen.getByText('Kubernetes')).toBeInTheDocument();
+  expect(
+    screen.queryByText('Production cluster for the payments team')
+  ).not.toBeInTheDocument();
+});
+
+function setupKubeCard(description?: string) {
+  const resource: UnifiedResourceKube = {
+    kind: 'kube_cluster',
+    name: 'production-us-east',
+    description,
+    labels: [],
+  };
+
+  const viewItem = makeUnifiedResourceViewItemKube(resource, {
+    ActionButton: <button>Connect</button>,
+  });
+
+  render(
+    <ResourceCard
+      pinned={false}
+      pinResource={() => {}}
+      selectResource={() => {}}
+      selected={false}
+      pinningSupport={PinningSupport.Supported}
+      onShowStatusInfo={() => {}}
+      showingStatusInfo={false}
+      viewItem={viewItem}
+      visibleInputFields={{
+        checkbox: false,
+        pin: false,
+        copy: false,
+        hoverState: false,
+      }}
+    />
+  );
+
+  return viewItem;
+}

--- a/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/viewItemsFactory.ts
@@ -103,9 +103,11 @@ export function makeUnifiedResourceViewItemKube(
     labels: resource.labels,
     cardViewProps: {
       primaryDesc: 'Kubernetes',
+      secondaryDesc: resource.description,
     },
     listViewProps: {
       resourceType: 'Kubernetes',
+      description: resource.description,
     },
     requiresRequest: resource.requiresRequest,
     status: resource.targetHealth?.status,

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -119,6 +119,7 @@ export interface UnifiedResourceNode {
 export interface UnifiedResourceKube {
   kind: 'kube_cluster';
   name: string;
+  description?: string;
   labels: ResourceLabel[];
   requiresRequest?: boolean;
   targetHealth?: ResourceTargetHealth;

--- a/web/packages/teleport/src/services/kube/kube.test.ts
+++ b/web/packages/teleport/src/services/kube/kube.test.ts
@@ -33,6 +33,7 @@ test('correct processed fetch response formatting', async () => {
       {
         kind: 'kube_cluster',
         name: 'tele.logicoma.dev-prod',
+        description: 'Production cluster for the payments team',
         labels: [
           { name: 'kernal', value: '4.15.0-51-generic' },
           { name: 'env', value: 'prod' },
@@ -72,7 +73,14 @@ test('handling of null labels', async () => {
   });
 
   expect(response.agents).toEqual([
-    { kind: 'kube_cluster', name: 'test', labels: [], users: [], groups: [] },
+    {
+      kind: 'kube_cluster',
+      name: 'test',
+      description: '',
+      labels: [],
+      users: [],
+      groups: [],
+    },
   ]);
 });
 
@@ -80,6 +88,7 @@ const mockApiResponse = {
   items: [
     {
       name: 'tele.logicoma.dev-prod',
+      description: 'Production cluster for the payments team',
       labels: [
         { name: 'kernal', value: '4.15.0-51-generic' },
         { name: 'env', value: 'prod' },

--- a/web/packages/teleport/src/services/kube/makeKube.ts
+++ b/web/packages/teleport/src/services/kube/makeKube.ts
@@ -19,12 +19,13 @@
 import { Kube, KubeResource, KubeServer } from './types';
 
 export function makeKube(json): Kube {
-  const { name, requiresRequest, targetHealth } = json;
+  const { name, description = '', requiresRequest, targetHealth } = json;
   const labels = json.labels || [];
 
   return {
     kind: 'kube_cluster',
     name,
+    description,
     labels,
     users: json.kubernetes_users || [],
     groups: json.kubernetes_groups || [],

--- a/web/packages/teleport/src/services/kube/types.ts
+++ b/web/packages/teleport/src/services/kube/types.ts
@@ -23,6 +23,7 @@ import { ResourceLabel } from 'teleport/services/agents';
 export interface Kube {
   kind: 'kube_cluster';
   name: string;
+  description?: string;
   labels: ResourceLabel[];
   users?: string[];
   groups?: string[];


### PR DESCRIPTION
Changelog: Added Kubernetes cluster descriptions to the unified resources Web UI.

## Manual Test Plan

- Storybook visual test (card & list view)
<img width="441" height="118" alt="image" src="https://github.com/user-attachments/assets/86a35bd0-235a-4c18-9259-fd5fd6ef3a24" />
<img width="1335" height="126" alt="image" src="https://github.com/user-attachments/assets/430e3f46-5f0e-4b87-aa7b-d0b85a01b431" />

### Test Environment

- Local Teleport development checkout.
- Backend tests run against `./lib/web/ui`.
- Frontend tests run with Jest and jsdom.
- No manual browser testing was performed.

### Test Cases

- [x] Verified Kubernetes cluster descriptions are propagated from `metadata.description`.
- [x] Verified descriptions render in unified resource cards.
- [x] Verified clusters without descriptions render as before.

Closes #68367