### PR TITLE
Clarified reporting service for duplicate k8s metrics

### DIFF
--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -164,12 +164,12 @@ OpenAI-compatible proxies.
 | `teleport_db_connection_setup_time_seconds` | histogram | Teleport Database Service | Initial time to setup DB connection, before any requests are handled.  |
 | `teleport_db_errors_total`                  | counter   | Teleport Database Service | Number of synthetic DB errors sent to the client.                      |
 
-### Kubernetes access
+## Kubernetes Access (Proxy)
 
 The following tables identify all metrics available in the Teleport Proxy
 Service if at least one Kubernetes cluster is enrolled in your Teleport cluster.
 
-#### Client
+### Client
 
 The following table identifies all metrics available when the service connects
 to upstream servers. In the case of `proxy`, the upstream server can be a
@@ -184,7 +184,7 @@ to upstream servers. In the case of `proxy`, the upstream server can be a
 | `teleport_kubernetes_client_first_byte_response_duration_seconds` | histogram | Teleport Kubernetes Proxy | Latency distribution of time to receive the first response byte from the upstream server.                 |
 | `teleport_kubernetes_client_request_duration_seconds`             | histogram | Teleport Kubernetes Proxy | Latency distribution of the upstream request time.                                                        |
 
-#### Server
+### Server
 
 The following table identifies all metrics available for incoming connections.
 
@@ -214,7 +214,7 @@ The following table identifies all metrics available for incoming connections.
 | - | - | - | - |
 | `user_max_concurrent_sessions_hit_total` | counter | Teleport SSH | Number of times a user exceeded their concurrent session limit. |
 
-## Teleport Kubernetes Service
+## Teleport Kubernetes Service (Agent)
 
 The following table identifies all metrics available when the service connects
 to upstream servers. In the case of `kubernetes_service`, the upstream server

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -167,7 +167,7 @@ OpenAI-compatible proxies.
 ## Kubernetes Access (Proxy)
 
 The following tables identify all metrics available in the [Teleport Proxy
-Service](https://goteleport.com/docs/reference/deployment/config/#proxy-service)
+Service](../../config/#proxy-service)
 if at least one Kubernetes cluster is enrolled in your Teleport cluster.
 
 ### Client
@@ -219,7 +219,7 @@ from clients (`tsh`, `kubectl`) to a Teleport Proxy.
 ## Teleport Kubernetes Service (Agent)
 
 These metrics are available when the Teleport process is configured with
-[kubernetes_service](https://goteleport.com/docs/reference/deployment/config/#kubernetes-service)
+[kubernetes_service](../../config/#kubernetes-service)
 and apply to traffic between the agent and Kubernetes API.
 
 The same metrics are also reported by the Proxy service, but apply to the proxy

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -150,27 +150,13 @@ OpenAI-compatible proxies.
 | `teleport_proxy_db_active_connections_total`           | gauge     | Teleport Proxy | Number of currently active connections to DB service from Proxy service.                                                                 |
 | `trusted_clusters`                                     | gauge     | Teleport Proxy | Number of outbound connections to leaf clusters.                                                                                         |
 
-## Database Service
-
-| Name                                        | Type      | Component                 | Description                                                            |
-| ------------------------------------------- | --------- | ------------------------- | ---------------------------------------------------------------------- |
-| `teleport_db_messages_from_client_total`    | counter   | Teleport Database Service | Number of messages (packets) received from the DB client.              |
-| `teleport_db_messages_from_server_total`    | counter   | Teleport Database Service | Number of messages (packets) received from the DB server.              |
-| `teleport_db_method_call_count_total`       | counter   | Teleport Database Service | Number of times a DB method was called.                                |
-| `teleport_db_method_call_latency_seconds`   | histogram | Teleport Database Service | Call latency for a DB method calls.                                    |
-| `teleport_db_initialized_connections_total` | counter   | Teleport Database Service | Number of initialized DB connections.                                  |
-| `teleport_db_active_connections_total`      | gauge     | Teleport Database Service | Number of active DB connections.                                       |
-| `teleport_db_connection_durations_seconds`  | histogram | Teleport Database Service | Duration of DB connection.                                             |
-| `teleport_db_connection_setup_time_seconds` | histogram | Teleport Database Service | Initial time to setup DB connection, before any requests are handled.  |
-| `teleport_db_errors_total`                  | counter   | Teleport Database Service | Number of synthetic DB errors sent to the client.                      |
-
-## Kubernetes Access (Proxy)
+### Kubernetes
 
 The following tables identify all metrics available in the [Teleport Proxy
 Service](../reference/deployment/config.mdx#proxy-service)
 if at least one Kubernetes cluster is enrolled in your Teleport cluster.
 
-### Client
+#### Client
 
 The following table identifies all metrics available when the service connects
 to upstream servers. In the case of `proxy`, the upstream server can be a
@@ -185,7 +171,7 @@ to upstream servers. In the case of `proxy`, the upstream server can be a
 | `teleport_kubernetes_client_first_byte_response_duration_seconds` | histogram | Teleport Kubernetes Proxy | Latency distribution of time to receive the first response byte from the upstream server.                 |
 | `teleport_kubernetes_client_request_duration_seconds`             | histogram | Teleport Kubernetes Proxy | Latency distribution of the upstream request time.                                                        |
 
-### Server
+#### Server
 
 The following table identifies all metrics available for incoming connections
 from clients (`tsh`, `kubectl`) to a Teleport Proxy.
@@ -204,6 +190,23 @@ from clients (`tsh`, `kubectl`) to a Teleport Proxy.
 | `teleport_kubernetes_server_join_sessions_total`            | counter   | Teleport Kubernetes Proxy | Total number of joining sessions.                   |
 
 
+
+
+## Database Service
+
+| Name                                        | Type      | Component                 | Description                                                            |
+| ------------------------------------------- | --------- | ------------------------- | ---------------------------------------------------------------------- |
+| `teleport_db_messages_from_client_total`    | counter   | Teleport Database Service | Number of messages (packets) received from the DB client.              |
+| `teleport_db_messages_from_server_total`    | counter   | Teleport Database Service | Number of messages (packets) received from the DB server.              |
+| `teleport_db_method_call_count_total`       | counter   | Teleport Database Service | Number of times a DB method was called.                                |
+| `teleport_db_method_call_latency_seconds`   | histogram | Teleport Database Service | Call latency for a DB method calls.                                    |
+| `teleport_db_initialized_connections_total` | counter   | Teleport Database Service | Number of initialized DB connections.                                  |
+| `teleport_db_active_connections_total`      | gauge     | Teleport Database Service | Number of active DB connections.                                       |
+| `teleport_db_connection_durations_seconds`  | histogram | Teleport Database Service | Duration of DB connection.                                             |
+| `teleport_db_connection_setup_time_seconds` | histogram | Teleport Database Service | Initial time to setup DB connection, before any requests are handled.  |
+| `teleport_db_errors_total`                  | counter   | Teleport Database Service | Number of synthetic DB errors sent to the client.                      |
+
+
 ## Application Service
 
 | Name | Type | Component | Description |
@@ -216,7 +219,7 @@ from clients (`tsh`, `kubectl`) to a Teleport Proxy.
 | - | - | - | - |
 | `user_max_concurrent_sessions_hit_total` | counter | Teleport SSH | Number of times a user exceeded their concurrent session limit. |
 
-## Teleport Kubernetes Service (Agent)
+## Teleport Kubernetes Service
 
 These metrics are available when the Teleport process is configured with
 [kubernetes_service](../reference/deployment/config.mdx#kubernetes-service)
@@ -225,7 +228,7 @@ and apply to traffic between the agent and Kubernetes API.
 The same metrics are also reported by the Proxy service, but apply to the proxy
 phase of Kubernetes connections.
 
-### Client
+#### Client {/* Intentionally #### to match Proxy Service/Kubernetes above */}
 
 The following table identifies all metrics available when the
 `kubernetes_service` connects to the API of a Kubernetes cluster.
@@ -240,7 +243,7 @@ The following table identifies all metrics available when the
 | `teleport_kubernetes_client_request_duration_seconds`             | histogram | Teleport Kubernetes Service | Latency distribution of the upstream request time.                                                        |
 
 
-### Server
+#### Server {/* Intentionally #### to match Proxy Service/Kubernetes above */}
 
 The following table identifies all metrics available for connections from
 clients/Teleport proxies to the Teleport `kubernetes_service`.

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -156,6 +156,9 @@ The following tables identify all metrics available in the [Teleport Proxy
 Service](../reference/deployment/config.mdx#proxy-service)
 if at least one Kubernetes cluster is enrolled in your Teleport cluster.
 
+The same metrics are also reported by the `kubernetes_service`, but apply to the
+agent leg of Kubernetes connections.
+
 #### Client
 
 The following table identifies all metrics available when the service connects
@@ -226,7 +229,7 @@ These metrics are available when the Teleport process is configured with
 and apply to traffic between the agent and Kubernetes API.
 
 The same metrics are also reported by the Proxy service, but apply to the proxy
-phase of Kubernetes connections.
+leg of Kubernetes connections.
 
 #### Client {/* Intentionally #### to match Proxy Service/Kubernetes above */}
 

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -167,7 +167,7 @@ OpenAI-compatible proxies.
 ## Kubernetes Access (Proxy)
 
 The following tables identify all metrics available in the [Teleport Proxy
-Service](../../config/#proxy-service)
+Service](../../config.mdx#proxy-service)
 if at least one Kubernetes cluster is enrolled in your Teleport cluster.
 
 ### Client
@@ -219,7 +219,7 @@ from clients (`tsh`, `kubectl`) to a Teleport Proxy.
 ## Teleport Kubernetes Service (Agent)
 
 These metrics are available when the Teleport process is configured with
-[kubernetes_service](../../config/#kubernetes-service)
+[kubernetes_service](../../config.mdx#kubernetes-service)
 and apply to traffic between the agent and Kubernetes API.
 
 The same metrics are also reported by the Proxy service, but apply to the proxy

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -166,8 +166,9 @@ OpenAI-compatible proxies.
 
 ## Kubernetes Access (Proxy)
 
-The following tables identify all metrics available in the Teleport Proxy
-Service if at least one Kubernetes cluster is enrolled in your Teleport cluster.
+The following tables identify all metrics available in the [Teleport Proxy
+Service](https://goteleport.com/docs/reference/deployment/config/#proxy-service)
+if at least one Kubernetes cluster is enrolled in your Teleport cluster.
 
 ### Client
 
@@ -186,7 +187,8 @@ to upstream servers. In the case of `proxy`, the upstream server can be a
 
 ### Server
 
-The following table identifies all metrics available for incoming connections.
+The following table identifies all metrics available for incoming connections
+from clients (`tsh`, `kubectl`) to a Teleport Proxy.
 
 | Name                                                        | Type      | Component                 | Description                                         |
 | ----------------------------------------------------------- | --------- | ------------------------- | --------------------------------------------------- |
@@ -216,20 +218,32 @@ The following table identifies all metrics available for incoming connections.
 
 ## Teleport Kubernetes Service (Agent)
 
-The following table identifies all metrics available when the service connects
-to upstream servers. In the case of `kubernetes_service`, the upstream server
-is always a Kubernetes cluster.
+These metrics are available when the Teleport process is configured with
+[kubernetes_service](https://goteleport.com/docs/reference/deployment/config/#kubernetes-service)
+and apply to traffic between the agent and Kubernetes API.
+
+The same metrics are also reported by the Proxy service, but apply to the proxy
+phase of Kubernetes connections.
+
+### Client
+
+The following table identifies all metrics available when the
+`kubernetes_service` connects to the API of a Kubernetes cluster.
 
 | Name                                                              | Type      | Component                   | Description                                                                                               |
 | ----------------------------------------------------------------- | --------- | --------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `teleport_kubernetes_client_in_flight_requests`                   | gauge     | Teleport Kubernetes Service | In-flight requests waiting for the upstream response. |
 | `teleport_kubernetes_client_requests_total`                       | counter   | Teleport Kubernetes Service | Total number of requests sent to the upstream teleport proxy, kube_service or Kubernetes Cluster servers. |
 | `teleport_kubernetes_client_tls_duration_seconds`                 | histogram | Teleport Kubernetes Service | Latency distribution of TLS handshakes.                                                                   |
-| `teleport_kubernetes_client_got_conn_duration_seconds`            | histogram | Teleport Kubernetes Service | Latency distribution of time to dial to the upstream server - using reversetunnel or direct dialer.       |
+| `teleport_kubernetes_client_got_conn_duration_seconds`            | histogram | Teleport Kubernetes Service | Latency distribution of time to dial to the upstream server - using reverse tunnel or direct dialer.       |
 | `teleport_kubernetes_client_first_byte_response_duration_seconds` | histogram | Teleport Kubernetes Service | Latency distribution of time to receive the first response byte from the upstream server.                 |
 | `teleport_kubernetes_client_request_duration_seconds`             | histogram | Teleport Kubernetes Service | Latency distribution of the upstream request time.                                                        |
 
-The following table identifies all metrics available for incoming connections.
+
+### Server
+
+The following table identifies all metrics available for connections from
+clients/Teleport proxies to the Teleport `kubernetes_service`.
 
 | Name                                                        | Type      | Component                   | Description                                         |
 | ----------------------------------------------------------- | --------- | --------------------------- | --------------------------------------------------- |

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -167,7 +167,7 @@ OpenAI-compatible proxies.
 ## Kubernetes Access (Proxy)
 
 The following tables identify all metrics available in the [Teleport Proxy
-Service](../../config.mdx#proxy-service)
+Service](../reference/deployment/config.mdx#proxy-service)
 if at least one Kubernetes cluster is enrolled in your Teleport cluster.
 
 ### Client
@@ -219,7 +219,7 @@ from clients (`tsh`, `kubectl`) to a Teleport Proxy.
 ## Teleport Kubernetes Service (Agent)
 
 These metrics are available when the Teleport process is configured with
-[kubernetes_service](../../config.mdx#kubernetes-service)
+[kubernetes_service](../reference/deployment/config.mdx#kubernetes-service)
 and apply to traffic between the agent and Kubernetes API.
 
 The same metrics are also reported by the Proxy service, but apply to the proxy


### PR DESCRIPTION
## TL;DR
* Fixed nesting of Proxy Service/Kubernetes Access (was under Database Service).
* Renamed "Kubernetes Access" to "Kubernetes" to comply with `messaging.protocol-products` vale check.
* Added parallel Client/Server sub-headings to Teleport Kubernetes Service to mirror those in Proxy Service/Kubernetes.
* Fixed typos

## Issue
The [Teleport Metrics](https://goteleport.com/docs/reference/deployment/monitoring/metrics/) doc page shows the following metrics in two different sections: "Kubernetes Access", "Teleport Kubernetes Service".

```
$ cat docs/pages/includes/metrics.mdx |grep '| `'|cut -f2 -d'`'|sort | uniq -c|sort -n| grep -v '^ *1'
   2 teleport_kubernetes_client_first_byte_response_duration_seconds
   2 teleport_kubernetes_client_got_conn_duration_seconds
   2 teleport_kubernetes_client_in_flight_requests
   2 teleport_kubernetes_client_request_duration_seconds
   2 teleport_kubernetes_client_requests_total
   2 teleport_kubernetes_client_tls_duration_seconds
   2 teleport_kubernetes_server_api_requests_total
   2 teleport_kubernetes_server_exec_in_flight_sessions
   2 teleport_kubernetes_server_exec_sessions_total
   2 teleport_kubernetes_server_in_flight_requests
   2 teleport_kubernetes_server_join_in_flight_sessions
   2 teleport_kubernetes_server_join_sessions_total
   2 teleport_kubernetes_server_portforward_in_flight_sessions
   2 teleport_kubernetes_server_portforward_sessions_total
   2 teleport_kubernetes_server_request_duration_seconds
   2 teleport_kubernetes_server_response_size_bytes
```

This makes sense because they are reported both by the Proxy service and Kubernetes service, but they mean slightly different things depending on the source. However, the section titles don't make that clear, or make it clear which is which.

This PR additional language clarify.

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] Review generated docs page
