### PR TITLE
Deprecate recording of join metadata into bot instance record

### DIFF
--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_protohybrid.pb.go
@@ -758,7 +758,10 @@ type BotInstanceStatusAuthentication struct {
 	// Deprecated: prefer using join_attrs.meta.join_token_name
 	JoinToken string `protobuf:"bytes,3,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
 	// The metadata sourced from the join method.
-	// Deprecated: prefer using join_attrs.
+	// Deprecated: prefer using join_attrs. No longer written since v19; only
+	// present on records written by older Auth Service versions.
+	//
+	// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 	Metadata *structpb.Struct `protobuf:"bytes,4,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// On each renewal, this generation is incremented. For delegated join
 	// methods, this counter is not checked during renewal. For the `token` join
@@ -824,6 +827,7 @@ func (x *BotInstanceStatusAuthentication) GetJoinToken() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 func (x *BotInstanceStatusAuthentication) GetMetadata() *structpb.Struct {
 	if x != nil {
 		return x.Metadata
@@ -864,6 +868,7 @@ func (x *BotInstanceStatusAuthentication) SetJoinToken(v string) {
 	x.JoinToken = v
 }
 
+// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 func (x *BotInstanceStatusAuthentication) SetMetadata(v *structpb.Struct) {
 	x.Metadata = v
 }
@@ -890,6 +895,7 @@ func (x *BotInstanceStatusAuthentication) HasAuthenticatedAt() bool {
 	return x.AuthenticatedAt != nil
 }
 
+// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 func (x *BotInstanceStatusAuthentication) HasMetadata() bool {
 	if x == nil {
 		return false
@@ -908,6 +914,7 @@ func (x *BotInstanceStatusAuthentication) ClearAuthenticatedAt() {
 	x.AuthenticatedAt = nil
 }
 
+// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 func (x *BotInstanceStatusAuthentication) ClearMetadata() {
 	x.Metadata = nil
 }
@@ -930,7 +937,10 @@ type BotInstanceStatusAuthentication_builder struct {
 	// Deprecated: prefer using join_attrs.meta.join_token_name
 	JoinToken string
 	// The metadata sourced from the join method.
-	// Deprecated: prefer using join_attrs.
+	// Deprecated: prefer using join_attrs. No longer written since v19; only
+	// present on records written by older Auth Service versions.
+	//
+	// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 	Metadata *structpb.Struct
 	// On each renewal, this generation is incremented. For delegated join
 	// methods, this counter is not checked during renewal. For the `token` join
@@ -1362,14 +1372,14 @@ const file_teleport_machineid_v1_bot_instance_proto_rawDesc = "" +
 	" \x01(\tR\x0fexternalUpdater\x128\n" +
 	"\x18external_updater_version\x18\v \x01(\tR\x16externalUpdaterVersion\x127\n" +
 	"\fupdater_info\x18\f \x01(\v2\x14.types.UpdaterV2InfoR\vupdaterInfo\x122\n" +
-	"\x04kind\x18\r \x01(\x0e2\x1e.teleport.machineid.v1.BotKindR\x04kind\"\xf7\x02\n" +
+	"\x04kind\x18\r \x01(\x0e2\x1e.teleport.machineid.v1.BotKindR\x04kind\"\xfb\x02\n" +
 	"\x1fBotInstanceStatusAuthentication\x12E\n" +
 	"\x10authenticated_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x0fauthenticatedAt\x12\x1f\n" +
 	"\vjoin_method\x18\x02 \x01(\tR\n" +
 	"joinMethod\x12\x1d\n" +
 	"\n" +
-	"join_token\x18\x03 \x01(\tR\tjoinToken\x123\n" +
-	"\bmetadata\x18\x04 \x01(\v2\x17.google.protobuf.StructR\bmetadata\x12\x1e\n" +
+	"join_token\x18\x03 \x01(\tR\tjoinToken\x127\n" +
+	"\bmetadata\x18\x04 \x01(\v2\x17.google.protobuf.StructB\x02\x18\x01R\bmetadata\x12\x1e\n" +
 	"\n" +
 	"generation\x18\x05 \x01(\x05R\n" +
 	"generation\x12\x1d\n" +

--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_protoopaque.pb.go
@@ -770,6 +770,7 @@ func (x *BotInstanceStatusAuthentication) GetJoinToken() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 func (x *BotInstanceStatusAuthentication) GetMetadata() *structpb.Struct {
 	if x != nil {
 		return x.xxx_hidden_Metadata
@@ -810,6 +811,7 @@ func (x *BotInstanceStatusAuthentication) SetJoinToken(v string) {
 	x.xxx_hidden_JoinToken = v
 }
 
+// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 func (x *BotInstanceStatusAuthentication) SetMetadata(v *structpb.Struct) {
 	x.xxx_hidden_Metadata = v
 }
@@ -836,6 +838,7 @@ func (x *BotInstanceStatusAuthentication) HasAuthenticatedAt() bool {
 	return x.xxx_hidden_AuthenticatedAt != nil
 }
 
+// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 func (x *BotInstanceStatusAuthentication) HasMetadata() bool {
 	if x == nil {
 		return false
@@ -854,6 +857,7 @@ func (x *BotInstanceStatusAuthentication) ClearAuthenticatedAt() {
 	x.xxx_hidden_AuthenticatedAt = nil
 }
 
+// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 func (x *BotInstanceStatusAuthentication) ClearMetadata() {
 	x.xxx_hidden_Metadata = nil
 }
@@ -876,7 +880,10 @@ type BotInstanceStatusAuthentication_builder struct {
 	// Deprecated: prefer using join_attrs.meta.join_token_name
 	JoinToken string
 	// The metadata sourced from the join method.
-	// Deprecated: prefer using join_attrs.
+	// Deprecated: prefer using join_attrs. No longer written since v19; only
+	// present on records written by older Auth Service versions.
+	//
+	// Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.
 	Metadata *structpb.Struct
 	// On each renewal, this generation is incremented. For delegated join
 	// methods, this counter is not checked during renewal. For the `token` join
@@ -1312,14 +1319,14 @@ const file_teleport_machineid_v1_bot_instance_proto_rawDesc = "" +
 	" \x01(\tR\x0fexternalUpdater\x128\n" +
 	"\x18external_updater_version\x18\v \x01(\tR\x16externalUpdaterVersion\x127\n" +
 	"\fupdater_info\x18\f \x01(\v2\x14.types.UpdaterV2InfoR\vupdaterInfo\x122\n" +
-	"\x04kind\x18\r \x01(\x0e2\x1e.teleport.machineid.v1.BotKindR\x04kind\"\xf7\x02\n" +
+	"\x04kind\x18\r \x01(\x0e2\x1e.teleport.machineid.v1.BotKindR\x04kind\"\xfb\x02\n" +
 	"\x1fBotInstanceStatusAuthentication\x12E\n" +
 	"\x10authenticated_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x0fauthenticatedAt\x12\x1f\n" +
 	"\vjoin_method\x18\x02 \x01(\tR\n" +
 	"joinMethod\x12\x1d\n" +
 	"\n" +
-	"join_token\x18\x03 \x01(\tR\tjoinToken\x123\n" +
-	"\bmetadata\x18\x04 \x01(\v2\x17.google.protobuf.StructR\bmetadata\x12\x1e\n" +
+	"join_token\x18\x03 \x01(\tR\tjoinToken\x127\n" +
+	"\bmetadata\x18\x04 \x01(\v2\x17.google.protobuf.StructB\x02\x18\x01R\bmetadata\x12\x1e\n" +
 	"\n" +
 	"generation\x18\x05 \x01(\x05R\n" +
 	"generation\x12\x1d\n" +

--- a/api/gen/proto/go/teleport/workloadidentity/v1/join_attrs_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/join_attrs_protohybrid.pb.go
@@ -72,7 +72,9 @@ type JoinAttrs struct {
 	// Attributes that are specific to the Env0 (`env0`) join method.
 	Env0 *JoinAttrsEnv0 `protobuf:"bytes,15,opt,name=env0,proto3" json:"env0,omitempty"`
 	// Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
-	GenericOidc   *JoinAttrsGenericOIDC `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3" json:"generic_oidc,omitempty"`
+	GenericOidc *JoinAttrsGenericOIDC `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3" json:"generic_oidc,omitempty"`
+	// Attributes that are specific to the Bound Keypair (`bound_keypair`) join method.
+	BoundKeypair  *JoinAttrsBoundKeypair `protobuf:"bytes,17,opt,name=bound_keypair,json=boundKeypair,proto3" json:"bound_keypair,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -214,6 +216,13 @@ func (x *JoinAttrs) GetGenericOidc() *JoinAttrsGenericOIDC {
 	return nil
 }
 
+func (x *JoinAttrs) GetBoundKeypair() *JoinAttrsBoundKeypair {
+	if x != nil {
+		return x.BoundKeypair
+	}
+	return nil
+}
+
 func (x *JoinAttrs) SetMeta(v *JoinAttrsMeta) {
 	x.Meta = v
 }
@@ -276,6 +285,10 @@ func (x *JoinAttrs) SetEnv0(v *JoinAttrsEnv0) {
 
 func (x *JoinAttrs) SetGenericOidc(v *JoinAttrsGenericOIDC) {
 	x.GenericOidc = v
+}
+
+func (x *JoinAttrs) SetBoundKeypair(v *JoinAttrsBoundKeypair) {
+	x.BoundKeypair = v
 }
 
 func (x *JoinAttrs) HasMeta() bool {
@@ -390,6 +403,13 @@ func (x *JoinAttrs) HasGenericOidc() bool {
 	return x.GenericOidc != nil
 }
 
+func (x *JoinAttrs) HasBoundKeypair() bool {
+	if x == nil {
+		return false
+	}
+	return x.BoundKeypair != nil
+}
+
 func (x *JoinAttrs) ClearMeta() {
 	x.Meta = nil
 }
@@ -454,6 +474,10 @@ func (x *JoinAttrs) ClearGenericOidc() {
 	x.GenericOidc = nil
 }
 
+func (x *JoinAttrs) ClearBoundKeypair() {
+	x.BoundKeypair = nil
+}
+
 type JoinAttrs_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -490,6 +514,8 @@ type JoinAttrs_builder struct {
 	Env0 *JoinAttrsEnv0
 	// Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
 	GenericOidc *JoinAttrsGenericOIDC
+	// Attributes that are specific to the Bound Keypair (`bound_keypair`) join method.
+	BoundKeypair *JoinAttrsBoundKeypair
 }
 
 func (b0 JoinAttrs_builder) Build() *JoinAttrs {
@@ -512,6 +538,7 @@ func (b0 JoinAttrs_builder) Build() *JoinAttrs {
 	x.AzureDevops = b.AzureDevops
 	x.Env0 = b.Env0
 	x.GenericOidc = b.GenericOidc
+	x.BoundKeypair = b.BoundKeypair
 	return m0
 }
 
@@ -3246,11 +3273,107 @@ func (b0 JoinAttrsGenericOIDC_builder) Build() *JoinAttrsGenericOIDC {
 	return m0
 }
 
+// Attributes that are specific to the Bound Keypair (`bound_keypair`) join
+// method.
+type JoinAttrsBoundKeypair struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The bound public key verified during this join, in SSH authorized_keys
+	// format.
+	PublicKey string `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`
+	// The token's configured recovery mode, e.g. `standard` or `relaxed`.
+	RecoveryMode string `protobuf:"bytes,2,opt,name=recovery_mode,json=recoveryMode,proto3" json:"recovery_mode,omitempty"`
+	// The token's recovery counter after this join.
+	RecoveryCount uint32 `protobuf:"varint,3,opt,name=recovery_count,json=recoveryCount,proto3" json:"recovery_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *JoinAttrsBoundKeypair) Reset() {
+	*x = JoinAttrsBoundKeypair{}
+	mi := &file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JoinAttrsBoundKeypair) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JoinAttrsBoundKeypair) ProtoMessage() {}
+
+func (x *JoinAttrsBoundKeypair) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *JoinAttrsBoundKeypair) GetPublicKey() string {
+	if x != nil {
+		return x.PublicKey
+	}
+	return ""
+}
+
+func (x *JoinAttrsBoundKeypair) GetRecoveryMode() string {
+	if x != nil {
+		return x.RecoveryMode
+	}
+	return ""
+}
+
+func (x *JoinAttrsBoundKeypair) GetRecoveryCount() uint32 {
+	if x != nil {
+		return x.RecoveryCount
+	}
+	return 0
+}
+
+func (x *JoinAttrsBoundKeypair) SetPublicKey(v string) {
+	x.PublicKey = v
+}
+
+func (x *JoinAttrsBoundKeypair) SetRecoveryMode(v string) {
+	x.RecoveryMode = v
+}
+
+func (x *JoinAttrsBoundKeypair) SetRecoveryCount(v uint32) {
+	x.RecoveryCount = v
+}
+
+type JoinAttrsBoundKeypair_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The bound public key verified during this join, in SSH authorized_keys
+	// format.
+	PublicKey string
+	// The token's configured recovery mode, e.g. `standard` or `relaxed`.
+	RecoveryMode string
+	// The token's recovery counter after this join.
+	RecoveryCount uint32
+}
+
+func (b0 JoinAttrsBoundKeypair_builder) Build() *JoinAttrsBoundKeypair {
+	m0 := &JoinAttrsBoundKeypair{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.PublicKey = b.PublicKey
+	x.RecoveryMode = b.RecoveryMode
+	x.RecoveryCount = b.RecoveryCount
+	return m0
+}
+
 var File_teleport_workloadidentity_v1_join_attrs_proto protoreflect.FileDescriptor
 
 const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/workloadidentity/v1/join_attrs.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1cgoogle/protobuf/struct.proto\"\xb1\t\n" +
+	"-teleport/workloadidentity/v1/join_attrs.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1cgoogle/protobuf/struct.proto\"\x8b\n" +
+	"\n" +
 	"\tJoinAttrs\x12?\n" +
 	"\x04meta\x18\x01 \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsMetaR\x04meta\x12E\n" +
 	"\x06gitlab\x18\x02 \x01(\v2-.teleport.workloadidentity.v1.JoinAttrsGitLabR\x06gitlab\x12E\n" +
@@ -3270,7 +3393,8 @@ const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"\x06oracle\x18\r \x01(\v2-.teleport.workloadidentity.v1.JoinAttrsOracleR\x06oracle\x12U\n" +
 	"\fazure_devops\x18\x0e \x01(\v22.teleport.workloadidentity.v1.JoinAttrsAzureDevopsR\vazureDevops\x12?\n" +
 	"\x04env0\x18\x0f \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsEnv0R\x04env0\x12U\n" +
-	"\fgeneric_oidc\x18\x10 \x01(\v22.teleport.workloadidentity.v1.JoinAttrsGenericOIDCR\vgenericOidc\"X\n" +
+	"\fgeneric_oidc\x18\x10 \x01(\v22.teleport.workloadidentity.v1.JoinAttrsGenericOIDCR\vgenericOidc\x12X\n" +
+	"\rbound_keypair\x18\x11 \x01(\v23.teleport.workloadidentity.v1.JoinAttrsBoundKeypairR\fboundKeypair\"X\n" +
 	"\rJoinAttrsMeta\x12&\n" +
 	"\x0fjoin_token_name\x18\x01 \x01(\tR\rjoinTokenName\x12\x1f\n" +
 	"\vjoin_method\x18\x02 \x01(\tR\n" +
@@ -3417,9 +3541,14 @@ const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"\x0edeployer_email\x18\f \x01(\tR\rdeployerEmail\x12\x19\n" +
 	"\benv0_tag\x18\r \x01(\tR\aenv0Tag\"G\n" +
 	"\x14JoinAttrsGenericOIDC\x12/\n" +
-	"\x06claims\x18\x01 \x01(\v2\x17.google.protobuf.StructR\x06claimsBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
+	"\x06claims\x18\x01 \x01(\v2\x17.google.protobuf.StructR\x06claims\"\x82\x01\n" +
+	"\x15JoinAttrsBoundKeypair\x12\x1d\n" +
+	"\n" +
+	"public_key\x18\x01 \x01(\tR\tpublicKey\x12#\n" +
+	"\rrecovery_mode\x18\x02 \x01(\tR\frecoveryMode\x12%\n" +
+	"\x0erecovery_count\x18\x03 \x01(\rR\rrecoveryCountBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
 
-var file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_teleport_workloadidentity_v1_join_attrs_proto_goTypes = []any{
 	(*JoinAttrs)(nil),                         // 0: teleport.workloadidentity.v1.JoinAttrs
 	(*JoinAttrsMeta)(nil),                     // 1: teleport.workloadidentity.v1.JoinAttrsMeta
@@ -3442,7 +3571,8 @@ var file_teleport_workloadidentity_v1_join_attrs_proto_goTypes = []any{
 	(*JoinAttrsAzureDevopsPipeline)(nil),      // 18: teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
 	(*JoinAttrsEnv0)(nil),                     // 19: teleport.workloadidentity.v1.JoinAttrsEnv0
 	(*JoinAttrsGenericOIDC)(nil),              // 20: teleport.workloadidentity.v1.JoinAttrsGenericOIDC
-	(*structpb.Struct)(nil),                   // 21: google.protobuf.Struct
+	(*JoinAttrsBoundKeypair)(nil),             // 21: teleport.workloadidentity.v1.JoinAttrsBoundKeypair
+	(*structpb.Struct)(nil),                   // 22: google.protobuf.Struct
 }
 var file_teleport_workloadidentity_v1_join_attrs_proto_depIdxs = []int32{
 	1,  // 0: teleport.workloadidentity.v1.JoinAttrs.meta:type_name -> teleport.workloadidentity.v1.JoinAttrsMeta
@@ -3461,16 +3591,17 @@ var file_teleport_workloadidentity_v1_join_attrs_proto_depIdxs = []int32{
 	17, // 13: teleport.workloadidentity.v1.JoinAttrs.azure_devops:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevops
 	19, // 14: teleport.workloadidentity.v1.JoinAttrs.env0:type_name -> teleport.workloadidentity.v1.JoinAttrsEnv0
 	20, // 15: teleport.workloadidentity.v1.JoinAttrs.generic_oidc:type_name -> teleport.workloadidentity.v1.JoinAttrsGenericOIDC
-	11, // 16: teleport.workloadidentity.v1.JoinAttrsGCP.gce:type_name -> teleport.workloadidentity.v1.JoinAttrsGCPGCE
-	14, // 17: teleport.workloadidentity.v1.JoinAttrsKubernetes.service_account:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesServiceAccount
-	13, // 18: teleport.workloadidentity.v1.JoinAttrsKubernetes.pod:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesPod
-	18, // 19: teleport.workloadidentity.v1.JoinAttrsAzureDevops.pipeline:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
-	21, // 20: teleport.workloadidentity.v1.JoinAttrsGenericOIDC.claims:type_name -> google.protobuf.Struct
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	21, // 16: teleport.workloadidentity.v1.JoinAttrs.bound_keypair:type_name -> teleport.workloadidentity.v1.JoinAttrsBoundKeypair
+	11, // 17: teleport.workloadidentity.v1.JoinAttrsGCP.gce:type_name -> teleport.workloadidentity.v1.JoinAttrsGCPGCE
+	14, // 18: teleport.workloadidentity.v1.JoinAttrsKubernetes.service_account:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesServiceAccount
+	13, // 19: teleport.workloadidentity.v1.JoinAttrsKubernetes.pod:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesPod
+	18, // 20: teleport.workloadidentity.v1.JoinAttrsAzureDevops.pipeline:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
+	22, // 21: teleport.workloadidentity.v1.JoinAttrsGenericOIDC.claims:type_name -> google.protobuf.Struct
+	22, // [22:22] is the sub-list for method output_type
+	22, // [22:22] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_teleport_workloadidentity_v1_join_attrs_proto_init() }
@@ -3484,7 +3615,7 @@ func file_teleport_workloadidentity_v1_join_attrs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc), len(file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   21,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/workloadidentity/v1/join_attrs_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/workloadidentity/v1/join_attrs_protoopaque.pb.go
@@ -56,6 +56,7 @@ type JoinAttrs struct {
 	xxx_hidden_AzureDevops    *JoinAttrsAzureDevops    `protobuf:"bytes,14,opt,name=azure_devops,json=azureDevops,proto3"`
 	xxx_hidden_Env0           *JoinAttrsEnv0           `protobuf:"bytes,15,opt,name=env0,proto3"`
 	xxx_hidden_GenericOidc    *JoinAttrsGenericOIDC    `protobuf:"bytes,16,opt,name=generic_oidc,json=genericOidc,proto3"`
+	xxx_hidden_BoundKeypair   *JoinAttrsBoundKeypair   `protobuf:"bytes,17,opt,name=bound_keypair,json=boundKeypair,proto3"`
 	unknownFields             protoimpl.UnknownFields
 	sizeCache                 protoimpl.SizeCache
 }
@@ -197,6 +198,13 @@ func (x *JoinAttrs) GetGenericOidc() *JoinAttrsGenericOIDC {
 	return nil
 }
 
+func (x *JoinAttrs) GetBoundKeypair() *JoinAttrsBoundKeypair {
+	if x != nil {
+		return x.xxx_hidden_BoundKeypair
+	}
+	return nil
+}
+
 func (x *JoinAttrs) SetMeta(v *JoinAttrsMeta) {
 	x.xxx_hidden_Meta = v
 }
@@ -259,6 +267,10 @@ func (x *JoinAttrs) SetEnv0(v *JoinAttrsEnv0) {
 
 func (x *JoinAttrs) SetGenericOidc(v *JoinAttrsGenericOIDC) {
 	x.xxx_hidden_GenericOidc = v
+}
+
+func (x *JoinAttrs) SetBoundKeypair(v *JoinAttrsBoundKeypair) {
+	x.xxx_hidden_BoundKeypair = v
 }
 
 func (x *JoinAttrs) HasMeta() bool {
@@ -373,6 +385,13 @@ func (x *JoinAttrs) HasGenericOidc() bool {
 	return x.xxx_hidden_GenericOidc != nil
 }
 
+func (x *JoinAttrs) HasBoundKeypair() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_BoundKeypair != nil
+}
+
 func (x *JoinAttrs) ClearMeta() {
 	x.xxx_hidden_Meta = nil
 }
@@ -437,6 +456,10 @@ func (x *JoinAttrs) ClearGenericOidc() {
 	x.xxx_hidden_GenericOidc = nil
 }
 
+func (x *JoinAttrs) ClearBoundKeypair() {
+	x.xxx_hidden_BoundKeypair = nil
+}
+
 type JoinAttrs_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -473,6 +496,8 @@ type JoinAttrs_builder struct {
 	Env0 *JoinAttrsEnv0
 	// Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
 	GenericOidc *JoinAttrsGenericOIDC
+	// Attributes that are specific to the Bound Keypair (`bound_keypair`) join method.
+	BoundKeypair *JoinAttrsBoundKeypair
 }
 
 func (b0 JoinAttrs_builder) Build() *JoinAttrs {
@@ -495,6 +520,7 @@ func (b0 JoinAttrs_builder) Build() *JoinAttrs {
 	x.xxx_hidden_AzureDevops = b.AzureDevops
 	x.xxx_hidden_Env0 = b.Env0
 	x.xxx_hidden_GenericOidc = b.GenericOidc
+	x.xxx_hidden_BoundKeypair = b.BoundKeypair
 	return m0
 }
 
@@ -3079,11 +3105,103 @@ func (b0 JoinAttrsGenericOIDC_builder) Build() *JoinAttrsGenericOIDC {
 	return m0
 }
 
+// Attributes that are specific to the Bound Keypair (`bound_keypair`) join
+// method.
+type JoinAttrsBoundKeypair struct {
+	state                    protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_PublicKey     string                 `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3"`
+	xxx_hidden_RecoveryMode  string                 `protobuf:"bytes,2,opt,name=recovery_mode,json=recoveryMode,proto3"`
+	xxx_hidden_RecoveryCount uint32                 `protobuf:"varint,3,opt,name=recovery_count,json=recoveryCount,proto3"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *JoinAttrsBoundKeypair) Reset() {
+	*x = JoinAttrsBoundKeypair{}
+	mi := &file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JoinAttrsBoundKeypair) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JoinAttrsBoundKeypair) ProtoMessage() {}
+
+func (x *JoinAttrsBoundKeypair) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *JoinAttrsBoundKeypair) GetPublicKey() string {
+	if x != nil {
+		return x.xxx_hidden_PublicKey
+	}
+	return ""
+}
+
+func (x *JoinAttrsBoundKeypair) GetRecoveryMode() string {
+	if x != nil {
+		return x.xxx_hidden_RecoveryMode
+	}
+	return ""
+}
+
+func (x *JoinAttrsBoundKeypair) GetRecoveryCount() uint32 {
+	if x != nil {
+		return x.xxx_hidden_RecoveryCount
+	}
+	return 0
+}
+
+func (x *JoinAttrsBoundKeypair) SetPublicKey(v string) {
+	x.xxx_hidden_PublicKey = v
+}
+
+func (x *JoinAttrsBoundKeypair) SetRecoveryMode(v string) {
+	x.xxx_hidden_RecoveryMode = v
+}
+
+func (x *JoinAttrsBoundKeypair) SetRecoveryCount(v uint32) {
+	x.xxx_hidden_RecoveryCount = v
+}
+
+type JoinAttrsBoundKeypair_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The bound public key verified during this join, in SSH authorized_keys
+	// format.
+	PublicKey string
+	// The token's configured recovery mode, e.g. `standard` or `relaxed`.
+	RecoveryMode string
+	// The token's recovery counter after this join.
+	RecoveryCount uint32
+}
+
+func (b0 JoinAttrsBoundKeypair_builder) Build() *JoinAttrsBoundKeypair {
+	m0 := &JoinAttrsBoundKeypair{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_PublicKey = b.PublicKey
+	x.xxx_hidden_RecoveryMode = b.RecoveryMode
+	x.xxx_hidden_RecoveryCount = b.RecoveryCount
+	return m0
+}
+
 var File_teleport_workloadidentity_v1_join_attrs_proto protoreflect.FileDescriptor
 
 const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"\n" +
-	"-teleport/workloadidentity/v1/join_attrs.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1cgoogle/protobuf/struct.proto\"\xb1\t\n" +
+	"-teleport/workloadidentity/v1/join_attrs.proto\x12\x1cteleport.workloadidentity.v1\x1a\x1cgoogle/protobuf/struct.proto\"\x8b\n" +
+	"\n" +
 	"\tJoinAttrs\x12?\n" +
 	"\x04meta\x18\x01 \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsMetaR\x04meta\x12E\n" +
 	"\x06gitlab\x18\x02 \x01(\v2-.teleport.workloadidentity.v1.JoinAttrsGitLabR\x06gitlab\x12E\n" +
@@ -3103,7 +3221,8 @@ const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"\x06oracle\x18\r \x01(\v2-.teleport.workloadidentity.v1.JoinAttrsOracleR\x06oracle\x12U\n" +
 	"\fazure_devops\x18\x0e \x01(\v22.teleport.workloadidentity.v1.JoinAttrsAzureDevopsR\vazureDevops\x12?\n" +
 	"\x04env0\x18\x0f \x01(\v2+.teleport.workloadidentity.v1.JoinAttrsEnv0R\x04env0\x12U\n" +
-	"\fgeneric_oidc\x18\x10 \x01(\v22.teleport.workloadidentity.v1.JoinAttrsGenericOIDCR\vgenericOidc\"X\n" +
+	"\fgeneric_oidc\x18\x10 \x01(\v22.teleport.workloadidentity.v1.JoinAttrsGenericOIDCR\vgenericOidc\x12X\n" +
+	"\rbound_keypair\x18\x11 \x01(\v23.teleport.workloadidentity.v1.JoinAttrsBoundKeypairR\fboundKeypair\"X\n" +
 	"\rJoinAttrsMeta\x12&\n" +
 	"\x0fjoin_token_name\x18\x01 \x01(\tR\rjoinTokenName\x12\x1f\n" +
 	"\vjoin_method\x18\x02 \x01(\tR\n" +
@@ -3250,9 +3369,14 @@ const file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc = "" +
 	"\x0edeployer_email\x18\f \x01(\tR\rdeployerEmail\x12\x19\n" +
 	"\benv0_tag\x18\r \x01(\tR\aenv0Tag\"G\n" +
 	"\x14JoinAttrsGenericOIDC\x12/\n" +
-	"\x06claims\x18\x01 \x01(\v2\x17.google.protobuf.StructR\x06claimsBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
+	"\x06claims\x18\x01 \x01(\v2\x17.google.protobuf.StructR\x06claims\"\x82\x01\n" +
+	"\x15JoinAttrsBoundKeypair\x12\x1d\n" +
+	"\n" +
+	"public_key\x18\x01 \x01(\tR\tpublicKey\x12#\n" +
+	"\rrecovery_mode\x18\x02 \x01(\tR\frecoveryMode\x12%\n" +
+	"\x0erecovery_count\x18\x03 \x01(\rR\rrecoveryCountBdZbgithub.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1;workloadidentityv1b\x06proto3"
 
-var file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_teleport_workloadidentity_v1_join_attrs_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_teleport_workloadidentity_v1_join_attrs_proto_goTypes = []any{
 	(*JoinAttrs)(nil),                         // 0: teleport.workloadidentity.v1.JoinAttrs
 	(*JoinAttrsMeta)(nil),                     // 1: teleport.workloadidentity.v1.JoinAttrsMeta
@@ -3275,7 +3399,8 @@ var file_teleport_workloadidentity_v1_join_attrs_proto_goTypes = []any{
 	(*JoinAttrsAzureDevopsPipeline)(nil),      // 18: teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
 	(*JoinAttrsEnv0)(nil),                     // 19: teleport.workloadidentity.v1.JoinAttrsEnv0
 	(*JoinAttrsGenericOIDC)(nil),              // 20: teleport.workloadidentity.v1.JoinAttrsGenericOIDC
-	(*structpb.Struct)(nil),                   // 21: google.protobuf.Struct
+	(*JoinAttrsBoundKeypair)(nil),             // 21: teleport.workloadidentity.v1.JoinAttrsBoundKeypair
+	(*structpb.Struct)(nil),                   // 22: google.protobuf.Struct
 }
 var file_teleport_workloadidentity_v1_join_attrs_proto_depIdxs = []int32{
 	1,  // 0: teleport.workloadidentity.v1.JoinAttrs.meta:type_name -> teleport.workloadidentity.v1.JoinAttrsMeta
@@ -3294,16 +3419,17 @@ var file_teleport_workloadidentity_v1_join_attrs_proto_depIdxs = []int32{
 	17, // 13: teleport.workloadidentity.v1.JoinAttrs.azure_devops:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevops
 	19, // 14: teleport.workloadidentity.v1.JoinAttrs.env0:type_name -> teleport.workloadidentity.v1.JoinAttrsEnv0
 	20, // 15: teleport.workloadidentity.v1.JoinAttrs.generic_oidc:type_name -> teleport.workloadidentity.v1.JoinAttrsGenericOIDC
-	11, // 16: teleport.workloadidentity.v1.JoinAttrsGCP.gce:type_name -> teleport.workloadidentity.v1.JoinAttrsGCPGCE
-	14, // 17: teleport.workloadidentity.v1.JoinAttrsKubernetes.service_account:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesServiceAccount
-	13, // 18: teleport.workloadidentity.v1.JoinAttrsKubernetes.pod:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesPod
-	18, // 19: teleport.workloadidentity.v1.JoinAttrsAzureDevops.pipeline:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
-	21, // 20: teleport.workloadidentity.v1.JoinAttrsGenericOIDC.claims:type_name -> google.protobuf.Struct
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	21, // 16: teleport.workloadidentity.v1.JoinAttrs.bound_keypair:type_name -> teleport.workloadidentity.v1.JoinAttrsBoundKeypair
+	11, // 17: teleport.workloadidentity.v1.JoinAttrsGCP.gce:type_name -> teleport.workloadidentity.v1.JoinAttrsGCPGCE
+	14, // 18: teleport.workloadidentity.v1.JoinAttrsKubernetes.service_account:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesServiceAccount
+	13, // 19: teleport.workloadidentity.v1.JoinAttrsKubernetes.pod:type_name -> teleport.workloadidentity.v1.JoinAttrsKubernetesPod
+	18, // 20: teleport.workloadidentity.v1.JoinAttrsAzureDevops.pipeline:type_name -> teleport.workloadidentity.v1.JoinAttrsAzureDevopsPipeline
+	22, // 21: teleport.workloadidentity.v1.JoinAttrsGenericOIDC.claims:type_name -> google.protobuf.Struct
+	22, // [22:22] is the sub-list for method output_type
+	22, // [22:22] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_teleport_workloadidentity_v1_join_attrs_proto_init() }
@@ -3317,7 +3443,7 @@ func file_teleport_workloadidentity_v1_join_attrs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc), len(file_teleport_workloadidentity_v1_join_attrs_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   21,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/machineid/v1/bot_instance.proto
+++ b/api/proto/teleport/machineid/v1/bot_instance.proto
@@ -139,8 +139,9 @@ message BotInstanceStatusAuthentication {
   // Deprecated: prefer using join_attrs.meta.join_token_name
   string join_token = 3;
   // The metadata sourced from the join method.
-  // Deprecated: prefer using join_attrs.
-  google.protobuf.Struct metadata = 4;
+  // Deprecated: prefer using join_attrs. No longer written since v19; only
+  // present on records written by older Auth Service versions.
+  google.protobuf.Struct metadata = 4 [deprecated = true];
 
   // On each renewal, this generation is incremented. For delegated join
   // methods, this counter is not checked during renewal. For the `token` join

--- a/api/proto/teleport/workloadidentity/v1/join_attrs.proto
+++ b/api/proto/teleport/workloadidentity/v1/join_attrs.proto
@@ -55,6 +55,8 @@ message JoinAttrs {
   JoinAttrsEnv0 env0 = 15;
   // Attributes that are specific to the generic OIDC (`generic_oidc`) join method.
   JoinAttrsGenericOIDC generic_oidc = 16;
+  // Attributes that are specific to the Bound Keypair (`bound_keypair`) join method.
+  JoinAttrsBoundKeypair bound_keypair = 17;
 }
 
 // The collection of attributes that result from the join process but are not
@@ -416,4 +418,16 @@ message JoinAttrsEnv0 {
 message JoinAttrsGenericOIDC {
   // A complete set of token claims.
   google.protobuf.Struct claims = 1;
+}
+
+// Attributes that are specific to the Bound Keypair (`bound_keypair`) join
+// method.
+message JoinAttrsBoundKeypair {
+  // The bound public key verified during this join, in SSH authorized_keys
+  // format.
+  string public_key = 1;
+  // The token's configured recovery mode, e.g. `standard` or `relaxed`.
+  string recovery_mode = 2;
+  // The token's recovery counter after this join.
+  uint32 recovery_count = 3;
 }

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/bot-instance.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/bot-instance.mdx
@@ -229,6 +229,7 @@ oracle: # [...]
 azure_devops: # [...]
 env0: # [...]
 generic_oidc: # [...]
+bound_keypair: # [...]
 ```
 
 |Field Name|Description|Type|
@@ -236,6 +237,7 @@ generic_oidc: # [...]
 |azure|Attributes that are specific to the Azure (`azure`) join method.|[Join Attrs Azure](#join-attrs-azure)|
 |azure_devops|Attributes that are specific to the Azure Devops (`azure_devops`) join method.|[Join Attrs Azure Devops](#join-attrs-azure-devops)|
 |bitbucket|Attributes that are specific to the Bitbucket (`bitbucket`) join method.|[Join Attrs Bitbucket](#join-attrs-bitbucket)|
+|bound_keypair|Attributes that are specific to the Bound Keypair (`bound_keypair`) join method.|[Join Attrs Bound Keypair](#join-attrs-bound-keypair)|
 |circleci|Attributes that are specific to the CircleCI (`circleci`) join method.|[Join Attrs CircleCI](#join-attrs-circleci)|
 |env0|Attributes that are specific to the Env0 (`env0`) join method.|[Join Attrs Env0](#join-attrs-env0)|
 |gcp|Attributes that are specific to the GCP (`gcp`) join method.|[Join Attrs GCP](#join-attrs-gcp)|
@@ -362,6 +364,25 @@ branch_name: "string"
 |step_uuid|The UUID of the pipeline step.|string|
 |sub|The `sub` claim of the Bitbucket JWT that was used to join.|string|
 |workspace_uuid|The UUID of the workspace the pipeline belongs to.|string|
+
+## Join Attrs Bound Keypair
+
+Attributes that are specific to the Bound Keypair (`bound_keypair`) join method.
+
+
+Example:
+
+```yaml
+public_key: "string"
+recovery_mode: "string"
+recovery_count: 1
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|public_key|The bound public key verified during this join, in SSH authorized_keys format.|string|
+|recovery_count|The token's recovery counter after this join.|number|
+|recovery_mode|The token's configured recovery mode, e.g. `standard` or `relaxed`.|string|
 
 ## Join Attrs CircleCI
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/bot-instance.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/bot-instance.mdx
@@ -158,7 +158,7 @@ join_attrs: # [...]
 |join_attrs|The attributes generated during the join process. Typically, this is information from the join attestation process itself. This field will eventually replace the `metadata` field, which is structureless.|[Join Attrs](#join-attrs)|
 |join_method|The join method used for this join or renewal. Deprecated: prefer using join_attrs.meta.join_method|string|
 |join_token|The join token used for this join or renewal. This is only populated for delegated join methods as the value for `token` join methods is sensitive. Deprecated: prefer using join_attrs.meta.join_token_name|string|
-|metadata|The metadata sourced from the join method. Deprecated: prefer using join_attrs.||
+|metadata|The metadata sourced from the join method. Deprecated: prefer using join_attrs. No longer written since v19; only present on records written by older Auth Service versions.  Deprecated: Marked as deprecated in teleport/machineid/v1/bot_instance.proto.||
 |public_key|The public key of the Bot instance. This must be a PEM wrapped, PKIX DER encoded public key. This provides consistency and supports multiple types of public key algorithm.|base64-encoded string|
 
 ## Bot Instance Status Heartbeat

--- a/docs/pages/reference/machine-workload-identity/workload-identity/attributes.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/attributes.mdx
@@ -81,6 +81,17 @@ documentation is available at https://support.atlassian.com/bitbucket-cloud/docs
 | `join.bitbucket.deployment_environment_uuid` | The UUID of the deployment environment the pipeline is running against. |
 | `join.bitbucket.branch_name`                 | The name of the branch the pipeline is running against.                 |
 
+### `join.bound_keypair`
+
+These attributes are present if the Bot joined using the Bound Keypair join
+method.
+
+| Field                               | Description                                                             |
+|-------------------------------------|-------------------------------------------------------------------------|
+| `join.bound_keypair.public_key`     | The bound public key verified during the join, in SSH authorized_keys format. |
+| `join.bound_keypair.recovery_mode`  | The join token's configured recovery mode, e.g. `standard` or `relaxed`. |
+| `join.bound_keypair.recovery_count` | The join token's recovery counter after the join.                       |
+
 ### `join.circleci`
 
 These attributes are present if the Bot joined using the CircleCI join method.

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -20,7 +20,6 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"maps"
@@ -30,7 +29,6 @@ import (
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -429,13 +427,6 @@ func (a *Server) GenerateBotCertsForJoin(
 		JoinAttrs:  params.Attrs,
 	}.Build()
 
-	var err error
-	// TODO(noah): In v19, we can drop writing to the deprecated Metadata field.
-	auth.Metadata, err = rawJoinAttrsToGoogleStruct(params.RawJoinClaims)
-	if err != nil {
-		a.logger.WarnContext(ctx, "Unable to encode struct value for join metadata", "error", err)
-	}
-
 	botUserName, err := botUserNameFromToken(token)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -678,19 +669,4 @@ func (a *Server) emitJoinEvent(ctx context.Context, token provision.Token, param
 	if err := a.emitter.EmitAuditEvent(ctx, joinEvent); err != nil {
 		a.logger.WarnContext(ctx, "Failed to emit instance join event", "error", err)
 	}
-}
-
-func rawJoinAttrsToGoogleStruct(in any) (*structpb.Struct, error) {
-	if in == nil {
-		return nil, nil
-	}
-	attrBytes, err := json.Marshal(in)
-	if err != nil {
-		return nil, trace.Wrap(err, "marshaling join attributes")
-	}
-	out := &structpb.Struct{}
-	if err := out.UnmarshalJSON(attrBytes); err != nil {
-		return nil, trace.Wrap(err, "unmarshaling join attributes")
-	}
-	return out, nil
 }

--- a/lib/boundkeypair/claims.go
+++ b/lib/boundkeypair/claims.go
@@ -18,6 +18,10 @@
 
 package boundkeypair
 
+import (
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+)
+
 // Claims contains extended claims resulting from bound keypair joining
 type Claims struct {
 	// PublicKey is the verified public key trusted at the end of the joining
@@ -29,4 +33,14 @@ type Claims struct {
 	// RecoveryMode is the recovery mode as configured at the time of the join
 	// attempt.
 	RecoveryMode RecoveryMode `json:"recovery_mode"`
+}
+
+// JoinAttrs returns the protobuf representation of the claims for inclusion
+// in a bot's join attributes.
+func (c *Claims) JoinAttrs() *workloadidentityv1pb.JoinAttrsBoundKeypair {
+	return workloadidentityv1pb.JoinAttrsBoundKeypair_builder{
+		PublicKey:     c.PublicKey,
+		RecoveryMode:  string(c.RecoveryMode),
+		RecoveryCount: c.RecoveryCount,
+	}.Build()
 }

--- a/lib/join/boundkeypair/boundkeypair.go
+++ b/lib/join/boundkeypair/boundkeypair.go
@@ -846,7 +846,7 @@ type JoinParams struct {
 	// validator, used to override the validator in tests.
 	CreateBoundKeypairValidator CreateBoundKeypairValidator
 	// GenerateBotCerts is a function that generates bot certificates.
-	GenerateBotCerts func(ctx context.Context, previousBotInstanceID string, claims any) (*messages.Certificates, string, error)
+	GenerateBotCerts func(ctx context.Context, previousBotInstanceID string, claims *boundkeypair.Claims) (*messages.Certificates, string, error)
 	// GenerateHostCerts is a function that generates host certificates. Unlike
 	// bots, hosts do not maintain an ID lineage and are expected to retain
 	// their host IDs indefinitely (or else start over from a clean slate

--- a/lib/join/join_bound_keypair_test.go
+++ b/lib/join/join_bound_keypair_test.go
@@ -443,6 +443,16 @@ func TestJoinBoundKeypair(t *testing.T) {
 				require.Equal(t, uint32(1), v2.Status.BoundKeypair.RecoveryCount)
 				require.NotEmpty(t, v2.Status.BoundKeypair.BoundBotInstanceID)
 				require.NotEmpty(t, v2.Status.BoundKeypair.BoundPublicKey)
+
+				bi, err := authServer.BotInstance.GetBotInstance(t.Context(), machineidv1pb.GetBotInstanceRequest_builder{
+					BotName:    "test",
+					InstanceId: v2.Status.BoundKeypair.BoundBotInstanceID,
+				}.Build())
+				require.NoError(t, err)
+				attrs := bi.GetStatus().GetInitialAuthentication().GetJoinAttrs().GetBoundKeypair()
+				require.Equal(t, v2.Status.BoundKeypair.BoundPublicKey, attrs.GetPublicKey())
+				require.Equal(t, boundkeypair.RecoveryModeInsecure, attrs.GetRecoveryMode())
+				require.Equal(t, uint32(1), attrs.GetRecoveryCount())
 			},
 		},
 		{

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
+	libboundkeypair "github.com/gravitational/teleport/lib/boundkeypair"
 	"github.com/gravitational/teleport/lib/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
@@ -88,13 +90,19 @@ func (s *Server) handleBoundKeypairJoin(
 		rotationResp, err := messages.RecvRequest[*messages.BoundKeypairRotationResponse](stream)
 		return rotationResp, trace.Wrap(err)
 	}
-	generateBotCerts := func(ctx context.Context, previousBotInstanceID string, claims any) (*messages.Certificates, string, error) {
+	generateBotCerts := func(ctx context.Context, previousBotInstanceID string, claims *libboundkeypair.Claims) (*messages.Certificates, string, error) {
+		var workloadIDAttrs *workloadidentityv1.JoinAttrs
+		if claims != nil {
+			workloadIDAttrs = workloadidentityv1.JoinAttrs_builder{
+				BoundKeypair: claims.JoinAttrs(),
+			}.Build()
+		}
 		botCertsParams, err := makeBotCertsParams(
 			diag,
 			authCtx,
 			boundKeypairInit.ClientParams.BotParams,
 			claims,
-			nil, // TODO(timothyb89): workload id claims
+			workloadIDAttrs,
 		)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
@@ -244,13 +252,19 @@ func AdaptRegisterUsingBoundKeypairMethod(
 		PreviousJoinState: req.PreviousJoinState,
 	}
 
-	generateBotCerts := func(ctx context.Context, previousBotInstanceID string, claims any) (*messages.Certificates, string, error) {
+	generateBotCerts := func(ctx context.Context, previousBotInstanceID string, claims *libboundkeypair.Claims) (*messages.Certificates, string, error) {
+		var workloadIDAttrs *workloadidentityv1.JoinAttrs
+		if claims != nil {
+			workloadIDAttrs = workloadidentityv1.JoinAttrs_builder{
+				BoundKeypair: claims.JoinAttrs(),
+			}.Build()
+		}
 		botCertsParams, err := makeBotCertsParams(
 			diag,
 			authCtx,
 			clientParams.BotParams,
 			claims,
-			nil, // TODO(timothyb89): workload id claims
+			workloadIDAttrs,
 		)
 		if err != nil {
 			return nil, "", trace.Wrap(err)

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -1302,6 +1302,8 @@ func formatBotInstanceAuthentication(record *machineidv1pb.BotInstanceStatusAuth
 	table.AddRow([]string{"Authenticated At:", record.GetAuthenticatedAt().AsTime().Format(time.RFC3339)})
 	table.AddRow([]string{"Join Method:", cmp.Or(record.GetJoinAttrs().GetMeta().GetJoinMethod(), record.GetJoinMethod())})
 	table.AddRow([]string{"Join Token:", cmp.Or(record.GetJoinAttrs().GetMeta().GetJoinTokenName(), record.GetJoinToken())})
+	//nolint:staticcheck // fallback for records written before join_attrs
+	// existed. TODO(noah): DELETE IN V20.0.0
 	var meta fmt.Stringer = record.GetMetadata()
 	if attrs := record.GetJoinAttrs(); attrs != nil {
 		meta = attrs


### PR DESCRIPTION
From V17, we started recording attributes from the join process in Bot Instances in a more structured way as `join_attrs`. We continued to write the legacy format into `metadata`. Since V17, readers have preferred pulling the `join_attrs` field.

This PR modifies the join logic to no longer write to the `metadata` field.

Changelog: Bot Instances authentication records no longer write the legacy `metadata` field in the legacy format. This was replaced by the `join_attrs` field.

## Manual Test Plan
### Test Environment

Local cluster

### Test Cases

- [x] Kubernetes join succeeds, and the bot instance does not contain an authentication record containing the `metadata` field.
