### PR TITLE
Validate rules verbs on role create.

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -831,6 +831,19 @@ const (
 	VerbUse = "use"
 )
 
+// RulesVerbs lists the supported Rules verbs.
+var RulesVerbs = []string{
+	VerbList,
+	VerbCreate,
+	VerbRead,
+	VerbReadNoSecrets,
+	VerbUpdate,
+	VerbDelete,
+	VerbCreateEnrollToken,
+	VerbEnroll,
+	VerbUse,
+}
+
 const (
 	// TeleportNamespace is used as the namespace prefix for labels defined by Teleport which can
 	// carry metadata such as cloud AWS account or instance. Those labels can be used for RBAC.

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -611,7 +611,7 @@ func validateSessionParticipantModes(modes []string) error {
 	return nil
 }
 
-// validateRule parses the where and action fields to validate the rule.
+// validateRule parses the where, action and verbs fields to validate the rule.
 func validateRule(r types.Rule) error {
 	if len(r.Where) != 0 {
 		parser, err := NewWhereParser(&Context{},
@@ -638,6 +638,14 @@ func validateRule(r types.Rule) error {
 			_, err = parser.Parse(action)
 			if err != nil {
 				return trace.BadParameter("could not parse action %v %q, error: %v", i, action, err)
+			}
+		}
+	}
+
+	if len(r.Verbs) != 0 {
+		for _, verb := range r.Verbs {
+			if !slices.Contains(types.RulesVerbs, verb) && verb != types.Wildcard {
+				return trace.BadParameter("unsupported verb %q; Supported: %v", verb, types.RulesVerbs)
 			}
 		}
 	}

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -963,6 +963,23 @@ func TestValidateRole(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid rules.verbs",
+			spec: types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Rules: []types.Rule{
+						{
+							Resources: []string{"role"},
+							Verbs:     []string{"unknown"},
+						},
+					},
+				},
+			},
+			expectErrorContains: []string{
+				"parsing allow.rules[0]",
+				"unsupported verb \"unknown\"",
+			},
+		},
+		{
 			name: "valid require_session_join.filter",
 			spec: types.RoleSpecV6{
 				Allow: types.RoleConditions{


### PR DESCRIPTION
Previously,  role creation generally accepted any string as a verb in a role's `allow`/`deny` rules without validation, silently persisting invalid verbs. This  PR adds validation against the supported verb list.

Closes #1284.
<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed a bug where roles could be created with invalid verbs in their allow/deny rules.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
