### PR TITLE
[v18] Fix `tbot` not watching OpenSSH CA rotation

### DIFF
--- a/lib/tbot/internal/carotation/service.go
+++ b/lib/tbot/internal/carotation/service.go
@@ -40,6 +40,13 @@ import (
 
 const caRotationRetryBackoff = time.Second * 2
 
+var caWatchTypes = []types.CertAuthType{
+	types.HostCA,
+	types.UserCA,
+	types.DatabaseCA,
+	types.OpenSSHCA,
+}
+
 // Config contains configuration options for the CA Rotation service.
 type Config struct {
 	// BroadcastFn is a function that will be called to broadcast that a
@@ -176,14 +183,15 @@ func (s *Service) watchCARotations(ctx context.Context, queueReload func()) erro
 
 	ident := s.cfg.GetBotIdentityFn()
 	clusterName := ident.ClusterName
+	filter := make(types.CertAuthorityFilter)
+	for _, t := range caWatchTypes {
+		filter[t] = clusterName
+	}
+
 	watcher, err := s.cfg.Client.NewWatcher(ctx, types.Watch{
 		Kinds: []types.WatchKind{{
-			Kind: types.KindCertAuthority,
-			Filter: types.CertAuthorityFilter{
-				types.HostCA:     clusterName,
-				types.UserCA:     clusterName,
-				types.DatabaseCA: clusterName,
-			}.IntoMap(),
+			Kind:   types.KindCertAuthority,
+			Filter: filter.IntoMap(),
 		}},
 	})
 	if err != nil {
@@ -252,12 +260,8 @@ func filterCAEvent(ctx context.Context, log *slog.Logger, event types.Event, clu
 		)
 	}
 
-	// We want to skip anything that is not host, user, or db
-	if !slices.Contains([]string{
-		string(types.HostCA),
-		string(types.UserCA),
-		string(types.DatabaseCA),
-	}, ca.GetSubKind()) {
+	// We want to skip any CAs that we did not intend to watch.
+	if !slices.Contains(caWatchTypes, types.CertAuthType(ca.GetSubKind())) {
 		return fmt.Sprintf("skipping due to CA kind '%s'", ca.GetSubKind())
 	}
 

--- a/lib/tbot/internal/carotation/service_test.go
+++ b/lib/tbot/internal/carotation/service_test.go
@@ -86,6 +86,15 @@ func Test_filterCAEvent(t *testing.T) {
 			},
 		},
 		{
+			name: "valid OpenSSH CA rotation",
+			event: types.Event{
+				Type: types.OpPut,
+				Resource: createCertAuthority(t, func(spec *types.CertAuthoritySpecV2) {
+					spec.Type = "openssh"
+				}),
+			},
+		},
+		{
 			name: "wrong type",
 			event: types.Event{
 				Type:     types.OpDelete,


### PR DESCRIPTION
Backport #68977 to branch/v18

changelog: Fix an issue in `tbot` where it failed to watch for OpenSSH CA rotation when configured to managed an OpenSSH host cert.

## Manual Test Plan
### Test Environment

Configure tbot to manage an OpenSSH host cert:
```yaml
version: v2
storage:
  type: directory
services:
  - type: ssh_host
    destination:
      type: directory
      path: /etc/ssh/teleport
    ca_type: openssh
    principals: [local.openssh]
debug: false
join_uri: <token>
credential_ttl: 1h0m0s
renewal_interval: 20m0s
leeway: 1m0s
oneshot: false
fips: false
```

### Test Cases
- [x] `tctl auth rotate --type=openssh` should trigger tbot to prepare new OpenSSH certs.