### PR TITLE
Prevent dropping the scope pin when extending a session

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -3155,6 +3155,16 @@ func (h *Handler) renewWebSession(w http.ResponseWriter, r *http.Request, params
 	// TODO(bl-nero): Fix session renewal for scoped sessions. This endpoint
 	// doesn't work for scoped sessions, but currently, the web UI doesn't even
 	// call it in such scenario.
+	identity, err := ctx.GetIdentity()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if identity.ScopePin != nil {
+		// Reject scoped sessions explicitly to prevent removing a scope pin from an existing session without reauthentication.
+		return nil, trace.BadParameter("Scoped sessions are not supported yet")
+	}
+
 	req := renewSessionRequest{}
 	if err := httplib.ReadResourceJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR temporarily seals the session renewal endpoint until session renewal is properly fixed. This is a forward-port of a fix for a problem that was detected while backporting a [different PR](https://github.com/gravitational/teleport/pull/69197) to v18.

## Manual Test Plan
### Test Environment

A cloud cluster with two users (Alice, Bob). Alice doesn't have scoped role assignments, Bob has multiple scoped role assignments. The cluster needs a SAML and OIDC provider; use Google Workspace for both. To turn on the feature:
- Turn on Scopes globally using `TELEPORT_UNSTABLE_SCOPES=yes` in the environment.
- Using Chrome dev tools, add `grv_teleport_use_login_scope_picker=true` to the application's local storage.

### Test Cases
- [ ] Both Alice and Bob can have their *unscoped* sessions renewed (wait until a successful renew API call shows up in the network inspector).
