### PR TITLE
Disambiguating same-name kube clusters by scope

### DIFF
--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -963,7 +963,7 @@ Arguments:
 
 |Argument|Default|Description|
 |---|---|---|
-|kube-cluster|*no default* (optional)|Name of the Kubernetes cluster to login to. Check 'tsh kube ls' for a list of available clusters.|
+|kube-cluster|*no default* (optional)|Name of the Kubernetes cluster to login to. Check 'tsh kube ls' for a list of available clusters. Can be scope-qualified using the format /\<scope\>::\<cluster-name\>.|
 
 ## tsh kube ls
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -137,6 +137,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/terraformcloud"
 	"github.com/gravitational/teleport/lib/join/tpmjoin"
 	kubetoken "github.com/gravitational/teleport/lib/kube/token"
+	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/loginrule"
 	"github.com/gravitational/teleport/lib/modules"
@@ -3969,7 +3970,7 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 		}
 	}
 
-	// Ensure that the Kubernetes cluster name specified in the request exists
+	// Ensure that the Kubernetes cluster name (or SQN) specified in the request exists
 	// when the certificate is intended for a local Kubernetes cluster.
 	// If the certificate is targeting a trusted Teleport cluster, it is the
 	// responsibility of the cluster to ensure its existence.
@@ -3979,8 +3980,24 @@ func generateCert(ctx context.Context, a *Server, req cert.Request, caType types
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
+			if pinnedScope := scopePin.GetScope(); pinnedScope != "" {
+				if !scopes.ResourceScope(ks.GetCluster().GetScope()).IsSubjectToScopeOfEffect(pinnedScope) {
+					// Skip kube clusters that aren't subject to the pinned scope. This prevents discovering the
+					// names of unscoped or orthogonally scoped kube clusters by attempting to generate credentials
+					// for them.
+					continue
+				}
+			}
 
-			if ks.GetCluster().GetName() == req.KubernetesCluster {
+			clusterSQN := scopes.QualifiedName{Name: req.KubernetesCluster}
+			if scopes.MaybeSQN(req.KubernetesCluster) {
+				var err error
+				clusterSQN, err = scopes.ParseQualifiedName(req.KubernetesCluster)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+			}
+			if kubeutils.KubeClusterMatchesSQN(ks.GetCluster(), clusterSQN) {
 				found = true
 				break
 			}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1246,12 +1246,16 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 	ctx := context.Background()
 	srv := newTestTLSServer(t, withScopesFeatures(scopes.Features{Enabled: true}))
 
-	const kubeClusterName = "kube-cluster-1"
+	const (
+		kubeClusterName = "kube-cluster-1"
+		scope           = "/test"
+	)
 	kubeCluster, err := types.NewKubernetesClusterV3(
 		types.Metadata{
 			Name: kubeClusterName,
 		},
 		types.KubernetesClusterSpecV3{},
+		types.KubeClusterWithScope(scope),
 	)
 	require.NoError(t, err)
 
@@ -1268,6 +1272,7 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+	kubeServer.Scope = scope
 
 	_, err = srv.Auth().UpsertKubernetesServer(ctx, kubeServer)
 	require.NoError(t, err)
@@ -1305,7 +1310,6 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 		return strings.ReplaceAll(strings.Trim(scope, "/"), "/", "-")
 	}
 
-	scope := "/test"
 	roleResp, err := srv.Auth().ScopedAccess().CreateScopedRole(ctx, scopedaccessv1.CreateScopedRoleRequest_builder{
 		Role: scopedaccessv1.ScopedRole_builder{
 			Kind:    scopedaccess.KindScopedRole,
@@ -1415,7 +1419,7 @@ func TestGenerateUserCertsForHeadlessKube(t *testing.T) {
 				TLSPublicKey:      tlsPubKey,
 				Username:          tt.user.GetName(),
 				Expires:           srv.Auth().GetClock().Now().Add(defaultDuration),
-				KubernetesCluster: kubeClusterName,
+				KubernetesCluster: scopes.QualifiedName{Name: kubeClusterName, Scope: scope}.String(),
 				RequesterName:     proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_HEADLESS,
 				Usage:             proto.UserCertsRequest_Kubernetes,
 			})
@@ -14410,7 +14414,8 @@ func TestScopedUserCertGeneration(t *testing.T) {
 	client, err := srv.NewClient(ident)
 	require.NoError(t, err)
 
-	createKubeServer(t, srv.Auth(), []string{"kube-cluster"}, "kube-host", scope)
+	createKubeServer(t, srv.Auth(), []string{"kube-cluster"}, "scoped-kube-host", scope)
+	createKubeServer(t, srv.Auth(), []string{"kube-cluster"}, "unscoped-kube-host", "")
 
 	scopedApp, err := types.NewAppV3(types.Metadata{
 		Name:   "test-app",
@@ -14425,6 +14430,7 @@ func TestScopedUserCertGeneration(t *testing.T) {
 	_, err = srv.Auth().UpsertApplicationServer(ctx, scopedAppServer)
 	require.NoError(t, err)
 
+	clusterSQN := scopes.QualifiedName{Scope: scope, Name: "kube-cluster"}
 	tts := []struct {
 		name       string
 		req        proto.UserCertsRequest
@@ -14432,7 +14438,18 @@ func TestScopedUserCertGeneration(t *testing.T) {
 		assertCert func(t *testing.T, cert *x509.Certificate)
 	}{
 		{
-			name: "valid request",
+			name: "valid scoped request",
+			req: proto.UserCertsRequest{
+				SSHPublicKey:      sshPubKey,
+				TLSPublicKey:      tlsPubKey,
+				Username:          username,
+				Usage:             proto.UserCertsRequest_Kubernetes,
+				KubernetesCluster: clusterSQN.String(),
+				Expires:           time.Now().Add(time.Hour),
+			},
+		},
+		{
+			name: "valid unscoped request",
 			req: proto.UserCertsRequest{
 				SSHPublicKey:      sshPubKey,
 				TLSPublicKey:      tlsPubKey,
@@ -14440,6 +14457,13 @@ func TestScopedUserCertGeneration(t *testing.T) {
 				Usage:             proto.UserCertsRequest_Kubernetes,
 				KubernetesCluster: "kube-cluster",
 				Expires:           time.Now().Add(time.Hour),
+			},
+			assertErr: func(t *testing.T, err error) {
+				// a scoped identity should not be able to request a cert for an unscoped
+				// kube cluster
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err))
+				require.ErrorContains(t, err, "is not registered")
 			},
 		},
 		{
@@ -14450,7 +14474,7 @@ func TestScopedUserCertGeneration(t *testing.T) {
 				Username:          username,
 				Usage:             proto.UserCertsRequest_Kubernetes,
 				RequesterName:     proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY,
-				KubernetesCluster: "kube-cluster",
+				KubernetesCluster: clusterSQN.String(),
 				Expires:           time.Now().Add(time.Hour * 24 * 7),
 			},
 			assertCert: func(t *testing.T, cert *x509.Certificate) {

--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -407,7 +407,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	for _, cluster := range cfg.Clusters {
 		select {
 		case sender := <-inventoryHandle.Sender():
-			server, err := testCtx.KubeServer.GetServerInfo(cluster.Name)
+			server, err := testCtx.KubeServer.GetServerInfo(scopes.QualifiedName{Name: cluster.Name})
 			require.NoError(t, err)
 			require.NoError(t, sender.Send(ctx, proto.InventoryHeartbeat_builder{
 				KubernetesServer: server,

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -34,7 +34,6 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
-
 	// Load kubeconfig auth plugins for gcp and azure.
 	// Without this, users can't provide a kubeconfig using those.
 	//

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -34,6 +34,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
+
 	// Load kubeconfig auth plugins for gcp and azure.
 	// Without this, users can't provide a kubeconfig using those.
 	//
@@ -46,6 +47,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -144,6 +146,10 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			continue
 		}
 
+		sqn := scopes.QualifiedName{
+			Name:  kubeCluster.GetName(),
+			Scope: kubeCluster.GetScope(),
+		}
 		details, err := newClusterDetails(ctx,
 			clusterDetailsConfig{
 				cluster:   kubeCluster,
@@ -160,7 +166,7 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			)
 			return trace.Wrap(err)
 		}
-		f.clusterDetails[cluster] = details
+		f.clusterDetails[sqn] = details
 	}
 	return nil
 }

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -168,7 +169,7 @@ current-context: foo
 		kubeCluster        string
 		serviceType        KubeServiceType
 		impersonationCheck servicecfg.ImpersonationPermissionsChecker
-		want               map[string]*kubeDetails
+		want               map[scopes.QualifiedName]*kubeDetails
 		assertErr          require.ErrorAssertionFunc
 	}{
 		{
@@ -176,26 +177,26 @@ current-context: foo
 			serviceType:        KubeService,
 			impersonationCheck: alwaysSucceeds,
 			assertErr:          require.Error,
-			want:               map[string]*kubeDetails{},
+			want:               map[scopes.QualifiedName]*kubeDetails{},
 		}, {
 			desc:               "proxy_service, no kube creds",
 			serviceType:        ProxyService,
 			impersonationCheck: alwaysSucceeds,
 			assertErr:          require.NoError,
-			want:               map[string]*kubeDetails{},
+			want:               map[scopes.QualifiedName]*kubeDetails{},
 		}, {
 			desc:               "legacy proxy_service, no kube creds",
 			serviceType:        ProxyService,
 			impersonationCheck: alwaysSucceeds,
 			assertErr:          require.NoError,
-			want:               map[string]*kubeDetails{},
+			want:               map[scopes.QualifiedName]*kubeDetails{},
 		}, {
 			desc:               "kubernetes_service, with kube creds",
 			serviceType:        KubeService,
 			kubeconfigPath:     kubeconfigPath,
 			impersonationCheck: alwaysSucceeds,
-			want: map[string]*kubeDetails{
-				"foo": {
+			want: map[scopes.QualifiedName]*kubeDetails{
+				scopes.QualifiedName{Name: "foo"}: {
 					kubeCreds: &staticKubeCreds{
 						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
@@ -209,7 +210,7 @@ current-context: foo
 						GitVersion: "1.20.0",
 					},
 				},
-				"bar": {
+				scopes.QualifiedName{Name: "bar"}: {
 					kubeCreds: &staticKubeCreds{
 						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
@@ -223,7 +224,7 @@ current-context: foo
 					},
 					kubeCluster: mustCreateKubernetesClusterV3(t, "bar"),
 				},
-				"baz": {
+				scopes.QualifiedName{Name: "baz"}: {
 					kubeCreds: &staticKubeCreds{
 						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
@@ -244,15 +245,15 @@ current-context: foo
 			kubeconfigPath:     kubeconfigPath,
 			serviceType:        ProxyService,
 			impersonationCheck: alwaysSucceeds,
-			want:               map[string]*kubeDetails{},
+			want:               map[scopes.QualifiedName]*kubeDetails{},
 			assertErr:          require.NoError,
 		}, {
 			desc:               "legacy proxy_service, with kube creds",
 			kubeconfigPath:     kubeconfigPath,
 			serviceType:        LegacyProxyService,
 			impersonationCheck: alwaysSucceeds,
-			want: map[string]*kubeDetails{
-				teleClusterName: {
+			want: map[scopes.QualifiedName]*kubeDetails{
+				scopes.QualifiedName{Name: teleClusterName}: {
 					kubeCreds: &staticKubeCreds{
 						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
@@ -273,8 +274,8 @@ current-context: foo
 			kubeconfigPath:     kubeconfigPath,
 			serviceType:        KubeService,
 			impersonationCheck: failsForCluster("bar"),
-			want: map[string]*kubeDetails{
-				"foo": {
+			want: map[scopes.QualifiedName]*kubeDetails{
+				scopes.QualifiedName{Name: "foo"}: {
 					kubeCreds: &staticKubeCreds{
 						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
@@ -288,7 +289,7 @@ current-context: foo
 					},
 					kubeCluster: mustCreateKubernetesClusterV3(t, "foo"),
 				},
-				"bar": {
+				scopes.QualifiedName{Name: "bar"}: {
 					kubeCreds: &staticKubeCreds{
 						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
@@ -302,7 +303,7 @@ current-context: foo
 					},
 					kubeCluster: mustCreateKubernetesClusterV3(t, "bar"),
 				},
-				"baz": {
+				scopes.QualifiedName{Name: "baz"}: {
 					kubeCreds: &staticKubeCreds{
 						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
@@ -324,7 +325,7 @@ current-context: foo
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 			fwd := &Forwarder{
-				clusterDetails: map[string]*kubeDetails{},
+				clusterDetails: map[scopes.QualifiedName]*kubeDetails{},
 				cfg: ForwarderConfig{
 					ClusterName:                   teleClusterName,
 					KubeServiceType:               tt.serviceType,

--- a/lib/kube/proxy/ephemeral_admin_client_test.go
+++ b/lib/kube/proxy/ephemeral_admin_client_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/set"
 )
@@ -48,12 +49,11 @@ import (
 // mapped kubernetes_users / kubernetes_groups rather than the proxy's admin kubeconfig.
 func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 	const (
-		clusterName = "test-cluster"
-		ns          = "default"
-		podName     = "test-app"
-		kubeUser    = "alice-k8s"
+		ns       = "default"
+		podName  = "test-app"
+		kubeUser = "alice-k8s"
 	)
-
+	clusterSQN := scopes.QualifiedName{Name: "test-cluster"}
 	var (
 		mu                  sync.Mutex
 		capturedImpersonate string
@@ -92,8 +92,8 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 		cfg: ForwarderConfig{
 			tracer: otel.Tracer("test"),
 		},
-		clusterDetails: map[string]*kubeDetails{
-			clusterName: {
+		clusterDetails: map[scopes.QualifiedName]*kubeDetails{
+			clusterSQN: {
 				kubeCreds: &staticKubeCreds{
 					kubeClient:    adminClient,
 					clientRestCfg: adminRestCfg,
@@ -108,10 +108,10 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 	// One kubernetes_users entry so computeAndValidateImpersonatedPrincipals
 	// picks it deterministically without consulting request headers.
 	authCtx := &authContext{
-		ScopedContext:   &authz.ScopedContext{User: teleportUser},
-		kubeClusterName: clusterName,
-		kubeUsers:       set.New(kubeUser),
-		kubeGroups:      set.New[string](),
+		ScopedContext:  &authz.ScopedContext{User: teleportUser},
+		kubeClusterSQN: clusterSQN,
+		kubeUsers:      set.New(kubeUser),
+		kubeGroups:     set.New[string](),
 	}
 
 	_, err = fwd.getPodForEphemeralPatch(
@@ -138,13 +138,13 @@ func TestGetPodForEphemeralPatch_UsesImpersonatedIdentity(t *testing.T) {
 // the synthetic Modified event after moderator approval, rather than hanging.
 func TestGetPatchedPodEvent_ReplaysStoredImpersonation(t *testing.T) {
 	const (
-		clusterName  = "test-cluster"
 		ns           = "default"
 		podName      = "test-app"
 		chosenUser   = "alice-k8s-b"
 		alternateUsr = "alice-k8s-a"
 		chosenGroup  = "system:authenticated"
 	)
+	clusterSQN := scopes.QualifiedName{Name: "test-cluster"}
 
 	var (
 		mu             sync.Mutex
@@ -178,8 +178,8 @@ func TestGetPatchedPodEvent_ReplaysStoredImpersonation(t *testing.T) {
 	fwd := &Forwarder{
 		log: logtest.NewLogger(),
 		cfg: ForwarderConfig{tracer: otel.Tracer("test")},
-		clusterDetails: map[string]*kubeDetails{
-			clusterName: {
+		clusterDetails: map[scopes.QualifiedName]*kubeDetails{
+			clusterSQN: {
 				kubeCreds: &staticKubeCreds{
 					kubeClient:    adminClient,
 					clientRestCfg: adminRestCfg,
@@ -195,10 +195,10 @@ func TestGetPatchedPodEvent_ReplaysStoredImpersonation(t *testing.T) {
 	// computeAndValidateImpersonatedPrincipals would refuse to pick.
 	sess := &clusterSession{
 		authContext: authContext{
-			ScopedContext:   &authz.ScopedContext{User: teleportUser},
-			kubeClusterName: clusterName,
-			kubeUsers:       set.New(chosenUser, alternateUsr),
-			kubeGroups:      set.New(chosenGroup),
+			ScopedContext:  &authz.ScopedContext{User: teleportUser},
+			kubeClusterSQN: clusterSQN,
+			kubeUsers:      set.New(chosenUser, alternateUsr),
+			kubeGroups:     set.New(chosenGroup),
 		},
 		codecFactory: &globalKubeCodecs,
 	}
@@ -208,7 +208,7 @@ func TestGetPatchedPodEvent_ReplaysStoredImpersonation(t *testing.T) {
 		"debug",
 		kubewaitingcontainerpb.KubernetesWaitingContainerSpec_builder{
 			Username:         "alice",
-			Cluster:          clusterName,
+			Cluster:          clusterSQN.String(),
 			Namespace:        ns,
 			PodName:          podName,
 			ContainerName:    "debug",

--- a/lib/kube/proxy/ephemeral_containers.go
+++ b/lib/kube/proxy/ephemeral_containers.go
@@ -266,7 +266,7 @@ func (f *Forwarder) createWaitingContainer(ctx context.Context, ephemeralContNam
 		ephemeralContName,
 		kubewaitingcontainerpb.KubernetesWaitingContainerSpec_builder{
 			Username:         authCtx.User.GetName(),
-			Cluster:          authCtx.kubeClusterName,
+			Cluster:          authCtx.kubeClusterSQN.String(),
 			Namespace:        authCtx.metaResource.requestedResource.namespace,
 			PodName:          authCtx.metaResource.requestedResource.resourceName,
 			ContainerName:    ephemeralContName,
@@ -286,9 +286,9 @@ func (f *Forwarder) createWaitingContainer(ctx context.Context, ephemeralContNam
 // impersonatedKubeClient returns a Kubernetes client that is impersonating
 // the identity in the provided authCtx.
 func (f *Forwarder) impersonatedKubeClient(authCtx *authContext, headers http.Header) (*kubernetes.Clientset, *kubeDetails, error) {
-	details, err := f.findKubeDetailsByClusterName(authCtx.kubeClusterName)
+	details, err := f.findKubeDetailsByClusterName(authCtx.kubeClusterSQN)
 	if err != nil {
-		return nil, nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
+		return nil, nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterSQN)
 	}
 	kubeUser, kubeGroups, err := computeAndValidateImpersonatedPrincipals(authCtx.kubeUsers, authCtx.kubeGroups, authCtx.User.GetName(), headers)
 	if err != nil {

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/scopes"
-	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 var (
@@ -93,97 +92,26 @@ func wildcardLabel() []*labelv1.Label {
 	}
 }
 
-func testExecKubeService(t *testing.T, testCtx *TestContext, scope string) {
-	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-	userWithSingleKubeUser, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		username,
-		RoleSpec{
-			Name:       roleName,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-		})
-
-	clusterSQN := scopes.QualifiedName{
-		Name:  kubeCluster,
-		Scope: testCtx.Scope,
-	}
+func testExecKubeService(t *testing.T, testCtx *TestContext) {
+	scope := testCtx.Scope
+	clusterSQN := scopes.QualifiedName{Name: kubeCluster, Scope: scope}
 	// generate a kube client with user certs for auth
 	_, configWithSingleKubeUser := testCtx.GenTestKubeClientTLSCert(
 		t,
-		userWithSingleKubeUser.GetName(),
+		username,
 		clusterSQN,
+		makeScopedOpts(t, testCtx, username, scope)...,
 	)
 	require.NotNil(t, configWithSingleKubeUser)
-
-	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-	userMultiKubeUsers, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		usernameMultiUsers,
-		RoleSpec{
-			Name:       roleNameMultiUsers,
-			KubeUsers:  append(slices.Clone(roleKubeUsers), "admin"),
-			KubeGroups: roleKubeGroups,
-		})
 
 	// generate a kube client with user certs for auth
 	_, configMultiKubeUsers := testCtx.GenTestKubeClientTLSCert(
 		t,
-		userMultiKubeUsers.GetName(),
+		usernameMultiUsers,
 		clusterSQN,
+		makeScopedOpts(t, testCtx, usernameMultiUsers, scope)...,
 	)
 	require.NotNil(t, configMultiKubeUsers)
-
-	if testCtx.Scope != "" {
-		scopedWithSingleKubeUser, scopedSingleKubeUserRole := testCtx.CreateUserAndScopedRole(
-			t,
-			"scoped-"+username,
-			scopedTestScope,
-			accessv1.ScopedRoleSpec_builder{
-				AssignableScopes: []string{scopedTestScope},
-				Kube: accessv1.ScopedRoleKube_builder{
-					Users:     roleKubeUsers,
-					Groups:    roleKubeGroups,
-					Resources: wildcardResource(),
-					Labels:    wildcardLabel(),
-				}.Build(),
-			}.Build())
-
-		scopedMultiKubeUsers, scopedMultiKubeUserRole := testCtx.CreateUserAndScopedRole(
-			t,
-			"scoped-"+usernameMultiUsers,
-			scopedTestScope,
-			accessv1.ScopedRoleSpec_builder{
-				AssignableScopes: []string{scopedTestScope},
-				Kube: accessv1.ScopedRoleKube_builder{
-					Users:     append(slices.Clone(roleKubeUsers), "admin"),
-					Groups:    roleKubeGroups,
-					Resources: wildcardResource(),
-					Labels:    wildcardLabel(),
-				}.Build(),
-			}.Build(),
-		)
-		waitForSRACache(t, testCtx.TLSServer, scopedSingleKubeUserRole, scopedMultiKubeUserRole)
-
-		_, configWithSingleKubeUser = testCtx.GenTestKubeClientTLSCert(
-			t,
-			scopedWithSingleKubeUser.GetName(),
-			clusterSQN,
-			func(i *tlsca.Identity) {
-				i.ScopePin = testCtx.GetScopePinForUser(t, scopedWithSingleKubeUser.GetName(), scopedTestScope)
-			},
-		)
-		_, configMultiKubeUsers = testCtx.GenTestKubeClientTLSCert(
-			t,
-			scopedMultiKubeUsers.GetName(),
-			clusterSQN,
-			func(i *tlsca.Identity) {
-				i.ScopePin = testCtx.GetScopePinForUser(t, scopedMultiKubeUsers.GetName(), scopedTestScope)
-			},
-		)
-	}
 
 	type args struct {
 		executorBuilder func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
@@ -320,30 +248,79 @@ func testExecKubeService(t *testing.T, testCtx *TestContext, scope string) {
 		})
 	}
 }
-
 func TestExecKubeService(t *testing.T) {
 	t.Parallel()
 	kubeMock, err := testingkubemock.NewKubeAPIMock()
 	require.NoError(t, err)
 	t.Cleanup(func() { kubeMock.Close() })
-	for _, scope := range []string{"", scopedTestScope} {
+	unscopedTestCtx := SetupTestContext(t.Context(), t, TestConfig{
+		Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
+	scopedTestCtx := CloneTestContext(t, unscopedTestCtx, scopedTestScope)
+	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+	_, _ = unscopedTestCtx.CreateUserAndRole(
+		t.Context(),
+		t,
+		username,
+		RoleSpec{
+			Name:       roleName,
+			KubeUsers:  roleKubeUsers,
+			KubeGroups: roleKubeGroups,
+		})
+
+	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+	_, _ = unscopedTestCtx.CreateUserAndRole(
+		t.Context(),
+		t,
+		usernameMultiUsers,
+		RoleSpec{
+			Name:       roleNameMultiUsers,
+			KubeUsers:  append(slices.Clone(roleKubeUsers), "admin"),
+			KubeGroups: roleKubeGroups,
+		})
+
+	scopedSingleKubeUserAssn := scopedTestCtx.CreateAndAssignScopedRole(
+		t,
+		username,
+		scopedTestScope,
+		accessv1.ScopedRoleSpec_builder{
+			AssignableScopes: []string{scopedTestScope},
+			Kube: accessv1.ScopedRoleKube_builder{
+				Users:     roleKubeUsers,
+				Groups:    roleKubeGroups,
+				Resources: wildcardResource(),
+				Labels:    wildcardLabel(),
+			}.Build(),
+		}.Build())
+
+	scopedMultiKubeUserAssn := scopedTestCtx.CreateAndAssignScopedRole(
+		t,
+		usernameMultiUsers,
+		scopedTestScope,
+		accessv1.ScopedRoleSpec_builder{
+			AssignableScopes: []string{scopedTestScope},
+			Kube: accessv1.ScopedRoleKube_builder{
+				Users:     append(slices.Clone(roleKubeUsers), "admin"),
+				Groups:    roleKubeGroups,
+				Resources: wildcardResource(),
+				Labels:    wildcardLabel(),
+			}.Build(),
+		}.Build(),
+	)
+	waitForSRACache(t, scopedTestCtx.TLSServer, scopedSingleKubeUserAssn, scopedMultiKubeUserAssn)
+
+	for _, testCtx := range []*TestContext{unscopedTestCtx, scopedTestCtx} {
 		name := "unscoped"
-		if scope != "" {
+		if testCtx.Scope != "" {
 			name = "scoped"
 		}
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			// creates a Kubernetes service with a configured cluster pointing to mock api server
-			testCtx := SetupTestContext(t.Context(), t, TestConfig{
-				Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-				Scope:    scope,
-				ScopesFeatures: scopes.Features{
-					Enabled:         true,
-					AgentPinEnabled: true,
-				},
-			})
-			t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
-			testExecKubeService(t, testCtx, scope)
+			testExecKubeService(t, testCtx)
 		})
 	}
 }
@@ -455,13 +432,33 @@ func TestExecKubeServiceWithFaultyPrimary(t *testing.T) {
 			failingAccessPoint.ClientI = client
 			return failingAccessPoint
 		},
-		Scope: scopedTestScope,
 		ScopesFeatures: scopes.Features{
 			Enabled:         true,
 			AgentPinEnabled: true,
 		},
 	})
 	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+	_, _ = testCtx.CreateUserAndRole(
+		t.Context(),
+		t,
+		username,
+		RoleSpec{
+			Name:       roleName,
+			KubeUsers:  roleKubeUsers,
+			KubeGroups: roleKubeGroups,
+		})
+
+	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+	_, _ = testCtx.CreateUserAndRole(
+		t.Context(),
+		t,
+		usernameMultiUsers,
+		RoleSpec{
+			Name:       roleNameMultiUsers,
+			KubeUsers:  append(slices.Clone(roleKubeUsers), "admin"),
+			KubeGroups: roleKubeGroups,
+		})
 
 	triggerFailure(errors.New("injected failure"))
 
@@ -470,7 +467,7 @@ func TestExecKubeServiceWithFaultyPrimary(t *testing.T) {
 		require.Greater(c, failingAccessPoint.newWatcherFails.Load(), int32(1))
 	}, time.Minute, time.Second)
 
-	testExecKubeService(t, testCtx, scopedTestScope)
+	testExecKubeService(t, testCtx)
 }
 
 type generateExecRequestConfig struct {
@@ -573,58 +570,56 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		for _, scope := range []string{"", scopedTestScope} {
-			t.Run(tt.name, func(t *testing.T) {
-				t.Parallel()
-				const errorCode = http.StatusForbidden
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const errorCode = http.StatusForbidden
 
-				kubeMock, err := testingkubemock.NewKubeAPIMock(
-					testingkubemock.WithExecError(
-						metav1.Status{
-							Status:  metav1.StatusFailure,
-							Message: tt.errorMessage,
-							Reason:  metav1.StatusReasonForbidden,
-							Code:    errorCode,
-						},
-					),
-				)
-				require.NoError(t, err)
-				t.Cleanup(func() { kubeMock.Close() })
-				var (
-					execEvent  *apievents.Exec
-					eventsLock sync.Mutex
-				)
-
-				// creates a Kubernetes service with a configured cluster pointing to mock api server
-				testCtx := SetupTestContext(
-					t.Context(),
-					t,
-					TestConfig{
-						Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-						OnEvent: func(evt apievents.AuditEvent) {
-							eventsLock.Lock()
-							defer eventsLock.Unlock()
-							if exec, ok := evt.(*apievents.Exec); ok {
-								execEvent = exec
-							}
-						},
-						Scope: scope,
-						ScopesFeatures: scopes.Features{
-							Enabled:         true,
-							AgentPinEnabled: true,
-						},
+			kubeMock, err := testingkubemock.NewKubeAPIMock(
+				testingkubemock.WithExecError(
+					metav1.Status{
+						Status:  metav1.StatusFailure,
+						Message: tt.errorMessage,
+						Reason:  metav1.StatusReasonForbidden,
+						Code:    errorCode,
 					},
-				)
-				t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+				),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { kubeMock.Close() })
+			var (
+				execEvent  *apievents.Exec
+				eventsLock sync.Mutex
+			)
+
+			unscopedTestCtx := SetupTestContext(t.Context(), t, TestConfig{
+				Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+				OnEvent: func(evt apievents.AuditEvent) {
+					eventsLock.Lock()
+					defer eventsLock.Unlock()
+					if exec, ok := evt.(*apievents.Exec); ok {
+						execEvent = exec
+					}
+				},
+				ScopesFeatures: scopes.Features{Enabled: true, AgentPinEnabled: true},
+			})
+			scopedTestCtx := CloneTestContext(t, unscopedTestCtx, scopedTestScope)
+
+			for _, testCtx := range []*TestContext{unscopedTestCtx, scopedTestCtx} {
+				scope := testCtx.Scope
+				namePrefix := "unscoped"
+				if scope != "" {
+					namePrefix = "scoped"
+				}
 
 				clusterSQN := scopes.QualifiedName{Name: kubeCluster, Scope: scope}
 				// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
 				user, _ := testCtx.CreateUserAndRole(
 					testCtx.Context,
 					t,
-					username,
+					namePrefix+"-"+username,
 					RoleSpec{
-						Name:       roleName,
+						Name:       namePrefix + "-" + roleName,
 						KubeUsers:  roleKubeUsers,
 						KubeGroups: roleKubeGroups,
 					})
@@ -632,7 +627,7 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 				if scope != "" {
 					scopedAssignment := testCtx.CreateAndAssignScopedRole(
 						t,
-						username,
+						user.GetName(),
 						scope,
 						accessv1.ScopedRoleSpec_builder{
 							AssignableScopes: []string{scope},
@@ -700,8 +695,8 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 				require.Equal(t, "403", execEvent.ExitCode)
 				require.NotEmpty(t, execEvent.Error)
 				eventsLock.Unlock()
-			})
-		}
+			}
+		})
 	}
 }
 
@@ -754,65 +749,56 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 		eventsLock sync.Mutex
 	)
 
-	for _, scope := range []string{"", scopedTestScope} {
-		// for _, scope := range []string{scopedTestScope} {
-		// creates a Kubernetes service with a configured cluster pointing to mock api server
-		testCtx := SetupTestContext(
-			t.Context(),
-			t,
-			TestConfig{
-				Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-				OnEvent: func(evt apievents.AuditEvent) {
-					eventsLock.Lock()
-					defer eventsLock.Unlock()
-					if exec, ok := evt.(*apievents.Exec); ok {
-						execEvent = exec
-					}
-				},
-				Scope: scope,
-				ScopesFeatures: scopes.Features{
-					Enabled:         true,
-					AgentPinEnabled: true,
-				},
-			},
-		)
+	unscopedTestCtx := SetupTestContext(t.Context(), t, TestConfig{
+		Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+		OnEvent: func(evt apievents.AuditEvent) {
+			eventsLock.Lock()
+			defer eventsLock.Unlock()
+			if exec, ok := evt.(*apievents.Exec); ok {
+				execEvent = exec
+			}
+		},
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
+	scopedTestCtx := CloneTestContext(t, unscopedTestCtx, scopedTestScope)
 
-		t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+	// Create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified).
+	// The scoped cases will reuse the same user, so we can generate it once outside of the test loop
+	user, _ := unscopedTestCtx.CreateUserAndRole(
+		t.Context(),
+		t,
+		username,
+		RoleSpec{
+			Name:       roleName,
+			KubeUsers:  roleKubeUsers,
+			KubeGroups: roleKubeGroups,
+		})
 
-		// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-		user, _ := testCtx.CreateUserAndRole(
-			testCtx.Context,
-			t,
-			username,
-			RoleSpec{
-				Name:       roleName,
-				KubeUsers:  roleKubeUsers,
-				KubeGroups: roleKubeGroups,
-			})
+	scopedAssignment := scopedTestCtx.CreateAndAssignScopedRole(
+		t,
+		username,
+		scopedTestCtx.Scope,
+		accessv1.ScopedRoleSpec_builder{
+			AssignableScopes: []string{scopedTestCtx.Scope},
+			Kube: accessv1.ScopedRoleKube_builder{
+				Users:     roleKubeUsers,
+				Groups:    roleKubeGroups,
+				Resources: wildcardResource(),
+				Labels:    wildcardLabel(),
+			}.Build(),
+		}.Build())
+	waitForSRACache(t, scopedTestCtx.TLSServer, scopedAssignment)
 
-		if scope != "" {
-			scopedAssignment := testCtx.CreateAndAssignScopedRole(
-				t,
-				username,
-				scope,
-				accessv1.ScopedRoleSpec_builder{
-					AssignableScopes: []string{scope},
-					Kube: accessv1.ScopedRoleKube_builder{
-						Users:     roleKubeUsers,
-						Groups:    roleKubeGroups,
-						Resources: wildcardResource(),
-						Labels:    wildcardLabel(),
-					}.Build(),
-				}.Build())
-			waitForSRACache(t, testCtx.TLSServer, scopedAssignment)
-		}
-
+	for _, testCtx := range []*TestContext{unscopedTestCtx, scopedTestCtx} {
 		// generate a kube client with user certs for auth
 		_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
 			t,
 			user.GetName(),
 			scopes.QualifiedName{Name: kubeCluster, Scope: testCtx.Scope},
-			makeScopedOpts(t, testCtx, username, scope)...,
+			makeScopedOpts(t, testCtx, user.GetName(), testCtx.Scope)...,
 		)
 
 		tests := []struct {

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -93,7 +93,7 @@ func wildcardLabel() []*labelv1.Label {
 	}
 }
 
-func testExecKubeService(t *testing.T, testCtx *TestContext) {
+func testExecKubeService(t *testing.T, testCtx *TestContext, scope string) {
 	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
 	userWithSingleKubeUser, _ := testCtx.CreateUserAndRole(
 		testCtx.Context,
@@ -105,11 +105,15 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			KubeGroups: roleKubeGroups,
 		})
 
+	clusterSQN := scopes.QualifiedName{
+		Name:  kubeCluster,
+		Scope: testCtx.Scope,
+	}
 	// generate a kube client with user certs for auth
 	_, configWithSingleKubeUser := testCtx.GenTestKubeClientTLSCert(
 		t,
 		userWithSingleKubeUser.GetName(),
-		kubeCluster,
+		clusterSQN,
 	)
 	require.NotNil(t, configWithSingleKubeUser)
 
@@ -128,56 +132,59 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 	_, configMultiKubeUsers := testCtx.GenTestKubeClientTLSCert(
 		t,
 		userMultiKubeUsers.GetName(),
-		kubeCluster,
+		clusterSQN,
 	)
 	require.NotNil(t, configMultiKubeUsers)
 
-	scopedWithSingleKubeUser, scopedSingleKubeUserRole := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+username,
-		scopedTestScope,
-		accessv1.ScopedRoleSpec_builder{
-			AssignableScopes: []string{scopedTestScope},
-			Kube: accessv1.ScopedRoleKube_builder{
-				Users:     roleKubeUsers,
-				Groups:    roleKubeGroups,
-				Resources: wildcardResource(),
-				Labels:    wildcardLabel(),
-			}.Build(),
-		}.Build())
+	if testCtx.Scope != "" {
+		scopedWithSingleKubeUser, scopedSingleKubeUserRole := testCtx.CreateUserAndScopedRole(
+			t,
+			"scoped-"+username,
+			scopedTestScope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scopedTestScope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Resources: wildcardResource(),
+					Labels:    wildcardLabel(),
+				}.Build(),
+			}.Build())
 
-	scopedMultiKubeUsers, scopedMultiKubeUserRole := testCtx.CreateUserAndScopedRole(
-		t,
-		"scoped-"+usernameMultiUsers,
-		scopedTestScope,
-		accessv1.ScopedRoleSpec_builder{
-			AssignableScopes: []string{scopedTestScope},
-			Kube: accessv1.ScopedRoleKube_builder{
-				Users:     append(slices.Clone(roleKubeUsers), "admin"),
-				Groups:    roleKubeGroups,
-				Resources: wildcardResource(),
-				Labels:    wildcardLabel(),
+		scopedMultiKubeUsers, scopedMultiKubeUserRole := testCtx.CreateUserAndScopedRole(
+			t,
+			"scoped-"+usernameMultiUsers,
+			scopedTestScope,
+			accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{scopedTestScope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     append(slices.Clone(roleKubeUsers), "admin"),
+					Groups:    roleKubeGroups,
+					Resources: wildcardResource(),
+					Labels:    wildcardLabel(),
+				}.Build(),
 			}.Build(),
-		}.Build(),
-	)
-	waitForSRACache(t, testCtx.TLSServer, scopedSingleKubeUserRole, scopedMultiKubeUserRole)
+		)
+		waitForSRACache(t, testCtx.TLSServer, scopedSingleKubeUserRole, scopedMultiKubeUserRole)
 
-	_, scopedConfigWithSingleKubeUser := testCtx.GenTestKubeClientTLSCert(
-		t,
-		scopedWithSingleKubeUser.GetName(),
-		kubeCluster,
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedWithSingleKubeUser.GetName(), scopedTestScope)
-		},
-	)
-	_, scopedConfigMultiKubeUsers := testCtx.GenTestKubeClientTLSCert(
-		t,
-		scopedMultiKubeUsers.GetName(),
-		kubeCluster,
-		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, scopedMultiKubeUsers.GetName(), scopedTestScope)
-		},
-	)
+		_, configWithSingleKubeUser = testCtx.GenTestKubeClientTLSCert(
+			t,
+			scopedWithSingleKubeUser.GetName(),
+			clusterSQN,
+			func(i *tlsca.Identity) {
+				i.ScopePin = testCtx.GetScopePinForUser(t, scopedWithSingleKubeUser.GetName(), scopedTestScope)
+			},
+		)
+		_, configMultiKubeUsers = testCtx.GenTestKubeClientTLSCert(
+			t,
+			scopedMultiKubeUsers.GetName(),
+			clusterSQN,
+			func(i *tlsca.Identity) {
+				i.ScopePin = testCtx.GetScopePinForUser(t, scopedMultiKubeUsers.GetName(), scopedTestScope)
+			},
+		)
+	}
+
 	type args struct {
 		executorBuilder func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
 		impersonateUser string
@@ -196,13 +203,6 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			},
 		},
 		{
-			name: "SPDY protocol - scoped",
-			args: args{
-				executorBuilder: remotecommand.NewSPDYExecutor,
-				config:          scopedConfigWithSingleKubeUser,
-			},
-		},
-		{
 			name: "Websocket protocol v4",
 			args: args{
 				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
@@ -215,18 +215,6 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			},
 		},
 		{
-			name: "Websocket protocol v4 - scoped",
-			args: args{
-				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
-				// is merged into k8s go-client.
-				// For now go-client does not support connections over websockets.
-				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
-					return newWebSocketClient(c, s, u)
-				},
-				config: scopedConfigWithSingleKubeUser,
-			},
-		},
-		{
 			name: "Websocket protocol v5",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
@@ -236,27 +224,10 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			},
 		},
 		{
-			name: "Websocket protocol v5 - scoped",
-			args: args{
-				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
-					return remotecommand.NewWebSocketExecutor(c, s, u.String())
-				},
-				config: scopedConfigWithSingleKubeUser,
-			},
-		},
-		{
 			name: "SPDY protocol for user with multiple kubernetes users",
 			args: args{
 				executorBuilder: remotecommand.NewSPDYExecutor,
 				config:          configMultiKubeUsers,
-				impersonateUser: "admin",
-			},
-		},
-		{
-			name: "SPDY protocol for user with multiple kubernetes users - scoped",
-			args: args{
-				executorBuilder: remotecommand.NewSPDYExecutor,
-				config:          scopedConfigMultiKubeUsers,
 				impersonateUser: "admin",
 			},
 		},
@@ -274,35 +245,12 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			},
 		},
 		{
-			name: "Websocket protocol v4 for user with multiple kubernetes users - scoped",
-			args: args{
-				// We can delete the dummy client once https://github.com/kubernetes/kubernetes/pull/110142
-				// is merged into k8s go-client.
-				// For now go-client does not support connections over websockets.
-				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
-					return newWebSocketClient(c, s, u)
-				},
-				config:          scopedConfigMultiKubeUsers,
-				impersonateUser: "admin",
-			},
-		},
-		{
 			name: "Websocket protocol v5 for user with multiple kubernetes users",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return remotecommand.NewWebSocketExecutor(c, s, u.String())
 				},
 				config:          configMultiKubeUsers,
-				impersonateUser: "admin",
-			},
-		},
-		{
-			name: "Websocket protocol v5 for user with multiple kubernetes users - scoped",
-			args: args{
-				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
-					return remotecommand.NewWebSocketExecutor(c, s, u.String())
-				},
-				config:          scopedConfigMultiKubeUsers,
 				impersonateUser: "admin",
 			},
 		},
@@ -315,30 +263,12 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 			wantErr: true,
 		},
 		{
-			name: "SPDY protocol for user with multiple kubernetes users without specifying impersonate user - scoped",
-			args: args{
-				executorBuilder: remotecommand.NewSPDYExecutor,
-				config:          scopedConfigMultiKubeUsers,
-			},
-			wantErr: true,
-		},
-		{
 			name: "Websocket protocol v5 for user with multiple kubernetes users without specifying impersonate user",
 			args: args{
 				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
 					return remotecommand.NewWebSocketExecutor(c, s, u.String())
 				},
 				config: configMultiKubeUsers,
-			},
-			wantErr: true,
-		},
-		{
-			name: "Websocket protocol v5 for user with multiple kubernetes users without specifying impersonate user - scoped",
-			args: args{
-				executorBuilder: func(c *rest.Config, s string, u *url.URL) (remotecommand.Executor, error) {
-					return remotecommand.NewWebSocketExecutor(c, s, u.String())
-				},
-				config: scopedConfigMultiKubeUsers,
 			},
 			wantErr: true,
 		},
@@ -392,22 +322,30 @@ func testExecKubeService(t *testing.T, testCtx *TestContext) {
 }
 
 func TestExecKubeService(t *testing.T) {
+	t.Parallel()
 	kubeMock, err := testingkubemock.NewKubeAPIMock()
 	require.NoError(t, err)
 	t.Cleanup(func() { kubeMock.Close() })
-
-	// creates a Kubernetes service with a configured cluster pointing to mock api server
-	testCtx := SetupTestContext(t.Context(), t, TestConfig{
-		Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-		Scope:    scopedTestScope,
-		ScopesFeatures: scopes.Features{
-			Enabled:         true,
-			AgentPinEnabled: true,
-		},
-	})
-
-	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
-	testExecKubeService(t, testCtx)
+	for _, scope := range []string{"", scopedTestScope} {
+		name := "unscoped"
+		if scope != "" {
+			name = "scoped"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// creates a Kubernetes service with a configured cluster pointing to mock api server
+			testCtx := SetupTestContext(t.Context(), t, TestConfig{
+				Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+				Scope:    scope,
+				ScopesFeatures: scopes.Features{
+					Enabled:         true,
+					AgentPinEnabled: true,
+				},
+			})
+			t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+			testExecKubeService(t, testCtx, scope)
+		})
+	}
 }
 
 // failingWatcherAccessPoint is a mocked accesspoint which when triggered closes the watcher and forwards an error.
@@ -532,7 +470,7 @@ func TestExecKubeServiceWithFaultyPrimary(t *testing.T) {
 		require.Greater(c, failingAccessPoint.newWatcherFails.Load(), int32(1))
 	}, time.Minute, time.Second)
 
-	testExecKubeService(t, testCtx)
+	testExecKubeService(t, testCtx, scopedTestScope)
 }
 
 type generateExecRequestConfig struct {
@@ -677,9 +615,9 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 						},
 					},
 				)
-
 				t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
+				clusterSQN := scopes.QualifiedName{Name: kubeCluster, Scope: scope}
 				// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
 				user, _ := testCtx.CreateUserAndRole(
 					testCtx.Context,
@@ -691,37 +629,31 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 						KubeGroups: roleKubeGroups,
 					})
 
+				if scope != "" {
+					scopedAssignment := testCtx.CreateAndAssignScopedRole(
+						t,
+						username,
+						scope,
+						accessv1.ScopedRoleSpec_builder{
+							AssignableScopes: []string{scope},
+							Kube: accessv1.ScopedRoleKube_builder{
+								Users:     roleKubeUsers,
+								Groups:    roleKubeGroups,
+								Resources: wildcardResource(),
+								Labels:    wildcardLabel(),
+							}.Build(),
+						}.Build())
+					waitForSRACache(t, testCtx.TLSServer, scopedAssignment)
+				}
+
 				// generate a kube client with user certs for auth
 				_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
 					t,
 					user.GetName(),
-					kubeCluster,
+					clusterSQN,
+					makeScopedOpts(t, testCtx, user.GetName(), scope)...,
 				)
 
-				scopedUser, scopedUserRole := testCtx.CreateUserAndScopedRole(
-					t,
-					"scoped-"+username,
-					scopedTestScope,
-					accessv1.ScopedRoleSpec_builder{
-						AssignableScopes: []string{scopedTestScope},
-						Kube: accessv1.ScopedRoleKube_builder{
-							Users:     roleKubeUsers,
-							Groups:    roleKubeGroups,
-							Resources: wildcardResource(),
-							Labels:    wildcardLabel(),
-						}.Build(),
-					}.Build())
-
-				waitForSRACache(t, testCtx.TLSServer, scopedUserRole)
-
-				_, scopedUserRestConfig := testCtx.GenTestKubeClientTLSCert(
-					t,
-					scopedUser.GetName(),
-					kubeCluster,
-					func(i *tlsca.Identity) {
-						i.ScopePin = testCtx.GetScopePinForUser(t, scopedUser.GetName(), scopedTestScope)
-					},
-				)
 				var streamOpts remotecommand.StreamOptions
 				if !tt.interactive {
 					streamOpts = remotecommand.StreamOptions{
@@ -751,11 +683,7 @@ func TestExecMissingGETPermissionError(t *testing.T) {
 					},
 				)
 				require.NoError(t, err)
-				cfg := userRestConfig
-				if scope != "" {
-					cfg = scopedUserRestConfig
-				}
-				exec, err := remotecommand.NewSPDYExecutor(cfg, http.MethodPost, req.URL())
+				exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
 				require.NoError(t, err)
 				err = exec.StreamWithContext(testCtx.Context, streamOpts)
 				require.Error(t, err)
@@ -805,120 +733,153 @@ func TestExecWebsocketEndToEndErrReturn(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.EqualValues(t, 2, kubeMock.KubeExecRequests.SPDY.Load(), "expected no SPDY requests")
-		require.EqualValues(t, 2, kubeMock.KubeExecRequests.Websocket.Load(), "expected one websocket request")
 		kubeMock.Close()
+
+		const expectedRequestsPerTestContext = 2
+		const expectedTestContexts = 2
+		const expectedRequests = expectedRequestsPerTestContext * expectedTestContexts
+		require.EqualValues(
+			t,
+			expectedRequests, kubeMock.KubeExecRequests.SPDY.Load(),
+			"expected %d SPDY requests, %d for the unscoped TestContext and %d for the scoped TestContext", expectedRequests, expectedRequestsPerTestContext, expectedRequestsPerTestContext,
+		)
+		require.EqualValues(
+			t,
+			expectedRequests, kubeMock.KubeExecRequests.Websocket.Load(),
+			"expected %d websocket requests, %d for the unscoped TestContext and %d for the scoped TestContext", expectedRequests, expectedRequestsPerTestContext, expectedRequestsPerTestContext,
+		)
 	})
 	var (
 		execEvent  *apievents.Exec
 		eventsLock sync.Mutex
 	)
 
-	// creates a Kubernetes service with a configured cluster pointing to mock api server
-	testCtx := SetupTestContext(
-		t.Context(),
-		t,
-		TestConfig{
-			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-			OnEvent: func(evt apievents.AuditEvent) {
-				eventsLock.Lock()
-				defer eventsLock.Unlock()
-				if exec, ok := evt.(*apievents.Exec); ok {
-					execEvent = exec
-				}
-			},
-			Scope: scopedTestScope,
-			ScopesFeatures: scopes.Features{
-				Enabled:         true,
-				AgentPinEnabled: true,
-			},
-		},
-	)
-
-	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
-
-	// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
-	user, _ := testCtx.CreateUserAndRole(
-		testCtx.Context,
-		t,
-		username,
-		RoleSpec{
-			Name:       roleName,
-			KubeUsers:  roleKubeUsers,
-			KubeGroups: roleKubeGroups,
-		})
-
-	// generate a kube client with user certs for auth
-	_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
-		t,
-		user.GetName(),
-		kubeCluster,
-	)
-
-	tests := []struct {
-		name        string
-		interactive bool
-	}{
-		{
-			name: "error propagation in non-interactive session",
-		},
-		{
-			name:        "error propgation in interactive session",
-			interactive: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var streamOpts remotecommand.StreamOptions
-			if !tt.interactive {
-				streamOpts = remotecommand.StreamOptions{
-					Stdin:  nil,
-					Stdout: &bytes.Buffer{},
-					Stderr: &bytes.Buffer{},
-					Tty:    false,
-				}
-			} else {
-				stdinReader, _ := io.Pipe()
-				t.Cleanup(func() { stdinReader.Close() })
-				streamOpts = remotecommand.StreamOptions{
-					Stdin:  stdinReader,
-					Stdout: &bytes.Buffer{},
-					Stderr: nil,
-					Tty:    true,
-				}
-			}
-			req, err := generateExecRequest(
-				generateExecRequestConfig{
-					addr:          testCtx.KubeProxyAddress(),
-					podName:       podName,
-					podNamespace:  podNamespace,
-					containerName: podContainerName,
-					cmd:           containerCommmandExecute, // placeholder for commands to execute in the dummy pod
-					options:       streamOpts,
+	for _, scope := range []string{"", scopedTestScope} {
+		// for _, scope := range []string{scopedTestScope} {
+		// creates a Kubernetes service with a configured cluster pointing to mock api server
+		testCtx := SetupTestContext(
+			t.Context(),
+			t,
+			TestConfig{
+				Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+				OnEvent: func(evt apievents.AuditEvent) {
+					eventsLock.Lock()
+					defer eventsLock.Unlock()
+					if exec, ok := evt.(*apievents.Exec); ok {
+						execEvent = exec
+					}
 				},
-			)
-			require.NoError(t, err)
+				Scope: scope,
+				ScopesFeatures: scopes.Features{
+					Enabled:         true,
+					AgentPinEnabled: true,
+				},
+			},
+		)
 
-			exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
-			require.NoError(t, err)
-			err = exec.StreamWithContext(t.Context(), streamOpts)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), kubernetes130BreakingChangeHint)
+		t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
 
-			require.Eventually(t, func() bool {
+		// create a user with access to kubernetes (kubernetes_user and kubernetes_groups specified)
+		user, _ := testCtx.CreateUserAndRole(
+			testCtx.Context,
+			t,
+			username,
+			RoleSpec{
+				Name:       roleName,
+				KubeUsers:  roleKubeUsers,
+				KubeGroups: roleKubeGroups,
+			})
+
+		if scope != "" {
+			scopedAssignment := testCtx.CreateAndAssignScopedRole(
+				t,
+				username,
+				scope,
+				accessv1.ScopedRoleSpec_builder{
+					AssignableScopes: []string{scope},
+					Kube: accessv1.ScopedRoleKube_builder{
+						Users:     roleKubeUsers,
+						Groups:    roleKubeGroups,
+						Resources: wildcardResource(),
+						Labels:    wildcardLabel(),
+					}.Build(),
+				}.Build())
+			waitForSRACache(t, testCtx.TLSServer, scopedAssignment)
+		}
+
+		// generate a kube client with user certs for auth
+		_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
+			t,
+			user.GetName(),
+			scopes.QualifiedName{Name: kubeCluster, Scope: testCtx.Scope},
+			makeScopedOpts(t, testCtx, username, scope)...,
+		)
+
+		tests := []struct {
+			name        string
+			interactive bool
+		}{
+			{
+				name: "error propagation in non-interactive session",
+			},
+			{
+				name:        "error propgation in interactive session",
+				interactive: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				var streamOpts remotecommand.StreamOptions
+				if !tt.interactive {
+					streamOpts = remotecommand.StreamOptions{
+						Stdin:  nil,
+						Stdout: &bytes.Buffer{},
+						Stderr: &bytes.Buffer{},
+						Tty:    false,
+					}
+				} else {
+					stdinReader, _ := io.Pipe()
+					t.Cleanup(func() { stdinReader.Close() })
+					streamOpts = remotecommand.StreamOptions{
+						Stdin:  stdinReader,
+						Stdout: &bytes.Buffer{},
+						Stderr: nil,
+						Tty:    true,
+					}
+				}
+				req, err := generateExecRequest(
+					generateExecRequestConfig{
+						addr:          testCtx.KubeProxyAddress(),
+						podName:       podName,
+						podNamespace:  podNamespace,
+						containerName: podContainerName,
+						cmd:           containerCommmandExecute, // placeholder for commands to execute in the dummy pod
+						options:       streamOpts,
+					},
+				)
+				require.NoError(t, err)
+
+				exec, err := remotecommand.NewSPDYExecutor(userRestConfig, http.MethodPost, req.URL())
+				require.NoError(t, err)
+				err = exec.StreamWithContext(t.Context(), streamOpts)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), kubernetes130BreakingChangeHint)
+
+				require.Eventually(t, func() bool {
+					eventsLock.Lock()
+					defer eventsLock.Unlock()
+					return execEvent != nil
+				}, 5*time.Second, 100*time.Millisecond, "expected exec event to be recorded")
+
 				eventsLock.Lock()
-				defer eventsLock.Unlock()
-				return execEvent != nil
-			}, 5*time.Second, 100*time.Millisecond, "expected exec event to be recorded")
-
-			eventsLock.Lock()
-			require.Equal(t, events.ExecFailureCode, execEvent.Code)
-			require.Equal(t, "403", execEvent.ExitCode)
-			require.NotEmpty(t, execEvent.Error)
-			eventsLock.Unlock()
-		})
+				require.Equal(t, events.ExecFailureCode, execEvent.Code)
+				require.Equal(t, "403", execEvent.ExitCode)
+				require.NotEmpty(t, execEvent.Error)
+				eventsLock.Unlock()
+			})
+		}
 	}
 }
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -622,9 +622,6 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 	if err != nil {
 		f.log.WarnContext(ctx, "Unable to setup context", "error", err)
 		if trace.IsAccessDenied(err) {
-			if errors.Is(err, errAmbiguousCluster) {
-				return nil, trace.Wrap(err)
-			}
 			return nil, trace.AccessDenied("%s", accessDeniedMsg)
 		}
 		return nil, trace.Wrap(err)
@@ -845,8 +842,6 @@ func kubeStatusCodeAndReason(respErr error) (int, metav1.StatusReason) {
 	return code, reason
 }
 
-var errAmbiguousCluster = &trace.AccessDeniedError{Message: "could not disambiguate between two or more scoped kube clusters with the same name, please login with credentials for a narrower scope"}
-
 func (f *Forwarder) setupContext(
 	ctx context.Context,
 	scopedCtx *authz.ScopedContext,
@@ -955,21 +950,6 @@ func (f *Forwarder) setupContext(
 		metaResource:             kubeResource,
 		isLocalKubernetesCluster: isLocalKubernetesCluster,
 	}, nil
-}
-
-// checkAmbiguousClusters accepts a list of kube servers that have already been filtered for a given cluster name
-// and determines if there is any ambiguity about which scope we should route to.
-func checkAmbiguousClusters(kubeServers []types.KubeServer) error {
-	var foundScope string
-	for i, ks := range kubeServers {
-		switch {
-		case i == 0:
-			foundScope = ks.GetScope()
-		case ks.GetScope() != foundScope:
-			return trace.Wrap(errAmbiguousCluster)
-		}
-	}
-	return nil
 }
 
 func (f *Forwarder) parseResourceFromRequest(req *http.Request, kubeClusterSQN scopes.QualifiedName) (metaResource, error) {

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -81,6 +81,7 @@ import (
 	"github.com/gravitational/teleport/lib/kube/internal"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
+	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -344,7 +345,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 		},
-		clusterDetails:  make(map[string]*kubeDetails),
+		clusterDetails:  make(map[scopes.QualifiedName]*kubeDetails),
 		cachedTransport: transportClients,
 	}
 
@@ -411,7 +412,7 @@ type Forwarder struct {
 	ctx context.Context
 	// clusterDetails contain kubernetes credentials for multiple clusters.
 	// map key is cluster name.
-	clusterDetails map[string]*kubeDetails
+	clusterDetails map[scopes.QualifiedName]*kubeDetails
 	rwMutexDetails sync.RWMutex
 	// sessions tracks in-flight sessions
 	sessions map[uuid.UUID]*session
@@ -441,7 +442,7 @@ type cachedTransportEntry struct {
 
 // getKubeServersByNameFunc is a function that returns a list of
 // kubernetes servers for a given kube cluster.
-type getKubeServersByNameFunc = func(ctx context.Context, name string) ([]types.KubeServer, error)
+type getKubeServersByNameFunc = func(ctx context.Context, sqn scopes.QualifiedName) ([]types.KubeServer, error)
 
 // Close signals close to all outstanding or background operations
 // to complete
@@ -464,7 +465,7 @@ type authContext struct {
 	kubeGroups        map[string]struct{}
 	kubeUsers         map[string]struct{}
 	kubeClusterLabels map[string]string
-	kubeClusterName   string
+	kubeClusterSQN    scopes.QualifiedName
 	teleportCluster   teleportClusterClient
 	recordingConfig   types.SessionRecordingConfig
 	// clientIdleTimeout sets information on client idle timeout
@@ -504,13 +505,13 @@ type authContext struct {
 }
 
 func (c authContext) String() string {
-	return fmt.Sprintf("user: %v, users: %v, groups: %v, teleport cluster: %v, kube cluster: %v", c.User.GetName(), c.kubeUsers, c.kubeGroups, c.teleportCluster.name, c.kubeClusterName)
+	return fmt.Sprintf("user: %v, users: %v, groups: %v, teleport cluster: %v, kube cluster: %v", c.User.GetName(), c.kubeUsers, c.kubeGroups, c.teleportCluster.name, c.kubeClusterSQN.String())
 }
 
 func (c *authContext) key() string {
 	// it is important that the context key contains user, kubernetes groups and certificate expiry,
 	// so that new logins with different parameters will not reuse this context
-	return fmt.Sprintf("%v:%v:%v:%v:%v:%v:%v", c.teleportCluster.name, c.User.GetName(), c.kubeUsers, c.kubeGroups, c.kubeClusterName, c.certExpires.Unix(), c.Identity.GetIdentity().ActiveRequests)
+	return fmt.Sprintf("%v:%v:%v:%v:%v:%v:%v", c.teleportCluster.name, c.User.GetName(), c.kubeUsers, c.kubeGroups, c.kubeClusterSQN.String(), c.certExpires.Unix(), c.Identity.GetIdentity().ActiveRequests)
 }
 
 func (c *authContext) eventClusterMeta(req *http.Request) apievents.KubernetesClusterMetadata {
@@ -525,7 +526,7 @@ func (c *authContext) eventClusterMeta(req *http.Request) apievents.KubernetesCl
 	}
 
 	return apievents.KubernetesClusterMetadata{
-		KubernetesCluster: c.kubeClusterName,
+		KubernetesCluster: c.kubeClusterSQN.String(),
 		KubernetesUsers:   kubeUsers,
 		KubernetesGroups:  kubeGroups,
 		KubernetesLabels:  c.kubeClusterLabels,
@@ -881,7 +882,14 @@ func (f *Forwarder) setupContext(
 		err          error
 	)
 
-	kubeCluster := identity.KubernetesCluster
+	kubeClusterSQN := scopes.QualifiedName{Name: identity.KubernetesCluster}
+	if scopes.MaybeSQN(identity.KubernetesCluster) {
+		var err error
+		if kubeClusterSQN, err = scopes.ParseQualifiedName(identity.KubernetesCluster); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	unscopedCtx, isUnscoped := scopedCtx.UnscopedContext()
 	// aliasing to isScoped because it's a bit easier to reason about
 	isScoped := !isUnscoped
@@ -891,24 +899,14 @@ func (f *Forwarder) setupContext(
 	// For remote clusters, everything will be remapped to new roles on the
 	// leaf and checked there.
 	if !isRemoteCluster {
-		kubeServers, err = f.getKubernetesServersForKubeCluster(ctx, kubeCluster)
+		kubeServers, err = f.getKubernetesServersForKubeCluster(ctx, kubeClusterSQN)
 		if err != nil || len(kubeServers) == 0 {
-			return nil, trace.NotFound("Kubernetes cluster %q not found", kubeCluster)
-		}
-
-		if !isScoped {
-			// If the calling identity is not scoped but there are multiple kube servers present in different scopes
-			// (e.g. when running in Proxy mode) we won't be able to disambiguate between them. In that case, we
-			// should return an error suggesting that the user logs in with scoped credentials
-			if err := checkAmbiguousClusters(kubeServers); err != nil {
-				return nil, trace.Wrap(err)
-			}
-
+			return nil, trace.NotFound("Kubernetes cluster %q not found", kubeClusterSQN)
 		}
 	}
-	isLocalKubernetesCluster := f.isLocalKubeCluster(isRemoteCluster, kubeCluster)
+	isLocalKubernetesCluster := f.isLocalKubeCluster(isRemoteCluster, kubeClusterSQN)
 	if isLocalKubernetesCluster {
-		kubeResource, err = f.parseResourceFromRequest(req, kubeCluster)
+		kubeResource, err = f.parseResourceFromRequest(req, kubeClusterSQN)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -945,7 +943,7 @@ func (f *Forwarder) setupContext(
 		clientIdleTimeoutMessage: netConfig.GetClientIdleTimeoutMessage(),
 		sessionTTL:               sessionTTL,
 		recordingConfig:          recordingConfig,
-		kubeClusterName:          kubeCluster,
+		kubeClusterSQN:           kubeClusterSQN,
 		certExpires:              identity.Expires,
 		disconnectExpiredCert:    scopedCtx.GetDisconnectCertExpiry(authPref),
 		teleportCluster: teleportClusterClient{
@@ -974,10 +972,10 @@ func checkAmbiguousClusters(kubeServers []types.KubeServer) error {
 	return nil
 }
 
-func (f *Forwarder) parseResourceFromRequest(req *http.Request, kubeClusterName string) (metaResource, error) {
+func (f *Forwarder) parseResourceFromRequest(req *http.Request, kubeClusterSQN scopes.QualifiedName) (metaResource, error) {
 	switch f.cfg.KubeServiceType {
 	case LegacyProxyService:
-		if details, err := f.findKubeDetailsByClusterName(kubeClusterName); err == nil {
+		if details, err := f.findKubeDetailsByClusterName(kubeClusterSQN); err == nil {
 			out, err := getResourceFromRequest(req, details)
 			return out, trace.Wrap(err)
 		}
@@ -997,7 +995,7 @@ func (f *Forwarder) parseResourceFromRequest(req *http.Request, kubeClusterName 
 		out, err := getResourceFromRequest(req, nil /*details*/)
 		return out, trace.Wrap(err)
 	case KubeService:
-		details, err := f.findKubeDetailsByClusterName(kubeClusterName)
+		details, err := f.findKubeDetailsByClusterName(kubeClusterSQN)
 		if err != nil {
 			return metaResource{}, trace.Wrap(err)
 		}
@@ -1120,9 +1118,11 @@ func (f *Forwarder) getKubeAccessDetails(
 	// Find requested kubernetes cluster name and get allowed kube users/groups names.
 	for _, s := range actx.kubeServers {
 		c := s.GetCluster()
-		if c.GetName() != actx.kubeClusterName {
+		// we can filter out clusters that don't match the requested sqn
+		if !kubeutils.KubeClusterMatchesSQN(c, actx.kubeClusterSQN) {
 			continue
 		}
+
 		// Once we find at least one cluster that matches by name, we should no longer return errNoMatchingCluster.
 		if errors.Is(implicitDenyOrNotFound, errNoMatchingCluster) {
 			implicitDenyOrNotFound = errImplicitDeny
@@ -1222,7 +1222,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		)
 		return nil
 	}
-	if actx.kubeClusterName == "" {
+	if actx.kubeClusterSQN.Name == "" {
 		if isScoped {
 			return trace.Wrap(services.ErrScopedIdentity, "authorizing with remote cluster")
 		}
@@ -1243,7 +1243,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			"Kubernetes resource kind %q in API group %q is not known to cluster %q",
 			actx.metaResource.requestedResource.resourceKind,
 			actx.metaResource.requestedResource.apiGroup,
-			actx.kubeClusterName,
+			actx.kubeClusterSQN,
 		)
 	}
 
@@ -1254,7 +1254,7 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 		return trace.Wrap(err)
 	}
 
-	notFoundMessage := fmt.Sprintf("kubernetes cluster %q not found", actx.kubeClusterName)
+	notFoundMessage := fmt.Sprintf("kubernetes cluster %q not found", actx.kubeClusterSQN)
 	var roleMatchers services.RoleMatchers
 	if !actx.metaResource.isList {
 		if rbacResource := actx.metaResource.rbacResource(); rbacResource != nil {
@@ -1383,9 +1383,12 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 	// If we were not granted access to any kube users or groups, we need to check if we should bypass auth for a
 	// proxy-based kube cluster. We should only skip authZ for unscoped identities connecting to proxy-based kube
 	// clusters.
-	if actx.kubeClusterName == f.cfg.ClusterName {
+	if actx.kubeClusterSQN.Name == f.cfg.ClusterName {
 		if isScoped {
 			return trace.Wrap(services.ErrScopedIdentity, "scoped identities do not support kube clusters exposed directly from the Teleport Proxy Service, only clusters exposed by the Teleport Kubernetes Service are supported")
+		}
+		if actx.kubeClusterSQN.Scope != "" {
+			return trace.Wrap(services.ErrScopedIdentity, "Teleport Proxy Service cannot directly forward for scoped kube clusters, only clusters exposed by the Teleport Kubernetes Service can be scoped")
 		}
 		f.log.DebugContext(ctx, "Skipping authorization for proxy-based kubernetes cluster",
 			"auth_context", logutils.StringerAttr(actx),
@@ -2793,15 +2796,6 @@ func (s *clusterSession) getProxier() func(req *http.Request) (*url.URL, error) 
 	return utilnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
 }
 
-// getClusterScope returns the scope associated with the cluster that the clusterSession
-// refers to.
-func (s *clusterSession) getClusterScope() string {
-	if s.kubeCluster != nil {
-		return s.kubeCluster.GetScope()
-	}
-	return ""
-}
-
 // TODO(awly): unit test this
 func (f *Forwarder) newClusterSession(ctx context.Context, authCtx authContext) (*clusterSession, error) {
 	ctx, span := f.cfg.tracer.Start(
@@ -2850,21 +2844,21 @@ func (f *Forwarder) newClusterSessionSameCluster(ctx context.Context, authCtx au
 	}
 
 	kubeServers := authCtx.kubeServers
-	if len(kubeServers) == 0 && authCtx.kubeClusterName == authCtx.teleportCluster.name {
+	if len(kubeServers) == 0 && authCtx.kubeClusterSQN.Name == authCtx.teleportCluster.name && authCtx.kubeClusterSQN.Scope == "" {
 		return nil, trace.Wrap(localErr)
 	}
 
 	if len(kubeServers) == 0 {
-		return nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
+		return nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterSQN)
 	}
 
 	return f.newClusterSessionDirect(ctx, authCtx)
 }
 
 func (f *Forwarder) newClusterSessionLocal(ctx context.Context, authCtx authContext) (*clusterSession, error) {
-	details, err := f.findKubeDetailsByClusterName(authCtx.kubeClusterName)
+	details, err := f.findKubeDetailsByClusterName(authCtx.kubeClusterSQN)
 	if err != nil {
-		return nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
+		return nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterSQN)
 	}
 
 	codecFactory, rbacSupportedResources, err := details.getClusterSupportedResources()
@@ -2948,46 +2942,46 @@ func (f *Forwarder) kubeClusters() types.KubeClusters {
 }
 
 // findKubeDetailsByClusterName searches for the cluster details otherwise returns a trace.NotFound error.
-func (f *Forwarder) findKubeDetailsByClusterName(name string) (*kubeDetails, error) {
+func (f *Forwarder) findKubeDetailsByClusterName(sqn scopes.QualifiedName) (*kubeDetails, error) {
 	f.rwMutexDetails.RLock()
 	defer f.rwMutexDetails.RUnlock()
 
-	if creds, ok := f.clusterDetails[name]; ok {
+	if creds, ok := f.clusterDetails[sqn]; ok {
 		return creds, nil
 	}
 
-	return nil, trace.NotFound("cluster %s not found", name)
+	return nil, trace.NotFound("cluster %s not found", sqn)
 }
 
 // upsertKubeDetails updates the details in f.ClusterDetails for key if they exist,
 // otherwise inserts them.
-func (f *Forwarder) upsertKubeDetails(key string, clusterDetails *kubeDetails) {
+func (f *Forwarder) upsertKubeDetails(sqn scopes.QualifiedName, clusterDetails *kubeDetails) {
 	f.rwMutexDetails.Lock()
 	defer f.rwMutexDetails.Unlock()
 
-	if oldDetails, ok := f.clusterDetails[key]; ok {
+	if oldDetails, ok := f.clusterDetails[sqn]; ok {
 		oldDetails.Close()
 	}
 	// replace existing details in map
-	f.clusterDetails[key] = clusterDetails
+	f.clusterDetails[sqn] = clusterDetails
 }
 
 // removeKubeDetails removes the kubeDetails from map.
-func (f *Forwarder) removeKubeDetails(name string) {
+func (f *Forwarder) removeKubeDetails(sqn scopes.QualifiedName) {
 	f.rwMutexDetails.Lock()
 	defer f.rwMutexDetails.Unlock()
 
-	if oldDetails, ok := f.clusterDetails[name]; ok {
+	if oldDetails, ok := f.clusterDetails[sqn]; ok {
 		oldDetails.Close()
 	}
-	delete(f.clusterDetails, name)
+	delete(f.clusterDetails, sqn)
 }
 
 // isLocalKubeCluster checks if the current service must hold the cluster and
 // if it's of Type KubeService.
 // KubeProxy services or remote clusters are automatically forwarded to
 // the final destination.
-func (f *Forwarder) isLocalKubeCluster(isRemoteTeleportCluster bool, kubeClusterName string) bool {
+func (f *Forwarder) isLocalKubeCluster(isRemoteTeleportCluster bool, sqn scopes.QualifiedName) bool {
 	switch f.cfg.KubeServiceType {
 	case KubeService:
 		// Kubernetes service is always local.
@@ -2999,7 +2993,7 @@ func (f *Forwarder) isLocalKubeCluster(isRemoteTeleportCluster bool, kubeCluster
 		}
 		// Legacy proxy service is local only if the kube cluster name matches
 		// with clusters served by this agent.
-		_, err := f.findKubeDetailsByClusterName(kubeClusterName)
+		_, err := f.findKubeDetailsByClusterName(sqn)
 		return err == nil
 	default:
 		return false

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -73,6 +73,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/fixtures"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
@@ -182,14 +183,14 @@ func TestAuthenticate(t *testing.T) {
 				KubeServiceType:   ProxyService,
 				LockWatcher:       lockWatcher,
 			},
-			getKubernetesServersForKubeCluster: func(ctx context.Context, name string) ([]types.KubeServer, error) {
+			getKubernetesServersForKubeCluster: func(ctx context.Context, sqn scopes.QualifiedName) ([]types.KubeServer, error) {
 				servers, err := ap.GetKubernetesServers(ctx)
 				if err != nil {
 					return nil, err
 				}
 				var filtered []types.KubeServer
 				for _, server := range servers {
-					if server.GetCluster().GetName() == name {
+					if kubeutils.KubeClusterMatchesSQN(server.GetCluster(), sqn) {
 						filtered = append(filtered, server)
 					}
 				}
@@ -199,6 +200,9 @@ func TestAuthenticate(t *testing.T) {
 	}
 
 	const remoteAddr = "user.example.com"
+	unscopedLocalSQN := scopes.QualifiedName{Name: "local"}
+	unscopedFooSQN := scopes.QualifiedName{Name: "foo"}
+	scopedLocalSQN := scopes.QualifiedName{Name: "local", Scope: scopedTestScope}
 	activeAccessRequests := []string{uuid.NewString(), uuid.NewString()}
 	tests := []struct {
 		desc                            string
@@ -207,7 +211,7 @@ func TestAuthenticate(t *testing.T) {
 		roleKubeUsers                   []string
 		roleKubeGroups                  []string
 		routeToCluster                  string
-		kubernetesCluster               string
+		kubeClusterSQN                  scopes.QualifiedName
 		haveKubeCreds                   bool
 		tunnel                          reversetunnelclient.Server
 		kubeServers                     []types.KubeServer
@@ -224,13 +228,13 @@ func TestAuthenticate(t *testing.T) {
 		wantDisconnectExpiredCert *time.Time
 	}{
 		{
-			desc:              "local user and cluster with active access request",
-			user:              authz.LocalUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "local user and cluster with active access request",
+			user:           authz.LocalUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedLocalSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -248,9 +252,9 @@ func TestAuthenticate(t *testing.T) {
 			),
 			activeRequests: activeAccessRequests,
 			wantCtx: &authContext{
-				kubeUsers:       set.New("user-a"),
-				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName: "local",
+				kubeUsers:      set.New("user-a"),
+				kubeGroups:     set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterSQN: scopes.QualifiedName{Name: "local"},
 				kubeClusterLabels: map[string]string{
 					"static_label1": "static_value1",
 					"static_label2": "static_value2",
@@ -278,13 +282,13 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:              "local user and cluster",
-			user:              authz.LocalUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "local user and cluster",
+			user:           authz.LocalUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedLocalSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -325,9 +329,9 @@ func TestAuthenticate(t *testing.T) {
 				},
 			),
 			wantCtx: &authContext{
-				kubeUsers:       set.New("user-a"),
-				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName: "local",
+				kubeUsers:      set.New("user-a"),
+				kubeGroups:     set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterSQN: scopes.QualifiedName{Name: "local"},
 				kubeClusterLabels: map[string]string{
 					"static_label1": "static_value1",
 					"static_label2": "static_value2",
@@ -361,7 +365,7 @@ func TestAuthenticate(t *testing.T) {
 			roleKubeGroups:     []string{"kube-group-a", "kube-group-b"},
 			scopedKubeLockMode: constants.LockingModeBestEffort,
 			routeToCluster:     "local",
-			kubernetesCluster:  "local",
+			kubeClusterSQN:     scopedLocalSQN,
 			haveKubeCreds:      true,
 			tunnel:             tun,
 			configureForwarder: configureStaleLockWatcher,
@@ -381,7 +385,7 @@ func TestAuthenticate(t *testing.T) {
 			wantCtx: &authContext{
 				kubeUsers:         set.New("user-a"),
 				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName:   "local",
+				kubeClusterSQN:    scopedLocalSQN,
 				kubeClusterLabels: make(map[string]string),
 				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
@@ -410,7 +414,7 @@ func TestAuthenticate(t *testing.T) {
 			roleKubeGroups:           []string{"kube-group-a", "kube-group-b"},
 			scopedKubeLockMode:       constants.LockingModeStrict,
 			routeToCluster:           "local",
-			kubernetesCluster:        "local",
+			kubeClusterSQN:           scopedLocalSQN,
 			haveKubeCreds:            true,
 			tunnel:                   tun,
 			configureForwarder:       configureStaleLockWatcher,
@@ -435,7 +439,7 @@ func TestAuthenticate(t *testing.T) {
 			scoped:                    true,
 			roleKubeGroups:            []string{"kube-group-a", "kube-group-b"},
 			routeToCluster:            "local",
-			kubernetesCluster:         "local",
+			kubeClusterSQN:            scopedLocalSQN,
 			haveKubeCreds:             true,
 			tunnel:                    tun,
 			wantDisconnectExpiredCert: &certExpiration,
@@ -455,7 +459,7 @@ func TestAuthenticate(t *testing.T) {
 			wantCtx: &authContext{
 				kubeUsers:         set.New("user-a"),
 				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName:   "local",
+				kubeClusterSQN:    scopedLocalSQN,
 				kubeClusterLabels: make(map[string]string),
 				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
@@ -483,7 +487,7 @@ func TestAuthenticate(t *testing.T) {
 			scoped:                          true,
 			roleKubeGroups:                  []string{"kube-group-a", "kube-group-b"},
 			routeToCluster:                  "local",
-			kubernetesCluster:               "local",
+			kubeClusterSQN:                  scopedLocalSQN,
 			scopedKubeDisconnectExpiredCert: ptr(false),
 			wantDisconnectExpiredCert:       &time.Time{},
 			haveKubeCreds:                   true,
@@ -504,7 +508,7 @@ func TestAuthenticate(t *testing.T) {
 			wantCtx: &authContext{
 				kubeUsers:         set.New("user-a"),
 				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName:   "local",
+				kubeClusterSQN:    scopedLocalSQN,
 				kubeClusterLabels: make(map[string]string),
 				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
@@ -534,7 +538,7 @@ func TestAuthenticate(t *testing.T) {
 			scopedKubeDisconnectExpiredCert: ptr(true),
 			wantDisconnectExpiredCert:       &certExpiration,
 			routeToCluster:                  "local",
-			kubernetesCluster:               "local",
+			kubeClusterSQN:                  scopedLocalSQN,
 			haveKubeCreds:                   true,
 			tunnel:                          tun,
 			kubeServers: newKubeServersFromKubeClusters(
@@ -553,7 +557,7 @@ func TestAuthenticate(t *testing.T) {
 			wantCtx: &authContext{
 				kubeUsers:         set.New("user-a"),
 				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName:   "local",
+				kubeClusterSQN:    scopedLocalSQN,
 				kubeClusterLabels: make(map[string]string),
 				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
@@ -576,13 +580,13 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:              "local user and cluster, no kubeconfig",
-			user:              authz.LocalUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     false,
-			tunnel:            tun,
+			desc:           "local user and cluster, no kubeconfig",
+			user:           authz.LocalUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedLocalSQN,
+			haveKubeCreds:  false,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -599,7 +603,7 @@ func TestAuthenticate(t *testing.T) {
 			wantCtx: &authContext{
 				kubeUsers:         set.New("user-a"),
 				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName:   "local",
+				kubeClusterSQN:    scopes.QualifiedName{Name: "local"},
 				kubeClusterLabels: make(map[string]string),
 				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
@@ -621,13 +625,13 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:              "remote user and local cluster",
-			user:              authz.RemoteUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "remote user and local cluster",
+			user:           authz.RemoteUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedLocalSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -643,7 +647,7 @@ func TestAuthenticate(t *testing.T) {
 			wantCtx: &authContext{
 				kubeUsers:         set.New("user-a"),
 				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName:   "local",
+				kubeClusterSQN:    unscopedLocalSQN,
 				certExpires:       certExpiration,
 				kubeClusterLabels: make(map[string]string),
 				teleportCluster: teleportClusterClient{
@@ -666,14 +670,14 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:              "remote user and local cluster with active request id",
-			user:              authz.RemoteUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
-			tunnel:            tun,
-			activeRequests:    activeAccessRequests,
+			desc:           "remote user and local cluster with active request id",
+			user:           authz.RemoteUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedLocalSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
+			activeRequests: activeAccessRequests,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -689,7 +693,7 @@ func TestAuthenticate(t *testing.T) {
 			wantCtx: &authContext{
 				kubeUsers:         set.New("user-a"),
 				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName:   "local",
+				kubeClusterSQN:    unscopedLocalSQN,
 				certExpires:       certExpiration,
 				kubeClusterLabels: make(map[string]string),
 				teleportCluster: teleportClusterClient{
@@ -773,14 +777,14 @@ func TestAuthenticate(t *testing.T) {
 			wantAuthErr: true,
 		},
 		{
-			desc:              "kube users passed in request",
-			user:              authz.LocalUser{},
-			roleKubeUsers:     []string{"kube-user-a", "kube-user-b"},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "kube users passed in request",
+			user:           authz.LocalUser{},
+			roleKubeUsers:  []string{"kube-user-a", "kube-user-b"},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedLocalSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -793,11 +797,10 @@ func TestAuthenticate(t *testing.T) {
 					},
 				},
 			),
-
 			wantCtx: &authContext{
 				kubeUsers:         set.New("kube-user-a", "kube-user-b"),
 				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName:   "local",
+				kubeClusterSQN:    unscopedLocalSQN,
 				kubeClusterLabels: make(map[string]string),
 				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
@@ -836,12 +839,12 @@ func TestAuthenticate(t *testing.T) {
 			wantAuthErr: true,
 		},
 		{
-			desc:              "local user and cluster, no tunnel",
-			user:              authz.LocalUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
+			desc:           "local user and cluster, no tunnel",
+			user:           authz.LocalUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedLocalSQN,
+			haveKubeCreds:  true,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -858,7 +861,7 @@ func TestAuthenticate(t *testing.T) {
 			wantCtx: &authContext{
 				kubeUsers:         set.New("user-a"),
 				kubeGroups:        set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName:   "local",
+				kubeClusterSQN:    unscopedLocalSQN,
 				kubeClusterLabels: make(map[string]string),
 				certExpires:       certExpiration,
 				teleportCluster: teleportClusterClient{
@@ -881,24 +884,24 @@ func TestAuthenticate(t *testing.T) {
 		},
 
 		{
-			desc:              "unknown kubernetes cluster in local cluster",
-			user:              authz.LocalUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "foo",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "unknown kubernetes cluster in local cluster",
+			user:           authz.LocalUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedFooSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 
 			wantErr: true,
 		},
 		{
-			desc:              "custom kubernetes cluster in local cluster",
-			user:              authz.LocalUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "foo",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "custom kubernetes cluster in local cluster",
+			user:           authz.LocalUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedFooSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -915,10 +918,10 @@ func TestAuthenticate(t *testing.T) {
 				},
 			),
 			wantCtx: &authContext{
-				kubeUsers:       set.New("user-a"),
-				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName: "foo",
-				certExpires:     certExpiration,
+				kubeUsers:      set.New("user-a"),
+				kubeGroups:     set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterSQN: unscopedFooSQN,
+				certExpires:    certExpiration,
 				kubeClusterLabels: map[string]string{
 					"static_label1": "static_value1",
 					"static_label2": "static_value2",
@@ -945,17 +948,17 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:              "custom kubernetes cluster in remote cluster",
-			user:              authz.LocalUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "remote",
-			kubernetesCluster: "foo",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "custom kubernetes cluster in remote cluster",
+			user:           authz.LocalUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "remote",
+			kubeClusterSQN: unscopedFooSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 
 			wantCtx: &authContext{
-				kubeClusterName: "foo",
-				certExpires:     certExpiration,
+				kubeClusterSQN: unscopedFooSQN,
+				certExpires:    certExpiration,
 				teleportCluster: teleportClusterClient{
 					name:       "remote",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -964,14 +967,14 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:              "local scoped user and scoped cluster",
-			user:              authz.LocalUser{},
-			scoped:            true,
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "local scoped user and scoped cluster",
+			user:           authz.LocalUser{},
+			scoped:         true,
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: scopedLocalSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -989,9 +992,9 @@ func TestAuthenticate(t *testing.T) {
 				},
 			),
 			wantCtx: &authContext{
-				kubeUsers:       set.New("user-a"),
-				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName: "local",
+				kubeUsers:      set.New("user-a"),
+				kubeGroups:     set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterSQN: scopedLocalSQN,
 				kubeClusterLabels: map[string]string{
 					"static_label1": "static_value1",
 					"static_label2": "static_value2",
@@ -1020,13 +1023,13 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:              "local unscoped user and scoped cluster",
-			user:              authz.LocalUser{},
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "local unscoped user and scoped cluster",
+			user:           authz.LocalUser{},
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: scopedLocalSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -1044,9 +1047,9 @@ func TestAuthenticate(t *testing.T) {
 				},
 			),
 			wantCtx: &authContext{
-				kubeUsers:       set.New("user-a"),
-				kubeGroups:      set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
-				kubeClusterName: "local",
+				kubeUsers:      set.New("user-a"),
+				kubeGroups:     set.New("kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated),
+				kubeClusterSQN: scopedLocalSQN,
 				kubeClusterLabels: map[string]string{
 					"static_label1": "static_value1",
 					"static_label2": "static_value2",
@@ -1075,14 +1078,14 @@ func TestAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			desc:              "local scoped user and scoped cluster - mismatched scope",
-			user:              authz.LocalUser{},
-			scoped:            true,
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "local scoped user and scoped cluster - mismatched scope",
+			user:           authz.LocalUser{},
+			scoped:         true,
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: scopes.QualifiedName{Name: "local", Scope: "/other"},
+			haveKubeCreds:  true,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -1102,14 +1105,14 @@ func TestAuthenticate(t *testing.T) {
 			wantAuthorizeErrContains: "[00] access denied",
 		},
 		{
-			desc:              "local scoped user and unscoped cluster",
-			user:              authz.LocalUser{},
-			scoped:            true,
-			roleKubeGroups:    []string{"kube-group-a", "kube-group-b"},
-			routeToCluster:    "local",
-			kubernetesCluster: "local",
-			haveKubeCreds:     true,
-			tunnel:            tun,
+			desc:           "local scoped user and unscoped cluster",
+			user:           authz.LocalUser{},
+			scoped:         true,
+			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
+			routeToCluster: "local",
+			kubeClusterSQN: unscopedLocalSQN,
+			haveKubeCreds:  true,
+			tunnel:         tun,
 			kubeServers: newKubeServersFromKubeClusters(
 				t,
 				&types.KubernetesClusterV3{
@@ -1153,7 +1156,7 @@ func TestAuthenticate(t *testing.T) {
 					Username:          username,
 					Groups:            roles.RoleNames(),
 					RouteToCluster:    tt.routeToCluster,
-					KubernetesCluster: tt.kubernetesCluster,
+					KubernetesCluster: tt.kubeClusterSQN.String(),
 					ActiveRequests:    tt.activeRequests,
 					Expires:           certExpiration,
 				}),
@@ -1161,7 +1164,7 @@ func TestAuthenticate(t *testing.T) {
 					Username:          username,
 					Groups:            roles.RoleNames(),
 					RouteToCluster:    tt.routeToCluster,
-					KubernetesCluster: tt.kubernetesCluster,
+					KubernetesCluster: tt.kubeClusterSQN.String(),
 					ActiveRequests:    tt.activeRequests,
 					Expires:           certExpiration,
 				}),
@@ -1204,7 +1207,13 @@ func TestAuthenticate(t *testing.T) {
 			req = req.WithContext(ctx)
 
 			if tt.haveKubeCreds {
-				f.clusterDetails = map[string]*kubeDetails{tt.routeToCluster: {kubeCreds: &staticKubeCreds{targetAddr: "k8s.example.com"}}}
+				clusterSQN := scopes.QualifiedName{Name: tt.routeToCluster}
+				if scopes.MaybeSQN(tt.routeToCluster) {
+					var err error
+					clusterSQN, err = scopes.ParseQualifiedName(tt.routeToCluster)
+					require.NoError(t, err)
+				}
+				f.clusterDetails = map[scopes.QualifiedName]*kubeDetails{clusterSQN: {kubeCreds: &staticKubeCreds{targetAddr: "k8s.example.com"}}}
 			} else {
 				f.clusterDetails = nil
 			}
@@ -1241,7 +1250,7 @@ func TestAuthenticate(t *testing.T) {
 				username,
 				tt.wantCtx.kubeUsers,
 				tt.wantCtx.kubeGroups,
-				tt.wantCtx.kubeClusterName,
+				tt.wantCtx.kubeClusterSQN.String(),
 				certExpiration.Unix(),
 				tt.activeRequests,
 			)
@@ -1507,7 +1516,7 @@ func mockAuthCtx(t *testing.T, kubeCluster string, isRemote bool) authContext {
 			name:     "kube-cluster",
 			isRemote: isRemote,
 		},
-		kubeClusterName: kubeCluster,
+		kubeClusterSQN: scopes.QualifiedName{Name: kubeCluster},
 		// getClientCreds requires sessions to be valid for at least 1 minute
 		sessionTTL: 2 * time.Minute,
 	}
@@ -1591,8 +1600,8 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 		},
 	} {
 
-		f.clusterDetails = map[string]*kubeDetails{
-			"local": {
+		f.clusterDetails = map[scopes.QualifiedName]*kubeDetails{
+			scopes.QualifiedName{Name: "local"}: {
 				kubeCreds: &staticKubeCreds{
 					targetAddr: mockKubeAPI.URL,
 					tlsConfig:  mockKubeAPI.TLS,
@@ -1601,7 +1610,7 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 			},
 		}
 
-		authCtx.kubeClusterName = "local"
+		authCtx.kubeClusterSQN = scopes.QualifiedName{Name: "local"}
 		sess, err := f.newClusterSession(ctx, authCtx)
 		require.NoError(t, err)
 		t.Cleanup(sess.close)
@@ -2138,7 +2147,7 @@ func TestKubernetesLicenseEnforcement(t *testing.T) {
 			client, _ := testCtx.GenTestKubeClientTLSCert(
 				t,
 				username,
-				kubeCluster,
+				scopes.QualifiedName{Name: kubeCluster},
 			)
 
 			_, err := client.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
@@ -2176,7 +2185,7 @@ func TestInvalidImpersonationGroupHeaderInjection(t *testing.T) {
 		},
 	)
 
-	client, _ := testCtx.GenTestKubeClientTLSCert(t, username, kubeCluster)
+	client, _ := testCtx.GenTestKubeClientTLSCert(t, username, scopes.QualifiedName{Name: kubeCluster})
 
 	_, err = client.CoreV1().Pods(metav1.NamespaceDefault).List(t.Context(), metav1.ListOptions{})
 	require.Error(t, err)
@@ -2213,7 +2222,7 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 				},
 				ctx: &authContext{
 					ScopedContext:     baseAuthCtx,
-					kubeClusterName:   "clusterName",
+					kubeClusterSQN:    scopes.QualifiedName{Name: "clusterName"},
 					kubeClusterLabels: kubeClusterLabels,
 					kubeGroups:        map[string]struct{}{"kube-group-a": {}, "kube-group-b": {}},
 					kubeUsers:         map[string]struct{}{"kube-user-a": {}},
@@ -2237,7 +2246,7 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 				},
 				ctx: &authContext{
 					ScopedContext:     baseAuthCtx,
-					kubeClusterName:   "clusterName",
+					kubeClusterSQN:    scopes.QualifiedName{Name: "clusterName"},
 					kubeClusterLabels: kubeClusterLabels,
 					kubeGroups:        map[string]struct{}{"kube-group-a": {}, "kube-group-b": {}, "kube-group-c": {}},
 					kubeUsers:         map[string]struct{}{"kube-user-a": {}, "kube-user-b": {}},
@@ -2258,7 +2267,7 @@ func Test_authContext_eventClusterMeta(t *testing.T) {
 				},
 				ctx: &authContext{
 					ScopedContext:     baseAuthCtx,
-					kubeClusterName:   "clusterName",
+					kubeClusterSQN:    scopes.QualifiedName{Name: "clusterName"},
 					kubeClusterLabels: kubeClusterLabels,
 					kubeGroups:        map[string]struct{}{"kube-group-a": {}, "kube-group-b": {}, "kube-group-c": {}},
 					kubeUsers:         map[string]struct{}{"kube-user-a": {}, "kube-user-b": {}},
@@ -2333,7 +2342,7 @@ func TestForwarderTLSConfigCAs(t *testing.T) {
 	require.False(t, getConnTLSRootsCalled)
 
 	// generate tlsConfig for the local cluster
-	_, localTLSConfig, err := f.newLocalClusterTransport(clusterName, "")
+	_, localTLSConfig, err := f.newLocalClusterTransport(scopes.QualifiedName{Name: clusterName})
 	require.NoError(t, err)
 	_ = localTLSConfig.VerifyConnection(tls.ConnectionState{
 		ServerName: "nonempty",
@@ -2394,8 +2403,8 @@ func TestKubeForwarder_GOAWAYErrors(t *testing.T) {
 			// Plug a stub round tripper that returns the GOAWAY-related error
 			// into a fake Kubernetes cluster, so the kube proxy's full
 			// error-handling pipeline runs against it.
-			f.clusterDetails = map[string]*kubeDetails{
-				"kube-cluster": {
+			f.clusterDetails = map[scopes.QualifiedName]*kubeDetails{
+				scopes.QualifiedName{Name: "kube-cluster"}: {
 					kubeCreds: &staticKubeCreds{
 						targetAddr: "kube.invalid:443",
 						tlsConfig:  &tls.Config{InsecureSkipVerify: true},
@@ -2460,8 +2469,8 @@ func TestGOAWAYHandling(t *testing.T) {
 	go func() { require.NoError(t, gs.Serve()) }()
 
 	// Insert a fake Kubernetes cluster that forwards requests to the GOAWAY server above.
-	f.clusterDetails = map[string]*kubeDetails{
-		"kube-cluster": {
+	f.clusterDetails = map[scopes.QualifiedName]*kubeDetails{
+		scopes.QualifiedName{Name: "kube-cluster"}: {
 			kubeCreds: &staticKubeCreds{
 				targetAddr: gs.URL(),
 				tlsConfig:  gs.tlsConfig,
@@ -2546,8 +2555,8 @@ func TestGOAWAYHandling_Concurrent(t *testing.T) {
 	prodTransport, err := newH2Transport(tlsCfg, nil)
 	require.NoError(t, err)
 
-	f.clusterDetails = map[string]*kubeDetails{
-		"kube-cluster": {
+	f.clusterDetails = map[scopes.QualifiedName]*kubeDetails{
+		scopes.QualifiedName{Name: "kube-cluster"}: {
 			kubeCreds: &staticKubeCreds{
 				targetAddr: gs.URL(),
 				tlsConfig:  tlsCfg,

--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes"
 	sessionpkg "github.com/gravitational/teleport/lib/session"
 )
 
@@ -255,7 +256,7 @@ func TestModeratedSessions(t *testing.T) {
 			_, config := testCtx.GenTestKubeClientTLSCert(
 				t,
 				tt.args.user.GetName(),
-				kubeCluster,
+				scopes.QualifiedName{Name: kubeCluster},
 			)
 
 			// create a user session.
@@ -299,7 +300,7 @@ func TestModeratedSessions(t *testing.T) {
 				_, config := testCtx.GenTestKubeClientTLSCert(
 					t,
 					tt.args.moderator.GetName(),
-					kubeCluster,
+					scopes.QualifiedName{Name: kubeCluster},
 				)
 
 				// Simulate a moderator joining the session.
@@ -611,19 +612,19 @@ func TestInteractiveSessionsNoAuth(t *testing.T) {
 	_, userStrictLockingConfig := testCtx.GenTestKubeClientTLSCert(
 		t,
 		userWithStrictLock.GetName(),
-		kubeCluster,
+		scopes.QualifiedName{Name: kubeCluster},
 	)
 
 	_, moderatorConfig := testCtx.GenTestKubeClientTLSCert(
 		t,
 		adminUser.GetName(),
-		kubeCluster,
+		scopes.QualifiedName{Name: kubeCluster},
 	)
 
 	_, userRequiringModeratorConfig := testCtx.GenTestKubeClientTLSCert(
 		t,
 		userRequiringModerator.GetName(),
-		kubeCluster,
+		scopes.QualifiedName{Name: kubeCluster},
 	)
 
 	// Mark the lock as stale so that the session with strict locking is denied.

--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/streaming/pkg/httpstream"
 
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -134,7 +135,7 @@ func TestPortForwardKubeService(t *testing.T) {
 			_, config := testCtx.GenTestKubeClientTLSCert(
 				t,
 				user.GetName(),
-				kubeCluster,
+				scopes.QualifiedName{Name: kubeCluster},
 			)
 			require.NoError(t, err)
 
@@ -248,7 +249,7 @@ func TestPortForwardKubeServiceMultiPort(t *testing.T) {
 	_, config := testCtx.GenTestKubeClientTLSCert(
 		t,
 		user.GetName(),
-		kubeCluster,
+		scopes.QualifiedName{Name: kubeCluster},
 	)
 
 	// Create 5 ports.
@@ -632,7 +633,7 @@ func TestPortForwardUnderlyingProtocol(t *testing.T) {
 			_, config := testCtx.GenTestKubeClientTLSCert(
 				t,
 				user.GetName(),
-				kubeCluster,
+				scopes.QualifiedName{Name: kubeCluster},
 			)
 			require.NoError(t, err)
 			// readyCh communicate when the port forward is ready to get traffic

--- a/lib/kube/proxy/resource_deletecollection.go
+++ b/lib/kube/proxy/resource_deletecollection.go
@@ -140,7 +140,7 @@ func (f *Forwarder) handleDeleteCollectionReq(req *http.Request, sess *clusterSe
 		return internalErrStatus, trace.Wrap(err)
 	}
 
-	details, err := f.findKubeDetailsByClusterName(sess.kubeClusterName)
+	details, err := f.findKubeDetailsByClusterName(sess.kubeClusterSQN)
 	if err != nil {
 		return internalErrStatus, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/resource_list.go
+++ b/lib/kube/proxy/resource_list.go
@@ -274,7 +274,7 @@ func (f *Forwarder) sendEphemeralContainerEvents(ctx context.Context, rw *respon
 		wcs, err := f.getUserEphemeralContainersForPod(
 			ctx,
 			sess.User.GetName(),
-			sess.kubeClusterName,
+			sess.kubeClusterSQN.String(),
 			sess.metaResource.requestedResource.namespace,
 			podName,
 		)

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -64,7 +64,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
-func TestListPodRBAC(t *testing.T) {
+func testListPodRBAC(t *testing.T, kubeMock *tkm.KubeMockServer, scope string) {
 	const (
 		usernameWithFullAccess        = "full_user"
 		usernameWithNamespaceAccess   = "default_user"
@@ -73,15 +73,7 @@ func TestListPodRBAC(t *testing.T) {
 		usernameWithoutListVerbAccess = "no_list_user"
 		usernameWithTraits            = "trait_user"
 		testPodName                   = "test"
-		scope                         = "/test"
 	)
-	// kubeMock is a Kubernetes API mock for the session tests.
-	// Once a new session is created, this mock will write to
-	// stdout and stdin (if available) the pod name, followed
-	// by copying the contents of stdin into both streams.
-	kubeMock, err := tkm.NewKubeAPIMock()
-	require.NoError(t, err)
-	t.Cleanup(func() { kubeMock.Close() })
 
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(
@@ -157,14 +149,17 @@ func TestListPodRBAC(t *testing.T) {
 		)
 		users[unscopedUser.GetName()] = unscopedUser
 
+		if scope == "" {
+			continue
+		}
 		// create scoped user
 		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
 		for idx, resource := range kubeResources {
 			scopedResources[idx] = toScopedKubeResource(resource)
 		}
-		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+		scopedAssignment := testCtx.CreateAndAssignScopedRole(
 			t,
-			scopedUsername(username),
+			username,
 			scope,
 			accessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{scope},
@@ -176,7 +171,6 @@ func TestListPodRBAC(t *testing.T) {
 				}.Build(),
 			}.Build())
 		scopedAssignments = append(scopedAssignments, scopedAssignment)
-		users[scopedUser.GetName()] = scopedUser
 	}
 	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
@@ -251,32 +245,19 @@ func TestListPodRBAC(t *testing.T) {
 		listPodsResult   []string
 		listPodErr       error
 		getTestPodResult error
+		skipScopedTest   bool
 	}
 	tests := []struct {
-		name string
-		args args
-		want want
+		name       string
+		args       args
+		want       want
+		wantScoped *want
 	}{
 		{
 			name: "list default namespace pods for user with full access",
 			args: args{
 				user:      users[usernameWithFullAccess],
 				namespace: metav1.NamespaceDefault,
-			},
-			want: want{
-				listPodsResult: []string{
-					"default/nginx-1",
-					"default/nginx-2",
-					"default/test",
-				},
-			},
-		},
-		{
-			name: "list default namespace pods for scoped user with full access",
-			args: args{
-				user:      users[scopedUsername(usernameWithFullAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -303,42 +284,10 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 		{
-			name: "list pods in every namespace for scoped user with full access",
-			args: args{
-				user:      users[scopedUsername(usernameWithFullAccess)],
-				namespace: metav1.NamespaceAll,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
-			},
-			want: want{
-				listPodsResult: []string{
-					"default/nginx-1",
-					"default/nginx-2",
-					"default/test",
-					"dev/nginx-1",
-					"dev/nginx-2",
-				},
-			},
-		},
-		{
 			name: "list default namespace pods for user with default namespace",
 			args: args{
 				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
-			},
-			want: want{
-				listPodsResult: []string{
-					"default/nginx-1",
-					"default/nginx-2",
-					"default/test",
-				},
-			},
-		},
-		{
-			name: "list default namespace pods for scoped user with default namespace",
-			args: args{
-				user:      users[scopedUsername(usernameWithNamespaceAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			want: want{
 				listPodsResult: []string{
@@ -363,21 +312,6 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 		{
-			name: "list pods in every namespace for scoped user with default namespace",
-			args: args{
-				user:      users[scopedUsername(usernameWithNamespaceAccess)],
-				namespace: metav1.NamespaceAll,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
-			},
-			want: want{
-				listPodsResult: []string{
-					"default/nginx-1",
-					"default/nginx-2",
-					"default/test",
-				},
-			},
-		},
-		{
 			name: "list default namespace pods for user with traits for default namespace",
 			args: args{
 				user:      userWithTraits,
@@ -389,6 +323,11 @@ func TestListPodRBAC(t *testing.T) {
 					"default/nginx-2",
 					"default/test",
 				},
+			},
+			// scoped identities don't support traits, skip this case
+			// TODO (eriktate): restore these cases once scoped traits are supported
+			wantScoped: &want{
+				skipScopedTest: true,
 			},
 		},
 		{
@@ -403,6 +342,11 @@ func TestListPodRBAC(t *testing.T) {
 					"default/nginx-2",
 					"default/test",
 				},
+			},
+			// scoped identities don't support traits, skip this case
+			// TODO (eriktate): restore these cases once scoped traits are supported
+			wantScoped: &want{
+				skipScopedTest: true,
 			},
 		},
 		{
@@ -427,28 +371,6 @@ func TestListPodRBAC(t *testing.T) {
 			},
 		},
 		{
-			name: "list default namespace pods for scoped user with limited access",
-			args: args{
-				user:      users[scopedUsername(usernameWithLimitedAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
-			},
-			want: want{
-				listPodsResult: []string{
-					"default/nginx-1",
-					"default/nginx-2",
-				},
-				getTestPodResult: &kubeerrors.StatusError{
-					ErrStatus: metav1.Status{
-						Status:  "Failure",
-						Message: "pods \"test\" is forbidden: User \"scoped-limited_user\" cannot get resource \"pods\" in API group \"\" in the namespace \"default\"",
-						Code:    403,
-						Reason:  metav1.StatusReasonForbidden,
-					},
-				},
-			},
-		},
-		{
 			name: "list pods in every namespace for user with default namespace deny rule",
 			args: args{
 				user: userWithDenyRule,
@@ -466,6 +388,11 @@ func TestListPodRBAC(t *testing.T) {
 						Reason:  metav1.StatusReasonForbidden,
 					},
 				},
+			},
+			wantScoped: &want{
+				// scoped roles don't have explicit deny rules, so there is no scoped equivalent for
+				// userWithDenyRule. skip that case
+				skipScopedTest: true,
 			},
 		},
 		{
@@ -496,6 +423,26 @@ func TestListPodRBAC(t *testing.T) {
 					ErrStatus: metav1.Status{
 						Status:  "Failure",
 						Message: "pods \"test\" is forbidden: User \"default_user\" cannot get resource \"pods\" in API group \"\" in the namespace \"default\"",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
+			// scoped identities don't support access requests, expect failures
+			wantScoped: &want{
+				listPodsResult: []string{},
+				listPodErr: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "access denied",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+				getTestPodResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "access denied",
 						Code:    403,
 						Reason:  metav1.StatusReasonForbidden,
 					},
@@ -539,6 +486,26 @@ func TestListPodRBAC(t *testing.T) {
 					},
 				},
 			},
+			// scoped identities don't support access requests, expect failure
+			wantScoped: &want{
+				listPodsResult: []string{},
+				listPodErr: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "access denied",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+				getTestPodResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "access denied",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
 		},
 		{
 			name: "user with pod access request that no longer fullfills the role requirements",
@@ -577,6 +544,26 @@ func TestListPodRBAC(t *testing.T) {
 					},
 				},
 			},
+			// scoped identities don't support access requests so this test case should fail
+			wantScoped: &want{
+				listPodsResult: []string{},
+				listPodErr: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "access denied",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+				getTestPodResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "access denied",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
 		},
 		{
 			name: "list default namespace pods for user with limited access",
@@ -596,25 +583,6 @@ func TestListPodRBAC(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "list default namespace pods for scoped user with limited access",
-			args: args{
-				user:      users[scopedUsername(usernameWithoutListVerbAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithoutListVerbAccess), scope),
-			},
-			want: want{
-				listPodsResult: []string{},
-				listPodErr: &kubeerrors.StatusError{
-					ErrStatus: metav1.Status{
-						Status:  "Failure",
-						Message: "pods is forbidden: User \"scoped-no_list_user\" cannot list resource \"pods\" in API group \"\" in the namespace \"default\"",
-						Code:    403,
-						Reason:  metav1.StatusReasonForbidden,
-					},
-				},
-			},
-		},
 	}
 	getPodsFromPodList := func(items []corev1.Pod) []string {
 		pods := make([]string, 0, len(items))
@@ -624,27 +592,38 @@ func TestListPodRBAC(t *testing.T) {
 		return pods
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s scope=%s", tt.name, scope), func(t *testing.T) {
 			t.Parallel()
+			want := tt.want
+			if scope != "" && tt.wantScoped != nil {
+				want = *tt.wantScoped
+			}
+			if want.skipScopedTest {
+				// skip test
+				return
+			}
 			// generate a kube client with user certs for auth
 			client, _ := testCtx.GenTestKubeClientTLSCert(
 				t,
 				tt.args.user.GetName(),
-				kubeCluster,
-				tt.args.opts...,
+				scopes.QualifiedName{
+					Name:  kubeCluster,
+					Scope: testCtx.Scope,
+				},
+				slices.Concat(tt.args.opts, makeScopedOpts(t, testCtx, tt.args.user.GetName(), scope))...,
 			)
 
 			rsp, err := client.CoreV1().Pods(tt.args.namespace).List(
 				testCtx.Context,
 				metav1.ListOptions{},
 			)
-			if tt.want.listPodErr != nil {
+			if want.listPodErr != nil {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.want.listPodErr.Error())
+				require.Contains(t, err.Error(), want.listPodErr.Error())
 			} else {
 				require.NoError(t, err)
 			}
-			require.Equal(t, tt.want.listPodsResult, getPodsFromPodList(rsp.Items))
+			require.Equal(t, want.listPodsResult, getPodsFromPodList(rsp.Items))
 
 			_, err = client.CoreV1().Pods(metav1.NamespaceDefault).Get(
 				testCtx.Context,
@@ -652,12 +631,34 @@ func TestListPodRBAC(t *testing.T) {
 				metav1.GetOptions{},
 			)
 
-			if tt.want.getTestPodResult == nil {
+			if want.getTestPodResult == nil {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.want.getTestPodResult.Error())
+				require.Contains(t, err.Error(), want.getTestPodResult.Error())
 			}
+		})
+	}
+}
+
+func TestListPodRBAC(t *testing.T) {
+	t.Parallel()
+	// kubeMock is a Kubernetes API mock for the session tests.
+	// Once a new session is created, this mock will write to
+	// stdout and stdin (if available) the pod name, followed
+	// by copying the contents of stdin into both streams.
+	kubeMock, err := tkm.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	for _, scope := range []string{"", scopedTestScope} {
+		name := "unscoped"
+		if scope != "" {
+			name = scope
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			testListPodRBAC(t, kubeMock, scope)
 		})
 	}
 }
@@ -709,7 +710,7 @@ func TestListResourcesAuditResponseCode(t *testing.T) {
 			},
 		},
 	)
-	client, _ := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), kubeCluster)
+	client, _ := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), scopes.QualifiedName{Name: kubeCluster})
 
 	_, err = client.CoreV1().Pods(metav1.NamespaceDefault).List(testCtx.Context, metav1.ListOptions{})
 	require.NoError(t, err)
@@ -1154,21 +1155,12 @@ func (f *fakeResponseWriter) Write(b []byte) (int, error) {
 	return f.writer.Write(b)
 }
 
-func TestDeletePodCollectionRBAC(t *testing.T) {
+func testDeletePodCollectionRBAC(t *testing.T, kubeMock *tkm.KubeMockServer, scope string) {
 	const (
 		usernameWithFullAccess      = "full_user"
 		usernameWithNamespaceAccess = "default_user"
 		usernameWithLimitedAccess   = "limited_user"
-		scope                       = "/test"
 	)
-	// kubeMock is a Kubernetes API mock for the session tests.
-	// Once a new session is created, this mock will write to
-	// stdout and stdin (if available) the pod name, followed
-	// by copying the contents of stdin into both streams.
-	kubeMock, err := tkm.NewKubeAPIMock()
-	require.NoError(t, err)
-	t.Cleanup(func() { kubeMock.Close() })
-
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(
 		context.Background(),
@@ -1233,13 +1225,16 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 		)
 		users[unscopedUser.GetName()] = unscopedUser
 
+		if scope == "" {
+			continue
+		}
 		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
 		for idx, resource := range kubeResources {
 			scopedResources[idx] = toScopedKubeResource(resource)
 		}
-		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+		scopedAssignment := testCtx.CreateAndAssignScopedRole(
 			t,
-			scopedUsername(username),
+			username,
 			scope,
 			accessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{scope},
@@ -1251,7 +1246,6 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 				}.Build(),
 			}.Build())
 		scopedAssignments = append(scopedAssignments, scopedAssignment)
-		users[scopedUser.GetName()] = scopedUser
 	}
 	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
@@ -1280,37 +1274,10 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 			},
 		},
 		{
-			name: "delete pods in default namespace for scoped user with full access",
-			args: args{
-				user:      users[scopedUsername(usernameWithFullAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
-			},
-
-			deletedPods: []string{
-				"default/nginx-1",
-				"default/nginx-2",
-				"default/test",
-			},
-		},
-		{
 			name: "delete pods for user limited to default namespace",
 			args: args{
 				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
-			},
-			deletedPods: []string{
-				"default/nginx-1",
-				"default/nginx-2",
-				"default/test",
-			},
-		},
-		{
-			name: "delete pods for scoped user limited to default namespace",
-			args: args{
-				user:      users[scopedUsername(usernameWithNamespaceAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			deletedPods: []string{
 				"default/nginx-1",
@@ -1328,16 +1295,6 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 			deletedPods: []string{},
 		},
 		{
-			name: "delete pods in dev namespace for scoped user limited to default",
-			args: args{
-				user:      users[scopedUsername(usernameWithNamespaceAccess)],
-				namespace: "dev",
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
-			},
-			wantErr:     true,
-			deletedPods: []string{},
-		},
-		{
 			name: "delete pods in default namespace for user with limited access",
 			args: args{
 				user:      users[usernameWithLimitedAccess],
@@ -1349,31 +1306,18 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 				"default/nginx-2",
 			},
 		},
-		{
-			name: "delete pods in default namespace for scoped user with limited access",
-			args: args{
-				user:      users[scopedUsername(usernameWithLimitedAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
-			},
-
-			deletedPods: []string{
-				"default/nginx-1",
-				"default/nginx-2",
-			},
-		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s scope=%s", tt.name, scope), func(t *testing.T) {
 			t.Parallel()
 			requestID := kubetypes.UID(uuid.NewString())
 			// generate a kube client with user certs for auth
 			client, _ := testCtx.GenTestKubeClientTLSCert(
 				t,
 				tt.args.user.GetName(),
-				kubeCluster,
-				tt.args.opts...,
+				scopes.QualifiedName{Name: kubeCluster, Scope: testCtx.Scope},
+				slices.Concat(tt.args.opts, makeScopedOpts(t, testCtx, tt.args.user.GetName(), scope))...,
 			)
 			err := client.CoreV1().Pods(tt.args.namespace).DeleteCollection(
 				testCtx.Context,
@@ -1398,20 +1342,34 @@ func TestDeletePodCollectionRBAC(t *testing.T) {
 	require.Empty(t, kubeMock.DeletedPods(""), "a request as received without metav1.DeleteOptions.Preconditions.UID")
 }
 
-func TestDeleteCRDCollectionRBAC(t *testing.T) {
-	const (
-		usernameWithFullAccess      = "full_user"
-		usernameWithNamespaceAccess = "default_user"
-		usernameWithLimitedAccess   = "limited_user"
-		scope                       = "/test"
-	)
+func TestDeletePodCollectionRBAC(t *testing.T) {
+	t.Parallel()
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
 	// stdout and stdin (if available) the pod name, followed
 	// by copying the contents of stdin into both streams.
-	kubeMock, err := tkm.NewKubeAPIMock(tkm.WithTeleportRoleCRD)
+	kubeMock, err := tkm.NewKubeAPIMock()
 	require.NoError(t, err)
 	t.Cleanup(func() { kubeMock.Close() })
+
+	for _, scope := range []string{"", scopedTestScope} {
+		name := "unscoped"
+		if scope != "" {
+			name = scope
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			testDeletePodCollectionRBAC(t, kubeMock, scope)
+		})
+	}
+}
+
+func testDeleteCRDCollectionRBAC(t *testing.T, kubeMock *tkm.KubeMockServer, scope string) {
+	const (
+		usernameWithFullAccess      = "full_user"
+		usernameWithNamespaceAccess = "default_user"
+		usernameWithLimitedAccess   = "limited_user"
+	)
 
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(
@@ -1477,13 +1435,16 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 		)
 		users[unscopedUser.GetName()] = unscopedUser
 
+		if scope == "" {
+			continue
+		}
 		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
 		for idx, resource := range kubeResources {
 			scopedResources[idx] = toScopedKubeResource(resource)
 		}
-		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+		scopedAssignment := testCtx.CreateAndAssignScopedRole(
 			t,
-			scopedUsername(username),
+			username,
 			scope,
 			accessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{scope},
@@ -1495,7 +1456,6 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 				}.Build(),
 			}.Build())
 		scopedAssignments = append(scopedAssignments, scopedAssignment)
-		users[scopedUser.GetName()] = scopedUser
 	}
 	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
@@ -1525,39 +1485,10 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 			},
 		},
 		{
-			name: "delete teleportroles in default namespace for scoped user with full access",
-			args: args{
-				user:      users[scopedUsername(usernameWithFullAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
-			},
-
-			deletedCRDs: []string{
-				"default/telerole-1",
-				"default/telerole-1",
-				"default/telerole-2",
-				"default/telerole-test",
-			},
-		},
-		{
 			name: "delete teleportroles for user limited to default namespace",
 			args: args{
 				user:      users[usernameWithNamespaceAccess],
 				namespace: metav1.NamespaceDefault,
-			},
-			deletedCRDs: []string{
-				"default/telerole-1",
-				"default/telerole-1",
-				"default/telerole-2",
-				"default/telerole-test",
-			},
-		},
-		{
-			name: "delete teleportroles for scoped user limited to default namespace",
-			args: args{
-				user:      users[scopedUsername(usernameWithNamespaceAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
 			},
 			deletedCRDs: []string{
 				"default/telerole-1",
@@ -1576,16 +1507,6 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 			deletedCRDs: []string{},
 		},
 		{
-			name: "delete teleportroles in dev namespace for scoped user limited to default",
-			args: args{
-				user:      users[scopedUsername(usernameWithNamespaceAccess)],
-				namespace: "dev",
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithNamespaceAccess), scope),
-			},
-			wantErr:     true,
-			deletedCRDs: []string{},
-		},
-		{
 			name: "delete teleportroles in default namespace for user with limited access",
 			args: args{
 				user:      users[usernameWithLimitedAccess],
@@ -1596,30 +1517,18 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 				"default/telerole-test",
 			},
 		},
-		{
-			name: "delete teleportroles in default namespace for scoped user with limited access",
-			args: args{
-				user:      users[scopedUsername(usernameWithLimitedAccess)],
-				namespace: metav1.NamespaceDefault,
-				opts:      makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
-			},
-
-			deletedCRDs: []string{
-				"default/telerole-test",
-			},
-		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s scope=%s", tt.name, scope), func(t *testing.T) {
 			t.Parallel()
 			requestID := kubetypes.UID(uuid.NewString())
 			// generate a kube client with user certs for auth
 			_, client, _ := testCtx.GenTestKubeClientsTLSCert(
 				t,
 				tt.args.user.GetName(),
-				kubeCluster,
-				tt.args.opts...,
+				scopes.QualifiedName{Name: kubeCluster, Scope: testCtx.Scope},
+				slices.Concat(tt.args.opts, makeScopedOpts(t, testCtx, tt.args.user.GetName(), scope))...,
 			)
 			err := client.Resource(schema.GroupVersionResource{
 				Group:    "resources.teleport.dev",
@@ -1648,20 +1557,35 @@ func TestDeleteCRDCollectionRBAC(t *testing.T) {
 	require.Empty(t, kubeMock.DeletedCRDs("TeleportRole", ""), "a request as received without metav1.DeleteOptions.Preconditions.UID")
 }
 
-func TestListClusterRoleRBAC(t *testing.T) {
-	const (
-		usernameWithFullAccess    = "full_user"
-		usernameWithLimitedAccess = "limited_user"
-		testClusterRoleName       = "cr-test"
-		scope                     = "/test"
-	)
+func TestDeleteCRDCollectionRBAC(t *testing.T) {
+	t.Parallel()
+
 	// kubeMock is a Kubernetes API mock for the session tests.
 	// Once a new session is created, this mock will write to
 	// stdout and stdin (if available) the pod name, followed
 	// by copying the contents of stdin into both streams.
-	kubeMock, err := tkm.NewKubeAPIMock()
+	kubeMock, err := tkm.NewKubeAPIMock(tkm.WithTeleportRoleCRD)
 	require.NoError(t, err)
 	t.Cleanup(func() { kubeMock.Close() })
+	for _, scope := range []string{"", scopedTestScope} {
+		name := "unscoped"
+		if scope != "" {
+			name = "scoped"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			testDeleteCRDCollectionRBAC(t, kubeMock, scope)
+		})
+	}
+}
+
+func testListClusterRoleRBAC(t *testing.T, kubeMock *tkm.KubeMockServer, scope string) {
+	const (
+		usernameWithFullAccess    = "full_user"
+		usernameWithLimitedAccess = "limited_user"
+		testClusterRoleName       = "cr-test"
+	)
 
 	// creates a Kubernetes service with a configured cluster pointing to mock api server
 	testCtx := SetupTestContext(
@@ -1716,13 +1640,17 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		)
 		users[unscopedUser.GetName()] = unscopedUser
 
+		if scope == "" {
+			// only apply scoped resources for scoped test cases
+			continue
+		}
 		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
 		for idx, resource := range kubeResources {
 			scopedResources[idx] = toScopedKubeResource(resource)
 		}
-		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+		scopedAssignment := testCtx.CreateAndAssignScopedRole(
 			t,
-			scopedUsername(username),
+			username,
 			scope,
 			accessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{scope},
@@ -1734,7 +1662,6 @@ func TestListClusterRoleRBAC(t *testing.T) {
 				}.Build(),
 			}.Build())
 		scopedAssignments = append(scopedAssignments, scopedAssignment)
-		users[scopedUser.GetName()] = scopedUser
 	}
 	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
 
@@ -1748,28 +1675,15 @@ func TestListClusterRoleRBAC(t *testing.T) {
 		getTestResult          error
 	}
 	tests := []struct {
-		name string
-		args args
-		want want
+		name       string
+		args       args
+		want       want
+		wantScoped *want
 	}{
 		{
 			name: "list cluster roles for user with full access",
 			args: args{
 				user: users[usernameWithFullAccess],
-			},
-			want: want{
-				listClusterRolesResult: []string{
-					"cr-nginx-1",
-					"cr-nginx-2",
-					"cr-test",
-				},
-			},
-		},
-		{
-			name: "list cluster roles for scoped user with full access",
-			args: args{
-				user: users[scopedUsername(usernameWithFullAccess)],
-				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listClusterRolesResult: []string{
@@ -1793,27 +1707,6 @@ func TestListClusterRoleRBAC(t *testing.T) {
 					ErrStatus: metav1.Status{
 						Status:  "Failure",
 						Message: "clusterroles \"cr-test\" is forbidden: User \"limited_user\" cannot get resource \"clusterroles\" in API group \"rbac.authorization.k8s.io\"",
-						Code:    403,
-						Reason:  metav1.StatusReasonForbidden,
-					},
-				},
-			},
-		},
-		{
-			name: "list cluster roles for scoped user with limited access",
-			args: args{
-				user: users[scopedUsername(usernameWithLimitedAccess)],
-				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
-			},
-			want: want{
-				listClusterRolesResult: []string{
-					"cr-nginx-1",
-					"cr-nginx-2",
-				},
-				getTestResult: &kubeerrors.StatusError{
-					ErrStatus: metav1.Status{
-						Status:  "Failure",
-						Message: "clusterroles \"cr-test\" is forbidden: User \"scoped-limited_user\" cannot get resource \"clusterroles\" in API group \"rbac.authorization.k8s.io\"",
 						Code:    403,
 						Reason:  metav1.StatusReasonForbidden,
 					},
@@ -1856,6 +1749,25 @@ func TestListClusterRoleRBAC(t *testing.T) {
 					},
 				},
 			},
+			wantScoped: &want{
+				listClusterRolesResult: []string{},
+				listClusterErr: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "access denied",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+				getTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "access denied",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
 		},
 	}
 
@@ -1870,25 +1782,31 @@ func TestListClusterRoleRBAC(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			want := tt.want
+			if scope != "" && tt.wantScoped != nil {
+				// we should override the expected results for scoped tests when wantScoped is defined
+				want = *tt.wantScoped
+			}
 			// Generate a kube client with user certs for auth.
 			client, _ := testCtx.GenTestKubeClientTLSCert(
 				t,
 				tt.args.user.GetName(),
-				kubeCluster,
-				tt.args.opts...,
+				scopes.QualifiedName{Name: kubeCluster, Scope: testCtx.Scope},
+				// always assign scoped opt since it's a no-op when scope == ""
+				slices.Concat(tt.args.opts, makeScopedOpts(t, testCtx, tt.args.user.GetName(), scope))...,
 			)
 
 			rsp, err := client.RbacV1().ClusterRoles().List(
 				testCtx.Context,
 				metav1.ListOptions{},
 			)
-			if tt.want.listClusterErr != nil {
+			if want.listClusterErr != nil {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.want.listClusterErr.Error())
+				require.Contains(t, err.Error(), want.listClusterErr.Error())
 			} else {
 				require.NoError(t, err)
 			}
-			require.Equal(t, tt.want.listClusterRolesResult, getClusterRolesFromList(rsp.Items))
+			require.Equal(t, want.listClusterRolesResult, getClusterRolesFromList(rsp.Items))
 
 			_, err = client.RbacV1().ClusterRoles().Get(
 				testCtx.Context,
@@ -1896,24 +1814,45 @@ func TestListClusterRoleRBAC(t *testing.T) {
 				metav1.GetOptions{},
 			)
 
-			if tt.want.getTestResult == nil {
+			if want.getTestResult == nil {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.want.getTestResult.Error())
+				require.Contains(t, err.Error(), want.getTestResult.Error())
 			}
+		})
+	}
+
+}
+func TestListClusterRoleRBAC(t *testing.T) {
+	t.Parallel()
+	// kubeMock is a Kubernetes API mock for the session tests.
+	// Once a new session is created, this mock will write to
+	// stdout and stdin (if available) the pod name, followed
+	// by copying the contents of stdin into both streams.
+	kubeMock, err := tkm.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+
+	for _, scope := range []string{"", scopedTestScope} {
+		name := "unscoped"
+		if scope != "" {
+			name = "scoped"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			testListClusterRoleRBAC(t, kubeMock, scope)
 		})
 	}
 }
 
-func TestGenericCustomResourcesRBAC(t *testing.T) {
+func testGenericCustomResourcesRBAC(t *testing.T, scope string) {
 	const (
 		usernameWithFullAccess     = "full_user"
 		usernameWithLimitedAccess  = "limited_user"
 		usernameWithSpecificAccess = "specific_user"
 		testTeleportRoleName       = "telerole-test"
 		testTeleportRoleNamespace  = "default"
-		scope                      = "/test"
 	)
 
 	kubeScheme, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
@@ -1972,13 +1911,17 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		)
 		users[unscopedUser.GetName()] = unscopedUser
 
+		if scope == "" {
+			continue
+		}
+		// we only create scoped resources against the scoped test context
 		scopedResources := make([]*accessv1.KubeResource, len(kubeResources))
 		for idx, resource := range kubeResources {
 			scopedResources[idx] = toScopedKubeResource(resource)
 		}
-		scopedUser, scopedAssignment := testCtx.CreateUserAndScopedRole(
+		scopedAssignment := testCtx.CreateAndAssignScopedRole(
 			t,
-			scopedUsername(username),
+			username,
 			scope,
 			accessv1.ScopedRoleSpec_builder{
 				AssignableScopes: []string{scope},
@@ -1990,9 +1933,9 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 				}.Build(),
 			}.Build())
 		scopedAssignments = append(scopedAssignments, scopedAssignment)
-		users[scopedUser.GetName()] = scopedUser
 	}
 	waitForSRACache(t, testCtx.TLSServer, scopedAssignments...)
+
 	type args struct {
 		user types.User
 		opts []GenTestKubeClientTLSCertOptions
@@ -2007,28 +1950,14 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 		name string
 		args args
 		want want
+		// some test cases have different expected results for scoped versus unscoped identities
+		wantScoped     *want
+		failWhenScoped bool
 	}{
 		{
 			name: "list teleport roles for user with full access",
 			args: args{
 				user: users[usernameWithFullAccess],
-			},
-			want: want{
-				listTeleportRolesResult: []string{
-					"default/telerole-1",
-					"default/telerole-1",
-					"default/telerole-2",
-					"default/telerole-test",
-					"dev/telerole-1",
-					"dev/telerole-2",
-				},
-			},
-		},
-		{
-			name: "list teleport roles for scoped user with full access",
-			args: args{
-				user: users[scopedUsername(usernameWithFullAccess)],
-				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithFullAccess), scope),
 			},
 			want: want{
 				listTeleportRolesResult: []string{
@@ -2065,30 +1994,6 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 			},
 		},
 		{
-			name: "list teleport roles for scoped user with specific crd access",
-			args: args{
-				user: users[scopedUsername(usernameWithSpecificAccess)],
-				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithSpecificAccess), scope),
-			},
-			want: want{
-				listTeleportRolesResult: []string{
-					"dev/telerole-1",
-					"dev/telerole-2",
-				},
-				getTestResult: &kubeerrors.StatusError{
-					ErrStatus: metav1.Status{
-						Status: "Failure",
-						Message: fmt.Sprintf(
-							"teleportroles \"telerole-test\" is forbidden: User %q cannot get resource \"teleportroles\" in API group \"resources.teleport.dev\"",
-							"scoped-"+usernameWithSpecificAccess,
-						),
-						Code:   403,
-						Reason: metav1.StatusReasonForbidden,
-					},
-				},
-			},
-		},
-		{
 			name: "list teleport roles for user with limited access",
 			args: args{
 				user: users[usernameWithLimitedAccess],
@@ -2102,27 +2007,6 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 					ErrStatus: metav1.Status{
 						Status:  "Failure",
 						Message: "teleportroles \"telerole-test\" is forbidden: User \"limited_user\" cannot get resource \"teleportroles\" in API group \"resources.teleport.dev\"",
-						Code:    403,
-						Reason:  metav1.StatusReasonForbidden,
-					},
-				},
-			},
-		},
-		{
-			name: "list teleport roles for scoped user with limited access",
-			args: args{
-				user: users[scopedUsername(usernameWithLimitedAccess)],
-				opts: makeScopedOpts(t, testCtx, scopedUsername(usernameWithLimitedAccess), scope),
-			},
-			want: want{
-				listTeleportRolesResult: []string{
-					"dev/telerole-1",
-					"dev/telerole-2",
-				},
-				getTestResult: &kubeerrors.StatusError{
-					ErrStatus: metav1.Status{
-						Status:  "Failure",
-						Message: "teleportroles \"telerole-test\" is forbidden: User \"scoped-limited_user\" cannot get resource \"teleportroles\" in API group \"resources.teleport.dev\"",
 						Code:    403,
 						Reason:  metav1.StatusReasonForbidden,
 					},
@@ -2165,8 +2049,27 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 					},
 				},
 			},
+			// scoped identities don't support access requests, so we expect failure to even connect to the cluster
+			wantScoped: &want{
+				wantListErr: true,
+				getTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "failed to get server groups",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+				deleteAllTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "failed to get server groups",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
 		},
-
 		{
 			name: "user with namespace access request that restricts the role requirements",
 			args: args{
@@ -2198,18 +2101,46 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 					},
 				},
 			},
+			// scoped identities don't support access requests, so we expect failure to even connect to the cluster
+			wantScoped: &want{
+				wantListErr: true,
+				getTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "failed to get server groups",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+				deleteAllTestResult: &kubeerrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  "Failure",
+						Message: "failed to get server groups",
+						Code:    403,
+						Reason:  metav1.StatusReasonForbidden,
+					},
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		want := tt.want
+		if scope != "" && tt.wantScoped != nil {
+			// we should override the expected results for scoped tests when wantScoped is defined
+			want = *tt.wantScoped
+		}
+		t.Run(fmt.Sprintf("%s scope=%s", tt.name, scope), func(t *testing.T) {
 			t.Parallel()
+
+			// always add scoped opts since they'll be ignored when scope == ""
+			tt.args.opts = slices.Concat(tt.args.opts, makeScopedOpts(t, testCtx, tt.args.user.GetName(), scope))
 
 			// Generate a kube client with user certs for auth.
 			_, rest := testCtx.GenTestKubeClientTLSCert(
 				t,
 				tt.args.user.GetName(),
-				kubeCluster,
+				scopes.QualifiedName{Name: kubeCluster, Scope: scope},
 				tt.args.opts...,
 			)
 
@@ -2223,7 +2154,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 
 				list := tkm.NewTeleportRoleCRD()
 
-				if err := client.List(context.Background(), list); tt.want.wantListErr {
+				if err := client.List(context.Background(), list); want.wantListErr {
 					require.Error(t, err)
 					return
 				} else {
@@ -2244,7 +2175,7 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 							return nil
 						},
 					))
-				require.ElementsMatch(t, tt.want.listTeleportRolesResult, teleportRolesList)
+				require.ElementsMatch(t, want.listTeleportRolesResult, teleportRolesList)
 			})
 
 			t.Run("get", func(t *testing.T) {
@@ -2258,13 +2189,13 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 						Namespace: testTeleportRoleNamespace,
 					},
 					get,
-				); tt.want.getTestResult == nil {
+				); want.getTestResult == nil {
 					require.NoError(t, err)
 					require.Equal(t, testTeleportRoleName, get.GetName())
 					require.Equal(t, testTeleportRoleNamespace, get.GetNamespace())
 				} else {
 					require.Error(t, err)
-					require.ErrorContains(t, err, tt.want.getTestResult.Error())
+					require.ErrorContains(t, err, want.getTestResult.Error())
 				}
 			})
 
@@ -2275,9 +2206,9 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 
 				if err := client.DeleteAllOf(context.Background(),
 					dl,
-				); tt.want.deleteAllTestResult != nil {
+				); want.deleteAllTestResult != nil {
 					require.Error(t, err)
-					require.ErrorContains(t, err, tt.want.deleteAllTestResult.Error())
+					require.ErrorContains(t, err, want.deleteAllTestResult.Error())
 					return
 				} else {
 					require.NoError(t, err)
@@ -2287,25 +2218,39 @@ func TestGenericCustomResourcesRBAC(t *testing.T) {
 	}
 }
 
+func TestGenericCustomResourcesRBAC(t *testing.T) {
+	t.Parallel()
+
+	for _, scope := range []string{"", scopedTestScope} {
+		name := "unscoped"
+		if scope != "" {
+			name = "scoped"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			testGenericCustomResourcesRBAC(t, scope)
+		})
+	}
+}
+
 func TestV8JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	const scope = "/test"
-	_, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
-
-	newTestUser := newTestUserFactoryWithScope(t, testCtx, "", types.V8, scope)
+	_, unscopedTestCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+	_, scopedTestCtx := newTestKubeCRDMock(t, scopedTestScope, tkm.WithTeleportRoleCRD)
 
 	tests := []struct {
-		name string
-		user types.User
-		ns   string
-		want []string
+		name       string
+		allow      []types.KubernetesResource
+		deny       []types.KubernetesResource
+		ns         string
+		want       []string
+		skipScoped bool
 	}{
 		{
 			name: "full default access",
-			// regnerate a factory without scopes because omitting kube resources
-			// is not allowed for scoped roles and newTestUser will fail
-			user: newTestUserFactory(t, testCtx, "", types.V8)(nil, nil),
 			ns:   "default",
 			want: []string{
 				// teleportroles.
@@ -2327,10 +2272,13 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 				"dev",
 				"prod",
 			},
+			// generating a test context for a scoped identity has to include
+			// at least one allow rule, so we skip this case when scoped
+			skipScoped: true,
 		},
 		{
 			name: "full wildcard access",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
 					Name:      types.Wildcard,
@@ -2345,7 +2293,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 					Verbs:     []string{types.Wildcard},
 					APIGroup:  types.Wildcard,
 				},
-			}, nil),
+			},
 			ns: "default",
 			want: []string{
 				// teleportroles.
@@ -2370,7 +2318,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "namespaced wildcard access",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
 					Name:      types.Wildcard,
@@ -2378,7 +2326,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 					Verbs:     []string{types.Wildcard},
 					APIGroup:  types.Wildcard,
 				},
-			}, nil),
+			},
 			ns: "default",
 			want: []string{
 				// teleportroles.
@@ -2400,7 +2348,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "clusterwide wildcard access",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
 					Name:      types.Wildcard,
@@ -2408,7 +2356,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 					Verbs:     []string{types.Wildcard},
 					APIGroup:  types.Wildcard,
 				},
-			}, nil),
+			},
 			ns: "default",
 			want: []string{
 				// teleportroles.
@@ -2426,7 +2374,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "single wildcard access",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
 					Name:      types.Wildcard,
@@ -2434,7 +2382,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 					Verbs:     []string{types.Wildcard},
 					APIGroup:  types.Wildcard,
 				},
-			}, nil),
+			},
 			ns: "default",
 			want: []string{
 				// teleportroles.
@@ -2454,7 +2402,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "wildcard single namespace access default",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
 					Name:      types.Wildcard,
@@ -2467,7 +2415,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 					Name:  "default",
 					Verbs: []string{types.Wildcard},
 				},
-			}, nil),
+			},
 			ns: "default",
 			want: []string{
 				// teleportroles.
@@ -2486,7 +2434,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "wildcard single namespace access dev",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
 					Name:      types.Wildcard,
@@ -2499,7 +2447,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 					Name:  "dev",
 					Verbs: []string{types.Wildcard},
 				},
-			}, nil),
+			},
 			ns: "dev",
 			want: []string{
 				// teleportroles.
@@ -2515,13 +2463,13 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "regular namespace all access by name",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:  "namespaces",
 					Name:  types.Wildcard,
 					Verbs: []string{types.Wildcard},
 				},
-			}, nil),
+			},
 			ns: "default",
 			want: []string{
 				// teleportroles.
@@ -2536,7 +2484,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "regular namespace all access by namespace",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:      "namespaces",
 					Name:      types.Wildcard,
@@ -2544,7 +2492,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 					Verbs:     []string{types.Wildcard},
 					APIGroup:  types.Wildcard,
 				},
-			}, nil),
+			},
 			ns: "default",
 			want: []string{
 				// teleportroles.
@@ -2559,13 +2507,13 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "regular namespace single access by name default",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:  "namespaces",
 					Name:  "default",
 					Verbs: []string{types.Wildcard},
 				},
-			}, nil),
+			},
 			ns: "default",
 			want: []string{
 				// teleportroles.
@@ -2577,13 +2525,13 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "regular namespace single access by name dev",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:  "namespaces",
 					Name:  "dev",
 					Verbs: []string{types.Wildcard},
 				},
-			}, nil),
+			},
 			ns: "dev",
 			want: []string{
 				// teleportroles.
@@ -2594,19 +2542,32 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for idx, tt := range tests {
 		// loop to run the test case against scoped and unscoped credentials
-		for _, scoped := range []bool{false, true} {
-			var opts []GenTestKubeClientTLSCertOptions
+		for _, scope := range []string{"", scopedTestScope} {
+			kubeClusterSQN := scopes.QualifiedName{Name: kubeCluster, Scope: scope}
 			want := tt.want
-			if scoped {
-				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
+			testCtx := unscopedTestCtx
+			if scope != "" {
+				if tt.skipScoped {
+					continue
+				}
+				testCtx = scopedTestCtx
 			}
+			user := newScopedUser(t, newScopedUserCfg{
+				testCtx:     testCtx,
+				scope:       scope,
+				roleVersion: types.V8,
+				allow:       tt.allow,
+				deny:        tt.deny,
+				idx:         idx,
+			})
+			opts := makeScopedOpts(t, testCtx, user.GetName(), scope)
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
 				// Generate a kube dynClient with user certs for auth.
-				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster, opts...)
+				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, user.GetName(), kubeClusterSQN, opts...)
 				// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
 				got := []string{}
 				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("resources.teleport.dev/v6/teleportroles")).Namespace(tt.ns))...)
@@ -2828,7 +2789,7 @@ func TestV7JailedNamespaceListRBAC(t *testing.T) {
 			t.Parallel()
 
 			// Generate a kube dynClient with user certs for auth.
-			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), scopes.QualifiedName{Name: kubeCluster})
 
 			// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
 			got := []string{}
@@ -3185,7 +3146,7 @@ func TestV7V8Match(t *testing.T) {
 
 			run := func(t *testing.T, userName string) {
 				// Generate a kube dynClient with user certs for auth.
-				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, userName, kubeCluster)
+				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, userName, scopes.QualifiedName{Name: kubeCluster})
 
 				// List TeleportRoles (namespaced), pods (namespaced), clusterroles (cluster wide) and namespaces (kind of cluster wide).
 				got := []string{}
@@ -3207,10 +3168,8 @@ func TestV7V8Match(t *testing.T) {
 func TestNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
-	const scope = "/test"
-	_, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
-
-	newTestUser := newTestUserFactoryWithScope(t, testCtx, "nslist", types.V8, scope)
+	_, unscopedTestCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+	_, scopedTestCtx := newTestKubeCRDMock(t, scopedTestScope, tkm.WithTeleportRoleCRD)
 
 	commonResources := []types.KubernetesResource{
 		{
@@ -3237,21 +3196,23 @@ func TestNamespaceListRBAC(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		user       types.User
+		allow      []types.KubernetesResource
+		deny       []types.KubernetesResource
 		want       []string
 		wantScoped []string
 	}{
 		{
-			name: "common resources",
-			user: newTestUser(commonResources, nil),
+			name:  "common resources",
+			allow: commonResources,
 			want: []string{
 				"test",
 				"prod",
 			},
 		},
 		{
-			name: "common resources with deny",
-			user: newTestUser(commonResources, []types.KubernetesResource{
+			name:  "common resources with deny",
+			allow: commonResources,
+			deny: []types.KubernetesResource{
 				{
 					Kind:      "teleportroles",
 					Name:      types.Wildcard,
@@ -3266,7 +3227,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 					Verbs:     []string{types.Wildcard},
 					APIGroup:  "",
 				},
-			}),
+			},
 			want: []string{
 				"test",
 				"prod",
@@ -3274,13 +3235,13 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "full wildcard access",
-			user: newTestUser(append(commonResources, types.KubernetesResource{
+			allow: append(commonResources, types.KubernetesResource{
 				Kind:      types.Wildcard,
 				Name:      types.Wildcard,
 				Namespace: types.Wildcard,
 				Verbs:     []string{types.Wildcard},
 				APIGroup:  types.Wildcard,
-			}), nil),
+			}),
 			want: []string{
 				// All namespaces because of the wildcard.
 				"default",
@@ -3291,13 +3252,13 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "single wildcard access",
-			user: newTestUser(append(commonResources, types.KubernetesResource{
+			allow: append(commonResources, types.KubernetesResource{
 				Kind:      types.Wildcard,
 				Name:      types.Wildcard,
 				Namespace: "dev",
 				Verbs:     []string{types.Wildcard},
 				APIGroup:  types.Wildcard,
-			}), nil),
+			}),
 			want: []string{
 				//  test and prod from common resources, dev from main one.
 				"test",
@@ -3307,11 +3268,11 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "reg ns access",
-			user: newTestUser(append(commonResources, types.KubernetesResource{
+			allow: append(commonResources, types.KubernetesResource{
 				Kind:  "namespaces",
 				Name:  "dev",
 				Verbs: []string{types.Wildcard},
-			}), nil),
+			}),
 			want: []string{
 				//  test and prod from common resources, dev from main one.
 				"test",
@@ -3321,13 +3282,13 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "ns wildcard access",
-			user: newTestUser(append(commonResources, types.KubernetesResource{
+			allow: append(commonResources, types.KubernetesResource{
 				Kind:      types.Wildcard,
 				Name:      types.Wildcard,
 				Namespace: types.Wildcard,
 				Verbs:     []string{types.Wildcard},
 				APIGroup:  types.Wildcard,
-			}), nil),
+			}),
 			want: []string{
 				// All namespaces because of the wildcard.
 				"default",
@@ -3338,13 +3299,13 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "wildcard ns single access",
-			user: newTestUser(append(commonResources, types.KubernetesResource{
+			allow: append(commonResources, types.KubernetesResource{
 				Kind:      types.Wildcard,
 				Name:      types.Wildcard,
 				Namespace: "test",
 				Verbs:     []string{types.Wildcard},
 				APIGroup:  types.Wildcard,
-			}), nil),
+			}),
 			want: []string{
 				// test and prod from the common resources, test from main one.
 				"test",
@@ -3353,7 +3314,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "jailed and reg ns single access",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:     "namespaces",
 					Name:     "default",
@@ -3374,7 +3335,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 					Verbs:     []string{types.Wildcard},
 					APIGroup:  types.Wildcard,
 				},
-			}, nil),
+			},
 			want: []string{
 				"default",
 				"test",
@@ -3383,19 +3344,20 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "deny single ns",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:  "namespaces",
 					Name:  "*",
 					Verbs: []string{types.Wildcard},
 				},
-			}, []types.KubernetesResource{
+			},
+			deny: []types.KubernetesResource{
 				{
 					Kind:  "namespaces",
 					Name:  "dev",
 					Verbs: []string{types.Wildcard},
 				},
-			}),
+			},
 			want: []string{
 				"default",
 				"test",
@@ -3411,13 +3373,14 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "ns resource deny cluster-wide wildcard",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:  "namespaces",
 					Name:  types.Wildcard,
 					Verbs: []string{types.Wildcard},
 				},
-			}, []types.KubernetesResource{
+			},
+			deny: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
 					APIGroup:  types.Wildcard,
@@ -3425,7 +3388,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 					Namespace: "",
 					Verbs:     []string{types.Wildcard},
 				},
-			}),
+			},
 			want: []string{},
 			wantScoped: []string{
 				"default",
@@ -3436,7 +3399,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "ns pods deny cluster-wide wildcard",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:  "namespaces",
 					Name:  types.Wildcard,
@@ -3448,7 +3411,8 @@ func TestNamespaceListRBAC(t *testing.T) {
 					Namespace: types.Wildcard,
 					Verbs:     []string{types.Wildcard},
 				},
-			}, []types.KubernetesResource{
+			},
+			deny: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
 					APIGroup:  types.Wildcard,
@@ -3456,7 +3420,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 					Namespace: "",
 					Verbs:     []string{types.Wildcard},
 				},
-			}),
+			},
 			// Even though the user has access to pods and still can get pods in all NSs, the list namespace is empty
 			// because of the deny rule.
 			want: []string{},
@@ -3470,7 +3434,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 		},
 		{
 			name: "ns pods deny ns wildcard",
-			user: newTestUser([]types.KubernetesResource{
+			allow: []types.KubernetesResource{
 				{
 					Kind:  "namespaces",
 					Name:  types.Wildcard,
@@ -3482,13 +3446,14 @@ func TestNamespaceListRBAC(t *testing.T) {
 					Namespace: types.Wildcard,
 					Verbs:     []string{types.Wildcard},
 				},
-			}, []types.KubernetesResource{
+			},
+			deny: []types.KubernetesResource{
 				{
 					Kind:  "namespaces",
 					Name:  types.Wildcard,
 					Verbs: []string{types.Wildcard},
 				},
-			}),
+			},
 			// Even though the user has access to pods and still can get pods in all NSs, the list namespace is empty
 			// because of the deny rule.
 			want: []string{},
@@ -3501,25 +3466,37 @@ func TestNamespaceListRBAC(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
+	for idx, tt := range tests {
 		// loop to run the test case against scoped and unscoped credentials
-		for _, scoped := range []bool{false, true} {
-			var opts []GenTestKubeClientTLSCertOptions
+		for _, scope := range []string{"", scopedTestScope} {
 			want := tt.want
-			if scoped {
-				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
-				// we only want to check tt.wantScoped if it was provided, otherwise a nil value means
-				// we should test scoped credentials against the same expectations
+			kubeClusterSQN := scopes.QualifiedName{Name: kubeCluster, Scope: scope}
+
+			testCtx := unscopedTestCtx
+			if scope != "" {
+				testCtx = scopedTestCtx
 				if tt.wantScoped != nil {
+					// we only want to check tt.wantScoped if it was provided, otherwise a nil value means
+					// we should test scoped credentials against the same expectations
 					want = tt.wantScoped
 				}
 			}
+			user := newScopedUser(t, newScopedUserCfg{
+				testCtx:     testCtx,
+				scope:       scope,
+				prefix:      "nslist",
+				roleVersion: types.V8,
+				allow:       tt.allow,
+				deny:        tt.deny,
+				idx:         idx,
+			})
+			opts := makeScopedOpts(t, testCtx, user.GetName(), scope)
 
-			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
+			t.Run(fmt.Sprintf("%s scope=%s", tt.name, scope), func(t *testing.T) {
 				t.Parallel()
 
 				// Generate a kube dynClient with user certs for auth.
-				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster, opts...)
+				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, user.GetName(), kubeClusterSQN, opts...)
 
 				got := []string{}
 				got = append(got, dynList(testCtx.Context, dynClient.Resource(gvr("v1/namespaces")))...)
@@ -3669,7 +3646,7 @@ func TestDenyClusterWideResources(t *testing.T) {
 			t.Parallel()
 
 			// Generate a kube dynClient with user certs for auth.
-			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), scopes.QualifiedName{Name: kubeCluster})
 
 			got := []string{}
 			// Get namespaces in read-only, should work.
@@ -3687,10 +3664,8 @@ func TestDenyClusterWideResources(t *testing.T) {
 func TestDeleteNamespaceDenial(t *testing.T) {
 	t.Parallel()
 
-	const scope = "/test"
-	_, testCtx := newTestKubeCRDMock(t, scope, tkm.WithTeleportRoleCRD)
-
-	newTestUser := newTestUserFactoryWithScope(t, testCtx, "delete-ns", types.V8, scope)
+	_, unscopedTestCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
+	_, scopedTestCtx := newTestKubeCRDMock(t, scopedTestScope, tkm.WithTeleportRoleCRD)
 
 	fullAccess := []types.KubernetesResource{
 		{
@@ -3704,13 +3679,13 @@ func TestDeleteNamespaceDenial(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		user    types.User
+		deny    []types.KubernetesResource
 		ns      string
 		wantErr bool
 	}{
 		{
 			name: "full access deny all wildcard ns",
-			user: newTestUser(fullAccess, []types.KubernetesResource{
+			deny: []types.KubernetesResource{
 				{
 					Kind:      types.Wildcard,
 					APIGroup:  types.Wildcard,
@@ -3718,79 +3693,94 @@ func TestDeleteNamespaceDenial(t *testing.T) {
 					Namespace: "test",
 					Verbs:     []string{types.Wildcard},
 				},
-			}),
+			},
 			ns:      "test",
 			wantErr: true,
 		},
 		{
 			name: "full access deny wildcard ns resource",
-			user: newTestUser(fullAccess, []types.KubernetesResource{
+			deny: []types.KubernetesResource{
 				{
 					Kind:     "namespaces",
 					APIGroup: types.Wildcard,
 					Name:     types.Wildcard,
 					Verbs:    []string{types.Wildcard},
 				},
-			}),
+			},
 			ns:      "test",
 			wantErr: true,
 		},
 		{
 			name: "full access deny specific ns resource - denied",
-			user: newTestUser(fullAccess, []types.KubernetesResource{
+			deny: []types.KubernetesResource{
 				{
 					Kind:     "namespaces",
 					APIGroup: types.Wildcard,
 					Name:     "test",
 					Verbs:    []string{types.Wildcard},
 				},
-			}),
+			},
 			ns:      "test",
 			wantErr: true,
 		},
 		{
 			name: "full access deny specific ns resource - allowed",
-			user: newTestUser(fullAccess, []types.KubernetesResource{
+			deny: []types.KubernetesResource{
 				{
 					Kind:     "namespaces",
 					APIGroup: types.Wildcard,
 					Name:     "test",
 					Verbs:    []string{types.Wildcard},
 				},
-			}),
+			},
 			ns:      "dev",
 			wantErr: false,
 		},
 		{
 			name: "full access deny unrelated resource - allowed",
-			user: newTestUser(fullAccess, []types.KubernetesResource{
+			deny: []types.KubernetesResource{
 				{
 					Kind:      "pods",
 					Name:      types.Wildcard,
 					Namespace: "test",
 					Verbs:     []string{types.Wildcard},
 				},
-			}),
+			},
 			ns: "test",
 			// TODO(@creack): Reconsider this behavior. We may consider denying this. Keeping as is for now
 			//                to maintain v17's / rolev7 behavior.
 			wantErr: false,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	for idx, tt := range tests {
+		for _, scope := range []string{"", scopedTestScope} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 
-			// Generate a kube dynClient with user certs for auth.
-			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+				testCtx := unscopedTestCtx
+				if scope != "" {
+					testCtx = scopedTestCtx
+				}
+				user := newScopedUser(t, newScopedUserCfg{
+					testCtx:     testCtx,
+					scope:       scope,
+					prefix:      "delete-ns",
+					roleVersion: types.V8,
+					allow:       fullAccess,
+					deny:        tt.deny,
+					idx:         idx,
+				})
+				// Generate a kube dynClient with user certs for auth.
+				_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, user.GetName(), scopes.QualifiedName{Name: kubeCluster, Scope: testCtx.Scope})
 
-			// Attempt to delete a namespace, should fail.
-			if err := dynClient.Resource(gvr("v1/namespaces")).Delete(testCtx.Context, tt.ns, metav1.DeleteOptions{}); tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
+				// Attempt to delete a namespace, should fail.
+				if err := dynClient.Resource(gvr("v1/namespaces")).Delete(testCtx.Context, tt.ns, metav1.DeleteOptions{}); tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		}
 	}
 }
 
@@ -3894,7 +3884,7 @@ func TestFullNamespaceNoDeleteRBAC(t *testing.T) {
 			t.Parallel()
 
 			// Generate a kube dynClient with user certs for auth.
-			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+			_, dynClient, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), scopes.QualifiedName{Name: kubeCluster})
 
 			require.NoError(t, dynClient.Resource(gvr("v1/pods")).DeleteCollection(testCtx.Context, metav1.DeleteOptions{}, metav1.ListOptions{}))
 			require.NoError(t, dynClient.Resource(gvr("v1/secrets")).DeleteCollection(testCtx.Context, metav1.DeleteOptions{}, metav1.ListOptions{}))
@@ -3938,99 +3928,120 @@ func newTestKubeCRDMock(t *testing.T, scope string, opts ...tkm.Option) (*runtim
 }
 
 func newTestUserFactory(t *testing.T, testCtx *TestContext, prefix, roleVersion string) func(allow, deny []types.KubernetesResource) types.User {
-	return newTestUserFactoryWithScope(t, testCtx, prefix, roleVersion, "")
+	count := 0
+
+	return func(allow, deny []types.KubernetesResource) types.User {
+		user := newScopedUser(t, newScopedUserCfg{
+			testCtx:     testCtx,
+			scope:       "",
+			prefix:      prefix,
+			roleVersion: roleVersion,
+			allow:       allow,
+			deny:        deny,
+			idx:         count,
+		})
+		count++
+		return user
+	}
 }
 
-func newTestUserFactoryWithScope(t *testing.T, testCtx *TestContext, prefix, roleVersion, scope string) func(allow, deny []types.KubernetesResource) types.User {
-	count := 0
+type newScopedUserCfg struct {
+	testCtx     *TestContext
+	prefix      string
+	roleVersion string
+	scope       string
+	allow       []types.KubernetesResource
+	deny        []types.KubernetesResource
+	idx         int
+}
+
+func newScopedUser(t *testing.T, cfg newScopedUserCfg) types.User {
+	t.Helper()
+	prefix := cfg.prefix
 	if prefix == "" {
 		prefix = "test"
 	}
 
-	return func(allow, deny []types.KubernetesResource) types.User {
-		t.Helper()
-		count++
-		name := fmt.Sprintf("%s-user-%s-%d", prefix, roleVersion, count)
-		user, _ := testCtx.CreateUserAndRoleVersion(
-			testCtx.Context,
-			t,
-			name,
-			roleVersion,
-			RoleSpec{
-				Name:       name,
-				KubeUsers:  roleKubeUsers,
-				KubeGroups: roleKubeGroups,
-				SetupRoleFunc: func(r types.Role) {
-					r.SetKubeResources(types.Allow, allow)
-					r.SetKubeResources(types.Deny, deny)
-				},
+	name := fmt.Sprintf("%s-user-%s-%d", prefix, cfg.roleVersion, cfg.idx)
+	user, _ := cfg.testCtx.CreateUserAndRoleVersion(
+		cfg.testCtx.Context,
+		t,
+		name,
+		cfg.roleVersion,
+		RoleSpec{
+			Name:       name,
+			KubeUsers:  roleKubeUsers,
+			KubeGroups: roleKubeGroups,
+			SetupRoleFunc: func(r types.Role) {
+				r.SetKubeResources(types.Allow, cfg.allow)
+				r.SetKubeResources(types.Deny, cfg.deny)
 			},
-		)
+		},
+	)
 
-		// don't generate scoped roles if scope wasn't provided
-		if scope == "" {
-			return user
-		}
-
-		// don't generate scoped roles for legacy role kinds
-		if roleVersion != "" && roleVersion != types.V8 {
-			return user
-		}
-
-		// scoped roles are implicit deny and only provide allow rules
-		scopedResources := make([]*accessv1.KubeResource, len(allow))
-		for idx, res := range allow {
-			scopedResources[idx] = toScopedKubeResource(res)
-		}
-		scopedAccess := testCtx.TLSServer.Auth().ScopedAccess()
-		role, err := scopedAccess.CreateScopedRole(t.Context(), accessv1.CreateScopedRoleRequest_builder{
-			Role: accessv1.ScopedRole_builder{
-				Kind:    access.KindScopedRole,
-				Version: types.V1,
-				Metadata: headerv1.Metadata_builder{
-					Name: name,
-				}.Build(),
-				Scope: scope,
-				Spec: accessv1.ScopedRoleSpec_builder{
-					AssignableScopes: []string{scope},
-					Kube: accessv1.ScopedRoleKube_builder{
-						Users:     roleKubeUsers,
-						Groups:    roleKubeGroups,
-						Labels:    wildcardLabel(),
-						Resources: scopedResources,
-					}.Build(),
-				}.Build(),
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
-
-		assignment, err := scopedAccess.CreateScopedRoleAssignment(t.Context(), accessv1.CreateScopedRoleAssignmentRequest_builder{
-			Assignment: accessv1.ScopedRoleAssignment_builder{
-				Kind:    access.KindScopedRoleAssignment,
-				Version: types.V1,
-				SubKind: access.SubKindDynamic,
-				Scope:   scope,
-				Metadata: headerv1.Metadata_builder{
-					Name: uuid.New().String(),
-				}.Build(),
-				Spec: accessv1.ScopedRoleAssignmentSpec_builder{
-					User: name,
-					Assignments: []*accessv1.Assignment{
-						accessv1.Assignment_builder{
-							Role: scopes.QualifiedName{
-								Name:  role.GetRole().GetMetadata().GetName(),
-								Scope: role.GetRole().GetScope(),
-							}.String(),
-							Scope: scope,
-						}.Build(),
-					},
-				}.Build(),
-			}.Build(),
-		}.Build())
-		require.NoError(t, err)
-		waitForSRACache(t, testCtx.TLSServer, assignment)
+	// don't generate scoped roles if scope wasn't provided
+	if cfg.scope == "" {
 		return user
 	}
+
+	// don't generate scoped roles for legacy role kinds
+	if cfg.roleVersion != "" && cfg.roleVersion != types.V8 {
+		return user
+	}
+
+	// scoped roles are implicit deny and only provide allow rules
+	scopedResources := make([]*accessv1.KubeResource, len(cfg.allow))
+	for idx, res := range cfg.allow {
+		scopedResources[idx] = toScopedKubeResource(res)
+	}
+	scopedAccess := cfg.testCtx.TLSServer.Auth().ScopedAccess()
+	role, err := scopedAccess.CreateScopedRole(t.Context(), accessv1.CreateScopedRoleRequest_builder{
+		Role: accessv1.ScopedRole_builder{
+			Kind:    access.KindScopedRole,
+			Version: types.V1,
+			Metadata: headerv1.Metadata_builder{
+				Name: name,
+			}.Build(),
+			Scope: cfg.scope,
+			Spec: accessv1.ScopedRoleSpec_builder{
+				AssignableScopes: []string{cfg.scope},
+				Kube: accessv1.ScopedRoleKube_builder{
+					Users:     roleKubeUsers,
+					Groups:    roleKubeGroups,
+					Labels:    wildcardLabel(),
+					Resources: scopedResources,
+				}.Build(),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	assignment, err := scopedAccess.CreateScopedRoleAssignment(t.Context(), accessv1.CreateScopedRoleAssignmentRequest_builder{
+		Assignment: accessv1.ScopedRoleAssignment_builder{
+			Kind:    access.KindScopedRoleAssignment,
+			Version: types.V1,
+			SubKind: access.SubKindDynamic,
+			Scope:   cfg.scope,
+			Metadata: headerv1.Metadata_builder{
+				Name: uuid.New().String(),
+			}.Build(),
+			Spec: accessv1.ScopedRoleAssignmentSpec_builder{
+				User: name,
+				Assignments: []*accessv1.Assignment{
+					accessv1.Assignment_builder{
+						Role: scopes.QualifiedName{
+							Name:  role.GetRole().GetMetadata().GetName(),
+							Scope: role.GetRole().GetScope(),
+						}.String(),
+						Scope: cfg.scope,
+					}.Build(),
+				},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	require.NoError(t, err)
+	waitForSRACache(t, cfg.testCtx.TLSServer, assignment)
+	return user
 }
 
 func unstructuredListNames(items *unstructured.UnstructuredList) []string {
@@ -4086,13 +4097,13 @@ func dynList(ctx context.Context, r dynamic.ResourceInterface) []string {
 //     name: *, ns dev, { pod name *, pod ns * }
 //     name: *, ns dev, staging
 func TestSpecificCustomResourcesRBAC(t *testing.T) {
+	t.Parallel()
 	telerolev8 := tkm.NewCRD("resources.teleport.dev", "v8", "teleportroles", "TeleportRole", "TeleportRoleList", true)
 	teleswagv1 := tkm.NewCRD("swag.teleport.dev", "v1", "teleswags", "TeleportSwag", "TeleportSwagList", true)
 	clusterswagv0 := tkm.NewCRD("resources.teleport.dev", "v0", "clusterswags", "ClusterSwag", "ClusterSwagList", false)
 
-	const scope = "/test"
-	kubeScheme, testCtx := newTestKubeCRDMock(t,
-		scope,
+	kubeScheme, unscopedTestCtx := newTestKubeCRDMock(t,
+		"",
 		tkm.WithTeleportRoleCRD,
 		tkm.WithCRD(telerolev8,
 			tkm.NewObject("default", "telerole-1"),
@@ -4111,11 +4122,30 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		),
 	)
 
-	newUser := newTestUserFactoryWithScope(t, testCtx, "crd-rbac", types.V8, scope)
+	_, scopedTestCtx := newTestKubeCRDMock(t,
+		scopedTestScope,
+		tkm.WithTeleportRoleCRD,
+		tkm.WithCRD(telerolev8,
+			tkm.NewObject("default", "telerole-1"),
+			tkm.NewObject("default", "telerole-2"),
+			tkm.NewObject("default", "telerole-test"),
+			tkm.NewObject("dev", "telerole-1"),
+			tkm.NewObject("dev", "telerole-2"),
+		),
+		tkm.WithCRD(teleswagv1,
+			tkm.NewObject("default", "teleswag-1"),
+		),
+		tkm.WithCRD(clusterswagv0,
+			tkm.NewObject("", "clusterswag-1"),
+			tkm.NewObject("", "clusterswag-2"),
+			tkm.NewObject("", "my-clusterswag"),
+		),
+	)
 
 	type args struct {
-		user types.User
-		crds []*tkm.CRD
+		allow []types.KubernetesResource
+		deny  []types.KubernetesResource
+		crds  []*tkm.CRD
 	}
 	type want struct {
 		listTeleportRolesResult [][]string // One list per CRDs in args.
@@ -4129,7 +4159,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "list crds on multiple versions",
 			args: args{
-				user: newUser([]types.KubernetesResource{
+				allow: []types.KubernetesResource{
 					{
 						Kind:      tkm.NewTeleportRoleCRD().GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4144,7 +4174,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}, nil),
+				},
 				crds: []*tkm.CRD{tkm.NewTeleportRoleCRD(), telerolev8.Copy()},
 			},
 			want: want{
@@ -4163,7 +4193,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "access to multiple crds listing one without access",
 			args: args{
-				user: newUser([]types.KubernetesResource{
+				allow: []types.KubernetesResource{
 					{
 						Kind:      tkm.NewTeleportRoleCRD().GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4178,7 +4208,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}, nil),
+				},
 				crds: []*tkm.CRD{tkm.NewTeleportRoleCRD(), telerolev8.Copy(), teleswagv1.Copy()},
 			},
 			want: want{
@@ -4199,7 +4229,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "valid kind format",
 			args: args{
-				user: newUser([]types.KubernetesResource{
+				allow: []types.KubernetesResource{
 					{
 						Kind:      "teleportroles",
 						Name:      types.Wildcard,
@@ -4214,7 +4244,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  "resources.teleport.dev",
 					},
-				}, nil),
+				},
 				crds: []*tkm.CRD{telerolev8},
 			},
 			want: want{
@@ -4230,7 +4260,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "different invalid kind format",
 			args: args{
-				user: newUser([]types.KubernetesResource{
+				allow: []types.KubernetesResource{
 					{
 						Kind:      "TeleportRole",
 						Name:      types.Wildcard,
@@ -4294,7 +4324,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}, nil),
+				},
 				crds: []*tkm.CRD{telerolev8},
 			},
 			want: want{
@@ -4304,7 +4334,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "cluster wide crd",
 			args: args{
-				user: newUser([]types.KubernetesResource{
+				allow: []types.KubernetesResource{
 					{
 						Kind:      clusterswagv0.GetKindPlural(),
 						Name:      "clusterswag-*",
@@ -4312,7 +4342,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}, nil),
+				},
 				crds: []*tkm.CRD{clusterswagv0},
 			},
 			want: want{
@@ -4328,7 +4358,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "cluster wide crd no access",
 			args: args{
-				user: newUser([]types.KubernetesResource{
+				allow: []types.KubernetesResource{
 					{
 						Kind:      telerolev8.GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4336,7 +4366,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}, nil),
+				},
 				crds: []*tkm.CRD{clusterswagv0},
 			},
 			want: want{
@@ -4346,7 +4376,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		{
 			name: "cluster wide crd no acces wildcard",
 			args: args{
-				user: newUser([]types.KubernetesResource{
+				allow: []types.KubernetesResource{
 					{
 						Kind:      telerolev8.GetKindPlural(),
 						Name:      types.Wildcard,
@@ -4354,7 +4384,7 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 						Verbs:     []string{types.Wildcard},
 						APIGroup:  types.Wildcard,
 					},
-				}, nil),
+				},
 				crds: []*tkm.CRD{clusterswagv0},
 			},
 			want: want{
@@ -4363,16 +4393,27 @@ func TestSpecificCustomResourcesRBAC(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		for _, scoped := range []bool{false, true} {
+	for idx, tt := range tests {
+		for _, scope := range []string{"", scopedTestScope} {
 			var opts []GenTestKubeClientTLSCertOptions
-			if scoped {
-				opts = makeScopedOpts(t, testCtx, tt.args.user.GetName(), scope)
+			testCtx := unscopedTestCtx
+			if scope != "" {
+				testCtx = scopedTestCtx
 			}
-			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
+			user := newScopedUser(t, newScopedUserCfg{
+				testCtx:     testCtx,
+				prefix:      "crd-rbac",
+				roleVersion: types.V8,
+				scope:       scope,
+				allow:       tt.args.allow,
+				deny:        tt.args.deny,
+				idx:         idx,
+			})
+			opts = makeScopedOpts(t, testCtx, user.GetName(), scope)
+			t.Run(fmt.Sprintf("%s scope=%s", tt.name, scope), func(t *testing.T) {
 				t.Parallel()
 				// Generate a kube client with user certs for auth.
-				_, rest := testCtx.GenTestKubeClientTLSCert(t, tt.args.user.GetName(), kubeCluster, opts...)
+				_, rest := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), scopes.QualifiedName{Name: kubeCluster, Scope: testCtx.Scope}, opts...)
 
 				client, err := controllerclient.New(rest, controllerclient.Options{
 					Scheme: kubeScheme,
@@ -4424,45 +4465,53 @@ func TestProxySubresourceRBAC(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { kubeMock.Close() })
 
-	const scope = "/test"
-	testCtx := SetupTestContext(
+	unscopedTestCtx := SetupTestContext(
 		context.Background(),
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-			Scope:    scope,
+		},
+	)
+
+	scopedTestCtx := SetupTestContext(
+		context.Background(),
+		t,
+		TestConfig{
+			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
+			Scope:    scopedTestScope,
 			ScopesFeatures: scopes.Features{
 				Enabled: true,
 			},
 		},
 	)
-	t.Cleanup(func() { require.NoError(t, testCtx.Close()) })
+	t.Cleanup(func() {
+		require.NoError(t, unscopedTestCtx.Close())
+		require.NoError(t, scopedTestCtx.Close())
+	})
 
-	newUser := newTestUserFactoryWithScope(t, testCtx, "subresource-rbac", types.V8, scope)
-
-	podGetUser := newUser([]types.KubernetesResource{{
+	allowPodGet := []types.KubernetesResource{{
 		Kind: "pods", Namespace: types.Wildcard, Name: types.Wildcard,
 		Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
-	}}, nil)
+	}}
 
-	serviceGetUser := newUser([]types.KubernetesResource{{
+	allowServiceGet := []types.KubernetesResource{{
 		Kind: "services", Namespace: types.Wildcard, Name: types.Wildcard,
 		Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
-	}}, nil)
+	}}
 
-	nodeGetUser := newUser([]types.KubernetesResource{{
+	allowNodeGet := []types.KubernetesResource{{
 		Kind: "nodes", Name: types.Wildcard,
 		Verbs: []string{"get", "list"}, APIGroup: types.Wildcard,
-	}}, nil)
+	}}
 	// Negative control: configmaps allow rule, no pods/services/nodes match.
-	noMatchUser := newUser([]types.KubernetesResource{{
+	noMatch := []types.KubernetesResource{{
 		Kind: "configmaps", Namespace: types.Wildcard, Name: types.Wildcard,
 		Verbs: []string{"get"}, APIGroup: types.Wildcard,
-	}}, nil)
+	}}
 
 	tests := []struct {
 		name         string
-		user         types.User
+		allow        []types.KubernetesResource
 		urlPath      string
 		wantCode     int
 		bodyContains string
@@ -4470,7 +4519,7 @@ func TestProxySubresourceRBAC(t *testing.T) {
 		{
 			// Sanity check that portforward verb denial still works.
 			name:         "portforward_denied_baseline",
-			user:         podGetUser,
+			allow:        allowPodGet,
 			urlPath:      "/api/v1/namespaces/default/pods/teleport/portforward",
 			wantCode:     http.StatusForbidden,
 			bodyContains: "cannot portforward resource",
@@ -4478,45 +4527,52 @@ func TestProxySubresourceRBAC(t *testing.T) {
 		{
 			// podGetUser has get/list on pods but not proxy.
 			name:         "pods_proxy_denied",
-			user:         podGetUser,
+			allow:        allowPodGet,
 			urlPath:      "/api/v1/namespaces/default/pods/teleport/proxy/8080",
 			wantCode:     http.StatusForbidden,
 			bodyContains: "cannot proxy resource",
 		},
 		{
 			name:         "services_proxy_denied",
-			user:         serviceGetUser,
+			allow:        allowServiceGet,
 			urlPath:      "/api/v1/namespaces/default/services/svc/proxy/path",
 			wantCode:     http.StatusForbidden,
 			bodyContains: "cannot proxy resource",
 		},
 		{
 			name:         "nodes_proxy_denied",
-			user:         nodeGetUser,
+			allow:        allowNodeGet,
 			urlPath:      "/api/v1/nodes/node-1/proxy/pods",
 			wantCode:     http.StatusForbidden,
 			bodyContains: "cannot proxy resource",
 		},
 		{
 			// noMatchUser has no allow rule for pods at all - confirms the
-			// resource matcher is in the request path. The body includes
-			// the user name to make this distinct from the podGetUser case
-			// above.
+			// resource matcher is in the request path.
 			name:         "negative_control_denied",
-			user:         noMatchUser,
+			allow:        noMatch,
 			urlPath:      "/api/v1/namespaces/default/pods/teleport/proxy/8080",
 			wantCode:     http.StatusForbidden,
-			bodyContains: fmt.Sprintf("User \\\"%s\\\" cannot proxy resource", noMatchUser.GetName()),
+			bodyContains: "cannot proxy resource",
 		},
 	}
-	for _, tt := range tests {
-		for _, scoped := range []bool{false, true} {
-			var opts []GenTestKubeClientTLSCertOptions
-			if scoped {
-				opts = makeScopedOpts(t, testCtx, tt.user.GetName(), scope)
+	for idx, tt := range tests {
+		for _, scope := range []string{"", scopedTestScope} {
+			testCtx := unscopedTestCtx
+			if scope != "" {
+				testCtx = scopedTestCtx
 			}
-			t.Run(fmt.Sprintf("%s scoped=%t", tt.name, scoped), func(t *testing.T) {
-				code, body := sendKubeGet(t, testCtx, tt.user, tt.urlPath, opts...)
+			user := newScopedUser(t, newScopedUserCfg{
+				testCtx:     testCtx,
+				scope:       scope,
+				prefix:      "subresource-rbac",
+				roleVersion: types.V8,
+				allow:       tt.allow,
+				idx:         idx,
+			})
+			opts := makeScopedOpts(t, testCtx, user.GetName(), scope)
+			t.Run(fmt.Sprintf("%s scope=%s", tt.name, scope), func(t *testing.T) {
+				code, body := sendKubeGet(t, testCtx, user, tt.urlPath, opts...)
 				require.Equal(t, tt.wantCode, code, "body: %s", body)
 				require.Contains(t, body, tt.bodyContains)
 			})
@@ -4528,7 +4584,9 @@ func TestProxySubresourceRBAC(t *testing.T) {
 func makeScopedOpts(t *testing.T, testCtx *TestContext, username, scope string) []GenTestKubeClientTLSCertOptions {
 	return []GenTestKubeClientTLSCertOptions{
 		func(i *tlsca.Identity) {
-			i.ScopePin = testCtx.GetScopePinForUser(t, username, scope)
+			if scope != "" {
+				i.ScopePin = testCtx.GetScopePinForUser(t, username, scope)
+			}
 		},
 	}
 }
@@ -4543,16 +4601,13 @@ func toScopedKubeResource(resource types.KubernetesResource) *accessv1.KubeResou
 	}.Build()
 }
 
-func scopedUsername(username string) string {
-	return "scoped-" + username
-}
-
 // TestProxySpecialVerbPathRBAC verifies that the Kubernetes "special verb" URL form,
 // where a proxy segment precedes the resource path
 // (/apis/{group}/{version}/proxy/namespaces/{ns}/{kind}/{name}),
 // is parsed as the resource it targets and enforced with the KubeVerbProxy verb,
 // instead of being rejected as a resource kind the cluster doesn't serve.
 func TestProxySpecialVerbPathRBAC(t *testing.T) {
+	t.Parallel()
 	const (
 		basePath     = "/apis/resources.teleport.dev/v6"
 		resourceKind = "teleportroles"
@@ -4639,7 +4694,7 @@ func TestProxySpecialVerbPathRBAC(t *testing.T) {
 // Raw HTTP rather than a typed client, so arbitrary URL paths can be exercised.
 func sendKubeGet(t *testing.T, testCtx *TestContext, user types.User, urlPath string, opts ...GenTestKubeClientTLSCertOptions) (int, string) {
 	t.Helper()
-	_, cfg := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), kubeCluster, opts...)
+	_, cfg := testCtx.GenTestKubeClientTLSCert(t, user.GetName(), scopes.QualifiedName{Name: kubeCluster, Scope: testCtx.Scope}, opts...)
 	transport, err := rest.TransportFor(cfg)
 	require.NoError(t, err)
 	client := &http.Client{Transport: transport}

--- a/lib/kube/proxy/resource_rbac_test.go
+++ b/lib/kube/proxy/resource_rbac_test.go
@@ -2563,7 +2563,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 				idx:         idx,
 			})
 			opts := makeScopedOpts(t, testCtx, user.GetName(), scope)
-			t.Run(tt.name, func(t *testing.T) {
+			t.Run(fmt.Sprintf("%s scope=%s", tt.name, scope), func(t *testing.T) {
 				t.Parallel()
 
 				// Generate a kube dynClient with user certs for auth.
@@ -2580,6 +2580,7 @@ func TestV8JailedNamespaceListRBAC(t *testing.T) {
 		}
 	}
 }
+
 func TestV7JailedNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
@@ -3169,7 +3170,7 @@ func TestNamespaceListRBAC(t *testing.T) {
 	t.Parallel()
 
 	_, unscopedTestCtx := newTestKubeCRDMock(t, "", tkm.WithTeleportRoleCRD)
-	_, scopedTestCtx := newTestKubeCRDMock(t, scopedTestScope, tkm.WithTeleportRoleCRD)
+	scopedTestCtx := CloneTestContext(t, unscopedTestCtx, scopedTestScope)
 
 	commonResources := []types.KubernetesResource{
 		{
@@ -4470,23 +4471,16 @@ func TestProxySubresourceRBAC(t *testing.T) {
 		t,
 		TestConfig{
 			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-		},
-	)
-
-	scopedTestCtx := SetupTestContext(
-		context.Background(),
-		t,
-		TestConfig{
-			Clusters: []KubeClusterConfig{{Name: kubeCluster, APIEndpoint: kubeMock.URL}},
-			Scope:    scopedTestScope,
 			ScopesFeatures: scopes.Features{
 				Enabled: true,
 			},
 		},
 	)
+
+	scopedTestCtx := CloneTestContext(t, unscopedTestCtx, scopedTestScope)
 	t.Cleanup(func() {
-		require.NoError(t, unscopedTestCtx.Close())
 		require.NoError(t, scopedTestCtx.Close())
+		require.NoError(t, unscopedTestCtx.Close())
 	})
 
 	allowPodGet := []types.KubernetesResource{{

--- a/lib/kube/proxy/response_rewriter.go
+++ b/lib/kube/proxy/response_rewriter.go
@@ -99,7 +99,7 @@ func (f *Forwarder) rewriteResponseForbidden(s *clusterSession) func(r *http.Res
 				Message: "GKE Autopilot denied the request because it impersonates the \"system:masters\" group.\n" +
 					fmt.Sprintf(
 						"Your Teleport Roles %v have given access to the \"system:masters\" group "+
-							"for the cluster %q.\n", collectSystemMastersTeleportRoles(s), s.kubeClusterName) +
+							"for the cluster %q.\n", collectSystemMastersTeleportRoles(s), s.kubeClusterSQN) +
 					"For additional information and resolution, " +
 					"please visit https://goteleport.com/docs/enroll-resources/kubernetes-access/troubleshooting/#unable-to-connect-to-gke-autopilot-clusters\n",
 			}

--- a/lib/kube/proxy/response_rewriter_test.go
+++ b/lib/kube/proxy/response_rewriter_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 func TestErrorRewriter(t *testing.T) {
@@ -153,7 +154,7 @@ func TestErrorRewriter(t *testing.T) {
 			client, _ := testCtx.GenTestKubeClientTLSCert(
 				t,
 				user.GetName(),
-				tt.args.kubeCluster,
+				scopes.QualifiedName{Name: tt.args.kubeCluster},
 			)
 
 			_, err := client.CoreV1().Pods(metav1.NamespaceDefault).Get(

--- a/lib/kube/proxy/self_subject_reviews.go
+++ b/lib/kube/proxy/self_subject_reviews.go
@@ -127,7 +127,7 @@ func (f *Forwarder) validateSelfSubjectAccessReview(sess *clusterSession, w http
 	if !ok {
 		// Mirror the data path so `kubectl auth can-i` matches a real request:
 		// discover the kind's group-version and, if it's still unknown, report denied.
-		details, derr := f.findKubeDetailsByClusterName(sess.kubeClusterName)
+		details, derr := f.findKubeDetailsByClusterName(sess.kubeClusterSQN)
 		if derr != nil {
 			return nil
 		}

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
@@ -408,7 +409,7 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 			client, _ := testCtx.GenTestKubeClientTLSCert(
 				t,
 				user.GetName(),
-				kubeCluster,
+				scopes.QualifiedName{Name: kubeCluster},
 			)
 
 			rsp, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(
@@ -573,7 +574,7 @@ func TestSelfSubjectAccessReviewsAllowed(t *testing.T) {
 			t.Parallel()
 
 			// Generate a kube dynClient with user certs for auth.
-			client, _, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), kubeCluster)
+			client, _, _ := testCtx.GenTestKubeClientsTLSCert(t, tt.user.GetName(), scopes.QualifiedName{Name: kubeCluster})
 
 			// Create a SelfSubjectAccessReview object.
 			obj := &authv1.SelfSubjectAccessReview{

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -215,7 +215,7 @@ type TLSServer struct {
 	fwd          *Forwarder
 	mu           sync.Mutex
 	listener     net.Listener
-	heartbeats   map[string]*srv.HeartbeatV2
+	heartbeats   map[scopes.QualifiedName]*srv.HeartbeatV2
 	closeContext context.Context
 	closeFunc    context.CancelFunc
 	// kubeClusterWatcher monitors changes to kube cluster resources.
@@ -286,7 +286,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		fwd:             fwd,
 		TLSServerConfig: cfg,
 		Server:          kubeHTTPserver,
-		heartbeats:      make(map[string]*srv.HeartbeatV2),
+		heartbeats:      make(map[scopes.QualifiedName]*srv.HeartbeatV2),
 		monitoredKubeClusters: monitoredKubeClusters{
 			static: fwd.kubeClusters(),
 		},
@@ -519,7 +519,7 @@ func (t *TLSServer) GetConfigForClient(info *tls.ClientHelloInfo) (*tls.Config, 
 
 // GetServerInfo returns a services.Server object for heartbeats (aka
 // presence).
-func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error) {
+func (t *TLSServer) GetServerInfo(sqn scopes.QualifiedName) (*types.KubernetesServerV3, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	var addr string
@@ -529,7 +529,7 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 		addr = t.listener.Addr().String()
 	}
 
-	cluster, err := t.getKubeClusterWithServiceLabels(name)
+	cluster, err := t.getKubeClusterWithServiceLabels(sqn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -540,7 +540,7 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 	// Note: we *don't* want to add suffix for kubernetes_service!
 	// This breaks reverse tunnel routing, which uses server.Name.
 	if t.KubeServiceType != KubeService {
-		name += teleport.KubeLegacyProxySuffix
+		sqn.Name += teleport.KubeLegacyProxySuffix
 	}
 
 	var relayGroup string
@@ -552,7 +552,7 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 	}
 	srv, err := types.NewKubernetesServerV3(
 		types.Metadata{
-			Name:      name,
+			Name:      sqn.Name,
 			Namespace: t.Namespace,
 		},
 		types.KubernetesServerSpecV3{
@@ -582,7 +582,10 @@ func (t *TLSServer) GetServerInfo(name string) (*types.KubernetesServerV3, error
 
 // startHealthCheck starts checking the health of a Kubernetes cluster.
 func (t *TLSServer) startHealthCheck(cluster types.KubeCluster) error {
-	kubeDetails, err := t.fwd.findKubeDetailsByClusterName(cluster.GetName())
+	kubeDetails, err := t.fwd.findKubeDetailsByClusterName(scopes.QualifiedName{
+		Name:  cluster.GetName(),
+		Scope: cluster.GetScope(),
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -606,7 +609,10 @@ func (t *TLSServer) startHeartbeatAndHealthCheck(cluster types.KubeCluster) erro
 	if err := t.startHealthCheck(cluster); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := t.startHeartbeat(cluster.GetName()); err != nil {
+	if err := t.startHeartbeat(scopes.QualifiedName{
+		Name:  cluster.GetName(),
+		Scope: cluster.GetScope(),
+	}); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -618,7 +624,10 @@ func (t *TLSServer) stopHeartbeatAndHealthCheck(cluster types.KubeCluster) error
 	if err := t.stopHealthCheck(cluster); err != nil {
 		errs = append(errs, err)
 	}
-	if err := t.stopHeartbeat(cluster.GetName()); err != nil {
+	if err := t.stopHeartbeat(scopes.QualifiedName{
+		Name:  cluster.GetName(),
+		Scope: cluster.GetScope(),
+	}); err != nil {
 		errs = append(errs, err)
 	}
 	return trace.NewAggregate(errs...)
@@ -655,10 +664,10 @@ func (t *TLSServer) getTargetHealth(ctx context.Context, cluster types.KubeClust
 // the cluster with the service dynamic and static labels.
 // We strip the Azure, AWS and Kubeconfig credentials so they are not leaked when
 // heartbeating the cluster.
-func (t *TLSServer) getKubeClusterWithServiceLabels(name string) (*types.KubernetesClusterV3, error) {
+func (t *TLSServer) getKubeClusterWithServiceLabels(sqn scopes.QualifiedName) (*types.KubernetesClusterV3, error) {
 	// it is safe do read from details since the structure is never updated.
 	// we replace the whole structure each time an update happens to a dynamic cluster.
-	details, err := t.fwd.findKubeDetailsByClusterName(name)
+	details, err := t.fwd.findKubeDetailsByClusterName(sqn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -690,10 +699,10 @@ func (t *TLSServer) getKubeClusterWithServiceLabels(name string) (*types.Kuberne
 }
 
 // startHeartbeat starts the registration heartbeat to the auth server.
-func (t *TLSServer) startHeartbeat(name string) error {
+func (t *TLSServer) startHeartbeat(sqn scopes.QualifiedName) error {
 	heartbeat, err := srv.NewKubernetesServerHeartbeat(srv.HeartbeatV2Config[*types.KubernetesServerV3]{
 		InventoryHandle: t.InventoryHandle,
-		GetResource:     func(context.Context) (*types.KubernetesServerV3, error) { return t.GetServerInfo(name) },
+		GetResource:     func(context.Context) (*types.KubernetesServerV3, error) { return t.GetServerInfo(sqn) },
 		OnHeartbeat:     t.TLSServerConfig.OnHeartbeat,
 	})
 	if err != nil {
@@ -702,7 +711,7 @@ func (t *TLSServer) startHeartbeat(name string) error {
 	go heartbeat.Run()
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.heartbeats[name] = heartbeat
+	t.heartbeats[sqn] = heartbeat
 	return nil
 }
 
@@ -740,14 +749,14 @@ func (t *TLSServer) startStaticClustersHeartbeat() error {
 }
 
 // stopHeartbeat stops the registration heartbeat to the auth server.
-func (t *TLSServer) stopHeartbeat(name string) error {
+func (t *TLSServer) stopHeartbeat(sqn scopes.QualifiedName) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	heartbeat, ok := t.heartbeats[name]
+	heartbeat, ok := t.heartbeats[sqn]
 	if !ok {
 		return nil
 	}
-	delete(t.heartbeats, name)
+	delete(t.heartbeats, sqn)
 	return trace.Wrap(heartbeat.Close())
 }
 
@@ -796,9 +805,9 @@ func (t *TLSServer) setServiceLabels(cluster types.KubeCluster) {
 func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNameFunc, error) {
 	switch t.KubeServiceType {
 	case KubeService:
-		return func(_ context.Context, name string) ([]types.KubeServer, error) {
+		return func(_ context.Context, sqn scopes.QualifiedName) ([]types.KubeServer, error) {
 			// If this is a kube_service, we can just return the local kube servers.
-			kube, err := t.getKubeClusterWithServiceLabels(name)
+			kube, err := t.getKubeClusterWithServiceLabels(sqn)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -811,13 +820,13 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 	case ProxyService:
 		return t.KubernetesServersWatcher.GetKubeServersForClusterName, nil
 	case LegacyProxyService:
-		return func(ctx context.Context, name string) ([]types.KubeServer, error) {
+		return func(ctx context.Context, sqn scopes.QualifiedName) ([]types.KubeServer, error) {
 			// If this is a legacy kube proxy, then we need to return the local kube servers if
 			// the local server is proxying the target cluster, otherwise act like a proxy_service.
 			// and forward the request to the next proxy.
-			kube, err := t.getKubeClusterWithServiceLabels(name)
+			kube, err := t.getKubeClusterWithServiceLabels(sqn)
 			if err != nil {
-				servers, err := t.KubernetesServersWatcher.GetKubeServersForClusterName(ctx, name)
+				servers, err := t.KubernetesServersWatcher.GetKubeServersForClusterName(ctx, sqn)
 				return servers, trace.Wrap(err)
 			}
 			srv, err := types.NewKubernetesServerV3FromCluster(kube, "", t.HostID)

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -158,7 +158,9 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 	if c.ConnectedProxyGetter == nil {
 		return trace.BadParameter("missing parameter ConnectedProxyGetter")
 	}
-	if c.HealthCheckManager == nil {
+
+	requiresHealthCheck := c.KubeServiceType != KubeService || c.GetScope() == ""
+	if c.HealthCheckManager == nil && requiresHealthCheck {
 		return trace.BadParameter("missing parameter HealthCheckManager")
 	}
 
@@ -582,6 +584,9 @@ func (t *TLSServer) GetServerInfo(sqn scopes.QualifiedName) (*types.KubernetesSe
 
 // startHealthCheck starts checking the health of a Kubernetes cluster.
 func (t *TLSServer) startHealthCheck(cluster types.KubeCluster) error {
+	if t.GetScope() != "" {
+		return nil
+	}
 	kubeDetails, err := t.fwd.findKubeDetailsByClusterName(scopes.QualifiedName{
 		Name:  cluster.GetName(),
 		Scope: cluster.GetScope(),
@@ -598,6 +603,9 @@ func (t *TLSServer) startHealthCheck(cluster types.KubeCluster) error {
 
 // stopHealthCheck stops checking the health of a Kubernetes cluster.
 func (t *TLSServer) stopHealthCheck(cluster types.KubeCluster) error {
+	if t.GetScope() != "" {
+		return nil
+	}
 	if err := t.HealthCheckManager.RemoveTarget(cluster); err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
@@ -635,6 +643,13 @@ func (t *TLSServer) stopHeartbeatAndHealthCheck(cluster types.KubeCluster) error
 
 // getTargetHealth returns the health of a Kubernetes cluster.
 func (t *TLSServer) getTargetHealth(ctx context.Context, cluster types.KubeCluster) *types.TargetHealth {
+	if t.GetScope() != "" {
+		return &types.TargetHealth{
+			Status:           string(types.TargetHealthStatusUnknown),
+			TransitionReason: string(types.TargetHealthTransitionReasonDisabled),
+			Message:          "Health checks are disabled for scoped Kubernetes services",
+		}
+	}
 	health, err := t.HealthCheckManager.GetTargetHealth(cluster)
 	if err == nil {
 		return health

--- a/lib/kube/proxy/server_test.go
+++ b/lib/kube/proxy/server_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/healthcheck"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -206,6 +207,7 @@ func TestGetServerInfo(t *testing.T) {
 	listener, err := net.Listen("tcp", "localhost:")
 	require.NoError(t, err)
 
+	clusterSQN := scopes.QualifiedName{Name: "kube-cluster"}
 	srv := &TLSServer{
 		TLSServerConfig: TLSServerConfig{
 			Log: logtest.NewLogger(),
@@ -222,8 +224,8 @@ func TestGetServerInfo(t *testing.T) {
 		},
 		fwd: &Forwarder{
 			cfg: ForwarderConfig{},
-			clusterDetails: map[string]*kubeDetails{
-				"kube-cluster": {
+			clusterDetails: map[scopes.QualifiedName]*kubeDetails{
+				clusterSQN: {
 					kubeCluster: mustCreateKubernetesClusterV3(t, "kube-cluster"),
 				},
 			},
@@ -232,7 +234,7 @@ func TestGetServerInfo(t *testing.T) {
 	}
 
 	t.Run("GetServerInfo gets listener addr with PublicAddr unset", func(t *testing.T) {
-		kubeServer, err := srv.GetServerInfo("kube-cluster")
+		kubeServer, err := srv.GetServerInfo(clusterSQN)
 		require.NoError(t, err)
 		require.Equal(t, listener.Addr().String(), kubeServer.GetHostname())
 	})
@@ -240,7 +242,7 @@ func TestGetServerInfo(t *testing.T) {
 	t.Run("GetServerInfo gets correct public addr with PublicAddr set", func(t *testing.T) {
 		srv.TLSServerConfig.ForwarderConfig.PublicAddr = "k8s.example.com"
 
-		kubeServer, err := srv.GetServerInfo("kube-cluster")
+		kubeServer, err := srv.GetServerInfo(clusterSQN)
 		require.NoError(t, err)
 		require.Equal(t, "k8s.example.com", kubeServer.GetHostname())
 	})

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -1164,7 +1164,7 @@ func (s *session) createEphemeralContainer() (*corev1.ContainerStatus, error) {
 		s.forwarder.ctx,
 		kubewaitingcontainerpb.GetKubernetesWaitingContainerRequest_builder{
 			Username:      username,
-			Cluster:       s.ctx.kubeClusterName,
+			Cluster:       s.ctx.kubeClusterSQN.String(),
 			Namespace:     namespace,
 			PodName:       podName,
 			ContainerName: container,
@@ -1180,7 +1180,7 @@ func (s *session) createEphemeralContainer() (*corev1.ContainerStatus, error) {
 		s.forwarder.ctx,
 		kubewaitingcontainerpb.DeleteKubernetesWaitingContainerRequest_builder{
 			Username:      username,
-			Cluster:       s.ctx.kubeClusterName,
+			Cluster:       s.ctx.kubeClusterSQN.String(),
 			Namespace:     namespace,
 			PodName:       podName,
 			ContainerName: container,
@@ -1212,7 +1212,7 @@ func (s *session) emitSessionJoinEvent(p *party) {
 			ClusterName: s.ctx.teleportCluster.name,
 		},
 		KubernetesClusterMetadata: apievents.KubernetesClusterMetadata{
-			KubernetesCluster: s.ctx.kubeClusterName,
+			KubernetesCluster: s.ctx.kubeClusterSQN.String(),
 			// joining moderators, obervers and peers don't have any
 			// kubernetes metadata configured.
 			KubernetesUsers:  []string{},
@@ -1463,7 +1463,7 @@ func (s *session) trackSession(p *party, policySet []*types.SessionTrackerPolicy
 		State:             types.SessionState_SessionStatePending,
 		Hostname:          path.Join(s.podNamespace, s.podName),
 		ClusterName:       s.ctx.teleportCluster.name,
-		KubernetesCluster: s.ctx.kubeClusterName,
+		KubernetesCluster: s.ctx.kubeClusterSQN.String(),
 		HostUser:          p.Ctx.User.GetName(),
 		HostPolicies:      policySet,
 		Login:             "root",
@@ -1616,7 +1616,7 @@ func (s *session) retrieveAlreadyStoppedPodLogs(namespace, podName, container st
 // retrieveEphemeralContainerCommand retrieves the command of an ephemeral container
 // if it exists.
 func (s *session) retrieveEphemeralContainerCommand(ctx context.Context, username, containerName string) []string {
-	containers, err := s.forwarder.getUserEphemeralContainersForPod(ctx, username, s.ctx.kubeClusterName, s.podNamespace, s.podName)
+	containers, err := s.forwarder.getUserEphemeralContainersForPod(ctx, username, s.ctx.kubeClusterSQN.String(), s.podNamespace, s.podName)
 	if err != nil {
 		s.log.WarnContext(ctx, "Failed to retrieve ephemeral containers", "error", err)
 		return nil

--- a/lib/kube/proxy/sess_test.go
+++ b/lib/kube/proxy/sess_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -132,7 +133,7 @@ func TestSessionEndError(t *testing.T) {
 			_, userRestConfig := testCtx.GenTestKubeClientTLSCert(
 				t,
 				user.GetName(),
-				kubeCluster,
+				scopes.QualifiedName{Name: kubeCluster},
 			)
 			require.NoError(t, err)
 
@@ -304,7 +305,7 @@ func Test_session_trackSession(t *testing.T) {
 					teleportCluster: teleportClusterClient{
 						name: "name",
 					},
-					kubeClusterName: "kubeClusterName",
+					kubeClusterSQN: scopes.QualifiedName{Name: "kubeClusterName"},
 				},
 				forwarder: &Forwarder{
 					cfg: ForwarderConfig{

--- a/lib/kube/proxy/single_cert_handler_test.go
+++ b/lib/kube/proxy/single_cert_handler_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // pathRoutedKubeClient uses the given rest.Config to build a Kubernetes client
@@ -210,7 +211,7 @@ func TestSingleCertRouting(t *testing.T) {
 			_, restConfig := testCtx.GenTestKubeClientTLSCert(
 				t,
 				username,
-				"",
+				scopes.QualifiedName{},
 				tt.genKubeCertificateOpts...,
 			)
 

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/healthcheck"
 	"github.com/gravitational/teleport/lib/kube/internal"
+	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils"
@@ -87,7 +88,7 @@ func (f *Forwarder) transportForRequestWithImpersonation(sess *clusterSession) (
 			httpTransport, tlsConfig, err = f.newRemoteClusterTransport(sess.teleportCluster.name)
 		} else if f.cfg.ReverseTunnelSrv != nil {
 			// If agent is running in proxy mode, create a new transport for the local cluster.
-			httpTransport, tlsConfig, err = f.newLocalClusterTransport(sess.kubeClusterName, sess.getClusterScope())
+			httpTransport, tlsConfig, err = f.newLocalClusterTransport(sess.kubeClusterSQN)
 		} else {
 			return nil, trace.BadParameter("no reverse tunnel server or credentials provided")
 		}
@@ -122,10 +123,10 @@ func transportCacheKey(sess *clusterSession) string {
 	if sess.teleportCluster.isRemote {
 		return fmt.Sprintf("%x", sess.teleportCluster.name)
 	}
-	if scope := sess.getClusterScope(); scope != "" {
-		return fmt.Sprintf("%x/%x/%x", sess.teleportCluster.name, scope, sess.kubeClusterName)
+	if scope := sess.kubeClusterSQN.Scope; scope != "" {
+		return fmt.Sprintf("%x/%x/%x", sess.teleportCluster.name, scope, sess.kubeClusterSQN.String())
 	}
-	return fmt.Sprintf("%x/%x", sess.teleportCluster.name, sess.kubeClusterName)
+	return fmt.Sprintf("%x/%x", sess.teleportCluster.name, sess.kubeClusterSQN.String())
 }
 
 // wrapTransport wraps the provided transport with the Kubernetes transport config
@@ -267,7 +268,7 @@ func (f *Forwarder) remoteClusterDialer(clusterName string) dialContextFunc {
 
 // newLocalClusterTransport returns a new [http.Transport] (https://golang.org/pkg/net/http/#Transport)
 // that can be used to dial Kubernetes Service in a local Teleport cluster.
-func (f *Forwarder) newLocalClusterTransport(kubeClusterName, scope string) (http.RoundTripper, *tls.Config, error) {
+func (f *Forwarder) newLocalClusterTransport(sqn scopes.QualifiedName) (http.RoundTripper, *tls.Config, error) {
 	tlsConfig := utils.TLSConfig(f.cfg.ConnTLSCipherSuites)
 	tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 		tlsCert, err := f.cfg.GetConnTLSCertificate()
@@ -279,7 +280,7 @@ func (f *Forwarder) newLocalClusterTransport(kubeClusterName, scope string) (htt
 	tlsConfig.InsecureSkipVerify = true
 	tlsConfig.VerifyConnection = utils.VerifyConnectionWithRoots(f.cfg.GetConnTLSRoots)
 
-	dialFn := f.localClusterDialer(kubeClusterName, scope)
+	dialFn := f.localClusterDialer(sqn)
 	// Create a new HTTP/2 transport that will be used to dial the remote cluster.
 	h2Transport, err := newH2Transport(tlsConfig, dialFn)
 	if err != nil {
@@ -296,7 +297,7 @@ func (f *Forwarder) newLocalClusterTransport(kubeClusterName, scope string) (htt
 // in a local Teleport cluster using the reverse tunnel.
 // The endpoints are fetched from the cached auth client and are shuffled
 // to avoid hotspots.
-func (f *Forwarder) localClusterDialer(kubeClusterName, scope string, opts ...contextDialerOption) dialContextFunc {
+func (f *Forwarder) localClusterDialer(sqn scopes.QualifiedName, opts ...contextDialerOption) dialContextFunc {
 	opt := contextDialerOptions{}
 	for _, o := range opts {
 		o(&opt)
@@ -323,7 +324,7 @@ func (f *Forwarder) localClusterDialer(kubeClusterName, scope string, opts ...co
 			return nil, trace.Wrap(err)
 		}
 
-		kubeServers, err := f.getKubernetesServersForKubeCluster(ctx, kubeClusterName)
+		kubeServers, err := f.getKubernetesServersForKubeCluster(ctx, sqn)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -334,13 +335,8 @@ func (f *Forwarder) localClusterDialer(kubeClusterName, scope string, opts ...co
 		// in case health status changed since last check.
 		var errs []error
 		for server := range healthcheck.OrderByTargetHealthStatus(kubeServers) {
-			// Skip servers that don't match the requested scope.
-			if scope != "" && scopes.Compare(server.GetScope(), scope) != scopes.Equivalent {
-				continue
-			}
-
-			// Validate that the requested kube cluster is registered.
-			if server.GetCluster().GetName() != kubeClusterName || !opt.matches(server.GetHostID()) {
+			// Validate that the requested kube cluster is registered
+			if !kubeutils.KubeClusterMatchesSQN(server.GetCluster(), sqn) || !opt.matches(server.GetHostID()) {
 				continue
 			}
 
@@ -371,7 +367,7 @@ func (f *Forwarder) localClusterDialer(kubeClusterName, scope string, opts ...co
 			return nil, trace.NewAggregate(errs...)
 		}
 
-		return nil, trace.NotFound("kubernetes cluster %q is not found in teleport cluster %q", kubeClusterName, f.cfg.ClusterName)
+		return nil, trace.NotFound("kubernetes cluster %q is not found in teleport cluster %q", sqn, f.cfg.ClusterName)
 	}
 }
 
@@ -429,7 +425,7 @@ func (f *Forwarder) getContextDialerFunc(s *clusterSession, opts ...contextDiale
 	} else if f.cfg.ReverseTunnelSrv != nil {
 		// If this is a local cluster, we need to connect to the remote proxy
 		// and then forward the connection to the local cluster.
-		return f.localClusterDialer(s.kubeClusterName, s.getClusterScope(), opts...)
+		return f.localClusterDialer(s.kubeClusterSQN, opts...)
 	}
 
 	return new(net.Dialer).DialContext

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -123,9 +123,6 @@ func transportCacheKey(sess *clusterSession) string {
 	if sess.teleportCluster.isRemote {
 		return fmt.Sprintf("%x", sess.teleportCluster.name)
 	}
-	if scope := sess.kubeClusterSQN.Scope; scope != "" {
-		return fmt.Sprintf("%x/%x/%x", sess.teleportCluster.name, scope, sess.kubeClusterSQN.String())
-	}
 	return fmt.Sprintf("%x/%x", sess.teleportCluster.name, sess.kubeClusterSQN.String())
 }
 

--- a/lib/kube/proxy/transport_test.go
+++ b/lib/kube/proxy/transport_test.go
@@ -36,41 +36,46 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestForwarderClusterDialer(t *testing.T) {
-	t.Parallel()
 	var (
-		hostname          = "localhost:8080"
-		hostId            = "hostId"
-		proxyIds          = []string{"proxyId"}
-		clusterName       = "cluster"
-		health            = types.TargetHealthStatusHealthy
-		scopedClusterName = "scoped-cluster"
-		testScope         = "/test"
-		otherHostname     = "localhost:8081"
-		otherHostID       = "other-hostId"
-		otherScope        = "/other"
+		hostname      = "localhost:8080"
+		hostId        = "hostId"
+		proxyIds      = []string{"proxyId"}
+		health        = types.TargetHealthStatusHealthy
+		testScope     = "/test"
+		otherHostname = "localhost:8081"
+		otherHostID   = "other-hostId"
+		otherScope    = "/other"
+		clusterName   = "cluster"
 	)
+	clusterSQN := scopes.QualifiedName{Name: clusterName}
+	scopedClusterSQN := scopes.QualifiedName{Name: clusterName, Scope: testScope}
+	otherClusterSQN := scopes.QualifiedName{Name: clusterName, Scope: otherScope}
 	f := &Forwarder{
 		cfg: ForwarderConfig{
 			tracer:      otel.Tracer("test"),
-			ClusterName: clusterName,
+			ClusterName: clusterSQN.Name,
 		},
-		getKubernetesServersForKubeCluster: func(_ context.Context, kubeClusterName string) ([]types.KubeServer, error) {
-			switch kubeClusterName {
-			case clusterName:
+		getKubernetesServersForKubeCluster: func(_ context.Context, sqn scopes.QualifiedName) ([]types.KubeServer, error) {
+			switch {
+			case sqn.Equals(clusterSQN):
 				return []types.KubeServer{
 					newKubeServer(t, hostname, hostId, proxyIds, health),
 				}, nil
-			case scopedClusterName:
+			case sqn.Equals(scopedClusterSQN):
 				return []types.KubeServer{
-					newScopedKubeServer(t, scopedClusterName, hostname, hostId, testScope, proxyIds, health),
-					newScopedKubeServer(t, scopedClusterName, otherHostname, otherHostID, otherScope, proxyIds, health),
+					newScopedKubeServer(t, clusterName, hostname, hostId, testScope, proxyIds, health),
+				}, nil
+			case sqn.Equals(otherClusterSQN):
+				return []types.KubeServer{
+					newScopedKubeServer(t, clusterName, otherHostname, otherHostID, otherScope, proxyIds, health),
 				}, nil
 			}
-			return nil, trace.NotFound("cluster %s is not found", kubeClusterName)
+			return nil, trace.NotFound("cluster %s is not found", sqn)
 		},
 	}
 	tests := []struct {
@@ -81,7 +86,7 @@ func TestForwarderClusterDialer(t *testing.T) {
 	}{
 		{
 			name:       "local site",
-			dialerFunc: f.localClusterDialer(clusterName, ""),
+			dialerFunc: f.localClusterDialer(clusterSQN),
 			want: reversetunnelclient.DialParams{
 				From: &utils.NetAddr{
 					Addr:        "0.0.0.0:0",
@@ -91,14 +96,14 @@ func TestForwarderClusterDialer(t *testing.T) {
 					Addr:        hostname,
 					AddrNetwork: "tcp",
 				},
-				ServerID: hostId + "." + clusterName,
+				ServerID: hostId + "." + clusterSQN.String(),
 				ConnType: types.KubeTunnel,
 				ProxyIDs: proxyIds,
 			},
 		},
 		{
 			name:       "remote site",
-			dialerFunc: f.remoteClusterDialer(clusterName),
+			dialerFunc: f.remoteClusterDialer(clusterSQN.String()),
 			want: reversetunnelclient.DialParams{
 				From: &utils.NetAddr{
 					Addr:        "0.0.0.0:0",
@@ -115,7 +120,7 @@ func TestForwarderClusterDialer(t *testing.T) {
 			name: "local site - test scope",
 			// It's important that the test scope and other scope cases resolve to the same cluster name.
 			// This ensures that the dialer checks for both name and scope match before selecting a kube server.
-			dialerFunc: f.localClusterDialer(scopedClusterName, testScope),
+			dialerFunc: f.localClusterDialer(scopedClusterSQN),
 			want: reversetunnelclient.DialParams{
 				From: &utils.NetAddr{
 					Addr:        "0.0.0.0:0",
@@ -125,7 +130,7 @@ func TestForwarderClusterDialer(t *testing.T) {
 					Addr:        hostname,
 					AddrNetwork: "tcp",
 				},
-				ServerID:    hostId + "." + clusterName,
+				ServerID:    hostId + "." + scopedClusterSQN.Name,
 				ConnType:    types.KubeTunnel,
 				ProxyIDs:    proxyIds,
 				TargetScope: testScope,
@@ -135,7 +140,7 @@ func TestForwarderClusterDialer(t *testing.T) {
 			name: "local site - other scope",
 			// It's important that the test scope and other scope cases resolve to the same cluster name.
 			// This ensures that the dialer checks for both name and scope match before selecting a kube server.
-			dialerFunc: f.localClusterDialer(scopedClusterName, otherScope),
+			dialerFunc: f.localClusterDialer(scopes.QualifiedName{Name: scopedClusterSQN.Name, Scope: otherScope}),
 			want: reversetunnelclient.DialParams{
 				From: &utils.NetAddr{
 					Addr:        "0.0.0.0:0",
@@ -145,7 +150,7 @@ func TestForwarderClusterDialer(t *testing.T) {
 					Addr:        otherHostname,
 					AddrNetwork: "tcp",
 				},
-				ServerID:    otherHostID + "." + clusterName,
+				ServerID:    otherHostID + "." + clusterSQN.Name,
 				ConnType:    types.KubeTunnel,
 				ProxyIDs:    proxyIds,
 				TargetScope: otherScope,
@@ -153,7 +158,7 @@ func TestForwarderClusterDialer(t *testing.T) {
 		},
 		{
 			name:       "local site - unknown scope",
-			dialerFunc: f.localClusterDialer(scopedClusterName, "/unknown"),
+			dialerFunc: f.localClusterDialer(scopes.QualifiedName{Name: scopedClusterSQN.Name, Scope: "/unknown"}),
 			assertErr: func(t require.TestingT, err error, msgAndArgs ...any) {
 				require.Error(t, err)
 				require.True(t, trace.IsNotFound(err), "expected not found error")
@@ -246,7 +251,7 @@ func TestDirectTransportNotCached(t *testing.T) {
 	clusterSess := &clusterSession{
 		kubeAPICreds: kubeAPICreds,
 		authContext: authContext{
-			kubeClusterName: "b",
+			kubeClusterSQN: scopes.QualifiedName{Name: "b"},
 			teleportCluster: teleportClusterClient{
 				name: "a",
 			},
@@ -293,38 +298,40 @@ func TestTransportCache(t *testing.T) {
 		},
 		ctx:             ctx,
 		cachedTransport: transportClients,
-		getKubernetesServersForKubeCluster: func(_ context.Context, _ string) ([]types.KubeServer, error) {
-			return []types.KubeServer{
-				unscopedServer,
-				testServer,
-				otherServer,
-			}, nil
+		getKubernetesServersForKubeCluster: func(_ context.Context, sqn scopes.QualifiedName) ([]types.KubeServer, error) {
+			for _, server := range []types.KubeServer{unscopedServer, testServer, otherServer} {
+				if sqn.Equals(scopes.QualifiedName{Name: server.GetName(), Scope: server.GetScope()}) {
+					return []types.KubeServer{server}, nil
+				}
+			}
+			return nil, trace.NotFound("no kube server found for %q", sqn)
 		},
 	}
 
-	clusterSess := &clusterSession{
-		authContext: authContext{
-			kubeClusterName: clusterName,
-			kubeCluster:     unscopedServer.GetCluster(),
-			teleportCluster: teleportClusterClient{
-				name: "a",
+	makeSessForServer := func(server types.KubeServer) *clusterSession {
+		return &clusterSession{
+			authContext: authContext{
+				kubeClusterSQN: scopes.QualifiedName{Name: server.GetName(), Scope: server.GetScope()},
+				kubeCluster:    server.GetCluster(),
+				teleportCluster: teleportClusterClient{
+					name: "a",
+				},
 			},
-		},
+		}
 	}
+	clusterSess := makeSessForServer(unscopedServer)
 
 	// generate transport for the unscoped server
 	_, _, err = forwarder.transportForRequestWithImpersonation(clusterSess)
 	require.NoError(t, err)
 
-	// replace the cluster on the clusterSession and ensure we generate a new
-	// transport rather than reusing the cached, unscoped transport
-	clusterSess.kubeCluster = testServer.GetCluster()
+	// generate transport for the /test scoped server
+	clusterSess = makeSessForServer(testServer)
 	_, _, err = forwarder.transportForRequestWithImpersonation(clusterSess)
 	require.NoError(t, err)
 
-	// replace again with a different scope and confirm we get another new
-	// transport
-	clusterSess.kubeCluster = otherServer.GetCluster()
+	// generate transport for the /other scoped server
+	clusterSess = makeSessForServer(otherServer)
 	_, _, err = forwarder.transportForRequestWithImpersonation(clusterSess)
 	require.NoError(t, err)
 
@@ -332,10 +339,10 @@ func TestTransportCache(t *testing.T) {
 	unscopedTransport, ok := forwarder.cachedTransport.GetIfExists(fmt.Sprintf("%x/%x", "a", clusterName))
 	require.True(t, ok, "expected transport to be cached")
 
-	testTransport, ok := forwarder.cachedTransport.GetIfExists(fmt.Sprintf("%x/%x/%x", "a", testScope, clusterName))
+	testTransport, ok := forwarder.cachedTransport.GetIfExists(fmt.Sprintf("%x/%x", "a", scopes.QualifiedName{Scope: testScope, Name: clusterName}.String()))
 	require.True(t, ok, "expected transport to be cached")
 
-	otherTransport, ok := forwarder.cachedTransport.GetIfExists(fmt.Sprintf("%x/%x/%x", "a", otherScope, clusterName))
+	otherTransport, ok := forwarder.cachedTransport.GetIfExists(fmt.Sprintf("%x/%x", "a", scopes.QualifiedName{Scope: otherScope, Name: clusterName}.String()))
 	require.True(t, ok, "expected transport to be cached")
 
 	// all of the cached transports should be unique because none of these clusters should collide
@@ -438,11 +445,11 @@ func TestLocalClusterDialsByHealth(t *testing.T) {
 					ClusterName:      clusterName,
 					ReverseTunnelSrv: healthReverseTunnel{},
 				},
-				getKubernetesServersForKubeCluster: func(context.Context, string) ([]types.KubeServer, error) {
+				getKubernetesServersForKubeCluster: func(context.Context, scopes.QualifiedName) ([]types.KubeServer, error) {
 					return tt.servers, nil
 				},
 			}
-			_, err := f.localClusterDialer(clusterName, "")(ctx, "tcp", "")
+			_, err := f.localClusterDialer(scopes.QualifiedName{Name: clusterName})(ctx, "tcp", "")
 			require.Error(t, err)
 
 			var aggErr trace.Aggregate

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -101,6 +102,18 @@ type TestContext struct {
 	heartbeatCtx       context.Context
 	heartbeatCancel    context.CancelFunc
 	lockWatcher        *services.LockWatcher
+	// The following fields are owned by the original context and are reused by
+	// scoped clones. They are intentionally private: callers should use the
+	// clone helper rather than sharing individual test components.
+	proxyAuthClient    *authclient.Client
+	kubeconfigPath     string
+	keyGen             *keygen.Keygen
+	clusterFeatures    func() proto.Features
+	healthCheckManager healthcheck.Manager
+	config             TestConfig
+	isClone            bool
+	closeOnce          sync.Once
+	closeErr           error
 }
 
 // KubeClusterConfig defines the cluster to be created
@@ -139,10 +152,12 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		heartbeatCtx:    heartbeatCtx,
 		heartbeatCancel: heartbeatCancel,
 		UploadHandler:   eventstest.NewMemoryUploader(),
+		config:          cfg,
 	}
 	t.Cleanup(func() { testCtx.Close() })
 
 	kubeConfigLocation := newKubeConfigFile(t, cfg.Clusters...)
+	testCtx.kubeconfigPath = kubeConfigLocation
 
 	streamer, err := events.NewProtoStreamer(
 		events.ProtoStreamerConfig{
@@ -208,6 +223,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			Client:    proxyAuthClient,
 		},
 	})
+	testCtx.proxyAuthClient = proxyAuthClient
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		testCtx.lockWatcher.Close()
@@ -243,6 +259,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	}()
 	keyGen, err := keygen.New(keygen.Config{BuildType: modules.BuildOSS})
 	require.NoError(t, err)
+	testCtx.keyGen = keyGen
 
 	client := newAuthClientWithStreamer(testCtx, cfg.CreateAuditStreamErr)
 
@@ -256,6 +273,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	if cfg.ClusterFeatures != nil {
 		features = cfg.ClusterFeatures
 	}
+	testCtx.clusterFeatures = features
 
 	testCtx.kubeServerListener, err = net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -289,6 +307,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, healthCheckManager.Close()) })
 	}
+	testCtx.healthCheckManager = healthCheckManager
 
 	var authClient authclient.ClientI = client
 	if cfg.WrapAuthClient != nil {
@@ -473,6 +492,232 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	return testCtx
 }
 
+// CloneTestContext creates a scoped kube service and proxy that share the
+// expensive auth and proxy-side test infrastructure of an unscoped context.
+// The clone owns its listeners, scoped client, inventory stream, watcher, and
+// TLS servers; closing it does not close parent or its shared backend.
+func CloneTestContext(t *testing.T, parent *TestContext, scope string) *TestContext {
+	t.Helper()
+	require.NotNil(t, parent)
+	require.Empty(t, parent.Scope, "only unscoped TestContexts can be cloned")
+	require.NotEmpty(t, scope)
+
+	ctx, cancel := context.WithCancel(parent.Context)
+	heartbeatCtx, heartbeatCancel := context.WithCancel(ctx)
+	clone := &TestContext{
+		ClusterName:     parent.ClusterName,
+		HostID:          uuid.NewString(),
+		Scope:           scope,
+		TLSServer:       parent.TLSServer,
+		AuthServer:      parent.AuthServer,
+		ScopedAuthz:     parent.ScopedAuthz,
+		Emitter:         parent.Emitter,
+		UploadHandler:   parent.UploadHandler,
+		Context:         ctx,
+		cancel:          cancel,
+		heartbeatCtx:    heartbeatCtx,
+		heartbeatCancel: heartbeatCancel,
+		lockWatcher:     parent.lockWatcher,
+		proxyAuthClient: parent.proxyAuthClient,
+		kubeconfigPath:  parent.kubeconfigPath,
+		keyGen:          parent.keyGen,
+		clusterFeatures: parent.clusterFeatures,
+		config:          parent.config,
+		isClone:         true,
+	}
+	clone.config.Scope = scope
+	t.Cleanup(func() { require.NoError(t, clone.Close()) })
+
+	var err error
+	clone.AuthClient, err = clone.TLSServer.NewClient(authtest.TestScopedServerID(types.RoleKube, clone.HostID, scope))
+	require.NoError(t, err)
+
+	client := newAuthClientWithStreamer(clone, clone.config.CreateAuditStreamErr)
+	var authClient authclient.ClientI = client
+	if clone.config.WrapAuthClient != nil {
+		authClient = clone.config.WrapAuthClient(client)
+	}
+	var accessPoint authclient.ClientI = client
+	if clone.config.WrapAuthClient != nil {
+		accessPoint = clone.config.WrapAuthClient(client)
+	}
+	proxyAccessPoint := authclient.ClientI(clone.proxyAuthClient)
+	if clone.config.WrapProxyAccessPoint != nil {
+		proxyAccessPoint = clone.config.WrapProxyAccessPoint(proxyAccessPoint)
+	}
+
+	clone.kubeServerListener, err = net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	clone.kubeProxyListener, err = net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	inventoryHandle, err := inventory.NewDownstreamHandle(client.InventoryControlStream,
+		func(context.Context) (*proto.UpstreamInventoryHello, error) {
+			return proto.UpstreamInventoryHello_builder{
+				ServerID: clone.HostID,
+				Version:  teleport.Version,
+				Services: types.SystemRoles{types.RoleKube}.StringSlice(),
+				Hostname: "test",
+				Scope:    scope,
+			}.Build(), nil
+		})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, inventoryHandle.Close()) })
+
+	kubeIdentity, err := authtest.NewScopedServerIdentity(clone.AuthServer, clone.HostID, scope, types.RoleKube)
+	require.NoError(t, err)
+	kubeTLS, err := kubeIdentity.TLSConfig(nil)
+	require.NoError(t, err)
+
+	clone.KubeServer, err = NewTLSServer(TLSServerConfig{
+		ForwarderConfig: ForwarderConfig{
+			Namespace:         apidefaults.Namespace,
+			Keygen:            clone.keyGen,
+			ClusterName:       clone.ClusterName,
+			ScopedAuthz:       clone.ScopedAuthz,
+			AuthClient:        authClient,
+			Emitter:           clone.Emitter,
+			DataDir:           t.TempDir(),
+			CachingAuthClient: accessPoint,
+			HostID:            clone.HostID,
+			Context:           clone.Context,
+			KubeconfigPath:    clone.kubeconfigPath,
+			KubeServiceType:   KubeService,
+			Component:         teleport.ComponentKube,
+			LockWatcher:       clone.lockWatcher,
+			CheckImpersonationPermissions: func(context.Context, string, authztypes.SelfSubjectAccessReviewInterface) error {
+				return nil
+			},
+			Clock:           clockwork.NewRealClock(),
+			ClusterFeatures: clone.clusterFeatures,
+			Scope:           scope,
+		},
+		TLS:                  kubeTLS.Clone(),
+		AccessPoint:          accessPoint,
+		LimiterConfig:        limiter.Config{MaxConnections: 1000},
+		OnHeartbeat:          func(error) {},
+		GetRotation:          func(types.SystemRole) (*types.Rotation, error) { return &types.Rotation{}, nil },
+		ResourceMatchers:     clone.config.ResourceMatchers,
+		OnReconcile:          clone.config.OnReconcile,
+		Log:                  logtest.NewLogger(),
+		InventoryHandle:      inventoryHandle,
+		ConnectedProxyGetter: reversetunnel.NewConnectedProxyGetter(),
+		// Scoped kube services do not run health checks. The proxy still needs
+		// a manager to satisfy its server configuration, but it never registers
+		// this scoped service as a health-check target.
+		HealthCheckManager: nil,
+	})
+	require.NoError(t, err)
+
+	kubeServersWatcher, err := kubewatcher.NewProxyKubeServerWatcher(clone.Context, kubewatcher.ProxyKubeServerWatcherConfig{
+		Logger:           logtest.NewLogger(),
+		AccessPoint:      proxyAccessPoint,
+		FallbackGetter:   clone.proxyAuthClient,
+		PrimaryTimeout:   time.Second,
+		FallbackInterval: time.Second,
+		MaxRetryPeriod:   time.Second,
+	})
+	require.NoError(t, err)
+
+	proxyIdentity, err := authtest.NewServerIdentity(clone.AuthServer, clone.HostID, types.RoleProxy)
+	require.NoError(t, err)
+	proxyTLS, err := proxyIdentity.TLSConfig(nil)
+	require.NoError(t, err)
+
+	clone.KubeProxy, err = NewTLSServer(TLSServerConfig{
+		ForwarderConfig: ForwarderConfig{
+			ReverseTunnelSrv: &reversetunnelclient.FakeServer{FakeClusters: []reversetunnelclient.Cluster{&fakeCluster{
+				FakeCluster: reversetunnelclient.NewFakeCluster(clone.ClusterName, client),
+				idToAddr:    map[string]string{clone.HostID: clone.kubeServerListener.Addr().String()},
+			}}},
+			Namespace:             apidefaults.Namespace,
+			Keygen:                clone.keyGen,
+			ClusterName:           clone.ClusterName,
+			ScopedAuthz:           clone.ScopedAuthz,
+			AuthClient:            authClient,
+			Emitter:               clone.Emitter,
+			DataDir:               t.TempDir(),
+			CachingAuthClient:     client,
+			HostID:                clone.HostID,
+			Context:               clone.Context,
+			KubeServiceType:       ProxyService,
+			Component:             teleport.ComponentKube,
+			LockWatcher:           clone.lockWatcher,
+			Clock:                 clockwork.NewRealClock(),
+			ClusterFeatures:       clone.clusterFeatures,
+			GetConnTLSCertificate: func() (*tls.Certificate, error) { return &proxyTLS.Certificates[0], nil },
+			GetConnTLSRoots:       func() (*x509.CertPool, error) { return proxyTLS.RootCAs, nil },
+			PROXYSigner:           &multiplexer.PROXYSigner{},
+		},
+		TLS:                      proxyTLS.Clone(),
+		AccessPoint:              proxyAccessPoint,
+		KubernetesServersWatcher: kubeServersWatcher,
+		LimiterConfig:            limiter.Config{MaxConnections: 1000},
+		Log:                      logtest.NewLogger(),
+		InventoryHandle:          inventoryHandle,
+		GetRotation:              func(types.SystemRole) (*types.Rotation, error) { return &types.Rotation{}, nil },
+		ConnectedProxyGetter:     reversetunnel.NewConnectedProxyGetter(),
+		HealthCheckManager:       parent.healthCheckManager,
+	})
+	require.NoError(t, err)
+
+	clone.startKubeServices(t)
+	for _, cluster := range clone.config.Clusters {
+		select {
+		case sender := <-inventoryHandle.Sender():
+			server, err := clone.KubeServer.GetServerInfo(scopes.QualifiedName{Name: cluster.Name, Scope: scope})
+			require.NoError(t, err)
+			require.NoError(t, sender.Send(clone.Context, proto.InventoryHeartbeat_builder{KubernetesServer: server}.Build()))
+		case <-time.After(20 * time.Second):
+			t.Fatal("timed out waiting for inventory handle sender")
+		}
+	}
+	require.NoError(t, kubeServersWatcher.WaitInitialization())
+	require.Eventually(t, func() bool { return kubeServersWatcher.ResourceCount() >= len(clone.config.Clusters) }, 3*time.Second, 100*time.Millisecond)
+
+	return clone
+}
+
+func TestCloneTestContext(t *testing.T) {
+	ctx := t.Context()
+	parent := SetupTestContext(ctx, t, TestConfig{
+		Clusters: []KubeClusterConfig{{Name: "kube", APIEndpoint: "https://127.0.0.1:1"}},
+		ScopesFeatures: scopes.Features{
+			Enabled:         true,
+			AgentPinEnabled: true,
+		},
+	})
+	clone := CloneTestContext(t, parent, "/staging")
+
+	require.Same(t, parent.TLSServer, clone.TLSServer)
+	require.Same(t, parent.AuthServer, clone.AuthServer)
+	require.Same(t, parent.ScopedAuthz, clone.ScopedAuthz)
+	require.Same(t, parent.Emitter, clone.Emitter)
+	require.Same(t, parent.UploadHandler, clone.UploadHandler)
+	require.Same(t, parent.lockWatcher, clone.lockWatcher)
+	require.Equal(t, parent.kubeconfigPath, clone.kubeconfigPath)
+	require.NotEqual(t, parent.HostID, clone.HostID)
+	require.NotSame(t, parent.AuthClient, clone.AuthClient)
+	require.NotEqual(t, parent.KubeProxyAddress(), clone.KubeProxyAddress())
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		servers, err := parent.AuthServer.GetKubernetesServers(ctx)
+		require.NoError(t, err)
+		found := make(map[string]bool)
+		for _, server := range servers {
+			if server.GetCluster().GetName() == "kube" {
+				found[server.GetCluster().GetScope()] = true
+			}
+		}
+		require.True(t, found[""], "missing unscoped kube server")
+		require.True(t, found["/staging"], "missing scoped kube server")
+	}, 5*time.Second, 100*time.Millisecond)
+
+	require.NoError(t, clone.Close())
+	_, err := parent.AuthServer.GetClusterName(ctx)
+	require.NoError(t, err, "closing a clone must not close the shared auth server")
+}
+
 // startKubeServices starts kube service and kube proxy to handle connections.
 func (c *TestContext) startKubeServices(t *testing.T) {
 	go func() {
@@ -496,16 +741,36 @@ func (c *TestContext) startKubeServices(t *testing.T) {
 
 // Close closes resources associated with the test context.
 func (c *TestContext) Close() error {
-	// cancel the heartbeat context to stop validating the heartbeat not found
-	// errors when deprovisioning.
-	c.heartbeatCancel()
-	// kubeServer closes the listener
-	errKubeServer := c.KubeServer.Close()
-	errKubeProxy := c.KubeProxy.Close()
-	authCErr := c.AuthClient.Close()
-	authSErr := c.AuthServer.Close()
-	c.cancel()
-	return trace.NewAggregate(errKubeServer, errKubeProxy, authCErr, authSErr)
+	c.closeOnce.Do(func() {
+		// Cancel the heartbeat context to stop validating heartbeat-not-found
+		// errors while the service unregisters itself.
+		if c.heartbeatCancel != nil {
+			c.heartbeatCancel()
+		}
+		var errs []error
+		if c.KubeServer != nil {
+			errs = append(errs, c.KubeServer.Close())
+		}
+		if c.KubeProxy != nil {
+			errs = append(errs, c.KubeProxy.Close())
+		}
+		if c.AuthClient != nil {
+			errs = append(errs, c.AuthClient.Close())
+		}
+		c.cancel()
+
+		// A clone borrows the auth server and proxy-side infrastructure from its
+		// parent. It must only release the resources it created itself.
+		if c.isClone {
+			c.closeErr = trace.NewAggregate(errs...)
+			return
+		}
+		if c.AuthServer != nil {
+			errs = append(errs, c.AuthServer.Close())
+		}
+		c.closeErr = trace.NewAggregate(errs...)
+	})
+	return c.closeErr
 }
 
 // KubeProxyAddress returns the address of the kube proxy.

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -85,6 +85,7 @@ import (
 type TestContext struct {
 	HostID             string
 	ClusterName        string
+	Scope              string
 	TLSServer          *authtest.TLSServer
 	AuthServer         *auth.Server
 	AuthClient         *authclient.Client
@@ -132,6 +133,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	testCtx := &TestContext{
 		ClusterName:     "root.example.com",
 		HostID:          uuid.New().String(),
+		Scope:           cfg.Scope,
 		Context:         ctx,
 		cancel:          cancel,
 		heartbeatCtx:    heartbeatCtx,
@@ -450,7 +452,7 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 	for _, cluster := range cfg.Clusters {
 		select {
 		case sender := <-inventoryHandle.Sender():
-			server, err := testCtx.KubeServer.GetServerInfo(cluster.Name)
+			server, err := testCtx.KubeServer.GetServerInfo(scopes.QualifiedName{Name: cluster.Name, Scope: cfg.Scope})
 			require.NoError(t, err)
 			require.NoError(t, sender.Send(ctx, proto.InventoryHeartbeat_builder{
 				KubernetesServer: server,
@@ -569,6 +571,11 @@ func (c *TestContext) CreateUserAndScopedRole(t *testing.T, username, scope stri
 	user, err := authtest.CreateUser(t.Context(), c.TLSServer.Auth(), username)
 	require.NoError(t, err)
 
+	return user, c.CreateAndAssignScopedRole(t, username, scope, roleSpec)
+}
+
+// CreateAndAssignScopedRole creates a scoped role and assigns it to the given username.
+func (c *TestContext) CreateAndAssignScopedRole(t *testing.T, username, scope string, roleSpec *accessv1.ScopedRoleSpec) *accessv1.CreateScopedRoleAssignmentResponse {
 	scopedAccess := c.TLSServer.Auth().ScopedAccess()
 	role, err := scopedAccess.CreateScopedRole(t.Context(), accessv1.CreateScopedRoleRequest_builder{
 		Role: accessv1.ScopedRole_builder{
@@ -605,7 +612,7 @@ func (c *TestContext) CreateUserAndScopedRole(t *testing.T, username, scope stri
 	}.Build())
 	require.NoError(t, err)
 
-	return user, assignment
+	return assignment
 }
 
 func newKubeConfigFile(t *testing.T, clusters ...KubeClusterConfig) string {
@@ -659,13 +666,13 @@ func WithMFAVerified() GenTestKubeClientTLSCertOptions {
 }
 
 // GenTestKubeClientTLSCert generates a kube client to access kube service
-func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName, kubeCluster string, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *rest.Config) {
-	client, _, cfg := c.GenTestKubeClientsTLSCert(t, userName, kubeCluster, opts...)
+func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName string, kubeClusterSQN scopes.QualifiedName, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *rest.Config) {
+	client, _, cfg := c.GenTestKubeClientsTLSCert(t, userName, kubeClusterSQN, opts...)
 	return client, cfg
 }
 
 // GenTestKubeClientsTLSCert generates a "regular" kube client and a dynamic one to access kube service
-func (c *TestContext) GenTestKubeClientsTLSCert(t *testing.T, userName, kubeCluster string, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *dynamic.DynamicClient, *rest.Config) {
+func (c *TestContext) GenTestKubeClientsTLSCert(t *testing.T, userName string, kubeClusterSQN scopes.QualifiedName, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *dynamic.DynamicClient, *rest.Config) {
 	authServer := c.AuthServer
 	clusterName, err := authServer.GetClusterName(t.Context())
 	require.NoError(t, err)
@@ -705,7 +712,7 @@ func (c *TestContext) GenTestKubeClientsTLSCert(t *testing.T, userName, kubeClus
 		Groups:            user.GetRoles(),
 		KubernetesUsers:   user.GetKubeUsers(),
 		KubernetesGroups:  user.GetKubeGroups(),
-		KubernetesCluster: kubeCluster,
+		KubernetesCluster: kubeClusterSQN.String(),
 		RouteToCluster:    c.ClusterName,
 		Traits:            user.GetTraits(),
 	}

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -29,6 +29,7 @@ import (
 
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/utils"
@@ -201,7 +202,10 @@ func (s *TLSServer) registerKubeCluster(ctx context.Context, cluster types.KubeC
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	s.fwd.upsertKubeDetails(cluster.GetName(), clusterDetails)
+	s.fwd.upsertKubeDetails(scopes.QualifiedName{
+		Name:  cluster.GetName(),
+		Scope: cluster.GetScope(),
+	}, clusterDetails)
 	return trace.Wrap(s.startHeartbeatAndHealthCheck(cluster))
 }
 
@@ -213,7 +217,10 @@ func (s *TLSServer) updateKubeCluster(ctx context.Context, cluster types.KubeClu
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	s.fwd.upsertKubeDetails(cluster.GetName(), clusterDetails)
+	s.fwd.upsertKubeDetails(scopes.QualifiedName{
+		Name:  cluster.GetName(),
+		Scope: cluster.GetScope(),
+	}, clusterDetails)
 	return nil
 }
 
@@ -226,8 +233,11 @@ func (s *TLSServer) unregisterKubeCluster(ctx context.Context, cluster types.Kub
 	if err := s.stopHeartbeatAndHealthCheck(cluster); err != nil {
 		errs = append(errs, err)
 	}
-	clusterName := cluster.GetName()
-	s.fwd.removeKubeDetails(clusterName)
+	clusterSQN := scopes.QualifiedName{
+		Name:  cluster.GetName(),
+		Scope: cluster.GetScope(),
+	}
+	s.fwd.removeKubeDetails(clusterSQN)
 
 	// A child process can be forked to upgrade the Teleport binary. The child
 	// will take over the heartbeats so do NOT delete them in that case.
@@ -243,7 +253,7 @@ func (s *TLSServer) unregisterKubeCluster(ctx context.Context, cluster types.Kub
 	}
 
 	if !isShutdown || shouldDeleteOnShutdown {
-		if err := s.deleteKubernetesServer(ctx, clusterName); err != nil {
+		if err := s.deleteKubernetesServer(ctx, clusterSQN); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -255,7 +265,7 @@ func (s *TLSServer) unregisterKubeCluster(ctx context.Context, cluster types.Kub
 	s.fwd.mu.Unlock()
 	// close active sessions
 	for _, sess := range sessions {
-		if sess.ctx.kubeClusterName == clusterName {
+		if clusterSQN.Equals(sess.ctx.kubeClusterSQN) {
 			// TODO(tigrato): check if we should send errors to each client
 			if err := sess.Close(); err != nil {
 				errs = append(errs, err)
@@ -267,11 +277,11 @@ func (s *TLSServer) unregisterKubeCluster(ctx context.Context, cluster types.Kub
 }
 
 // deleteKubernetesServer deletes kubernetes server for the specified cluster.
-func (s *TLSServer) deleteKubernetesServer(ctx context.Context, name string) error {
+func (s *TLSServer) deleteKubernetesServer(ctx context.Context, sqn scopes.QualifiedName) error {
 	err := s.AuthClient.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
-		Scope:  s.GetScope(),
 		HostId: s.HostID,
-		Name:   name,
+		Name:   sqn.Name,
+		Scope:  sqn.Scope,
 	}.Build())
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)

--- a/lib/kube/proxy/watcher/watcher.go
+++ b/lib/kube/proxy/watcher/watcher.go
@@ -30,6 +30,8 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/kube/utils"
+	"github.com/gravitational/teleport/lib/scopes"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -548,7 +550,7 @@ func (w *ProxyKubeServerWatcher) WaitInitialization() error {
 }
 
 // GetKubeServersForClusterName returns a copy of the resources known to the watcher that match the given cluster name.
-func (w *ProxyKubeServerWatcher) GetKubeServersForClusterName(ctx context.Context, clusterName string) ([]types.KubeServer, error) {
+func (w *ProxyKubeServerWatcher) GetKubeServersForClusterName(ctx context.Context, sqn scopes.QualifiedName) ([]types.KubeServer, error) {
 	if err := w.maybeFetchFromUpstream(ctx); err != nil {
 		// This is an indication things are in a very bad state, it means the primary acccess point is not responsive
 		// and the fallback getter is failing. Log this as a warning.
@@ -561,7 +563,7 @@ func (w *ProxyKubeServerWatcher) GetKubeServersForClusterName(ctx context.Contex
 
 	var out []types.KubeServer
 	for _, resource := range w.current {
-		if resource.GetCluster().GetName() == clusterName {
+		if utils.KubeClusterMatchesSQN(resource.GetCluster(), sqn) {
 			out = append(out, types.KubeServer.Copy(resource))
 		}
 	}

--- a/lib/kube/proxy/watcher/watcher_test.go
+++ b/lib/kube/proxy/watcher/watcher_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // mockKubeServerWatcherGetter is a testify mock for the [services.KubernetesServerWatcherGetter] interface.
@@ -188,13 +189,13 @@ func testProxyKubeServerWatcherStartsWithFaultyPrimarySynctest(t *testing.T) {
 
 	fallback.On("GetKubernetesServers", mock.Anything).
 		Return([]types.KubeServer{newTestKubeServer(t, "foo", "bar")}, nil)
-	srvs, err := w.GetKubeServersForClusterName(ctx, "foo")
+	srvs, err := w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.NoError(t, err)
 	require.Len(t, srvs, 1)
 	require.Equal(t, "foo", srvs[0].GetName())
 	require.Equal(t, 1, w.ResourceCount())
 
-	srvs, err = w.GetKubeServersForClusterName(ctx, "baz")
+	srvs, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "baz"})
 	require.NoError(t, err)
 	require.Empty(t, srvs)
 
@@ -218,7 +219,7 @@ func testProxyKubeServerWatcherStartsWithFaultyPrimarySynctest(t *testing.T) {
 	results := make(chan result, 64)
 	for range 64 {
 		wg.Go(func() {
-			srvs, err := w.GetKubeServersForClusterName(ctx, "foo")
+			srvs, err := w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 			results <- result{srvs: srvs, err: err}
 		})
 	}
@@ -282,7 +283,7 @@ func testWatcherProcessesEventsSynctest(t *testing.T) {
 	synctest.Wait()
 
 	// Single call to backup since watcher is not ready.
-	resources, err := w.GetKubeServersForClusterName(ctx, "foo")
+	resources, err := w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.NoError(t, err)
 	require.Empty(t, resources, "Watcher should start with empty cache before warm-up")
 
@@ -295,7 +296,7 @@ func testWatcherProcessesEventsSynctest(t *testing.T) {
 	fw.send(types.Event{Type: types.OpPut, Resource: newTestKubeServer(t, "foo", "host2")})
 	synctest.Wait()
 
-	resources, err = w.GetKubeServersForClusterName(ctx, "foo")
+	resources, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.NoError(t, err)
 	require.Len(t, resources, 2)
 	require.Equal(t, 2, w.ResourceCount())
@@ -311,7 +312,7 @@ func testWatcherProcessesEventsSynctest(t *testing.T) {
 	fw.send(types.Event{Type: types.OpDelete, Resource: newTestKubeServer(t, "foo", "host2")})
 	synctest.Wait()
 
-	resources, err = w.GetKubeServersForClusterName(ctx, "foo")
+	resources, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 	require.Equal(t, "foo", resources[0].GetName())
@@ -373,24 +374,24 @@ func proxyKubeServerWatcherFetchAndInitializeStateAppliesQueuedEventsSynctest(t 
 	require.True(t, isHealthy(w))
 	require.Empty(t, fw.Events(), "All events should be processed by the time initialization is complete")
 
-	resources, err := w.GetKubeServersForClusterName(ctx, "kept")
+	resources, err := w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "kept"})
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 
-	resources, err = w.GetKubeServersForClusterName(ctx, "added")
+	resources, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "added"})
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 
-	resources, err = w.GetKubeServersForClusterName(ctx, "updated")
+	resources, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "updated"})
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 	require.Equal(t, "1", resources[0].GetRevision())
 
-	resources, err = w.GetKubeServersForClusterName(ctx, "deleted")
+	resources, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "deleted"})
 	require.NoError(t, err)
 	require.Empty(t, resources)
 
-	resources, err = w.GetKubeServersForClusterName(ctx, "transient")
+	resources, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "transient"})
 	require.NoError(t, err)
 	require.Empty(t, resources)
 
@@ -429,7 +430,7 @@ func testWatcherUnknownEventsHardFaultSynctest(t *testing.T) {
 	synctest.Wait()
 
 	// Single call to backup since watcher is not ready.
-	resources, err := w.GetKubeServersForClusterName(ctx, "initial")
+	resources, err := w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "initial"})
 	require.NoError(t, err)
 	require.Empty(t, resources, "Watcher should start with empty cache before warm-up")
 
@@ -444,7 +445,7 @@ func testWatcherUnknownEventsHardFaultSynctest(t *testing.T) {
 	require.False(t, isHealthy(w), "Watcher should be unhealthy after receiving invalid event")
 	require.False(t, w.shouldFetchFromFallback(time.Now()), "The fallback timeout should not expire yet.")
 
-	resources, err = w.GetKubeServersForClusterName(ctx, "initial")
+	resources, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "initial"})
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 	require.Equal(t, "initial", resources[0].GetName())
@@ -499,7 +500,7 @@ func testProxyKubeServerWatcherRetryWatchAfterTimeoutSynctest(t *testing.T) {
 	require.False(t, w.shouldFetchFromFallback(time.Now()), "watcher should now be serving from the event stream, not fallback")
 
 	// Verify no calls to the back up are made.
-	srvs, err := w.GetKubeServersForClusterName(ctx, "initial")
+	srvs, err := w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "initial"})
 	require.NoError(t, err)
 	require.Empty(t, srvs)
 
@@ -592,7 +593,7 @@ func testProxyKubeServerWatcherDiscardsStaleOnFallbackFailSynctest(t *testing.T)
 
 	synctest.Wait()
 
-	srvs, err := w.GetKubeServersForClusterName(ctx, "foo")
+	srvs, err := w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.NoError(t, err)
 	require.Len(t, srvs, 1)
 	require.Equal(t, "foo", srvs[0].GetName())
@@ -601,7 +602,7 @@ func testProxyKubeServerWatcherDiscardsStaleOnFallbackFailSynctest(t *testing.T)
 	fw.send(types.Event{Type: types.OpDelete, Resource: srvs[0]})
 	synctest.Wait()
 
-	srvs, err = w.GetKubeServersForClusterName(ctx, "foo")
+	srvs, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.NoError(t, err)
 	require.Empty(t, srvs)
 
@@ -618,7 +619,7 @@ func testProxyKubeServerWatcherDiscardsStaleOnFallbackFailSynctest(t *testing.T)
 
 	synctest.Wait()
 
-	srvs, err = w.GetKubeServersForClusterName(ctx, "foo")
+	srvs, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.NoError(t, err)
 	require.Len(t, srvs, numberOfEvents)
 
@@ -637,14 +638,14 @@ func testProxyKubeServerWatcherDiscardsStaleOnFallbackFailSynctest(t *testing.T)
 	require.False(t, isHealthy(w), "Watcher is imminently unhealthy after the primary watcher fails")
 	require.False(t, w.shouldFetchFromFallback(time.Now()), "Watcher should not fetch from fallback immediately after primary watcher fails")
 
-	nonstale, err := w.GetKubeServersForClusterName(ctx, "foo")
+	nonstale, err := w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.NoError(t, err)
 	require.Len(t, nonstale, numberOfEvents)
 
 	time.Sleep(10 * time.Second) // exceed max staleness.
 	require.False(t, isHealthy(w), "Watcher is not hot after max staleness is exceeded")
 
-	srvs, err = w.GetKubeServersForClusterName(ctx, "foo")
+	srvs, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.Error(t, err)
 	require.Empty(t, srvs, "Expected no servers to be returned when watcher is unhealthy and fallback is failing")
 
@@ -664,7 +665,7 @@ func testProxyKubeServerWatcherDiscardsStaleOnFallbackFailSynctest(t *testing.T)
 	require.True(t, isHealthy(w), "Watcher should be hot after new watcher is created and receives OpInit")
 
 	// Calls should not be routed to fallback.
-	srvs, err = w.GetKubeServersForClusterName(ctx, "foo")
+	srvs, err = w.GetKubeServersForClusterName(ctx, scopes.QualifiedName{Name: "foo"})
 	require.NoError(t, err)
 	require.Len(t, srvs, numberOfEvents)
 
@@ -888,7 +889,7 @@ func testProxyKubeServerWatcher_ParentContextCanceledSynctest(t *testing.T) {
 
 	resultCh := make(chan error, 1)
 	go func() {
-		_, err := w.GetKubeServersForClusterName(parentCtx, "foo")
+		_, err := w.GetKubeServersForClusterName(parentCtx, scopes.QualifiedName{Name: "foo"})
 		resultCh <- err
 	}()
 

--- a/lib/kube/proxy/watcher_test.go
+++ b/lib/kube/proxy/watcher_test.go
@@ -190,7 +190,7 @@ func TestWatcher(t *testing.T) {
 			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
 		))
 		// make sure credentials were updated as well.
-		require.Equal(t, strings.TrimPrefix(kubeMock.URL, "https://"), testCtx.KubeServer.fwd.clusterDetails["kube2"].kubeCreds.getTargetAddr())
+		require.Equal(t, strings.TrimPrefix(kubeMock.URL, "https://"), testCtx.KubeServer.fwd.clusterDetails[scopes.QualifiedName{Name: "kube2"}].kubeCreds.getTargetAddr())
 	case <-time.After(time.Second):
 		t.Fatal("Didn't receive reconcile event after 1s.")
 	}

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // GetKubeClient returns instance of client to the kubernetes cluster
@@ -187,4 +188,12 @@ func extractAndSortKubeClusters(kss []types.KubeServer) []types.KubeCluster {
 func GetKubeAgentVersion(ctx context.Context, versionGetter version.Getter) (*semver.Version, error) {
 	v, err := versionGetter.GetVersion(ctx)
 	return v, trace.Wrap(err)
+}
+
+// KubeClusterMatchesSQN checks if a given [types.KubeCluster] matches the given [scopes.QualifiedName]
+func KubeClusterMatchesSQN(cluster types.KubeCluster, sqn scopes.QualifiedName) bool {
+	return sqn.Equals(scopes.QualifiedName{
+		Name:  cluster.GetName(),
+		Scope: cluster.GetScope(),
+	})
 }

--- a/lib/scopes/qualified.go
+++ b/lib/scopes/qualified.go
@@ -171,3 +171,16 @@ func WeakValidateQualifiedName(sqn string) error {
 	}
 	return qn.WeakValidate()
 }
+
+// Equals determines if the target [QualifiedName] is equivalent to the receiving [QualifiedName].
+func (qn QualifiedName) Equals(target QualifiedName) bool {
+	if qn.Name != target.Name {
+		return false
+	}
+
+	if qn.Scope == "" && target.Scope == "" {
+		return true
+	}
+
+	return Compare(qn.Scope, target.Scope) == Equivalent
+}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
@@ -1132,13 +1133,21 @@ func (s *PresenceService) RangeKubernetesServersWithName(ctx context.Context, cl
 		return stream.Fail[types.KubeServer](trace.BadParameter("missing kubernetes cluster name"))
 	}
 
+	sqn := scopes.QualifiedName{Name: clusterName}
+	if scopes.MaybeSQN(clusterName) {
+		var err error
+		sqn, err = scopes.ParseQualifiedName(clusterName)
+		if err != nil {
+			return stream.Fail[types.KubeServer](trace.Wrap(err))
+		}
+	}
 	// TODO(wethreetrees): if Metadata.Name == Spec.Cluster.GetName() becomes a
 	// CheckAndSetDefaults invariant, this filter could check against the backend
 	// key's trailing component before unmarshalling. Currently no such invariant
 	// exists, so we unmarshal every item to read the embedded cluster name.
 	mapFn := func(server types.KubeServer) (types.KubeServer, bool) {
 		cluster := server.GetCluster()
-		return server, cluster != nil && cluster.GetName() == clusterName
+		return server, cluster != nil && kubeutils.KubeClusterMatchesSQN(cluster, sqn)
 	}
 
 	return stream.FilterMap(s.kubeServers.Resources(ctx, "", ""), mapFn)

--- a/lib/services/unified_resource.go
+++ b/lib/services/unified_resource.go
@@ -605,6 +605,9 @@ func makeResourceSortKey(resource types.Resource) resourceSortKey {
 			name = r.GetCluster().GetName()
 			kind = types.KindKubernetesCluster
 		}
+		if scope := r.GetScope(); scope != "" {
+			name = scopes.QualifiedName{Name: name, Scope: scope}.String()
+		}
 	case types.DatabaseServer:
 		db := r.GetDatabase()
 		if db != nil {

--- a/lib/services/unified_resource_test.go
+++ b/lib/services/unified_resource_test.go
@@ -985,7 +985,7 @@ func TestUnifiedResourceCache_AppServerComponentFeaturesIntersection(t *testing.
 	})
 }
 
-func TestUnifiedResourceWatcher_ScopedResources(t *testing.T) {
+func TestUnifiedResourceWatcher_ScopedApps(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	client := newClient(t)
@@ -1064,6 +1064,94 @@ func TestUnifiedResourceWatcher_ScopedResources(t *testing.T) {
 		require.ElementsMatch(t, []string{"/prod"}, getScopes(res))
 	}, 5*time.Second, 10*time.Millisecond)
 
+}
+
+func TestUnifiedResourceWatcher_ScopedKube(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	client := newClient(t)
+	w, err := services.NewUnifiedResourceCache(ctx, services.UnifiedResourceCacheConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentUnifiedResource,
+			Client:    client,
+		},
+		ResourceGetter: client,
+	})
+	require.NoError(t, err)
+
+	newScopedKubeServer := func(scope string) *types.KubernetesServerV3 {
+		const name = "kube"
+		return &types.KubernetesServerV3{
+			Metadata: types.Metadata{
+				Name: name,
+			},
+			Scope: scope,
+			Spec: types.KubernetesServerSpecV3{
+				HostID: uuid.NewString(),
+				Cluster: &types.KubernetesClusterV3{
+					Metadata: types.Metadata{
+						Name: name,
+					},
+					Scope: scope,
+				},
+			},
+		}
+	}
+
+	staging := newScopedKubeServer("/staging")
+	prod := newScopedKubeServer("/prod")
+	unscoped := newScopedKubeServer("")
+
+	for _, srv := range []*types.KubernetesServerV3{staging, prod, unscoped} {
+		_, err = client.UpsertKubernetesServer(ctx, srv)
+		require.NoError(t, err)
+	}
+
+	getScopes := func(res []types.ResourceWithLabels) []string {
+		require.NoError(t, err)
+		scopes := []string{}
+		for _, r := range res {
+			kubeServer, ok := r.(types.KubeServer)
+			require.True(t, ok, "expected types.KubeServer, got %T", r)
+			scopes = append(scopes, kubeServer.GetScope())
+		}
+		return scopes
+	}
+
+	// All three same-named kube servers must be distinct entries.
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		res, err := w.GetUnifiedResources(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, res, 3)
+		require.ElementsMatch(t, []string{"", "/staging", "/prod"}, getScopes(res))
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Deleting the staging kube server (identified by hostID/name only, like the
+	// real deletion paths) must prune exactly the staging entry.
+	require.NoError(t, client.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+		HostId: staging.Spec.HostID,
+		Name:   staging.GetName(),
+		Scope:  staging.GetScope(),
+	}.Build()))
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		res, err := w.GetUnifiedResources(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, res, 2)
+		require.ElementsMatch(t, []string{"", "/prod"}, getScopes(res))
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// The unscoped kube server is still deletable through the legacy path.
+	require.NoError(t, client.DeleteKubeServer(ctx, presencev1.DeleteKubeServerRequest_builder{
+		HostId: unscoped.Spec.HostID,
+		Name:   unscoped.GetName(),
+		Scope:  unscoped.GetScope(),
+	}.Build()))
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		res, err := w.GetUnifiedResources(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, res, 1)
+		require.ElementsMatch(t, []string{"/prod"}, getScopes(res))
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestUnifiedResourceWatcher_DeleteEvent(t *testing.T) {

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -70,6 +70,7 @@ import (
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	kuberelay "github.com/gravitational/teleport/lib/kube/relay"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -1241,7 +1242,7 @@ func newKubeLoginCommand(parent *kingpin.CmdClause) *kubeLoginCommand {
 		CmdClause: parent.Command("login", "Login to a Kubernetes cluster."),
 	}
 	c.Flag("cluster", clusterHelp).Short('c').StringVar(&c.siteName)
-	c.Arg("kube-cluster", "Name of the Kubernetes cluster to login to. Check 'tsh kube ls' for a list of available clusters.").StringVar(&c.kubeCluster)
+	c.Arg("kube-cluster", "Name of the Kubernetes cluster to login to. Check 'tsh kube ls' for a list of available clusters. Can be scope-qualified using the format /<scope>::<cluster-name>.").StringVar(&c.kubeCluster)
 	c.Flag("labels", labelHelp).StringVar(&c.labels)
 	c.Flag("query", queryHelp).StringVar(&c.predicateExpression)
 	c.Flag("as", "Configure custom Kubernetes user impersonation.").StringVar(&c.impersonateUser)
@@ -1363,7 +1364,15 @@ func (c *kubeLoginCommand) selectorsOrWildcard() string {
 
 // checkClusterSelection checks the kube clusters selected by user input.
 func (c *kubeLoginCommand) checkClusterSelection(cf *CLIConf, tc *client.TeleportClient, clusters types.KubeClusters) error {
-	clusters = matchClustersByNameOrDiscoveredName(c.kubeCluster, clusters)
+	sqn := scopes.QualifiedName{Name: c.kubeCluster}
+	if scopes.MaybeSQN(c.kubeCluster) {
+		var err error
+		sqn, err = scopes.ParseQualifiedName(c.kubeCluster)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	clusters = matchClustersByNameOrDiscoveredName(sqn, clusters)
 	err := checkClusterSelection(cf, clusters, c.kubeCluster)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1371,7 +1380,7 @@ func (c *kubeLoginCommand) checkClusterSelection(cf *CLIConf, tc *client.Telepor
 	if c.kubeCluster != "" && len(clusters) == 1 {
 		// Populate settings using the selected kube cluster, which contains
 		// the full cluster name.
-		c.kubeCluster = clusters[0].GetName()
+		c.kubeCluster = scopes.QualifiedName{Name: clusters[0].GetName(), Scope: clusters[0].GetScope()}.String()
 		// Set CLIConf.KubernetesCluster so that the kube cluster's context
 		// is automatically selected.
 		cf.KubernetesCluster = c.kubeCluster
@@ -1414,15 +1423,15 @@ func (c *kubeLoginCommand) getSelectors() resourceSelectors {
 	}
 }
 
-func matchClustersByNameOrDiscoveredName(name string, clusters types.KubeClusters) types.KubeClusters {
-	if name == "" {
+func matchClustersByNameOrDiscoveredName(sqn scopes.QualifiedName, clusters types.KubeClusters) types.KubeClusters {
+	if sqn.Name == "" {
 		return clusters
 	}
 
 	// look for exact full name matches.
 	var out types.KubeClusters
 	for _, kc := range clusters {
-		if kc.GetName() == name {
+		if kubeutils.KubeClusterMatchesSQN(kc, sqn) {
 			out = append(out, kc)
 		}
 	}
@@ -1433,7 +1442,7 @@ func matchClustersByNameOrDiscoveredName(name string, clusters types.KubeCluster
 	// or look for exact "discovered name" matches.
 	for _, kc := range clusters {
 		discoveredName, ok := kc.GetLabel(types.DiscoveredNameLabel)
-		if ok && discoveredName == name {
+		if ok && discoveredName == sqn.Name {
 			out = append(out, kc)
 		}
 	}
@@ -1533,7 +1542,7 @@ func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleport
 func kubeClustersToStrings(kubeClusters []types.KubeCluster) []string {
 	names := make([]string, len(kubeClusters))
 	for i, cluster := range kubeClusters {
-		names[i] = cluster.GetName()
+		names[i] = scopes.QualifiedName{Name: cluster.GetName(), Scope: cluster.GetScope()}.String()
 	}
 
 	return names

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -258,7 +259,7 @@ func (c *proxyKubeCommand) prepare(cf *CLIConf, tc *client.TeleportClient) (*cli
 		for _, kc := range kubeClusters {
 			clusters = append(clusters, kubeconfig.LocalProxyCluster{
 				TeleportCluster:   tc.SiteName,
-				KubeCluster:       kc.GetName(),
+				KubeCluster:       scopes.QualifiedName{Name: kc.GetName(), Scope: kc.GetScope()}.String(),
 				Impersonate:       c.impersonateUser,
 				ImpersonateGroups: c.impersonateGroups,
 				Namespace:         c.namespace,
@@ -590,7 +591,11 @@ func combineMatchedClusters(matchMap map[string]types.KubeClusters) types.KubeCl
 func matchClustersByNames(clusters types.KubeClusters, names ...string) map[string]types.KubeClusters {
 	matchesForNames := make(map[string]types.KubeClusters)
 	for _, name := range names {
-		matchesForNames[name] = matchClustersByNameOrDiscoveredName(name, clusters)
+		sqn, err := scopes.ParseQualifiedName(name)
+		if err != nil {
+			sqn = scopes.QualifiedName{Name: name}
+		}
+		matchesForNames[name] = matchClustersByNameOrDiscoveredName(sqn, clusters)
 	}
 	return matchesForNames
 }


### PR DESCRIPTION
We currently return an ambiguity error when the kube forwarder is unable to disambiguate between scoped and unscoped kube clusters of the same name.

For example, given the following kube clusters represented by name/SQN:
```
my-kube-cluster
/local::my-kube-cluster
/local/k8s::my-kube-cluster
```
Using `tsh kube login my-kube-cluster` with an unscoped identity would not provide the Teleport Proxy enough information when calling `tsh kube credentials` to route requests appropriately. The same ambiguity would be present for identities scoped to `/local` since both `/local::my-kube-cluster` and `/local/k8s::my-kube-cluster` are both visible and both match on name. The solution is two-fold:
- `tsh kube` subcommands for `login` and `credentials` should both support SQNs in addition to bare names.
- The kube forwarder should reference the kube clusters it's forwarding for by SQN instead of by name.

This PR updates `tsh kube login` and `tsh kube credentials` to accept SQNs and populate the URLs referenced by `kubectl` with SQNs instead of names. This gives the Teleport Proxy the ability to disambiguate between `my-kube-cluster` and `/local::my-kube-cluster` when routing to kube agents.

It also updates the kube forwarder used by both the teleport proxy and the kube agent to reference kube clusters by SQN. Although this results in relatively few functional changes, there are many call-sites and tests that need to be updated as well.

Many tests that had previously been relying on a single `TestContext` instance for both unscoped and scoped test cases required refactoring to spin up two separate contexts. This was mainly due to `/local::my-kube-cluster` no longer resolving for scoped identities looking for `my-kube-cluster` and vice versa. This has increased test execution times to the point that flaky tests are failing so I'm currently working on speeding these up before this PR will be ready to merge.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Local Teleport cluster with scopes enabled
### Test Cases
- [x] Join kube clusters using the same name as unscoped, `/local`, and `/local/kube` at the same time
- [x] `tsh kube ls` reports all 3 clusters with the appropriate name/SQN.
- [x] `tctl get kube_server` reports all 3 kube servers wrapping the expected clusters
- [x] While unscoped
  - [x] `tsh kube login <cluster-name>` runs without error
  - [x] `tsh kube credentials --teleport-cluster=<teleport-cluster> --kube-cluster=<cluster-name>` runs without error
  - [x] `tsh kubectl get namespaces` returns the list of namespaces present on the kube cluster
  - [x] `tsh kube login /local::<cluster-name>` runs without error
  - [x] `tsh kube credentials --teleport-cluster=<teleport-cluster> --kube-cluster=/local::<cluster-name>` runs without error
  - [x] `tsh kubectl get namespaces` returns the list of namespaces present on the kube cluster
  - [x] `tsh kube login /local/kube::<cluster-name>` runs without error
  - [x] `tsh kube credentials --teleport-cluster=<teleport-cluster> --kube-cluster=/local/kube::<cluster-name>` runs without error
   - [x] `tsh kubectl get namespaces` returns the list of namespaces present on the kube cluster
- [x] While scoped to `/local`
  - [x] `tsh kube login <cluster-name>` fails due to cluster not found
  - [x] `tsh kube credentials --teleport-cluster=<teleport-cluster> --kube-cluster=<cluster-name>` fails due to cluster not found
  - [x] `tsh kube login /local::<cluster-name>` runs without error
  - [x] `tsh kube credentials --teleport-cluster=<teleport-cluster> --kube-cluster=/local::<cluster-name>` runs without error
  - [x] `tsh kubectl get namespaces` returns the list of namespaces present on the kube cluster
  - [x] `tsh kube login /local/kube::<cluster-name>` runs without error
  - [x] `tsh kube credentials --teleport-cluster=<teleport-cluster> --kube-cluster=/local/kube::<cluster-name>` runs without error
  - [x] `tsh kubectl get namespaces` returns the list of namespaces present on the kube cluster
- [x] While scoped to `/local/kube`
  - [x] `tsh kube login <cluster-name>` fails due to cluster not found
  - [x] `tsh kube credentials --teleport-cluster=<teleport-cluster> --kube-cluster=<cluster-name>` fails due to cluster not found
  - [x] `tsh kube login /local::<cluster-name>` fails due to cluster not found
  - [x] `tsh kube credentials --teleport-cluster=<teleport-cluster> --kube-cluster=/local::<cluster-name>` fails due to cluster not found
  - [x] `tsh kube login /local/kube::<cluster-name>` runs without error
  - [x] `tsh kube credentials --teleport-cluster=<teleport-cluster> --kube-cluster=/local/kube::<cluster-name>` runs without error
  - [x] `tsh kubectl get namespaces` returns the list of namespaces present on the kube cluster
- [ ] No regressions for unscoped discovery
- [ ] No regressions for unscoped RBAC
- [ ] No regressions for unscoped access requests