### PR TITLE
[v18] [pgbk] Handle 42P07 in Retry{Idempotent}

### DIFF
--- a/lib/backend/pgbk/common/utils.go
+++ b/lib/backend/pgbk/common/utils.go
@@ -107,7 +107,9 @@ func Retry[T any](ctx context.Context, log *slog.Logger, f func() (T, error)) (T
 // on serialization or deadlock errors, and backing off more on other errors. It
 // assumes that f is idempotent, so it will retry even in ambiguous situations.
 // It will retry unique constraint violation and exclusion constraint
-// violations, so the closure should not rely on those for normal behavior.
+// violations, so the closure should not rely on those for normal behavior. It
+// will also retry duplicate table errors, which can be returned by concurrent
+// idempotent DDL setup.
 func RetryIdempotent[T any](ctx context.Context, log *slog.Logger, f func() (T, error)) (T, error) {
 	const idempotent = true
 	v, err := retry(ctx, log, idempotent, f)
@@ -142,18 +144,24 @@ func retry[T any](ctx context.Context, log *slog.Logger, isIdempotent bool, f fu
 		var pgErr *pgconn.PgError
 		_ = errors.As(err, &pgErr)
 
-		if pgErr != nil && isSerializationErrorCode(pgErr.Code) {
+		isSerializationConflict := pgErr != nil && isSerializationErrorCode(pgErr.Code)
+		isIdempotentDDLConflict := pgErr != nil && isIdempotent && isIdempotentDDLConflictErrorCode(pgErr.Code)
+		isRetryable := (isIdempotent && pgErr == nil) || pgconn.SafeToRetry(err)
+
+		// Check for fast retryable errors first
+		if isSerializationConflict || isIdempotentDDLConflict {
 			log.LogAttrs(ctx, slog.LevelDebug,
 				"Operation failed due to conflicts, retrying quickly.",
 				slog.Int("attempt", i),
 				slog.Any("error", err),
 			)
 			retry.Reset()
-			// the very first attempt gets instant retry on serialization failure
+			// The very first attempt gets instant retry on conflicts that are
+			// likely to settle quickly.
 			if i > 1 {
 				retry.Inc()
 			}
-		} else if (isIdempotent && pgErr == nil) || pgconn.SafeToRetry(err) {
+		} else if isRetryable {
 			log.LogAttrs(ctx, slog.LevelDebug,
 				"Operation failed, retrying.",
 				slog.Int("attempt", i),
@@ -201,6 +209,18 @@ func isSerializationErrorCode(code string) bool {
 	// https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html
 	switch code {
 	case pgerrcode.SerializationFailure, pgerrcode.DeadlockDetected, pgerrcode.UniqueViolation, pgerrcode.ExclusionViolation:
+		return true
+	default:
+		return false
+	}
+}
+
+// isIdempotentDDLConflictErrorCode returns true if the error code can be
+// returned by concurrent DDL for an object that is safe to observe as already
+// created when the whole operation is idempotent.
+func isIdempotentDDLConflictErrorCode(code string) bool {
+	switch code {
+	case pgerrcode.DuplicateTable:
 		return true
 	default:
 		return false

--- a/lib/backend/pgbk/common/utils_test.go
+++ b/lib/backend/pgbk/common/utils_test.go
@@ -1,0 +1,190 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package pgcommon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+type fakeSafeError struct {
+	safe bool
+}
+
+func (e *fakeSafeError) Error() string     { return "fake connection error" }
+func (e *fakeSafeError) SafeToRetry() bool { return e.safe }
+
+// sequencer returns a mocked closure suitable for passing to retry(). It
+// returns the given errors in order
+func sequencer(t *testing.T, errs ...error) (f func() (int, error), callCount func() int) {
+	t.Helper()
+	calls := 0
+	return func() (int, error) {
+		require.Lessf(t, calls, len(errs), "f() called more times than expected")
+		err := errs[calls]
+		calls++
+		return 0, err
+	}, func() int { return calls }
+}
+
+func TestRetry_SucceedsFirstTry(t *testing.T) {
+	t.Parallel()
+	f, callCount := sequencer(t, nil)
+
+	_, err := retry(t.Context(), logtest.NewLogger(), false, f)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount())
+}
+
+func TestRetry_SerializationConflictRetriesThenSucceeds(t *testing.T) {
+	t.Parallel()
+	f, callCount := sequencer(t,
+		&pgconn.PgError{Code: pgerrcode.SerializationFailure},
+		&pgconn.PgError{Code: pgerrcode.DeadlockDetected},
+		nil,
+	)
+
+	_, err := retry(t.Context(), logtest.NewLogger(), false, f)
+
+	require.NoError(t, err)
+	require.Equal(t, 3, callCount())
+}
+
+func TestRetry_NonRetryablePgErrorReturnsImmediately(t *testing.T) {
+	t.Parallel()
+	// NotNullViolation is neither a serialization conflict nor an idempotent
+	// DDL conflict
+	f, callCount := sequencer(t,
+		&pgconn.PgError{Code: pgerrcode.NotNullViolation},
+		nil,
+	)
+
+	_, err := retry(t.Context(), logtest.NewLogger(), false, f)
+	require.Error(t, err)
+	require.Equal(t, 1, callCount())
+}
+
+func TestRetry_IdempotentDDLConflictRetriedOnlyWhenIdempotent(t *testing.T) {
+	t.Parallel()
+	t.Run("idempotent: retried and succeeds", func(t *testing.T) {
+		f, callCount := sequencer(t,
+			&pgconn.PgError{Code: pgerrcode.DuplicateTable},
+			nil,
+		)
+
+		_, err := retry(t.Context(), logtest.NewLogger(), true, f)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, callCount())
+	})
+
+	t.Run("non-idempotent: not retried", func(t *testing.T) {
+		f, callCount := sequencer(t,
+			&pgconn.PgError{Code: pgerrcode.DuplicateTable},
+			nil,
+		)
+
+		_, err := retry(t.Context(), logtest.NewLogger(), false, f)
+
+		require.Error(t, err)
+		require.Equal(t, 1, callCount())
+	})
+}
+
+func TestRetry_AmbiguousNonSafeErrorNotRetriedWhenNotIdempotent(t *testing.T) {
+	t.Parallel()
+	f, callCount := sequencer(t,
+		&fakeSafeError{safe: false},
+		nil,
+	)
+
+	_, err := retry(t.Context(), logtest.NewLogger(), false, f)
+
+	require.Error(t, err)
+	require.Equal(t, 1, callCount())
+}
+
+func TestRetry_SafeToRetryNonPgErrorIsRetried(t *testing.T) {
+	t.Parallel()
+	f, callCount := sequencer(t,
+		&fakeSafeError{safe: true},
+		nil,
+	)
+
+	_, err := retry(t.Context(), logtest.NewLogger(), false, f)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, callCount())
+}
+
+func TestRetry_IdempotentNonPgErrorAlwaysRetried(t *testing.T) {
+	t.Parallel()
+	// A plain error is still retried when the caller told us f is idempotent.
+	f, callCount := sequencer(t,
+		errors.New("boom"),
+		errors.New("BOOM"),
+		nil,
+	)
+
+	_, err := retry(t.Context(), logtest.NewLogger(), true, f)
+
+	require.NoError(t, err)
+	require.Equal(t, 3, callCount())
+}
+
+func TestRetry_AlreadyCancelledContextReturnsImmediately(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	f, callCount := sequencer(t,
+		&pgconn.PgError{Code: pgerrcode.SerializationFailure},
+		nil,
+	)
+
+	_, err := retry(ctx, logtest.NewLogger(), false, f)
+
+	require.ErrorIs(t, err, context.Canceled)
+	// f is always called at least once
+	require.Equal(t, 1, callCount())
+}
+
+func TestRetry_TooManyRetriesGivesUp(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	f := func() (int, error) {
+		calls++
+		return calls, &pgconn.PgError{Code: pgerrcode.SerializationFailure}
+	}
+
+	_, err := retry(t.Context(), logtest.NewLogger(), false, f)
+
+	require.Error(t, err)
+	require.True(t, trace.IsLimitExceeded(err), "expected a LimitExceeded error, got: %v", err)
+	// Initial call + 9 retries.
+	require.Equal(t, 10, calls)
+
+}

--- a/lib/backend/pgbk/pgbk_test.go
+++ b/lib/backend/pgbk/pgbk_test.go
@@ -21,14 +21,21 @@ package pgbk
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/lib/backend"
+	pgcommon "github.com/gravitational/teleport/lib/backend/pgbk/common"
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/utils/clocki"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -73,4 +80,101 @@ func TestPostgresBackend(t *testing.T) {
 	}
 
 	test.RunBackendComplianceSuite(t, newBackend)
+}
+
+func TestSetupAndMigrateDynamicConcurrent(t *testing.T) {
+	ctx := t.Context()
+	pool := newPostgresPoolForTest(t, ctx)
+
+	id := time.Now().UnixNano()
+
+	versionTableName := fmt.Sprintf("pgbk_version_%d", id)
+	migratedTableName := fmt.Sprintf("pgbk_migration_%d", id)
+	migratedTable := pgx.Identifier{migratedTableName}.Sanitize()
+	versionTable := pgx.Identifier{versionTableName}.Sanitize()
+
+	cleanup := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", migratedTable), pgx.QueryExecModeExec)
+		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", versionTable), pgx.QueryExecModeExec)
+	}
+	cleanup() // This should be impossible, but ensure the tables are gone either way.
+	t.Cleanup(cleanup)
+
+	staleMigrationReady := make(chan struct{})
+	releaseStaleMigration := make(chan struct{})
+	var builderCalls atomic.Int64
+	schemas := []string{
+		fmt.Sprintf("CREATE TABLE %s (key bytea PRIMARY KEY)", migratedTable),
+	}
+
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	schemasBuilder := func(*pgx.Conn) ([]string, error) {
+		if builderCalls.Add(1) == 1 {
+			close(staleMigrationReady)
+			select {
+			case <-releaseStaleMigration:
+			case <-groupCtx.Done():
+				return nil, groupCtx.Err()
+			}
+		}
+		return schemas, nil
+	}
+
+	group.Go(func() error {
+		return pgcommon.SetupAndMigrateDynamic(groupCtx, logtest.NewLogger(), pool, versionTableName, schemasBuilder)
+	})
+
+	select {
+	case <-staleMigrationReady:
+	case <-groupCtx.Done():
+		t.Fatal(groupCtx.Err())
+	}
+
+	committedMigration := make(chan struct{})
+	group.Go(func() error {
+		err := pgcommon.SetupAndMigrateDynamic(groupCtx, logtest.NewLogger(), pool, versionTableName, schemasBuilder)
+		close(committedMigration)
+		return err
+	})
+
+	select {
+	case <-committedMigration:
+	case <-groupCtx.Done():
+		t.Fatal(groupCtx.Err())
+	}
+
+	close(releaseStaleMigration)
+
+	require.NoError(t, group.Wait())
+	require.GreaterOrEqual(t, builderCalls.Load(), int64(3))
+}
+
+func newPostgresPoolForTest(t *testing.T, ctx context.Context) *pgxpool.Pool {
+	t.Helper()
+
+	paramString := os.Getenv("TELEPORT_PGBK_TEST_PARAMS_JSON")
+	if paramString == "" {
+		t.Skip("Postgres backend tests are disabled. Enable them by setting the TELEPORT_PGBK_TEST_PARAMS_JSON variable.")
+	}
+
+	var cfg Config
+	require.NoError(t, json.Unmarshal([]byte(paramString), &cfg))
+	require.NotEmpty(t, cfg.ConnString)
+
+	poolConfig, err := pgxpool.ParseConfig(cfg.ConnString)
+	require.NoError(t, err)
+
+	// We need at least 2 connections to test concurrent migrations.
+	poolConfig.MaxConns = max(poolConfig.MaxConns, 2)
+
+	require.NoError(t, cfg.AuthConfig.ApplyToPoolConfigs(ctx, logtest.NewLogger(), poolConfig))
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	return pool
 }


### PR DESCRIPTION
Backport #69321 to branch/v18

changelog: Fix a narrow race in Postgres backend setup leading to Auth potentially erroring out on startup when creating a fresh table with 'kv already exists (SQLSTATE 42P07)'


## Manual Test Plan
### Test Environment
Local with postgres via docker

### Test Cases
- [x] Local pg integration suite
- [x] `go test ./lib/backend/pgbk -run TestSetupAndMigrateDynamicConcurrent -count=100 -v`
- [x] Antithesis run to verify

