### PR TITLE
IAC Operator - SSH Server Namespacing support

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
@@ -24,6 +24,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
 |kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
 |metadata|object||
+|scope|string|The advertized scope of the server which can not change once assigned.|
 |spec|[object](#spec)|OpenSSHEICEServer resource definition v2 from Teleport|
 
 ### spec

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
@@ -24,6 +24,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |apiVersion|string|APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources|
 |kind|string|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|
 |metadata|object||
+|scope|string|The advertized scope of the server which can not change once assigned.|
 |spec|[object](#spec)|OpenSSHServer resource definition v2 from Teleport|
 
 ### spec

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_openssheiceserversv2.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_openssheiceserversv2.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    resources.teleport.dev/scoped: "false"
+    resources.teleport.dev/scoped: "true"
   name: teleportopenssheiceserversv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev
@@ -24,6 +24,10 @@ spec:
     - description: Server address, with SSH port.
       jsonPath: .spec.addr
       name: Address
+      type: string
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
       type: string
     - description: The age of this resource
       jsonPath: .metadata.creationTimestamp
@@ -47,6 +51,14 @@ spec:
             type: string
           metadata:
             type: object
+          scope:
+            description: The advertized scope of the server which can not change once
+              assigned.
+            type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: OpenSSHEICEServer resource definition v2 from Teleport
             properties:
@@ -271,6 +283,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_opensshserversv2.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_opensshserversv2.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    resources.teleport.dev/scoped: "false"
+    resources.teleport.dev/scoped: "true"
   name: teleportopensshserversv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev
@@ -25,6 +25,10 @@ spec:
       jsonPath: .spec.addr
       name: Address
       type: string
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
     - description: The age of this resource
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -46,6 +50,14 @@ spec:
             type: string
           metadata:
             type: object
+          scope:
+            description: The advertized scope of the server which can not change once
+              assigned.
+            type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: OpenSSHServer resource definition v2 from Teleport
             properties:
@@ -270,6 +282,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/integrations/operator/apis/resources/v1/openssheicserverv2_types.go
+++ b/integrations/operator/apis/resources/v1/openssheicserverv2_types.go
@@ -42,6 +42,7 @@ type TeleportOpenSSHEICEServerV2 struct {
 
 	Spec   TeleportOpenSSHEICEServerV2Spec `json:"spec"`
 	Status teleportcr.Status               `json:"status"`
+	Scope  string                          `json:"scope"`
 }
 
 //+kubebuilder:object:root=true
@@ -63,7 +64,8 @@ func (r TeleportOpenSSHEICEServerV2) ToTeleport() types.Server {
 			Labels:      r.Labels,
 			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
-		Spec: types.ServerSpecV2(r.Spec),
+		Spec:  types.ServerSpecV2(r.Spec),
+		Scope: r.Scope,
 	}
 }
 

--- a/integrations/operator/apis/resources/v1/opensshserverv2_types.go
+++ b/integrations/operator/apis/resources/v1/opensshserverv2_types.go
@@ -42,6 +42,7 @@ type TeleportOpenSSHServerV2 struct {
 
 	Spec   TeleportOpenSSHServerV2Spec `json:"spec"`
 	Status teleportcr.Status           `json:"status"`
+	Scope  string                      `json:"scope"`
 }
 
 //+kubebuilder:object:root=true
@@ -63,7 +64,8 @@ func (r TeleportOpenSSHServerV2) ToTeleport() types.Server {
 			Labels:      r.Labels,
 			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
-		Spec: types.ServerSpecV2(r.Spec),
+		Spec:  types.ServerSpecV2(r.Spec),
+		Scope: r.Scope,
 	}
 }
 

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_openssheiceserversv2.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_openssheiceserversv2.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    resources.teleport.dev/scoped: "false"
+    resources.teleport.dev/scoped: "true"
   name: teleportopenssheiceserversv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev
@@ -24,6 +24,10 @@ spec:
     - description: Server address, with SSH port.
       jsonPath: .spec.addr
       name: Address
+      type: string
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
       type: string
     - description: The age of this resource
       jsonPath: .metadata.creationTimestamp
@@ -47,6 +51,14 @@ spec:
             type: string
           metadata:
             type: object
+          scope:
+            description: The advertized scope of the server which can not change once
+              assigned.
+            type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: OpenSSHEICEServer resource definition v2 from Teleport
             properties:
@@ -271,6 +283,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_opensshserversv2.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_opensshserversv2.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    resources.teleport.dev/scoped: "false"
+    resources.teleport.dev/scoped: "true"
   name: teleportopensshserversv2.resources.teleport.dev
 spec:
   group: resources.teleport.dev
@@ -25,6 +25,10 @@ spec:
       jsonPath: .spec.addr
       name: Address
       type: string
+    - description: Resource's scope.
+      jsonPath: .scope
+      name: scope
+      type: string
     - description: The age of this resource
       jsonPath: .metadata.creationTimestamp
       name: Age
@@ -46,6 +50,14 @@ spec:
             type: string
           metadata:
             type: object
+          scope:
+            description: The advertized scope of the server which can not change once
+              assigned.
+            type: string
+            x-kubernetes-validations:
+            - message: Scope is immutable. To create the resource in a different scope
+                you must delete it first.
+              rule: self == oldSelf
           spec:
             description: OpenSSHServer resource definition v2 from Teleport
             properties:
@@ -270,6 +282,10 @@ spec:
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: Scope is immutable. To create the resource in a different scope
+            you must delete it first.
+          rule: has(self.scope) == has(oldSelf.scope)
     served: true
     storage: true
     subresources:

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller.go
@@ -40,7 +40,10 @@ type openSSHEICEServerClient struct {
 
 // Get gets the Teleport OpenSSHEICE server of a given name.
 func (r openSSHEICEServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
-	server, err := r.teleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build())
+	server, err := r.teleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name:  key.Name,
+		Scope: key.Scope,
+	}.Build())
 	if err != nil {
 		return server, trace.Wrap(err)
 	}
@@ -68,20 +71,24 @@ func (r openSSHEICEServerClient) Update(ctx context.Context, server types.Server
 
 // Delete deletes a Teleport OpenSSHEICE server.
 func (r openSSHEICEServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
-	return trace.Wrap(r.teleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build()))
+	return trace.Wrap(r.teleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Name:  key.Name,
+		Scope: key.Scope,
+	}.Build()))
 }
 
 // NewOpenSSHEICEServerV2Reconciler instantiates a new Kubernetes controller
 // reconciling OpenSSHEICE server resources.
-func NewOpenSSHEICEServerV2Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
+func NewOpenSSHEICEServerV2Reconciler(client kclient.Client, tClient *client.Client, metadata reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	serverClient := &openSSHEICEServerClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler, err := reconcilers.NewTeleportResourceWithLabelsReconciler[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](
+	resourceReconciler, err := reconcilers.NewTeleportScopedResourceWithLabelsReconciler[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](
 		client,
 		serverClient,
-		reconcilers.Config{},
+		reconcilers.Config{Scoped: true},
+		metadata,
 	)
 
 	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
@@ -62,21 +62,32 @@ func (g *opensshEICEServerV2TestingPrimitives) SetupTeleportFixtures(ctx context
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) CreateTeleportResource(ctx context.Context, name string) error {
-	node, err := types.NewNode(name, types.SubKindOpenSSHEICENode, opensshEICEServerV2Spec, nil)
+	labels := map[string]string{}
+	if g.setup.OperatorMetadata().Scope != "" {
+		labels[reconcilers.OperatorIDLabel] = g.setup.OperatorMetadata().ID
+	}
+	node, err := types.NewNode(name, types.SubKindOpenSSHEICENode, opensshEICEServerV2Spec, labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	node.SetOrigin(types.OriginKubernetes)
+	node.(*types.ServerV2).Scope = g.setup.OperatorMetadata().Scope
 	_, err = g.setup.TeleportClient.UpsertNode(ctx, node)
 	return trace.Wrap(err)
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Server, error) {
-	return g.setup.TeleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
+	return g.setup.TeleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name:  name,
+		Scope: g.setup.OperatorMetadata().Scope,
+	}.Build())
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
-	return trace.Wrap(g.setup.TeleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build()))
+	return trace.Wrap(g.setup.TeleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Name:  name,
+		Scope: g.setup.OperatorMetadata().Scope,
+	}.Build()))
 }
 
 func (g *opensshEICEServerV2TestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {
@@ -85,7 +96,8 @@ func (g *opensshEICEServerV2TestingPrimitives) CreateKubernetesResource(ctx cont
 			Name:      name,
 			Namespace: g.setup.Namespace.Name,
 		},
-		Spec: resourcesv1.TeleportOpenSSHEICEServerV2Spec(opensshEICEServerV2Spec),
+		Spec:  resourcesv1.TeleportOpenSSHEICEServerV2Spec(opensshEICEServerV2Spec),
+		Scope: g.setup.OperatorMetadata().Scope,
 	}
 	return trace.Wrap(g.setup.K8sClient.Create(ctx, node))
 }
@@ -142,4 +154,24 @@ func TestTeleportOpensshEICEServerV2DeletionDrift(t *testing.T) {
 func TestTeleportOpensshEICEServerV2Update(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
 	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
+}
+
+func TestScopedOpensshEICEServerV2Creation(t *testing.T) {
+	test := &opensshEICEServerV2TestingPrimitives{}
+	testlib.ResourceCreationSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test, testlib.WithScope(testScope))
+}
+
+func TestScopedOpensshEICEServerV2Deletion(t *testing.T) {
+	test := &opensshEICEServerV2TestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test, testlib.WithScope(testScope))
+}
+
+func TestScopedOpensshEICEServerV2DeletionDrift(t *testing.T) {
+	test := &opensshEICEServerV2TestingPrimitives{}
+	testlib.ResourceDeletionDriftSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test, testlib.WithScope(testScope))
+}
+
+func TestScopedOpensshEICEServerV2Update(t *testing.T) {
+	test := &opensshEICEServerV2TestingPrimitives{}
+	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test, testlib.WithScope(testScope))
 }

--- a/integrations/operator/controllers/resources/opensshserverv2_controller.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller.go
@@ -40,7 +40,10 @@ type openSSHServerClient struct {
 
 // Get gets the Teleport OpenSSH server of a given name.
 func (r openSSHServerClient) Get(ctx context.Context, key reconcilers.ResourceKey) (types.Server, error) {
-	server, err := r.teleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build())
+	server, err := r.teleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name:  key.Name,
+		Scope: key.Scope,
+	}.Build())
 	if err != nil {
 		return server, trace.Wrap(err)
 	}
@@ -68,20 +71,24 @@ func (r openSSHServerClient) Update(ctx context.Context, server types.Server) er
 
 // Delete deletes a Teleport OpenSSH server.
 func (r openSSHServerClient) Delete(ctx context.Context, key reconcilers.ResourceKey) error {
-	return trace.Wrap(r.teleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: key.Name, Scope: key.Scope}.Build()))
+	return trace.Wrap(r.teleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Name:  key.Name,
+		Scope: key.Scope,
+	}.Build()))
 }
 
 // NewOpenSSHServerV2Reconciler instantiates a new Kubernetes controller
 // reconciling OpenSSH server resources.
-func NewOpenSSHServerV2Reconciler(client kclient.Client, tClient *client.Client, _ reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
+func NewOpenSSHServerV2Reconciler(client kclient.Client, tClient *client.Client, metadata reconcilers.OperatorMetadata) (controllers.Reconciler, error) {
 	serverClient := &openSSHServerClient{
 		teleportClient: tClient,
 	}
 
-	resourceReconciler, err := reconcilers.NewTeleportResourceWithLabelsReconciler[types.Server, *resourcesv1.TeleportOpenSSHServerV2](
+	resourceReconciler, err := reconcilers.NewTeleportScopedResourceWithLabelsReconciler[types.Server, *resourcesv1.TeleportOpenSSHServerV2](
 		client,
 		serverClient,
-		reconcilers.Config{},
+		reconcilers.Config{Scoped: true},
+		metadata,
 	)
 
 	return resourceReconciler, trace.Wrap(err, "building teleport resource reconciler")

--- a/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
@@ -54,21 +54,32 @@ func (g *opensshServerV2TestingPrimitives) SetupTeleportFixtures(ctx context.Con
 }
 
 func (g *opensshServerV2TestingPrimitives) CreateTeleportResource(ctx context.Context, name string) error {
-	node, err := types.NewNode(name, types.SubKindOpenSSHNode, opensshServerV2Spec, nil)
+	labels := map[string]string{}
+	if g.setup.OperatorMetadata().Scope != "" {
+		labels[reconcilers.OperatorIDLabel] = g.setup.OperatorMetadata().ID
+	}
+	node, err := types.NewNode(name, types.SubKindOpenSSHNode, opensshServerV2Spec, labels)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	node.SetOrigin(types.OriginKubernetes)
+	node.(*types.ServerV2).Scope = g.setup.OperatorMetadata().Scope
 	_, err = g.setup.TeleportClient.UpsertNode(ctx, node)
 	return trace.Wrap(err)
 }
 
 func (g *opensshServerV2TestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Server, error) {
-	return g.setup.TeleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{Name: name}.Build())
+	return g.setup.TeleportClient.GetSSHServer(ctx, presencev1.GetSSHServerRequest_builder{
+		Name:  name,
+		Scope: g.setup.OperatorMetadata().Scope,
+	}.Build())
 }
 
 func (g *opensshServerV2TestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
-	return trace.Wrap(g.setup.TeleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{Name: name}.Build()))
+	return trace.Wrap(g.setup.TeleportClient.DeleteSSHServer(ctx, presencev1.DeleteSSHServerRequest_builder{
+		Name:  name,
+		Scope: g.setup.OperatorMetadata().Scope,
+	}.Build()))
 }
 
 func (g *opensshServerV2TestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {
@@ -77,7 +88,8 @@ func (g *opensshServerV2TestingPrimitives) CreateKubernetesResource(ctx context.
 			Name:      name,
 			Namespace: g.setup.Namespace.Name,
 		},
-		Spec: resourcesv1.TeleportOpenSSHServerV2Spec(opensshServerV2Spec),
+		Spec:  resourcesv1.TeleportOpenSSHServerV2Spec(opensshServerV2Spec),
+		Scope: g.setup.OperatorMetadata().Scope,
 	}
 	return trace.Wrap(g.setup.K8sClient.Create(ctx, node))
 }
@@ -134,4 +146,24 @@ func TestTeleportOpensshServerV2DeletionDrift(t *testing.T) {
 func TestTeleportOpensshServerV2Update(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
 	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
+}
+
+func TestScopedOpensshServerV2Creation(t *testing.T) {
+	test := &opensshServerV2TestingPrimitives{}
+	testlib.ResourceCreationSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test, testlib.WithScope(testScope))
+}
+
+func TestScopedOpensshServerV2Deletion(t *testing.T) {
+	test := &opensshServerV2TestingPrimitives{}
+	testlib.ResourceDeletionSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test, testlib.WithScope(testScope))
+}
+
+func TestScopedOpensshServerV2DeletionDrift(t *testing.T) {
+	test := &opensshServerV2TestingPrimitives{}
+	testlib.ResourceDeletionDriftSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test, testlib.WithScope(testScope))
+}
+
+func TestScopedOpensshServerV2Update(t *testing.T) {
+	test := &opensshServerV2TestingPrimitives{}
+	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test, testlib.WithScope(testScope))
 }

--- a/integrations/operator/crdgen/handlerequest.go
+++ b/integrations/operator/crdgen/handlerequest.go
@@ -210,6 +210,7 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 			opts: []resourceSchemaOption{
 				withNameOverride("OpenSSHServer"),
 				withAdditionalColumns(serverColumns),
+				withScope(),
 			},
 		},
 		{
@@ -217,6 +218,7 @@ func generateSchema(file *File, groupName string, format crdFormatFunc, resp *go
 			opts: []resourceSchemaOption{
 				withNameOverride("OpenSSHEICEServer"),
 				withAdditionalColumns(serverColumns),
+				withScope(),
 			},
 		},
 		{name: "TrustedClusterV2"},


### PR DESCRIPTION
This pr adds scope namespacing support for ssh servers in teleport's operator.

Note: Tim Ross had a hand in some of the code here.



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Add scope namespacing support to K8s operator


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

K3d deployment

### Test Cases
- [x] Add/update/delete ssh scoped and unscoped servers in k8s
- [x] Ensure users can ssh into created ssh servers
- [x] Ensure they cannot ssh when the ssh server is deleted 
