### PR TITLE
Make internal skills available to codex by default

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
Symlink `.agents/skills` to `.claude/skills` so internal skills work by default when you launch `codex` from the Teleport repo as well.