### PR TITLE
[v17] Allow deletion of a role named "admin"

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -665,10 +665,6 @@ const (
 // SCP is Secure Copy.
 const SCP = "scp"
 
-// AdminRoleName is the name of the default admin role for all local users if
-// another role is not explicitly assigned
-const AdminRoleName = "admin"
-
 const (
 	// PresetEditorRoleName is a name of a preset role that allows
 	// editing cluster configuration.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4944,14 +4944,6 @@ func (a *ServerWithRoles) DeleteRole(ctx context.Context, name string) error {
 		return trace.Wrap(err)
 	}
 
-	// DELETE IN (7.0)
-	// It's OK to delete this code alongside migrateOSS code in auth.
-	// It prevents 6.0 from migrating resources multiple times
-	// and the role is used for `tctl users add` code too.
-	if modules.GetModules().IsOSSBuild() && name == teleport.AdminRoleName {
-		return trace.AccessDenied("can not delete system role %q", name)
-	}
-
 	return a.authServer.DeleteRole(ctx, name)
 }
 


### PR DESCRIPTION
This is a relic of the Teleport 6 days before we added RBAC to OSS Teleport. Back then, every local user had a role named "admin", and we had some protection in place preventing that role from being deleted.

Today, no such role exists, but the deletion prevention remains. This means you can create your own custom role named "admin" and Teleport won't let you delete it.

Closes #69222

Changelog: Fixed a bug preventing custom roles named "admin" from being deleted.

<img width="520" height="285" alt="image" src="https://github.com/user-attachments/assets/ee5a70dc-6c53-4f82-a909-fd5896a699cd" />

## Manual Test Plan
### Test Environment
Local cluster
### Test Cases
- [x] Create a role named admin. Try to delete it. Verify no error occurs.

Backports #69486
