### PR TITLE
Deflake TestIntegrations/LeafSessionRecording

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1083,6 +1083,8 @@ func testLeafProxySessionRecording(t *testing.T, suite *integrationTestSuite) {
 				uploadChan = leaf.UploadEventsC
 			}
 
+			helpers.WaitForActiveTunnelConnections(t, root.Tunnel, leaf.Secrets.SiteName, 1)
+
 			tc, err := root.NewClient(helpers.ClientConfig{
 				Login:   suite.Me.Username,
 				Cluster: "leaf-test",
@@ -1104,15 +1106,15 @@ func testLeafProxySessionRecording(t *testing.T, suite *integrationTestSuite) {
 			tc.Stdout = term
 			tc.Stdin = term
 
-			go func() {
-				nodeClient, err := tc.ConnectToNode(
-					ctx,
-					clt,
-					client.NodeDetails{Addr: "leaf-zero:0", Cluster: clt.ClusterName()},
-					tc.Config.HostLogin,
-				)
-				assert.NoError(t, err)
+			nodeClient, err := tc.ConnectToNode(
+				ctx,
+				clt,
+				client.NodeDetails{Addr: "leaf-zero:0", Cluster: clt.ClusterName()},
+				tc.Config.HostLogin,
+			)
+			require.NoError(t, err)
 
+			go func() {
 				errCh <- nodeClient.RunInteractiveShell(ctx, "", "", nil)
 				assert.NoError(t, nodeClient.Close())
 			}()


### PR DESCRIPTION
The test did not wait for the leaf cluster to establish a reverse tunnel prior to attempting to use it.

Additionally, it used a non-fatal assertion that resulted in a nil pointer dereference when this scenario is hit.

```
   panic: runtime error: invalid memory address or nil pointer dereference
   [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x121a1940]

   goroutine 324197 [running]:
   github.com/gravitational/teleport/lib/client.(*NodeClient).RunInteractiveShell(0x0, {0x1aba0d08, 0xc00c90c820}, {0x191bedd4, 0x4}, {0x0, 0x0}, 0x0)
       /__w/teleport/teleport/lib/client/client.go:407 +0x120
   github.com/gravitational/teleport/integration.testLeafProxySessionRecording.func1.3()
       /__w/teleport/teleport/integration/integration_test.go:1126 +0x265
   created by github.com/gravitational/teleport/integration.testLeafProxySessionRecording.func1 in goroutine 315315
       /__w/teleport/teleport/integration/integration_test.go:1117 +0x99d
```