### PR TITLE
Antithesis: Add early signal capture to redirect node kills

### DIFF
--- a/lib/service/signals_antithesis.go
+++ b/lib/service/signals_antithesis.go
@@ -1,0 +1,29 @@
+//go:build antithesis && cgo
+
+package service
+
+/*
+#include <signal.h>
+#include <unistd.h>
+#include <time.h>
+#include <stdio.h>
+
+static void stamp(const char *what, int s) {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	char buf[96];
+	int n = snprintf(buf, sizeof buf, "earlysig: %s sig=%d %ld.%09ld\n",
+	                 what, s, (long)ts.tv_sec, ts.tv_nsec);
+	write(2, buf, n);
+}
+
+static void h(int s) { stamp("caught", s); _exit(128+s); }
+
+__attribute__((constructor)) static void install(void) {
+	signal(SIGTERM, h);
+	signal(SIGINT,  h);
+	signal(SIGHUP,  h);
+	stamp("installed", -1);
+}
+*/
+import "C"

--- a/lib/service/signals_antithesis.go
+++ b/lib/service/signals_antithesis.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 //go:build antithesis && cgo && linux
 
 package service

--- a/lib/service/signals_antithesis.go
+++ b/lib/service/signals_antithesis.go
@@ -1,4 +1,4 @@
-//go:build antithesis && cgo
+//go:build antithesis && cgo && linux
 
 package service
 

--- a/lib/service/signals_antithesis.go
+++ b/lib/service/signals_antithesis.go
@@ -1,3 +1,5 @@
+//go:build antithesis && cgo && linux
+
 // Teleport
 // Copyright (C) 2026 Gravitational, Inc.
 //
@@ -13,8 +15,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-//go:build antithesis && cgo && linux
 
 package service
 


### PR DESCRIPTION
Antithesis node termination faults can deliver a signal before Teleport reaches `signal.Notify`, and a signal arriving in that window is handled by the Go runtime defaults rather than by `WaitForSignals`. For `SIGTERM` the runtime dies by re-raising the signal, which as PID 1 the kernel discards, leaving runtime.exit(2). This is flagged as a finding.

Install handlers from a C constructor, which runs in `.init_array` before Go runtime init, so the window is covered from exec onward. `runtime.initsig`[0] later replaces these handlers but saves them in `fwdSig`, and runtime.dieFromSignal[2] clears `handlingSig` before re-raising, which routes the signal back through `sigfwdgo`[3] into the handler installed.

The handler exits with 128+signum, matching shell convention, so the container reports 143 for `SIGTERM` rather than 2.

Only signals flagged `_SigKill`[4] in the runtime's sigtable benefit from the `fwdSig` forwarding path. `SIGQUIT` is `_SigThrow`, which goes to `fatalsignal` and exits 2 without consulting `fwdSig`, so it is not covered here; the SUT sets `STOPSIGNAL SIGTERM` to keep node stops on the covered path. Companion e change: https://github.com/gravitational/teleport.e/pull/9399

- [0] https://github.com/golang/go/blob/go1.26.5/src/runtime/signal_unix.go#L115
- [2] https://github.com/golang/go/blob/go1.26.5/src/runtime/signal_unix.go#L969
- [3] https://github.com/golang/go/blob/128a36cf0367c46daff2528de89da4225f001dcd/src/runtime/signal_unix.go#L1170
- [4] https://github.com/golang/go/blob/go1.26.5/src/runtime/sigtab_linux_generic.go#L25C25-L25C33

Guarded by `//go:build antithesis && cgo && linux`, non-Antithesis builds are unaffected.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
Antitethesis
### Test Cases
- [x] Run a node kill scenario with this change and confirm no false positive exit 2 codes.
