### PR TITLE
[v18] Add documentation for `generic_oidc` (#69216)

### DIFF
--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -73,6 +73,26 @@ teleport:
             # `registration_secret_` fields should be set.
             static_key_path: /path/to/key
 
+        # generic_oidc specifies parameters specific to the `generic_oidc` join
+        # method and should be omitted if any other join method is configured in the
+        # `method` field above.
+        generic_oidc:
+            # A command used to fetch a JWT. This can call a platform tool, a custom
+            # helper you write, or a tool like `curl` to fetch a JWT from an internal
+            # issuer. The first parameter is the executable to run, followed by any
+            # arguments. Commands have a default timeout of 1m, which can be
+            # overridden. Cannot be used with `env`.
+            command: ["example-command", "issue-jwt", "--audience=example.teleport.sh/token"]
+
+            # Overrides the default command timeout of 1m.
+            # timeout: 1m
+
+            # env is the name of an environment variable containing a JWT. This can be
+            # used instead of `command` if the JWT you wish to authenticate with
+            # exists in an environment variable already. Cannot be used with
+            # `command`, and `timeout` is ignored if set.
+            # env: ENV_VAR_NAME
+
     # Optional CA pin of the Auth Service. Specifying a CA pin enables new
     # agents to trust a Teleport cluster when joining via the Auth Service
     # directly. You can assign the ca_pin field to the literal value of the CA

--- a/docs/pages/includes/provision-token/generic-oidc-how-it-works.mdx
+++ b/docs/pages/includes/provision-token/generic-oidc-how-it-works.mdx
@@ -1,0 +1,37 @@
+Instead of using shared secrets, the `generic_oidc` join method allows Teleport
+Agents and Bots to authenticate to the Teleport Auth Service using a JWT issued
+by any OIDC-compatible provider.
+
+Many CI/CD platforms and cloud providers act as OIDC providers and can issue
+short-lived JWTs to workloads that serve as proof of the workload's identity.
+In fact, this is how many of Teleport's join methods work today, including
+the `github`, `kubernetes` (in `oidc` mode), and `gcp` join methods, among
+others.
+
+The `generic_oidc` join method extends this support to any provider that can
+issue compatible JWTs, allowing you to freely specify any compatible provider
+and a set of free-form joining rules to select exactly which workloads are
+allowed to join, without requiring a dedicated join method for the provider.
+
+Be aware that due to the nature of `generic_oidc`, this guide is meaningfully
+less directed than other deployment guides. The configuration shown here is only
+useful as an example or reference, and you will need to thoroughly customize
+and verify any configuration made before deploying it into a production
+environment.
+
+<Admonition type="warning">
+Be aware that not all OIDC providers are equally secure. When using
+`generic_oidc`, you are responsible for both properly vetting the provider and
+writing secure rules that will not allow unintended clients to join.
+
+Where possible, one of Teleport's [dedicated join
+methods](../../reference/deployment/join-methods.mdx) should be used instead of
+`generic_oidc`, which benefit from dedicated documentation and vetted,
+predefined rules.
+
+Additionally, due to its generic nature, this document cannot fully guide you in
+setting up the `tbot` client to run seamlessly on arbitrary platforms.
+Teleport's dedicated join methods have guides and supporting documentation
+tailored specifically for use with those platforms; with `generic_oidc` you will
+need to determine the best deployment method yourself.
+</Admonition>

--- a/docs/pages/includes/provision-token/generic-oidc-security-notes.mdx
+++ b/docs/pages/includes/provision-token/generic-oidc-security-notes.mdx
@@ -1,0 +1,101 @@
+Before getting started with `generic_oidc`, it is important to consider the
+potential security impacts associated with trusting arbitrary identity
+providers, as not all providers are created equal.
+
+When Teleport adds support for a new identity provider, care is taken to ensure
+they meet minimum security requirements and that joining rules ensure a minimum
+bar for security. This includes:
+- Ensuring the provider is actually OIDC compliant and issues sane credentials
+  to workloads
+- Ensuring those issued credentials contain useful identifying claims, and that
+  one or more of those claims are required
+
+When using `generic_oidc`, you should ensure any providers whose tokens you
+decide to trust provide at least the above properties.
+
+As a hypothetical example, consider Google Cloud Platform. Note that Teleport
+has a dedicated
+[`gcp` join method](../../reference/deployment/join-methods.mdx#gcp-service-account-gcp)
+which should be used instead of `generic_oidc`, but it makes for a useful
+example. If you naively issue a token using the `gcloud` tool it contains very
+few useful claims:
+```code
+$ gcloud auth print-identity-token --audiences=example.teleport.sh | jwt decode -
+[...]
+{
+  "aud": "example.teleport.sh",
+  "azp": "115001032080118155850",
+  "exp": 1784168534,
+  "iat": 1784164934,
+  "iss": "https://accounts.google.com",
+  "sub": "115001032080118155850"
+}
+```
+
+Note the following:
+- There are no custom claims to match against
+- Only `sub` contains any identifying information at all
+- The issuer (`iss`) is global (https://accounts.google.com) and applies to all
+  GCP users
+- The audience (`aud`) is determined by the client and is generally not a claim
+  that should be used for client verification
+
+Given this, if you configured a `generic_oidc` join token to trust these GCP
+tokens, it would be trivially easy to write a rule that accidentally allowed
+_any_ GCP user to authenticate to your Teleport cluster if your rule for the
+single useful claim (`sub`) was written incorrectly. As such, we would not
+recommend using `generic_oidc` to allow clients to join with a token this
+limited.
+
+In GCP's case, you can pass an additional flag (`--token-format=full`) to the
+`gcloud` tool to include a larger set of useful claims in the issued JWT, like
+service account, instance, and project information - this is what Teleport's
+[dedicated `gcp` join method](../../reference/deployment/join-methods.mdx#gcp-service-account-gcp)
+ensures - and is why built-in join methods are generally preferred where
+available.
+
+### Limitations
+
+Be aware that not all possible rules can be configured at this time. The
+`generic_oidc` join method has 3 different rule types, but it still may not
+always possible to encode arbitrarily complex logic into the token to account
+for especially unusual providers.
+
+Limitations to be aware of include:
+- Teleport's predicate language currently cannot compare floating point numbers,
+  so `expression` rules within `allow_any` cannot validate numeric fields. Use
+  `must_match_fields` or `conditions` if you need to compare a number field.
+  Note that numbers _encoded as strings_ in the JWT can be compared as strings
+  without issue.
+- Teleport's predicate language currently has limited support for lists and
+  unary strings within its built-in functions, so string and list values must be
+  wrapped using the `set()` helper to be used certain functions like
+  `regexp.match()`, `contains_all()`, or `contains_any()`.
+- The `generic_oidc` join method will refuse to compare integers encoded in
+  number fields if they are larger than 2^53-1. This is because JSON numbers
+  (64 bit IEEE floating point values) cannot uniquely represent numbers larger
+  than 2^53-1, meaning multiple values would would match your expected number
+  beyond this limit. If your token tries to compare a field with an integer
+  value larger than this - on either side of the comparison - the join attempt
+  will be rejected.
+- Teleport's Terraform provider currently does not support `must_match_fields`
+  and will **drop any values** you enter into the field.
+- Teleport's Kubernetes operator currently has limited support for
+  `must_match_fields` and only top-level claims fields (i.e. not nested fields)
+  can be validated with this rule type.
+
+### Identity provider requirements
+
+Additionally, there are a number of minimum security requirements that identity
+providers must meet to work with `generic_oidc`:
+
+1. They must use a modern signature algorithm, including: `RS256` or larger,
+   `PS256` or larger, `ES256` or larger, or `EdDSA`
+2. They must provide a `kid` in the token header
+3. They must issue JWTs with standard fields set, including `exp`, `iat`, `sub`,
+   `aud`, and `iss`
+4. They must be able to serve OIDC discovery and JWKS resources within 10
+   seconds (unless `static_jwks` is used)
+5. They must serve OIDC discovery and JWKS resources via HTTPS (unless
+   `insecure_allow_http_issuer` is set in the token) at the standard path:
+   `$ISSUER/.well-known/openid-configuration`

--- a/docs/pages/includes/provision-token/generic-oidc-spec-hcl.mdx
+++ b/docs/pages/includes/provision-token/generic-oidc-spec-hcl.mdx
@@ -1,0 +1,147 @@
+```hcl
+resource "teleport_provision_token" "generic-oidc-token" {
+  version = "v2"
+  metadata = {
+    # name identifies the token. When configuring a bot or node to join using
+    # this token, this name should be specified.
+    name = "generic-oidc-token"
+
+    labels = {
+      // This label is added on the Teleport side by default
+      "teleport.dev/origin" = "dynamic"
+    }
+  }
+
+  spec = {
+    // For Machine & Workload Identity joining, roles will always be "Bot". For
+    // standard Teleport agents, roles may include "Node", "Kube", "App", "db",
+    // or similar, depending on the desired services.
+    roles = ["Node"]
+
+    // This field is always "generic_oidc" for Generic OIDC joining.
+    join_method = "generic_oidc"
+
+    // bot_name specifies the name of the bot that this token will grant access
+    // to when it is used. If joining a standard Teleport agent, this field
+    // should be omitted. This field is required for bots
+    // bot_name = "generic-oidc-demo"
+
+    generic_oidc = {
+      // The OIDC issuer. Must exactly match the `iss` value in incoming OIDC
+      // tokens. This value is always required.
+      //
+      // Unless `static_jwks` is configured, this issuer must be accessible over
+      // HTTPS to the Teleport cluster and must serve valid OIDC metadata,
+      // including discovery configuration and JWKS keys.
+      issuer = "https://example.com"
+
+      // If set, this flag allows the use of HTTP-only issuers. Not recommended
+      // for production use.
+      // insecure_allow_http_issuer = false
+
+      // The audience (`aud`) value to require in the incoming JWTs. This value
+      // is always required.
+      //
+      // Note that not all issuers allow you to configure or request an audience
+      // value of your choosing. For issuers that require use of prescribed
+      // `aud` values, that value should be entered here exactly.
+      //
+      // Otherwise, for providers that do allow you to configure or request a
+      // value, we recommend making the value unique to this cluster and join
+      // token. You can include your Teleport cluster name (example.teleport.sh)
+      // and the name of the token, as shown below, or use a random UUID if you
+      // prefer.
+      audience = "teleport.example.com/generic-oidc-token"
+
+      // The TLS CA certificate or certificates, if your OIDC provider's TLS
+      // certificates are not trusted by the standard system trust store. If
+      // set, this value replaces the system CA store outright, so you can
+      // include multiple concatenated certificates if necessary.
+      //
+      // The CAs specified here are only used to validate requests using this
+      // token and will not be used to verify any other join attempts or TLS
+      // connections for other Teleport features. Be aware that if the issuer's
+      // TLS certificate is rotated such that it is no longer trusted by the CA
+      // certs specified here, join attempts will be rejected and this token
+      // will need to be updated to include the updated CA certificates.
+      //
+      // Most users will not need to configure this value.
+      //
+      // tls_ca = <<-EOT
+      //   -----BEGIN CERTIFICATE-----
+      //   ...
+      //   -----END CERTIFICATE-----
+      // EOT
+
+      // NOTE: `must_match_fields` is currently NOT SUPPORTED in Teleport's
+      // Terraform provider, and any rules you specify here will be SILENTLY
+      // IGNORED. When using the Terraform provider, you must rely exclusively
+      // on `allow_any` rules instead.
+      // must_match_fields = { ... }
+
+      // If specified, at least one of these rules must match. These are
+      // evaluated with "OR" semantics, after all `must_match_fields` rules have
+      // been evaluated successfully (if any were written). At least one rule
+      // must be written between `must_match_fields` and `allow_any`. Because the
+      // Terraform provider does not support `must_match_fields`, `allow_any`
+      // must contain at least one rule here.
+      //
+      // Note that for a given entry, at most one of `expression` or
+      // `conditions` can be configured.
+      allow_any = [
+        {
+          // A Teleport predicate expression. Claims are available under the
+          // `claims` object.
+          // Note the following limitations with Teleport's predicate language
+          // and claim evaluation:
+          // - Numbers cannot be compared; use `conditions` for numeric
+          //   comparisons instead.
+          // - Lists must be wrapped in `set()` for use with most predicate
+          //   functions.
+          expression = "claims.organization_name == \"acme-corp\""
+        },
+        {
+          // A list of simple field conditions. Unlike expressions, attributes
+          // are not prefixed with "claims" and instead are a dot-separated list
+          // of fields starting from the top level of the JWT.
+          //
+          // Valid operators include: eq, not_eq, in, not_in
+          conditions = [
+            {
+              attribute = "email_verified"
+              eq = {
+                value = "true"
+              }
+            },
+            {
+              // Nested fields are supported. This denies join requests where
+              // the project named "invalid-project" is present in the JWT.
+              attribute = "example.project_name"
+              not_eq = {
+                value = "invalid-project"
+              }
+            },
+            {
+              // `in` can be used to accept one from a set of values, for
+              // example this allows join attempts where `project_name` is any
+              // of "foo", "bar", or "baz".
+              attribute = "example.project_name"
+              in = {
+                values = ["foo", "bar", "baz"]
+              }
+            },
+            {
+              // `not_in` can be used to exclude a set of values, for example
+              // this denies join attempts where `zone` is `us-central1-a|b|c`
+              attribute = "zone"
+              not_in = {
+                values = ["us-central1-a", "us-central1-b", "us-central1-c"]
+              }
+            },
+          ]
+        },
+      ]
+    }
+  }
+}
+```

--- a/docs/pages/includes/provision-token/generic-oidc-spec-kube.mdx
+++ b/docs/pages/includes/provision-token/generic-oidc-spec-kube.mdx
@@ -1,0 +1,169 @@
+```yaml
+apiVersion: "resources.teleport.dev/v2"
+kind: TeleportProvisionToken
+metadata:
+  # name identifies the token. When configuring a bot or node to join using this
+  # token, this name should be specified.
+  name: generic-oidc-token
+  labels:
+    # This label is added on the Teleport side by default
+    "teleport.dev/origin": "dynamic"
+spec:
+  # For Machine & Workload Identity bots, roles will always be "Bot". For
+  # standard Teleport agents, roles may include "Node", "Kube", "App", "db", or
+  # similar, depending on the desired services.
+  roles: [Node]
+
+  # This field is always "generic_oidc" for Generic OIDC joining.
+  join_method: generic_oidc
+
+  # bot_name specifies the name of the bot that this token will grant access to
+  # when it is used. If joining a standard Teleport agent, this field should be
+  # omitted. This field is required for bots.
+  # bot_name: generic-oidc-demo
+
+  generic_oidc:
+    # The OIDC issuer. Must exactly match the `iss` value in incoming OIDC
+    # tokens. This value is always required.
+    #
+    # Unless `static_jwks` is configured, this issuer must be accessible over
+    # HTTPS to the Teleport cluster and must serve valid OIDC metadata,
+    # including discovery configuration and JWKS keys.
+    issuer: https://example.com
+
+    # If set, this flag allows the use of HTTP-only issuers. Not recommended for
+    # production use.
+    # insecure_allow_http_issuer: false
+
+    # The audience (`aud`) value to require in the incoming JWTs. This value is
+    # always required.
+    #
+    # Note that not all issuers allow you to configure or request an audience
+    # value of your choosing. For issuers that require use of prescribed `aud`
+    # values, that value should be entered here exactly.
+    #
+    # Otherwise, for providers that do allow you to configure or request a
+    # value, we recommend making the value unique to this cluster and join
+    # token. You can include your Teleport cluster name (example.teleport.sh)
+    # and the name of the token, as shown below, or use a random UUID if you
+    # prefer.
+    audience: teleport.example.com/generic-oidc-token
+
+    # The TLS CA certificate or certificates, if your OIDC provider's TLS
+    # certificates are not trusted by the standard system trust store. If set,
+    # this value replaces the system CA store outright, so you can include
+    # multiple concatenated certificates if necessary.
+    #
+    # The CAs specified here are only used to validate requests using this token
+    # and will not be used to verify any other join attempts or TLS connections
+    # for other Teleport features. Be aware that if the issuer's TLS certificate
+    # is rotated such that it is no longer trusted by the CA certs specified
+    # here, join attempts will be rejected and this token will need to be
+    # updated to include the updated CA certificates.
+    #
+    # Most users will not need to configure this value.
+    #
+    # tls_ca: |
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+
+    # These fields perform simple equality matches against the incoming JWT
+    # using "AND" semantics. Rules are written by mirroring the structure of the
+    # JWT, and each written value must be equal to the value in the JWT
+    # presented by the client.
+    #
+    # These field rules can be used as simple "global" matchers that apply to
+    # all join attempts using this token. For example, you can use this to
+    # ensure all `allow_any` rules also check `organization_name` to ensure they
+    # can never accidentally skip an important check.
+    #
+    # If any rules are specified here, all must match. If any rules are
+    # specified in `allow_any`, these rules are evaluated first, if any exist,
+    # and `allow_any` is only evaluated if all of these checks pass. If no rules
+    # are specified here, only `allow_any` rules are evaluated. At least one
+    # rule must exist between `must_match_fields` and `allow_any`.
+    #
+    # Note the following limitations for field rules:
+    # - Strings, numbers, booleans, and nested objects are supported.
+    # - List values are currently not supported.
+    # - Integer comparisons must be less than 2^53-1, as integers larger than
+    #   this cannot be accurately represented in JSON's 64-bit floating point
+    #   number type. If either a rule or incoming value is larger than this, the
+    #   join attempt will be rejected.
+    #
+    # NOTE: must_match_fields currently has limited support when using
+    # Teleport's Kubernetes operator to provision resources. Nested fields are
+    # currently not supported and will result in an error at creation time.
+    # Only top-level fields (direct children of `must_match_fields`) will work
+    # as expected. The nested `example` block below is included for parity with
+    # the source token, but will be rejected by the operator as written; remove
+    # it or flatten it to top-level fields when using the Kubernetes operator.
+    must_match_fields:
+      organization_name: "acme-corp"
+
+      # Fields can be nested freely to match the structure of the incoming JWT.
+      example:
+        project_id: example-1234567
+
+        # Numeric comparisons are supported, but be mindful of the datatype as
+        # determined by YAML parsing rules.
+        # This will be parsed as a number, and the datatype of the equivalent
+        # field on the incoming JWT must also be a number. To compare as a
+        # string, it must be quoted, e.g.: "1234"
+        number_field: 1234
+
+        # Boolean values are supported, but as above, this also requires that
+        # the equivalent field on the incoming JWT is a boolean. To compare it
+        # as a string, the value must be quoted, e.g.: "true"
+        boolean_field: true
+
+    # If specified, at least one of these rules must match. These are evaluated
+    # with "OR" semantics, after all `must_match_fields` rules have been
+    # evaluated successfully (if any were written). At least one rule must be
+    # written between `must_match_fields` and `allow_any`.
+    #
+    # Note that for a given entry, at most one of `expression` or `conditions`
+    # can be configured.
+    allow_any:
+      # A Teleport predicate expression. Claims are available under the `claims`
+      # object.
+      # Note the following limitations with Teleport's predicate language and
+      # claim evaluation:
+      # - Numbers cannot be compared; use `conditions` or `must_match_fields`
+      #   for numeric comparisons instead.
+      # - List support is currently limited.
+      - expression: 'claims.organization_name == "acme-corp"'
+
+      # A list of simple field conditions. Unlike expressions, attributes are
+      # not prefixed with "claims" and instead are a dot-separated list of
+      # fields starting from the top level of the JWT.
+      #
+      # Valid operators include: eq, not_eq, in, not_in
+      - conditions:
+        # Condition values are always compared as strings: the incoming
+        # attribute is cast to a string before it is compared, so the value must
+        # be quoted (e.g. "true" rather than true).
+        - attribute: email_verified
+          eq:
+            value: "true"
+
+        # Nested fields are supported. This denies join requests where the
+        # project named "invalid-project" is present in the JWT.
+        - attribute: example.project_name
+          not_eq:
+            value: "invalid-project"
+
+        # `in` can be used to accept one from a set of values, for example this
+        # allows join attempts where `project_name` is any of "foo", "bar", or
+        # "baz".
+        - attribute: example.project_name
+          in:
+            values: [foo, bar, baz]
+
+        # `not_in` can be used to exclude a set of values, for example this
+        # denies join attempts where `zone` is `us-central1-a|b|c`
+        - attribute: zone
+          not_in:
+            values: ["us-central1-a", "us-central1-b", "us-central1-c"]
+```

--- a/docs/pages/includes/provision-token/generic-oidc-spec.mdx
+++ b/docs/pages/includes/provision-token/generic-oidc-spec.mdx
@@ -1,0 +1,168 @@
+```yaml
+kind: token
+version: v2
+metadata:
+  # name identifies the token. When configuring a bot or node to join using this
+  # token, this name should be specified.
+  name: generic-oidc-token
+spec:
+  # For Machine & Workload Identity bots, roles will always be "Bot". For
+  # standard Teleport agents, roles may include "Node", "Kube", "App", "db", or
+  # similar, depending on the desired services.
+  roles: [Node]
+
+  # This field is always "generic_oidc" for Generic OIDC joining.
+  join_method: generic_oidc
+
+  # bot_name specifies the name of the bot that this token will grant access to
+  # when it is used. If joining a standard Teleport agent, this field should be
+  # omitted. It is required for bots.
+  # bot_name: generic-oidc-demo
+
+  generic_oidc:
+    # The OIDC issuer. Must exactly match the `iss` value in incoming OIDC
+    # tokens. This value is always required.
+    #
+    # Unless `static_jwks` is configured, this issuer must be accessible over
+    # HTTPS to the Teleport cluster and must serve valid OIDC metadata,
+    # including discovery configuration and JWKS keys.
+    issuer: https://example.com
+
+    # If set, this flag allows the use of HTTP-only issuers. Not recommended for
+    # production use.
+    # insecure_allow_http_issuer: false
+
+    # The audience (`aud`) value to require in the incoming JWTs. This value is
+    # always required.
+    #
+    # Note that not all issuers allow you to configure or request an audience
+    # value of your choosing. For issuers that require use of prescribed `aud`
+    # values, that value should be entered here exactly.
+    #
+    # Otherwise, for providers that do allow you to configure or request a
+    # value, we recommend making the value unique to this cluster and join
+    # token. You can include your Teleport cluster name (teleport.example.com)
+    # and the name of the token, as shown below, or use a random UUID if you
+    # prefer.
+    audience: teleport.example.com/generic-oidc-token
+
+    # The TLS CA certificate or certificates, if your OIDC provider's TLS
+    # certificates are not trusted by the standard system trust store. If set,
+    # this value replaces the system CA store outright, so you can include
+    # multiple concatenated certificates if necessary.
+    #
+    # The CAs specified here are only used to validate requests using this token
+    # and will not be used to verify any other join attempts or TLS connections
+    # for other Teleport features. Be aware that if the issuer's TLS certificate
+    # is rotated such that it is no longer trusted by the CA certs specified
+    # here, join attempts will be rejected and this token will need to be
+    # updated to include the updated CA certificates.
+    #
+    # Most users will not need to configure this value.
+    #
+    # tls_ca: |
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+
+    # These fields perform simple equality matches against the incoming JWT
+    # using "AND" semantics. Rules are written by mirroring the structure of the
+    # JWT, and each written value must be equal to the value in the JWT
+    # presented by the client.
+    #
+    # These field rules can be used as simple "global" matchers that apply to
+    # all join attempts using this token. For example, you can use this to
+    # ensure all `allow_any` rules also check `organization_name` to ensure they
+    # can never accidentally skip an important check.
+    #
+    # If any rules are specified here, all must match. If any rules are
+    # specified in `allow_any`, these rules are evaluated first, if any exist,
+    # and `allow_any` is only evaluated if all of these checks pass. If no rules
+    # are specified here, only `allow_any` rules are evaluated. At least one
+    # rule must exist between `must_match_fields` and `allow_any`.
+    #
+    # Note the following limitations for field rules:
+    # - This field currently cannot be configured via the Teleport Terraform
+    #   provider and `allow_any` must be used instead.
+    # - Strings, numbers, booleans, and nested objects are supported.
+    # - List values are currently not supported.
+    # - Integer comparisons must be less than 2^53-1, as integers larger than
+    #   this cannot be accurately represented in JSON's 64-bit floating point
+    #   number type. If either a rule or incoming value is larger than this, the
+    #   join attempt will be rejected.
+    #
+    # NOTE: must_match_fields is currently NOT SUPPORTED in Teleport's Terraform
+    # provider, and any rules you specify here will be SILENTLY IGNORED. If
+    # using the Terraform provider, you must rely exclusively on `allow_any`
+    # rules instead.
+    #
+    # NOTE: must_match_fields currently has limited support if using Teleport's
+    # Kubernetes operator to provision resources. Nested fields are currently
+    # not supported and will result in an error at creation time. Top-level
+    # fields (direct children of `must_match_fields`) will work as expected.
+    must_match_fields:
+      organization_name: "acme-corp"
+
+      # Fields can be nested freely to match the structure of the incoming JWT.
+      example:
+        project_id: example-1234567
+
+        # Numeric comparisons are supported, but be mindful of the datatype as
+        # determined by YAML parsing rules.
+        # This will be parsed as a number, and the datatype of the equivalent
+        # field on the incoming JWT must also be a number. To compare as a
+        # string, it must be quoted, e.g.: "1234"
+        number_field: 1234
+
+        # Boolean values are supported, but as above, this also requires that
+        # the equivalent field on the incoming JWT is a boolean. To compare it
+        # as a string, the value must be quoted, e.g.: "true"
+        boolean_field: true
+
+    # If specified, at least one of these rules must match. These are evaluated
+    # with "OR" semantics, after all `must_match_fields` rules have been
+    # evaluated successfully (if any were written). At least one rule must be
+    # written between `must_match_fields` and `allow_any`.
+    #
+    # Note that for a given entry, at most one of `expression` or `conditions`
+    # can be configured.
+    allow_any:
+      # A Teleport predicate expression. Claims are available under the `claims`
+      # object.
+      # Note the following limitations with Teleport's predicate language and
+      # claim evaluation:
+      # - Numbers cannot be compared; use `conditions` or `must_match_fields`
+      #   for numeric comparisons instead.
+      # - Lists must be wrapped in `set()` for use with most predicate
+      #   functions.
+      - expression: 'claims.organization_name == "acme-corp"'
+
+      # A list of simple field conditions. Unlike expressions, attributes are
+      # not prefixed with "claims" and instead are a dot-separated list of
+      # fields starting from the top level of the JWT.
+      #
+      # Valid operators include: eq, not_eq, in, not_in
+      - conditions:
+        - attribute: email_verified
+          eq:
+            value: "true"
+
+        # Nested fields are supported. This denies join requests where the
+        # project named "invalid-project" is present in the JWT.
+        - attribute: example.project_name
+          not_eq:
+            value: "invalid-project"
+
+        # `in` can be used to accept one from a set of values, for example this
+        # allows join attempts where `project_name` is any of "foo", "bar", or
+        # "baz".
+        - attribute: example.project_name
+          in:
+            values: [foo, bar, baz]
+
+        # `not_in` can be used to exclude a set of values, for example this
+        # denies join attempts where `zone` is `us-central1-a|b|c`
+        - attribute: zone
+          not_in:
+            values: ["us-central1-a", "us-central1-b", "us-central1-c"]
+```

--- a/docs/pages/installation/agents/agents.mdx
+++ b/docs/pages/installation/agents/agents.mdx
@@ -25,7 +25,7 @@ the services that run on it.
 ![Diagram showing the architecture of an Agent pool](../../../img/agent-pool-diagram.png)
 
 Read our guide for how to use Terraform to [deploy a pool of
-Agents](../../configuration/terraform-provider/terraform-getting-started.mdx). 
+Agents](../../configuration/terraform-provider/terraform-getting-started.mdx).
 
 For more information on the architecture of Teleport Agents, read
 [Teleport Agent Architecture](../../reference/architecture/agents.mdx).
@@ -47,6 +47,7 @@ Service. Choose the method that best suits your infrastructure:
 |[Azure Managed Identity](azure.mdx)|A Teleport process demonstrates that it runs in your Azure subscription by sending a signed attested data document and access token to the Teleport Auth Service.|Your Teleport process will run on Azure.|
 |[Kubernetes ServiceAccount](kubernetes.mdx)|A Teleport process uses a Kubernetes-signed proof to establish a trust relationship with your Teleport cluster.|Your Teleport process will run on Kubernetes.|
 |[GCP IAM](gcp.mdx)|A Teleport process uses a GCP-signed token to establish a trust relationship with your Teleport cluster.|Your Teleport process will run on a GCP VM.|
+|[Generic OIDC](generic-oidc.mdx)|A Teleport process authenticates using a JWT from an arbitrary, trusted provider.|Your Teleport process will run in an environment that issues OIDC tokens but lacks a dedicated Teleport join method.|
 |[OCI IAM](oracle.mdx)|A Teleport process uses Oracle Cloud credentials to join the cluster.|Your Teleport process will run on an OCI Compute instance.|
 |[Bound Keypair](bound-keypair.mdx)|A Teleport process exchanges a keypair with your Teleport cluster and uses it to complete a joining challenge.|There is no other supported method for your cloud provider.|
 |[Bound Keypair (Static Keys)](bound-keypair-static-keys.mdx)|You create a keypair for your Teleport process and configure your Teleport cluster to trust it. It then uses that keypair to complete a joining challenge.|There is no other supported method for your cloud provider.|

--- a/docs/pages/installation/agents/generic-oidc.mdx
+++ b/docs/pages/installation/agents/generic-oidc.mdx
@@ -1,0 +1,282 @@
+---
+title: Joining Services with any OIDC provider via Generic OIDC
+sidebar_label: Generic OIDC
+description: Use OIDC tokens from arbitrary providers to join services using the Generic OIDC join method.
+tags:
+ - how-to
+ - zero-trust
+ - infrastructure-identity
+---
+
+While Teleport natively supports many cloud platforms and identity providers, it
+is still often necessary to join Teleport services using identity providers that
+do not have a dedicated join method. Generic OIDC allows you to join Teleport
+services from any platform or provider where workloads are issued OIDC
+compatible JWTs, and allows you to define custom rules to allow only the
+intended hosts or workloads to authenticate to Teleport.
+
+This guide will explain how to use the **Generic OIDC join method** to configure
+Teleport services to join your Teleport cluster by establishing trust with an
+OIDC-compatible issuer of your choice.
+
+## How it works
+
+(!docs/pages/includes/provision-token/generic-oidc-how-it-works.mdx!)
+
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.11.0 or higher)"!)
+
+- An OIDC-compatible issuer of your choice (see below for specific requirements)
+- An environment or workload that can fetch JWTs from your OIDC-compatible
+  issuer
+- (!docs/pages/includes/iac-clients.mdx!)
+
+## Security considerations and limitations
+
+(!docs/pages/includes/provision-token/generic-oidc-security-notes.mdx!)
+
+## Step 1/2. Create a Generic OIDC join token
+
+To allow your new agent to authenticate with Teleport, you'll need to create a
+join token. Join tokens define the criteria by which the Teleport Auth Service
+decides whether a join attempt will be allowed or rejected. In this step, you'll
+create a `generic_oidc`-type join token.
+
+### Retrieving a reference token
+
+To create a `generic_oidc` join token, you'll first need to determine which OIDC
+provider you're using and then find or generate a reference JWT to use as a
+template for building your join token and rules.
+
+Many providers provide documented token examples, for example:
+- [GitHub Actions](https://docs.github.com/en/actions/concepts/security/openid-connect#understanding-the-oidc-token)
+- [BuildKite](https://buildkite.com/docs/agent/cli/reference/oidc)
+- [GitLab CI](https://docs.gitlab.com/ci/secrets/id_token_authentication/#token-payload)
+- [Google Cloud](https://docs.cloud.google.com/compute/docs/instances/verifying-instance-identity)
+
+Note that many of these providers (like GitHub, GitLab, and Google Cloud) have
+dedicated Teleport join methods which should be used instead of `generic_oidc`.
+
+Alternatively, if you can fetch a JWT inside your existing workload, then you
+can decode it with a tool like [`jwt-cli`](https://github.com/mike-engel/jwt-cli):
+```code
+$ echo "$EXAMPLE_TOKEN" | jwt decode -
+```
+
+Different providers issue tokens to workloads in different ways, for example:
+- Many CI/CD providers insert a token into a job's environment as an environment
+  variable before the job starts. Note that many providers require a config
+  parameter to enable this for a given step or workflow, or require a
+  project-level setting to enable OIDC token issuance.
+- Some platforms have a CLI tool that can fetch tokens and write them to stdout.
+- Other platforms have an internal private HTTP API you can query to request a
+  token.
+
+Regardless of your provider, to continue you'll need to determine which of the
+two options you'll use to configure the `tbot` client to use the token:
+1. An environment variable that contains a JWT
+2. A command to run that fetches a JWT. For providers that provide an HTTP
+   endpoint, you may need to provide your own script that fetches the token, for
+   example using `curl`.
+
+For this example, we'll use a hypothetical provider named ExampleCI. They
+provide a command to run to fetch tokens with a given audience (`aud`) value,
+and their tokens look like this:
+```code
+$ example-ci issue-token --audience=teleport.example.com/example-agent | jwt decode -
+{
+  "namespace_id": "123",
+  "namespace_path": "acme-corp",
+  "project_id": "456",
+  "project_path": "acme-corp/example-project",
+  "user_id": "1",
+  "user_login": "alice",
+  "user_email": "alice@example.com",
+  "job_id": "100",
+  "ref": "feature-branch-1",
+  "ref_type": "branch",
+  "ref_path": "refs/heads/feature-branch-1",
+  "ref_protected": "false",
+  "runner": {
+    "environment": "self-hosted",
+    "protected": "false",
+    "action": "start"
+  },
+  "job_source": "push",
+  "jti": "235b3a54-b797-45c7-ae9a-f72d7bc6ef5b",
+  "iss": "https://example.com",
+  "iat": 1681395193,
+  "nbf": 1681395188,
+  "exp": 1681398793,
+  "sub": "project_path:acme-corp/example-project:ref_type:branch:ref:feature-branch-1",
+  "aud": "teleport.example.com/example-agent"
+}
+```
+
+### Creating a join token
+
+With this JWT template in mind, you will create a join token that grants access
+to any CI/CD workflow runs within the `acme-corp/example-project` repository,
+with some additional restrictions included for demonstration purposes. You can
+find a full list of the available rules and syntax on the
+[join token reference page.](../../reference/deployment/join-methods.mdx#generic-oidc-generic_oidc)
+
+To do so, decide how you wish to create the token - directly via `tctl`, via
+Teleport's Terraform provider, or via Teleport's Kubernetes operator - and
+refer to the matching token template to use as a starting point:
+
+<Tabs>
+<TabItem label="tctl">
+
+Create `token.yaml` with this initial content:
+
+(!docs/pages/includes/provision-token/generic-oidc-spec.mdx!)
+
+Customize it as necessary, and when ready, create the token:
+
+```code
+$ tctl create token.yaml
+```
+
+Finally, validate the token was created:
+
+```code
+$ tctl get token/generic-oidc-token
+
+kind: token
+metadata:
+  expires: "3000-01-01T00:00:00Z"
+  name: generic-oidc-token
+spec:
+  join_method: generic_oidc
+  roles:
+  - Node
+version: v2
+```
+
+</TabItem>
+<TabItem label="Terraform">
+<Admonition type="warning" title="must_match_fields limitation">
+Note that `must_match_fields` is currently not supported in Teleport's Terraform
+provider and any rules you specify in that field **will be silently ignored**.
+
+For now, either write all rules instead within `allow_any`, or create your
+`generic_oidc` tokens via `tctl`.
+</Admonition>
+
+Add the following resource to your Terraform configuration, adjusting values and
+rules as necessary:
+
+(!docs/pages/includes/provision-token/generic-oidc-spec-hcl.mdx!)
+
+</TabItem>
+<TabItem label="Kubernetes">
+<Admonition type="warning" title="must_match_fields limitation">
+Note that `must_match_fields` has limited support in Teleport's Kubernetes
+operator: rules can only be written against root-level claims on the incoming
+JWT. Attempting to check nested claim fields will result in an error.
+
+If you need to check nested fields, either write those checks within `allow_any`
+rules, or create your `generic_oidc` token via `tctl` which does not have this
+limitation.
+</Admonition>
+
+Add the following Kubernetes resource manifest, adjusting values and rules as
+necessary:
+
+(!docs/pages/includes/provision-token/generic-oidc-spec-kube.mdx!)
+</TabItem>
+</Tabs>
+
+Be aware that the examples shown above are for demonstrative purposes. Make sure
+to replace all rules with values tailored to your provider and environment,
+using the reference token you fetched as a guide.
+
+Broadly, we recommend the following minimum rules:
+- Define some "global" requirements in `must_match_fields`, like an organization
+  name or ID. These are always required, and are cheap insurance to protect
+  against an `allow_any` rule that might accidentally let unintended clients in.
+  At worst, these can limit the blast radius to within your organization.
+
+  In the example JWT shown above, `namespace_id` and `namespace_path` might be
+  good global rules to configure for all joining clients.
+
+- Define one or more `allow_any` rules to allow individual workloads or other
+  compute units that should be granted access, using either `expression` or
+  `conditions`.
+
+  With the example JWT in mind, `project_id` and `project_path` might be useful
+  fields to perform an equality check on, to ensure join attempts are coming
+  from an authorized project.
+
+  - The `conditions` rule allows you to specify a list of simple conditions
+    (`eq`, `not_eq`, `in`, `not_in`) that claim attributes must match.
+
+  - The `expression` rule type uses Teleport's [predicate
+    language](../../reference/access-controls/predicate-language.mdx) to
+    evaluate claims based on complex logic.
+
+    See the [limitations](#limitations) section above for some specific
+    compatibility notes when using some built-in predicate functions.
+
+Additionally, be aware of the rule evaluation order:
+- First, all `must_match_fields` checks are executed. All values specified here
+   must both exist and match the corresponding values on the incoming JWT. If
+   `must_match_fields` is empty, this is skipped.
+- Next, each rule listed in `allow_any` is evaluated sequentially and evaluation
+  stops after the first matching rule (either an `expression` or `conditions`).
+- You may combine as many rules as you'd like between either `must_match_fields`
+  or `allow_any`, or skip either variant entirely if you prefer. At least one
+  rule or value must be matched between both rule types.
+
+## Step 2/2. Set up Teleport on your provider
+
+The Generic OIDC join method can be used for Teleport processes running the SSH,
+Proxy, Kubernetes, Application, Database, or Desktop Service.
+
+1. Install Teleport on your target environment (VM or physical machine)
+
+   (!docs/pages/includes/install-linux.mdx!)
+
+1. Configure your Teleport process with a custom `teleport.yaml` file. Use the
+   `join_params` section with `token_name` matching your token created in Step 1
+   and `method: generic_oidc` as shown in the following example config:
+
+   ```yaml
+   # /etc/teleport.yaml
+   version: v3
+   teleport:
+     join_params:
+       token_name: generic-oidc-token
+       method: generic_oidc
+       generic_oidc:
+         # Specify a command to run. The first value must be the executable to run,
+         # followed by arguments, one per list entry. This example calls
+         # `example-provider issue-token ...` with a client-specified audience
+         # request. Your provider will differ.
+         command: ["example-ci", "issue-token", "--audience=teleport.example.com/example-agent"]
+
+         # By default, commands timeout after 1 minute. If your OIDC provider
+         # needs a different value, specify it in `timeout`
+         # timeout: 1m
+
+         # Alternatively, if the token can be found inside an environment
+         # variable, you can simply specify the name of the variable containing
+         # the token. This cannot be combined with `command`.
+         # env: "ENV_VAR_WITH_JWT"
+     proxy_server: <Var name="teleport.example.com:443"/>
+   ssh_service:
+     enabled: true
+   auth_service:
+     enabled: false
+   proxy_service:
+     enabled: false
+   ```
+
+1. Start Teleport:
+
+   (!docs/pages/includes/start-teleport.mdx!)
+
+1. Confirm that your Teleport process is able to connect to and join your
+   cluster. You're all set!

--- a/docs/pages/machine-workload-identity/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/deployment/deployment.mdx
@@ -118,6 +118,11 @@ and [Architecture](../../reference/architecture/machine-id-architecture.mdx) to 
       icon: <Icon name="lock" size="xl" />,
       to: "../../reference/machine-workload-identity/bound-keypair/getting-started",
       name: "Bound Keypair Joining",
+    },
+    {
+      icon: <Icon name="integrations" size="xl" />,
+      to: "./generic-oidc",
+      name: "Generic OIDC",
     }
   ]}
 />
@@ -173,6 +178,11 @@ and continuous deployment platform.
       icon: <Icon name="lock" size="xl" />,
       to: "../../reference/machine-workload-identity/bound-keypair/static-keys",
       name: "Bound Keypair static keys (Generic)",
+    },
+    {
+      icon: <Icon name="integrations" size="xl" />,
+      to: "./generic-oidc",
+      name: "Generic OIDC",
     }
   ]}
 />
@@ -181,7 +191,11 @@ and continuous deployment platform.
 
 <Admonition type="tip" title="Unsupported Provider?">
 If your CI/CD provider does not have a dedicated join method listed above,
-consider using [Bound Keypair static keys][bound-keypair-static] as a fallback.
+consider using the [Generic OIDC join method](./generic-oidc.mdx) if it can
+issue workflows OIDC identities, or consider using
+[Bound Keypair static keys][bound-keypair-static] as a fallback if it cannot.
+
+
 </Admonition>
 
 [bound-keypair-static]: ../../reference/machine-workload-identity/bound-keypair/static-keys.mdx

--- a/docs/pages/machine-workload-identity/deployment/generic-oidc.mdx
+++ b/docs/pages/machine-workload-identity/deployment/generic-oidc.mdx
@@ -1,0 +1,391 @@
+---
+title: Deploying tbot with any OIDC provider via Generic OIDC
+description: How to install and configure the Machine & Workload Identity agent, `tbot`, on any OIDC provider using Generic OIDC
+sidebar_label: Generic OIDC
+tags:
+ - ci-cd
+ - how-to
+ - mwi
+ - infrastructure-identity
+page_type: how-to
+---
+
+While Teleport natively supports many cloud platforms and identity providers, it
+is still often necessary to join bots using identity providers that do not have
+a dedicated join method. Generic OIDC allows you to join bots from any platform
+or provider where workloads are issued OIDC compatible JWTs, and allows you to
+define custom rules to allow only the intended workloads to authenticate to
+Teleport.
+
+In this guide, you will create a Machine & Workload Identity Bot and configure
+Teleport to allow it to join from a hypothetical provider that does not have a
+Teleport join method, and without using any long-lived credentials.
+
+## How it works
+
+(!docs/pages/includes/provision-token/generic-oidc-how-it-works.mdx!)
+
+## Prerequisites
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.11.0 or higher)"!)
+
+- (!docs/pages/includes/tctl.mdx!)
+- Your user should have the privileges to create token resources.
+- You must already have an OIDC-compliant identity provider that can issue JWTs
+  to your bot environment
+
+## Security considerations and limitations
+
+(!docs/pages/includes/provision-token/generic-oidc-security-notes.mdx!)
+
+## Step 1/3. Create a Bot
+
+(!docs/pages/includes/machine-id/create-a-bot.mdx!)
+
+## Step 2/3. Create a join token for Generic OIDC
+
+In order to allow your workload to authenticate with your Teleport cluster,
+you'll need to create a join token. These tokens define criteria by which the
+Auth Service decides whether to allow a bot or node to join.
+
+### Retrieving a reference token
+
+To create a `generic_oidc` join token, you'll first need to determine which OIDC
+provider you're using and then find or generate a reference JWT to use as a
+template for building your join token and rules.
+
+Many providers provide documented token examples, for example:
+- [GitHub Actions](https://docs.github.com/en/actions/concepts/security/openid-connect#understanding-the-oidc-token)
+- [BuildKite](https://buildkite.com/docs/agent/cli/reference/oidc)
+- [GitLab CI](https://docs.gitlab.com/ci/secrets/id_token_authentication/#token-payload)
+
+Note that many of these providers (like GitHub) have dedicated Teleport join
+methods which should be used instead of `generic_oidc`.
+
+Alternatively, if you can fetch a JWT inside your existing workload, then you
+can decode it with a tool like [`jwt-cli`](https://github.com/mike-engel/jwt-cli):
+```code
+$ echo "$EXAMPLE_TOKEN" | jwt decode -
+```
+
+Different providers issue tokens to workloads in different ways, for example:
+- Many CI/CD providers insert a token into a job's environment as an environment
+  variable before the job starts. Note that many providers require a config
+  parameter to enable this for a given step or workflow, or require a
+  project-level setting to enable OIDC token issuance.
+- Some platforms have a CLI tool that can fetch tokens and write them to stdout.
+- Other platforms have an internal private HTTP API you can query to request a
+  token.
+
+Regardless of your provider, to continue you'll need to determine which of the
+two options you'll use to configure the `tbot` client to use the token:
+1. An environment variable that contains a JWT
+2. A command to run that fetches a JWT
+
+For this example, we'll use a hypothetical provider named ExampleCI. They
+provide a command to run to fetch tokens with a given audience (`aud`) value,
+and their tokens look like this:
+```code
+$ example-ci issue-token --audience=example.teleport.sh/example-bot | jwt decode -
+{
+  "namespace_id": "123",
+  "namespace_path": "acme-corp",
+  "project_id": "456",
+  "project_path": "acme-corp/example-project",
+  "user_id": "1",
+  "user_login": "alice",
+  "user_email": "alice@example.com",
+  "job_id": "100",
+  "ref": "feature-branch-1",
+  "ref_type": "branch",
+  "ref_path": "refs/heads/feature-branch-1",
+  "ref_protected": "false",
+  "runner": {
+    "environment": "self-hosted",
+    "protected": "false",
+    "action": "start"
+  },
+  "job_source": "push",
+  "jti": "235b3a54-b797-45c7-ae9a-f72d7bc6ef5b",
+  "iss": "https://example.com",
+  "iat": 1681395193,
+  "nbf": 1681395188,
+  "exp": 1681398793,
+  "sub": "project_path:acme-corp/example-project:ref_type:branch:ref:feature-branch-1",
+  "aud": "example.teleport.sh/example-bot"
+}
+```
+
+### Creating a join token
+
+With this JWT template in mind, you will create a join token that grants access
+to any CI/CD workflow runs within the `acme-corp/example-project` repository,
+with some additional restrictions included for demonstration purposes. You can
+find a full list of the available rules and syntax on the
+[join token reference page.](../../reference/deployment/join-methods.mdx#generic-oidc-generic_oidc)
+
+Create a file named `bot-token.yaml`:
+
+```yaml
+kind: token
+version: v2
+metadata:
+  name: example-bot
+spec:
+  # The Bot role indicates that this token grants access to a bot user, rather
+  # than allowing a node to join. This role is built in to Teleport.
+  roles: [Bot]
+  join_method: generic_oidc
+
+  # The bot_name indicates which bot user this token grants access to. This
+  # should match the name of the bot that you created in the previous step.
+  bot_name: example
+
+  generic_oidc:
+    # Issuer is the JWT issuer, and must match the `iss` value in the token
+    # template. Additionally, it must serve OIDC discovery and JWKS documents,
+    # unless `static_jwks` is configured as well.
+    issuer: https://example.com
+
+    # The token audience, or `aud` value. If your provider lets you set or
+    # request this value, it should uniquely identify the Teleport cluster and
+    # token, like the example below. You can use a random value like a UUID
+    # if you prefer not to use the token.
+    # If your provider does not allow you to specify the audience, enter the
+    # value they provide here directly. Additionally, some providers include an
+    # array of audiences; if so, the value specified here must be present in the
+    # array.
+    # The audience is always validated regardless of any custom rules you
+    # specify.
+    audience: <Var name="example.teleport.sh"/>/example-bot
+
+    # These "field"-style matchers are "global" and are applied to all join
+    # attempts using this token. They're useful for ensuring all `allow_any`
+    # rules still check important fields, like the organization or namespace,
+    # and ensure that even a mistake in an `allow_any` rule that might otherwise
+    # allow joins from an unintended party still check at least that field.
+    #
+    # These match against the structure of the incoming JWT, so you can freely
+    # specify even nested fields. Note that only strings, numbers, and booleans
+    # can be used here. To check
+    # against lists, you must use `allow_any` rules.
+    #
+    # This field is optional if you only want to use `allow_any` rules; at least
+    # one rule is required between both rule categories.
+    must_match_fields:
+      # This ensures all joins at least come from the "acme-corp" namespace. Be
+      # cautious of only matching against bare repository names: they may not be
+      # adequately namespaced, so attackers might be able to make a repository
+      # with the same name in a different namespace. A `must_match_fields` check
+      # ensures all `allow_any` rules that allow different repositories or other
+      # sub-resources at least must fall within this namespace, even if a given
+      # expression accidentally allows unintended clients.
+      namespace_path: acme-corp
+
+      # Note the datatype: a plain 123 in YAML would parse a number and would
+      # not match the datatype in the template JWT (a number inside a string).
+      # As a security tip, for providers that provide both forms, it may be
+      # helpful to match both a name and unique ID:
+      # - Unique IDs help prevent name-reuse attacks if a repository or
+      #   namespace is deleted
+      # - Named identifiers help give a readable name to an arbitrary number or
+      #   UUID
+      # Combining both can help keep tokens both secure and auditable.
+      namespace_id: "123"
+
+      # You can nest fields freely. If a parent field doesn't exist, the join
+      # attempt is rejected.
+      runner:
+        environment: self-hosted
+
+    # These rules are evaluated after `must_match_fields` (if any), and only one
+    # needs to match for the join to be allowed. This lets you allow joins from
+    # multiple different repositories within the same token, if desired.
+    #
+    # This field is optional if you are satisfied with the "AND"-only rules of
+    # `must_match_fields`; at least one rule is required between both rule
+    # categories.
+    allow_any:
+      # This rule uses a Teleport Predicate expression to allow joins where the
+      # user email matches a given suffix via regex.
+      # All claim fields are available under the `claims` variable. Note that
+      # the `set()` helper must be used to wrap any list or string values for
+      # functions that expect a Set, like `regexp.match()` or `contains_all()`.
+      # Note that the expression is wrapped in single quotes ('...') due to the
+      # double quotes inside the expression itself.
+      - expression: 'regexp.match(set(claims.user_email), "^.+@example.com$")'
+
+      # This allows workflows from the `acme-corp/example-project` repo to join
+      # without further restrictions.
+      - conditions:
+        - attribute: project_path
+          eq:
+            value: acme-corp/example-project
+
+      # This allows workflows from `acme-corp/other-project`, but only if they
+      # are run against the `feature-branch-1` branch.
+      - conditions:
+        - attribute: project_path
+          eq:
+            value: acme-corp/other-project
+        - attribute: ref_type
+          eq:
+            value: branch
+        - attribute: ref
+          eq:
+            value: feature-branch-1
+
+```
+
+As these are explicitly demonstration values, make sure to replace all of these
+rules with values tailored to your provider and environment. Broadly, we
+recommend the following minimum rules:
+- Define some "global" requirements in `must_match_fields`, like an organization
+  name or ID. These are always required, and are cheap insurance to protect
+  against an `allow_any` rule that might accidentally let unintended clients in.
+  At worst, these can limit the blast radius to within your organization.
+
+- Define one or more `allow_any` rules to allow individual repositories,
+  workloads, or other units that should be granted access, using either
+  `expression` or `conditions`.
+
+  - The `conditions` rule allows you to specify a list of simple conditions
+    (`eq`, `not_eq`, `in`, `not_in`) that claim attributes must match.
+
+  - The `expression` rule type uses Teleport's [predicate
+    language](../../reference/access-controls/predicate-language.mdx) to
+    evaluate claims based on complex logic.
+
+    See the [limitations](#limitations) section above for some specific
+    compatibility notes when using some built-in predicate functions.
+
+Additionally, be aware of the rule evaluation order:
+- First, all `must_match_fields` checks are executed. All values specified here
+   must both exist and match the corresponding values on the incoming JWT. If
+   `must_match_fields` is empty, this is skipped.
+- Next, each rule listed in `allow_any` is evaluated sequentially and evaluation
+  stops after the first matching rule (either an `expression` or `conditions`).
+- You may combine as many rules as you'd like between either `must_match_fields`
+  or `allow_any`, or skip either variant entirely if you prefer. At least one
+  rule or value must be matched between both rule types.
+
+Once you've written your token YAML, create it with `tctl`:
+
+```code
+$ tctl create -f bot-token.yaml
+```
+
+Check that token `example-bot` has been created with the following
+command:
+
+```code
+$ tctl tokens ls
+Token       Type Labels Expiry Time (UTC)
+----------- ---- ------ ----------------------------------------------
+example-bot Bot         01 Jan 00 00:00 UTC (2562047h47m16.854775807s)
+```
+
+## Step 3/3. Configure `tbot` within your workflow
+
+Due to the wide variation in potential providers or platforms you might use
+`generic_oidc` on, we can only provide generalized advice for running `tbot`.
+
+First, to install `tbot`, you can use your Teleport cluster's `install.sh` to
+download and install the proper version:
+```code
+$ curl "https://<Var name="example.teleport.sh"/>:443/scripts/install.sh" | bash
+```
+
+Next, `tbot` needs to be configured to connect to your Teleport cluster, and
+must also to be configured to actually fetch the JWT. This can be done inside
+`tbot.yaml`, but you might use a slightly different starting template depending
+on the type of workload or provider in use.
+
+### Ephemeral workloads
+
+For ephemeral workloads like CI/CD runs, there's no need to specify a long-lived
+`storage` directory, so the `memory` type can be used. Start with this
+`tbot.yaml`:
+```yaml
+version: v2
+proxy_server: <Var name="example.teleport.sh"/>:443
+onboarding:
+  join_method: generic_oidc
+  token: example-bot
+  generic_oidc:
+    # Specify a command to run. The first value must be the executable to run,
+    # followed by arguments, one per list entry.
+    command: ["example-ci", "issue-token", "--audience=<Var name="example.teleport.sh"/>/example-bot"]
+
+    # By default, commands timeout after 1 minute. If your OIDC provider needs
+    # a different value, specify it in `timeout`
+    # timeout: 1m
+
+    # Alternatively, if the token can be found inside an environment variable,
+    # you can simply specify the name of the variable containing the token:
+    # env: "ENV_VAR_WITH_JWT"
+
+storage:
+  # For ephemeral workloads, there is no need to store data persistently
+  type: memory
+
+# Configure one or more services. Refer to the Access Guides to set up your
+# desired services.
+services: []
+```
+
+### Long-lived workloads
+
+For deployments where you expect a single `tbot` instance to last a long time,
+and if it has a persistent filesystem, you might instead start with this
+`tbot.yaml`:
+
+```yaml
+version: v2
+proxy_server: <Var name="example.teleport.sh"/>:443
+onboarding:
+  join_method: generic_oidc
+  token: example-bot
+  generic_oidc:
+    # Specify a command to run. The first value must be the executable to run,
+    # followed by arguments, one per list entry.
+    command: ["example-ci", "issue-token", "--audience=<Var name="example.teleport.sh"/>/example-bot"]
+
+    # By default, commands timeout after 1 minute. If your OIDC provider needs
+    # a different value, specify it in `timeout`
+    # timeout: 1m
+
+    # Alternatively, if the token can be found inside an environment variable,
+    # you can simply specify the name of the variable containing the token:
+    # env: "ENV_VAR_WITH_JWT"
+
+storage:
+  # This writes long-lived bot data to the configured directory. Note that the
+  # Unix user that runs `tbot` must have write access to this path.
+  type: directory
+  path: /var/lib/teleport/bot
+
+# Configure one or more services. Refer to the Access Guides to set up your
+# desired services.
+services: []
+```
+
+### Running `tbot`
+
+Once configured, run the `tbot` client:
+```code
+$ tbot start -c tbot.yaml
+```
+
+Note that the exact mechanics for running `tbot`, especially if you need it to
+run in the background to serve proxies or other long-lived services, will vary
+between different providers and platforms.
+
+## Next steps
+
+- Follow the [access guides](../access-guides/access-guides.mdx) to finish
+  configuring `tbot` for your environment by assigning roles and configuring
+  services.
+- For more information about the `generic_oidc` join method, read the
+  [join token reference page](../../reference/deployment/join-methods.mdx#generic-oidc-generic_oidc)
+- [More information about `anonymous-telemetry`.](../../reference/machine-workload-identity/telemetry.mdx)

--- a/docs/pages/reference/deployment/join-methods.mdx
+++ b/docs/pages/reference/deployment/join-methods.mdx
@@ -124,6 +124,7 @@ Delegated join methods are:
 - [`ec2`](#aws-ec2-identity-document-ec2)
 - [`env0`](#env0-env0)
 - [`gcp`](#gcp-service-account-gcp)
+- [`generic_oidc`](#generic-oidc-generic_oidc)
 - [`github`](#github-actions-github)
 - [`gitlab`](#gitlab-gitlab)
 - [`iam`](#aws-iam-role-iam)
@@ -162,6 +163,7 @@ Non-renewable join methods are:
 - [`azure_devops`](#azure-devops-azure_devops)
 - [`env0`](#env0-env0)
 - [`gcp`](#gcp-service-account-gcp)
+- [`generic_oidc`](#generic-oidc-generic_oidc)
 - [`github`](#github-actions-github)
 - [`circleci`](#circleci-circleci)
 - [`gitlab`](#gitlab-gitlab)
@@ -399,6 +401,29 @@ on the Teleport process joining the cluster.
 <Admonition type="note" title="See Also">
 - How to [Join Services with GCP](../../installation/agents/gcp.mdx).
 - [Deploying Machine & Workload Identity on GCP](../../machine-workload-identity/deployment/gcp.mdx)
+</Admonition>
+
+### Generic OIDC: `generic_oidc`
+
+The `generic_oidc` join method can be used to join bots and agents by
+authenticating via any OIDC-compatible provider. Any provider can be specified
+provided it meets certain minimum requirements, and you can specify your own
+joining rules to ensure only trusted clients or workloads are allowed to join.
+
+Note that where available, dedicated provider-specific join methods are still
+preferred. Dedicated join methods, even those that themselves authenticate via
+OIDC, are individually vetted and are designed to ensure a relatively secure
+configuration baseline has been met. When using `generic_oidc`, you are solely
+responsible for the joining configuration and must ensure all rules are valid
+and secure.
+
+The `generic_oidc` join method requires Teleport v18.11.0 or later.
+
+(!docs/pages/includes/provision-token/generic-oidc-spec.mdx!)
+
+<Admonition type="note" title="See Also">
+- [Deploying Machine & Workload Identity on arbitrary OIDC providers](../../machine-workload-identity/deployment/generic-oidc.mdx)
+- [Joining Services with any OIDC provider via Generic OIDC](../../installation/agents/generic-oidc.mdx)
 </Admonition>
 
 ### GitHub Actions: `github`

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -148,6 +148,25 @@ onboarding:
     #
     # token_path: "./path/to/token"
 
+  # generic_oidc holds parameters specific to the "generic_oidc" join method and
+  # should be omitted when another join method is used.
+  generic_oidc:
+    # A command used to fetch a JWT. This can call a platform tool, a custom
+    # helper you write, or a tool like `curl` to fetch a JWT from an internal
+    # issuer. The first parameter is the executable to run, followed by any
+    # arguments. Commands have a default timeout of 1m, which can be overridden.
+    # Cannot be used with `env`.
+    command: ["example-command", "issue-jwt", "--audience=example.teleport.sh/token"]
+
+    # Overrides the default command timeout of 1m.
+    # timeout: 1m
+
+    # env is the name of an environment variable containing a JWT. This can be
+    # used instead of `command` if the JWT you wish to authenticate with is
+    # in an environment variable already. Cannot be used with `command`, and
+    # `timeout` is ignored if set.
+    # env: ENV_VAR_NAME
+
 # storage specifies the destination that `tbot` should use to store its
 # internal state. This state is sensitive, and you should ensure that the
 # destination you specify here can only be accessed by `tbot`.


### PR DESCRIPTION
Backport of #69216 to branch/v18

---

This adds documentation for the new `generic_oidc` join method, to be released in v18.11.0. It includes reference material and guides for joining both bots and agents.

No changelog, docs only.