### PR TITLE
[v18] `tctl edit integration` now supports updating GitHub OAuth credentials

### DIFF
--- a/tool/tctl/common/resources/integration.go
+++ b/tool/tctl/common/resources/integration.go
@@ -59,6 +59,8 @@ func (c *integrationCollection) WriteText(w io.Writer, verbose bool) error {
 		switch ig.GetSubKind() {
 		case types.IntegrationSubKindAWSOIDC:
 			specProps = append(specProps, fmt.Sprintf("RoleARN=%s", ig.GetAWSOIDCIntegrationSpec().RoleARN))
+		case types.IntegrationSubKindGitHub:
+			specProps = append(specProps, fmt.Sprintf("Organization=%s", ig.GetGitHubIntegrationSpec().Organization))
 		}
 		rows = append(rows, []string{
 			ig.GetName(), ig.GetSubKind(), strings.Join(specProps, ","),
@@ -151,7 +153,11 @@ func updateExistingIntegration(ctx context.Context, client *authclient.Client, e
 		existingIntegration.SetAWSOIDCIntegrationSpec(integration.GetAWSOIDCIntegrationSpec())
 	case types.IntegrationSubKindGitHub:
 		existingIntegration.SetGitHubIntegrationSpec(integration.GetGitHubIntegrationSpec())
-		// TODO(greedy52) allow overwriting credentials.
+		if integration.GetCredentials() != nil {
+			if err := existingIntegration.SetCredentials(integration.GetCredentials()); err != nil {
+				return trace.Wrap(err)
+			}
+		}
 	case types.IntegrationSubKindAWSRolesAnywhere:
 		existingIntegration.SetAWSRolesAnywhereIntegrationSpec(integration.GetAWSRolesAnywhereIntegrationSpec())
 	case types.IntegrationSubKindAzureOIDC:

--- a/tool/tctl/common/resources/integration.go
+++ b/tool/tctl/common/resources/integration.go
@@ -153,8 +153,8 @@ func updateExistingIntegration(ctx context.Context, client *authclient.Client, e
 		existingIntegration.SetAWSOIDCIntegrationSpec(integration.GetAWSOIDCIntegrationSpec())
 	case types.IntegrationSubKindGitHub:
 		existingIntegration.SetGitHubIntegrationSpec(integration.GetGitHubIntegrationSpec())
-		if integration.GetCredentials() != nil {
-			if err := existingIntegration.SetCredentials(integration.GetCredentials()); err != nil {
+		if creds := integration.GetCredentials(); creds != nil {
+			if err := existingIntegration.SetCredentials(creds); err != nil {
 				return trace.Wrap(err)
 			}
 		}

--- a/tool/tctl/common/resources/integration_test.go
+++ b/tool/tctl/common/resources/integration_test.go
@@ -162,8 +162,7 @@ func TestGitHubIntegrationHandler(t *testing.T) {
 		require.NoError(t, err)
 		updated := collection.Resources()[0].(types.Integration)
 		require.Equal(t, "updated-org", updated.GetGitHubIntegrationSpec().Organization)
-		// TODO(greedy52) look for new-id once new credentials is passed to backend.
-		mustFindOAuthClientID(t, "github-test-org", "test-id")
+		mustFindOAuthClientID(t, "github-test-org", "new-id")
 	})
 
 	t.Run("CreateForce", func(t *testing.T) {

--- a/tool/tctl/common/resources/testdata/TestIntegrationCollection_WriteText.golden
+++ b/tool/tctl/common/resources/testdata/TestIntegrationCollection_WriteText.golden
@@ -1,4 +1,4 @@
 Name            Type     Spec                                           
 --------------- -------- ---------------------------------------------- 
 aws-integration aws-oidc RoleARN=arn:aws:iam::123456789012:role/OpsTeam 
-github-my-org   github                                                  
+github-my-org   github   Organization=my-org                            


### PR DESCRIPTION
Backport #68730 to branch/v18

changelog: added `tctl edit integration` support for updating GitHub integration OAuth credentials

## Manual Test Plan
### Test Environment

https://falling-sea.beams.run/

(tctl side only though so no deployment)

### Test Cases
- [x] tctl get integration --format text
- [x] update credentials via `tctl edit integration` (and verified via sqlite3 backend)