### PR TITLE
`audit/types.ts`: Remove unused `eventGroupTypes`

### DIFF
--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -18,21 +18,6 @@
 
 import { SortDir } from '../agents';
 
-// eventGroupTypes contains a map of events that were grouped under the same
-// event type but have different event codes. This is used to filter out duplicate
-// event types when listing event filters and provide modified description of event.
-export const eventGroupTypes = {
-  'db.session.start': 'Database Session Start',
-  exec: 'Command Execution',
-  port: 'Port Forwarding',
-  scp: 'SCP',
-  sftp: 'SFTP',
-  subsystem: 'Subsystem Request',
-  'user.login': 'User Logins',
-  'spiffe.svid.issued': 'SPIFFE SVID Issuance',
-  'device.enroll_pairing.request': 'Device Enroll Pairing Request',
-};
-
 /**
  * eventCodes is a map of event codes.
  *
@@ -40,8 +25,6 @@ export const eventGroupTypes = {
  *  1: Define fields from JSON response in `RawEvents` object (in this file)
  *  2: Define formatter in `makeEvent.ts` file which defines *events types and
  *     defines short and long event definitions
- *  * Some events can have same event "type" but have unique "code".
- *    These duplicated event types needs to be defined in `eventGroupTypes` object
  *  3: Define icons for events under `EventTypeCell.tsx` file
  *  4: Add an actual JSON event to the fixtures file in `src/Audit/fixtures/index.ts`.
  */


### PR DESCRIPTION
While answering a question on my PR that adds audit events for approving an enroll pairing (https://github.com/gravitational/teleport/pull/69505#discussion_r3750122920), I found out that `eventGroupTypes` had no consumers, neither in OSS nor ent, ever since it was added in https://github.com/gravitational/webapps/pull/329.

This PR removes `eventGroupTypes` and removes the line from `eventCodes` JSDoc that instructs people to update `eventGroupTypes`.