### PR TITLE
MFA service stores and propagates the device ID used to satisfy a challenge.

### DIFF
--- a/api/gen/proto/go/teleport/mfa/v2/service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v2/service_protohybrid.pb.go
@@ -643,7 +643,10 @@ type ReplicateValidatedMFAChallengeRequest struct {
 	TargetCluster string `protobuf:"bytes,4,opt,name=target_cluster,json=targetCluster,proto3" json:"target_cluster,omitempty"`
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified by source_cluster.
-	Username      string `protobuf:"bytes,5,opt,name=username,proto3" json:"username,omitempty"`
+	Username string `protobuf:"bytes,5,opt,name=username,proto3" json:"username,omitempty"`
+	// ID of the MFA device that satisfied the challenge in the source cluster. Must match the device_id of the validated
+	// challenge being replicated so that mfa_device locks are enforced in the target cluster.
+	DeviceId      string `protobuf:"bytes,6,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -708,6 +711,13 @@ func (x *ReplicateValidatedMFAChallengeRequest) GetUsername() string {
 	return ""
 }
 
+func (x *ReplicateValidatedMFAChallengeRequest) GetDeviceId() string {
+	if x != nil {
+		return x.DeviceId
+	}
+	return ""
+}
+
 func (x *ReplicateValidatedMFAChallengeRequest) SetName(v string) {
 	x.Name = v
 }
@@ -726,6 +736,10 @@ func (x *ReplicateValidatedMFAChallengeRequest) SetTargetCluster(v string) {
 
 func (x *ReplicateValidatedMFAChallengeRequest) SetUsername(v string) {
 	x.Username = v
+}
+
+func (x *ReplicateValidatedMFAChallengeRequest) SetDeviceId(v string) {
+	x.DeviceId = v
 }
 
 func (x *ReplicateValidatedMFAChallengeRequest) HasPayload() bool {
@@ -756,6 +770,9 @@ type ReplicateValidatedMFAChallengeRequest_builder struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified by source_cluster.
 	Username string
+	// ID of the MFA device that satisfied the challenge in the source cluster. Must match the device_id of the validated
+	// challenge being replicated so that mfa_device locks are enforced in the target cluster.
+	DeviceId string
 }
 
 func (b0 ReplicateValidatedMFAChallengeRequest_builder) Build() *ReplicateValidatedMFAChallengeRequest {
@@ -767,6 +784,7 @@ func (b0 ReplicateValidatedMFAChallengeRequest_builder) Build() *ReplicateValida
 	x.SourceCluster = b.SourceCluster
 	x.TargetCluster = b.TargetCluster
 	x.Username = b.Username
+	x.DeviceId = b.DeviceId
 	return m0
 }
 
@@ -974,7 +992,10 @@ func (b0 VerifyValidatedMFAChallengeRequest_builder) Build() *VerifyValidatedMFA
 
 // VerifyValidatedMFAChallengeResponse is the response message for VerifyValidatedMFAChallenge.
 type VerifyValidatedMFAChallengeResponse struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// ID of the MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for
+	// the session and MUST reject an empty value.
+	DeviceId      string `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1004,15 +1025,30 @@ func (x *VerifyValidatedMFAChallengeResponse) ProtoReflect() protoreflect.Messag
 	return mi.MessageOf(x)
 }
 
+func (x *VerifyValidatedMFAChallengeResponse) GetDeviceId() string {
+	if x != nil {
+		return x.DeviceId
+	}
+	return ""
+}
+
+func (x *VerifyValidatedMFAChallengeResponse) SetDeviceId(v string) {
+	x.DeviceId = v
+}
+
 type VerifyValidatedMFAChallengeResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
+	// ID of the MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for
+	// the session and MUST reject an empty value.
+	DeviceId string
 }
 
 func (b0 VerifyValidatedMFAChallengeResponse_builder) Build() *VerifyValidatedMFAChallengeResponse {
 	m0 := &VerifyValidatedMFAChallengeResponse{}
 	b, x := &b0, m0
 	_, _ = b, x
+	x.DeviceId = b.DeviceId
 	return m0
 }
 
@@ -1175,21 +1211,23 @@ const file_teleport_mfa_v2_service_proto_rawDesc = "" +
 	"\x06filter\x18\x03 \x01(\v21.teleport.mfa.v2.ListValidatedMFAChallengesFilterR\x06filter\"\xa7\x01\n" +
 	"\"ListValidatedMFAChallengesResponse\x12Y\n" +
 	"\x14validated_challenges\x18\x01 \x03(\v2&.teleport.mfa.v2.ValidatedMFAChallengeR\x13validatedChallenges\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xeb\x01\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x88\x02\n" +
 	"%ReplicateValidatedMFAChallengeRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12D\n" +
 	"\apayload\x18\x02 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x03 \x01(\tR\rsourceCluster\x12%\n" +
 	"\x0etarget_cluster\x18\x04 \x01(\tR\rtargetCluster\x12\x1a\n" +
-	"\busername\x18\x05 \x01(\tR\busername\"\x83\x01\n" +
+	"\busername\x18\x05 \x01(\tR\busername\x12\x1b\n" +
+	"\tdevice_id\x18\x06 \x01(\tR\bdeviceId\"\x83\x01\n" +
 	"&ReplicateValidatedMFAChallengeResponse\x12Y\n" +
 	"\x14replicated_challenge\x18\x01 \x01(\v2&.teleport.mfa.v2.ValidatedMFAChallengeR\x13replicatedChallenge\"\xc1\x01\n" +
 	"\"VerifyValidatedMFAChallengeRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12D\n" +
 	"\apayload\x18\x02 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x03 \x01(\tR\rsourceCluster\x12\x1a\n" +
-	"\busername\x18\x04 \x01(\tR\busername\"%\n" +
-	"#VerifyValidatedMFAChallengeResponse\"{\n" +
+	"\busername\x18\x04 \x01(\tR\busername\"B\n" +
+	"#VerifyValidatedMFAChallengeResponse\x12\x1b\n" +
+	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\"{\n" +
 	"\"CompleteBrowserMFAChallengeRequest\x12U\n" +
 	"\x14browser_mfa_response\x18\x01 \x01(\v2#.teleport.mfa.v2.BrowserMFAResponseR\x12browserMfaResponse\"O\n" +
 	"#CompleteBrowserMFAChallengeResponse\x12(\n" +

--- a/api/gen/proto/go/teleport/mfa/v2/service_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v2/service_protohybrid.pb.go
@@ -644,9 +644,9 @@ type ReplicateValidatedMFAChallengeRequest struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified by source_cluster.
 	Username string `protobuf:"bytes,5,opt,name=username,proto3" json:"username,omitempty"`
-	// ID of the MFA device that satisfied the challenge in the source cluster. Must match the device_id of the validated
-	// challenge being replicated so that mfa_device locks are enforced in the target cluster.
-	DeviceId      string `protobuf:"bytes,6,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
+	// MFA device that satisfied the challenge in source_cluster. Must match the mfa_device of the validated challenge
+	// being replicated so that mfa_device locks are enforced in the target cluster.
+	MfaDevice     *MFADevice `protobuf:"bytes,6,opt,name=mfa_device,json=mfaDevice,proto3" json:"mfa_device,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -711,11 +711,11 @@ func (x *ReplicateValidatedMFAChallengeRequest) GetUsername() string {
 	return ""
 }
 
-func (x *ReplicateValidatedMFAChallengeRequest) GetDeviceId() string {
+func (x *ReplicateValidatedMFAChallengeRequest) GetMfaDevice() *MFADevice {
 	if x != nil {
-		return x.DeviceId
+		return x.MfaDevice
 	}
-	return ""
+	return nil
 }
 
 func (x *ReplicateValidatedMFAChallengeRequest) SetName(v string) {
@@ -738,8 +738,8 @@ func (x *ReplicateValidatedMFAChallengeRequest) SetUsername(v string) {
 	x.Username = v
 }
 
-func (x *ReplicateValidatedMFAChallengeRequest) SetDeviceId(v string) {
-	x.DeviceId = v
+func (x *ReplicateValidatedMFAChallengeRequest) SetMfaDevice(v *MFADevice) {
+	x.MfaDevice = v
 }
 
 func (x *ReplicateValidatedMFAChallengeRequest) HasPayload() bool {
@@ -749,8 +749,19 @@ func (x *ReplicateValidatedMFAChallengeRequest) HasPayload() bool {
 	return x.Payload != nil
 }
 
+func (x *ReplicateValidatedMFAChallengeRequest) HasMfaDevice() bool {
+	if x == nil {
+		return false
+	}
+	return x.MfaDevice != nil
+}
+
 func (x *ReplicateValidatedMFAChallengeRequest) ClearPayload() {
 	x.Payload = nil
+}
+
+func (x *ReplicateValidatedMFAChallengeRequest) ClearMfaDevice() {
+	x.MfaDevice = nil
 }
 
 type ReplicateValidatedMFAChallengeRequest_builder struct {
@@ -770,9 +781,9 @@ type ReplicateValidatedMFAChallengeRequest_builder struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified by source_cluster.
 	Username string
-	// ID of the MFA device that satisfied the challenge in the source cluster. Must match the device_id of the validated
-	// challenge being replicated so that mfa_device locks are enforced in the target cluster.
-	DeviceId string
+	// MFA device that satisfied the challenge in source_cluster. Must match the mfa_device of the validated challenge
+	// being replicated so that mfa_device locks are enforced in the target cluster.
+	MfaDevice *MFADevice
 }
 
 func (b0 ReplicateValidatedMFAChallengeRequest_builder) Build() *ReplicateValidatedMFAChallengeRequest {
@@ -784,7 +795,7 @@ func (b0 ReplicateValidatedMFAChallengeRequest_builder) Build() *ReplicateValida
 	x.SourceCluster = b.SourceCluster
 	x.TargetCluster = b.TargetCluster
 	x.Username = b.Username
-	x.DeviceId = b.DeviceId
+	x.MfaDevice = b.MfaDevice
 	return m0
 }
 
@@ -993,9 +1004,9 @@ func (b0 VerifyValidatedMFAChallengeRequest_builder) Build() *VerifyValidatedMFA
 // VerifyValidatedMFAChallengeResponse is the response message for VerifyValidatedMFAChallenge.
 type VerifyValidatedMFAChallengeResponse struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
-	// ID of the MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for
-	// the session and MUST reject an empty value.
-	DeviceId      string `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
+	// MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for the
+	// session and MUST reject a nil or empty value.
+	MfaDevice     *MFADevice `protobuf:"bytes,1,opt,name=mfa_device,json=mfaDevice,proto3" json:"mfa_device,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1025,30 +1036,41 @@ func (x *VerifyValidatedMFAChallengeResponse) ProtoReflect() protoreflect.Messag
 	return mi.MessageOf(x)
 }
 
-func (x *VerifyValidatedMFAChallengeResponse) GetDeviceId() string {
+func (x *VerifyValidatedMFAChallengeResponse) GetMfaDevice() *MFADevice {
 	if x != nil {
-		return x.DeviceId
+		return x.MfaDevice
 	}
-	return ""
+	return nil
 }
 
-func (x *VerifyValidatedMFAChallengeResponse) SetDeviceId(v string) {
-	x.DeviceId = v
+func (x *VerifyValidatedMFAChallengeResponse) SetMfaDevice(v *MFADevice) {
+	x.MfaDevice = v
+}
+
+func (x *VerifyValidatedMFAChallengeResponse) HasMfaDevice() bool {
+	if x == nil {
+		return false
+	}
+	return x.MfaDevice != nil
+}
+
+func (x *VerifyValidatedMFAChallengeResponse) ClearMfaDevice() {
+	x.MfaDevice = nil
 }
 
 type VerifyValidatedMFAChallengeResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ID of the MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for
-	// the session and MUST reject an empty value.
-	DeviceId string
+	// MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for the
+	// session and MUST reject a nil or empty value.
+	MfaDevice *MFADevice
 }
 
 func (b0 VerifyValidatedMFAChallengeResponse_builder) Build() *VerifyValidatedMFAChallengeResponse {
 	m0 := &VerifyValidatedMFAChallengeResponse{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.DeviceId = b.DeviceId
+	x.MfaDevice = b.MfaDevice
 	return m0
 }
 
@@ -1211,23 +1233,25 @@ const file_teleport_mfa_v2_service_proto_rawDesc = "" +
 	"\x06filter\x18\x03 \x01(\v21.teleport.mfa.v2.ListValidatedMFAChallengesFilterR\x06filter\"\xa7\x01\n" +
 	"\"ListValidatedMFAChallengesResponse\x12Y\n" +
 	"\x14validated_challenges\x18\x01 \x03(\v2&.teleport.mfa.v2.ValidatedMFAChallengeR\x13validatedChallenges\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x88\x02\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xa6\x02\n" +
 	"%ReplicateValidatedMFAChallengeRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12D\n" +
 	"\apayload\x18\x02 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x03 \x01(\tR\rsourceCluster\x12%\n" +
 	"\x0etarget_cluster\x18\x04 \x01(\tR\rtargetCluster\x12\x1a\n" +
-	"\busername\x18\x05 \x01(\tR\busername\x12\x1b\n" +
-	"\tdevice_id\x18\x06 \x01(\tR\bdeviceId\"\x83\x01\n" +
+	"\busername\x18\x05 \x01(\tR\busername\x129\n" +
+	"\n" +
+	"mfa_device\x18\x06 \x01(\v2\x1a.teleport.mfa.v2.MFADeviceR\tmfaDevice\"\x83\x01\n" +
 	"&ReplicateValidatedMFAChallengeResponse\x12Y\n" +
 	"\x14replicated_challenge\x18\x01 \x01(\v2&.teleport.mfa.v2.ValidatedMFAChallengeR\x13replicatedChallenge\"\xc1\x01\n" +
 	"\"VerifyValidatedMFAChallengeRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12D\n" +
 	"\apayload\x18\x02 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x03 \x01(\tR\rsourceCluster\x12\x1a\n" +
-	"\busername\x18\x04 \x01(\tR\busername\"B\n" +
-	"#VerifyValidatedMFAChallengeResponse\x12\x1b\n" +
-	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\"{\n" +
+	"\busername\x18\x04 \x01(\tR\busername\"`\n" +
+	"#VerifyValidatedMFAChallengeResponse\x129\n" +
+	"\n" +
+	"mfa_device\x18\x01 \x01(\v2\x1a.teleport.mfa.v2.MFADeviceR\tmfaDevice\"{\n" +
 	"\"CompleteBrowserMFAChallengeRequest\x12U\n" +
 	"\x14browser_mfa_response\x18\x01 \x01(\v2#.teleport.mfa.v2.BrowserMFAResponseR\x12browserMfaResponse\"O\n" +
 	"#CompleteBrowserMFAChallengeResponse\x12(\n" +
@@ -1260,7 +1284,8 @@ var file_teleport_mfa_v2_service_proto_goTypes = []any{
 	(*AuthenticateChallenge)(nil),                  // 14: teleport.mfa.v2.AuthenticateChallenge
 	(*AuthenticateResponse)(nil),                   // 15: teleport.mfa.v2.AuthenticateResponse
 	(*ValidatedMFAChallenge)(nil),                  // 16: teleport.mfa.v2.ValidatedMFAChallenge
-	(*BrowserMFAResponse)(nil),                     // 17: teleport.mfa.v2.BrowserMFAResponse
+	(*MFADevice)(nil),                              // 17: teleport.mfa.v2.MFADevice
+	(*BrowserMFAResponse)(nil),                     // 18: teleport.mfa.v2.BrowserMFAResponse
 }
 var file_teleport_mfa_v2_service_proto_depIdxs = []int32{
 	13, // 0: teleport.mfa.v2.CreateSessionChallengeRequest.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
@@ -1269,26 +1294,28 @@ var file_teleport_mfa_v2_service_proto_depIdxs = []int32{
 	4,  // 3: teleport.mfa.v2.ListValidatedMFAChallengesRequest.filter:type_name -> teleport.mfa.v2.ListValidatedMFAChallengesFilter
 	16, // 4: teleport.mfa.v2.ListValidatedMFAChallengesResponse.validated_challenges:type_name -> teleport.mfa.v2.ValidatedMFAChallenge
 	13, // 5: teleport.mfa.v2.ReplicateValidatedMFAChallengeRequest.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
-	16, // 6: teleport.mfa.v2.ReplicateValidatedMFAChallengeResponse.replicated_challenge:type_name -> teleport.mfa.v2.ValidatedMFAChallenge
-	13, // 7: teleport.mfa.v2.VerifyValidatedMFAChallengeRequest.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
-	17, // 8: teleport.mfa.v2.CompleteBrowserMFAChallengeRequest.browser_mfa_response:type_name -> teleport.mfa.v2.BrowserMFAResponse
-	0,  // 9: teleport.mfa.v2.MFAService.CreateSessionChallenge:input_type -> teleport.mfa.v2.CreateSessionChallengeRequest
-	2,  // 10: teleport.mfa.v2.MFAService.ValidateSessionChallenge:input_type -> teleport.mfa.v2.ValidateSessionChallengeRequest
-	5,  // 11: teleport.mfa.v2.MFAService.ListValidatedMFAChallenges:input_type -> teleport.mfa.v2.ListValidatedMFAChallengesRequest
-	7,  // 12: teleport.mfa.v2.MFAService.ReplicateValidatedMFAChallenge:input_type -> teleport.mfa.v2.ReplicateValidatedMFAChallengeRequest
-	9,  // 13: teleport.mfa.v2.MFAService.VerifyValidatedMFAChallenge:input_type -> teleport.mfa.v2.VerifyValidatedMFAChallengeRequest
-	11, // 14: teleport.mfa.v2.MFAService.CompleteBrowserMFAChallenge:input_type -> teleport.mfa.v2.CompleteBrowserMFAChallengeRequest
-	1,  // 15: teleport.mfa.v2.MFAService.CreateSessionChallenge:output_type -> teleport.mfa.v2.CreateSessionChallengeResponse
-	3,  // 16: teleport.mfa.v2.MFAService.ValidateSessionChallenge:output_type -> teleport.mfa.v2.ValidateSessionChallengeResponse
-	6,  // 17: teleport.mfa.v2.MFAService.ListValidatedMFAChallenges:output_type -> teleport.mfa.v2.ListValidatedMFAChallengesResponse
-	8,  // 18: teleport.mfa.v2.MFAService.ReplicateValidatedMFAChallenge:output_type -> teleport.mfa.v2.ReplicateValidatedMFAChallengeResponse
-	10, // 19: teleport.mfa.v2.MFAService.VerifyValidatedMFAChallenge:output_type -> teleport.mfa.v2.VerifyValidatedMFAChallengeResponse
-	12, // 20: teleport.mfa.v2.MFAService.CompleteBrowserMFAChallenge:output_type -> teleport.mfa.v2.CompleteBrowserMFAChallengeResponse
-	15, // [15:21] is the sub-list for method output_type
-	9,  // [9:15] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	17, // 6: teleport.mfa.v2.ReplicateValidatedMFAChallengeRequest.mfa_device:type_name -> teleport.mfa.v2.MFADevice
+	16, // 7: teleport.mfa.v2.ReplicateValidatedMFAChallengeResponse.replicated_challenge:type_name -> teleport.mfa.v2.ValidatedMFAChallenge
+	13, // 8: teleport.mfa.v2.VerifyValidatedMFAChallengeRequest.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
+	17, // 9: teleport.mfa.v2.VerifyValidatedMFAChallengeResponse.mfa_device:type_name -> teleport.mfa.v2.MFADevice
+	18, // 10: teleport.mfa.v2.CompleteBrowserMFAChallengeRequest.browser_mfa_response:type_name -> teleport.mfa.v2.BrowserMFAResponse
+	0,  // 11: teleport.mfa.v2.MFAService.CreateSessionChallenge:input_type -> teleport.mfa.v2.CreateSessionChallengeRequest
+	2,  // 12: teleport.mfa.v2.MFAService.ValidateSessionChallenge:input_type -> teleport.mfa.v2.ValidateSessionChallengeRequest
+	5,  // 13: teleport.mfa.v2.MFAService.ListValidatedMFAChallenges:input_type -> teleport.mfa.v2.ListValidatedMFAChallengesRequest
+	7,  // 14: teleport.mfa.v2.MFAService.ReplicateValidatedMFAChallenge:input_type -> teleport.mfa.v2.ReplicateValidatedMFAChallengeRequest
+	9,  // 15: teleport.mfa.v2.MFAService.VerifyValidatedMFAChallenge:input_type -> teleport.mfa.v2.VerifyValidatedMFAChallengeRequest
+	11, // 16: teleport.mfa.v2.MFAService.CompleteBrowserMFAChallenge:input_type -> teleport.mfa.v2.CompleteBrowserMFAChallengeRequest
+	1,  // 17: teleport.mfa.v2.MFAService.CreateSessionChallenge:output_type -> teleport.mfa.v2.CreateSessionChallengeResponse
+	3,  // 18: teleport.mfa.v2.MFAService.ValidateSessionChallenge:output_type -> teleport.mfa.v2.ValidateSessionChallengeResponse
+	6,  // 19: teleport.mfa.v2.MFAService.ListValidatedMFAChallenges:output_type -> teleport.mfa.v2.ListValidatedMFAChallengesResponse
+	8,  // 20: teleport.mfa.v2.MFAService.ReplicateValidatedMFAChallenge:output_type -> teleport.mfa.v2.ReplicateValidatedMFAChallengeResponse
+	10, // 21: teleport.mfa.v2.MFAService.VerifyValidatedMFAChallenge:output_type -> teleport.mfa.v2.VerifyValidatedMFAChallengeResponse
+	12, // 22: teleport.mfa.v2.MFAService.CompleteBrowserMFAChallenge:output_type -> teleport.mfa.v2.CompleteBrowserMFAChallengeResponse
+	17, // [17:23] is the sub-list for method output_type
+	11, // [11:17] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_teleport_mfa_v2_service_proto_init() }

--- a/api/gen/proto/go/teleport/mfa/v2/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v2/service_protoopaque.pb.go
@@ -624,7 +624,7 @@ type ReplicateValidatedMFAChallengeRequest struct {
 	xxx_hidden_SourceCluster string                     `protobuf:"bytes,3,opt,name=source_cluster,json=sourceCluster,proto3"`
 	xxx_hidden_TargetCluster string                     `protobuf:"bytes,4,opt,name=target_cluster,json=targetCluster,proto3"`
 	xxx_hidden_Username      string                     `protobuf:"bytes,5,opt,name=username,proto3"`
-	xxx_hidden_DeviceId      string                     `protobuf:"bytes,6,opt,name=device_id,json=deviceId,proto3"`
+	xxx_hidden_MfaDevice     *MFADevice                 `protobuf:"bytes,6,opt,name=mfa_device,json=mfaDevice,proto3"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -689,11 +689,11 @@ func (x *ReplicateValidatedMFAChallengeRequest) GetUsername() string {
 	return ""
 }
 
-func (x *ReplicateValidatedMFAChallengeRequest) GetDeviceId() string {
+func (x *ReplicateValidatedMFAChallengeRequest) GetMfaDevice() *MFADevice {
 	if x != nil {
-		return x.xxx_hidden_DeviceId
+		return x.xxx_hidden_MfaDevice
 	}
-	return ""
+	return nil
 }
 
 func (x *ReplicateValidatedMFAChallengeRequest) SetName(v string) {
@@ -716,8 +716,8 @@ func (x *ReplicateValidatedMFAChallengeRequest) SetUsername(v string) {
 	x.xxx_hidden_Username = v
 }
 
-func (x *ReplicateValidatedMFAChallengeRequest) SetDeviceId(v string) {
-	x.xxx_hidden_DeviceId = v
+func (x *ReplicateValidatedMFAChallengeRequest) SetMfaDevice(v *MFADevice) {
+	x.xxx_hidden_MfaDevice = v
 }
 
 func (x *ReplicateValidatedMFAChallengeRequest) HasPayload() bool {
@@ -727,8 +727,19 @@ func (x *ReplicateValidatedMFAChallengeRequest) HasPayload() bool {
 	return x.xxx_hidden_Payload != nil
 }
 
+func (x *ReplicateValidatedMFAChallengeRequest) HasMfaDevice() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_MfaDevice != nil
+}
+
 func (x *ReplicateValidatedMFAChallengeRequest) ClearPayload() {
 	x.xxx_hidden_Payload = nil
+}
+
+func (x *ReplicateValidatedMFAChallengeRequest) ClearMfaDevice() {
+	x.xxx_hidden_MfaDevice = nil
 }
 
 type ReplicateValidatedMFAChallengeRequest_builder struct {
@@ -748,9 +759,9 @@ type ReplicateValidatedMFAChallengeRequest_builder struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified by source_cluster.
 	Username string
-	// ID of the MFA device that satisfied the challenge in the source cluster. Must match the device_id of the validated
-	// challenge being replicated so that mfa_device locks are enforced in the target cluster.
-	DeviceId string
+	// MFA device that satisfied the challenge in source_cluster. Must match the mfa_device of the validated challenge
+	// being replicated so that mfa_device locks are enforced in the target cluster.
+	MfaDevice *MFADevice
 }
 
 func (b0 ReplicateValidatedMFAChallengeRequest_builder) Build() *ReplicateValidatedMFAChallengeRequest {
@@ -762,7 +773,7 @@ func (b0 ReplicateValidatedMFAChallengeRequest_builder) Build() *ReplicateValida
 	x.xxx_hidden_SourceCluster = b.SourceCluster
 	x.xxx_hidden_TargetCluster = b.TargetCluster
 	x.xxx_hidden_Username = b.Username
-	x.xxx_hidden_DeviceId = b.DeviceId
+	x.xxx_hidden_MfaDevice = b.MfaDevice
 	return m0
 }
 
@@ -959,10 +970,10 @@ func (b0 VerifyValidatedMFAChallengeRequest_builder) Build() *VerifyValidatedMFA
 
 // VerifyValidatedMFAChallengeResponse is the response message for VerifyValidatedMFAChallenge.
 type VerifyValidatedMFAChallengeResponse struct {
-	state               protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_DeviceId string                 `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	state                protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_MfaDevice *MFADevice             `protobuf:"bytes,1,opt,name=mfa_device,json=mfaDevice,proto3"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *VerifyValidatedMFAChallengeResponse) Reset() {
@@ -990,30 +1001,41 @@ func (x *VerifyValidatedMFAChallengeResponse) ProtoReflect() protoreflect.Messag
 	return mi.MessageOf(x)
 }
 
-func (x *VerifyValidatedMFAChallengeResponse) GetDeviceId() string {
+func (x *VerifyValidatedMFAChallengeResponse) GetMfaDevice() *MFADevice {
 	if x != nil {
-		return x.xxx_hidden_DeviceId
+		return x.xxx_hidden_MfaDevice
 	}
-	return ""
+	return nil
 }
 
-func (x *VerifyValidatedMFAChallengeResponse) SetDeviceId(v string) {
-	x.xxx_hidden_DeviceId = v
+func (x *VerifyValidatedMFAChallengeResponse) SetMfaDevice(v *MFADevice) {
+	x.xxx_hidden_MfaDevice = v
+}
+
+func (x *VerifyValidatedMFAChallengeResponse) HasMfaDevice() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_MfaDevice != nil
+}
+
+func (x *VerifyValidatedMFAChallengeResponse) ClearMfaDevice() {
+	x.xxx_hidden_MfaDevice = nil
 }
 
 type VerifyValidatedMFAChallengeResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	// ID of the MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for
-	// the session and MUST reject an empty value.
-	DeviceId string
+	// MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for the
+	// session and MUST reject a nil or empty value.
+	MfaDevice *MFADevice
 }
 
 func (b0 VerifyValidatedMFAChallengeResponse_builder) Build() *VerifyValidatedMFAChallengeResponse {
 	m0 := &VerifyValidatedMFAChallengeResponse{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_DeviceId = b.DeviceId
+	x.xxx_hidden_MfaDevice = b.MfaDevice
 	return m0
 }
 
@@ -1174,23 +1196,25 @@ const file_teleport_mfa_v2_service_proto_rawDesc = "" +
 	"\x06filter\x18\x03 \x01(\v21.teleport.mfa.v2.ListValidatedMFAChallengesFilterR\x06filter\"\xa7\x01\n" +
 	"\"ListValidatedMFAChallengesResponse\x12Y\n" +
 	"\x14validated_challenges\x18\x01 \x03(\v2&.teleport.mfa.v2.ValidatedMFAChallengeR\x13validatedChallenges\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x88\x02\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xa6\x02\n" +
 	"%ReplicateValidatedMFAChallengeRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12D\n" +
 	"\apayload\x18\x02 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x03 \x01(\tR\rsourceCluster\x12%\n" +
 	"\x0etarget_cluster\x18\x04 \x01(\tR\rtargetCluster\x12\x1a\n" +
-	"\busername\x18\x05 \x01(\tR\busername\x12\x1b\n" +
-	"\tdevice_id\x18\x06 \x01(\tR\bdeviceId\"\x83\x01\n" +
+	"\busername\x18\x05 \x01(\tR\busername\x129\n" +
+	"\n" +
+	"mfa_device\x18\x06 \x01(\v2\x1a.teleport.mfa.v2.MFADeviceR\tmfaDevice\"\x83\x01\n" +
 	"&ReplicateValidatedMFAChallengeResponse\x12Y\n" +
 	"\x14replicated_challenge\x18\x01 \x01(\v2&.teleport.mfa.v2.ValidatedMFAChallengeR\x13replicatedChallenge\"\xc1\x01\n" +
 	"\"VerifyValidatedMFAChallengeRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12D\n" +
 	"\apayload\x18\x02 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x03 \x01(\tR\rsourceCluster\x12\x1a\n" +
-	"\busername\x18\x04 \x01(\tR\busername\"B\n" +
-	"#VerifyValidatedMFAChallengeResponse\x12\x1b\n" +
-	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\"{\n" +
+	"\busername\x18\x04 \x01(\tR\busername\"`\n" +
+	"#VerifyValidatedMFAChallengeResponse\x129\n" +
+	"\n" +
+	"mfa_device\x18\x01 \x01(\v2\x1a.teleport.mfa.v2.MFADeviceR\tmfaDevice\"{\n" +
 	"\"CompleteBrowserMFAChallengeRequest\x12U\n" +
 	"\x14browser_mfa_response\x18\x01 \x01(\v2#.teleport.mfa.v2.BrowserMFAResponseR\x12browserMfaResponse\"O\n" +
 	"#CompleteBrowserMFAChallengeResponse\x12(\n" +
@@ -1223,7 +1247,8 @@ var file_teleport_mfa_v2_service_proto_goTypes = []any{
 	(*AuthenticateChallenge)(nil),                  // 14: teleport.mfa.v2.AuthenticateChallenge
 	(*AuthenticateResponse)(nil),                   // 15: teleport.mfa.v2.AuthenticateResponse
 	(*ValidatedMFAChallenge)(nil),                  // 16: teleport.mfa.v2.ValidatedMFAChallenge
-	(*BrowserMFAResponse)(nil),                     // 17: teleport.mfa.v2.BrowserMFAResponse
+	(*MFADevice)(nil),                              // 17: teleport.mfa.v2.MFADevice
+	(*BrowserMFAResponse)(nil),                     // 18: teleport.mfa.v2.BrowserMFAResponse
 }
 var file_teleport_mfa_v2_service_proto_depIdxs = []int32{
 	13, // 0: teleport.mfa.v2.CreateSessionChallengeRequest.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
@@ -1232,26 +1257,28 @@ var file_teleport_mfa_v2_service_proto_depIdxs = []int32{
 	4,  // 3: teleport.mfa.v2.ListValidatedMFAChallengesRequest.filter:type_name -> teleport.mfa.v2.ListValidatedMFAChallengesFilter
 	16, // 4: teleport.mfa.v2.ListValidatedMFAChallengesResponse.validated_challenges:type_name -> teleport.mfa.v2.ValidatedMFAChallenge
 	13, // 5: teleport.mfa.v2.ReplicateValidatedMFAChallengeRequest.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
-	16, // 6: teleport.mfa.v2.ReplicateValidatedMFAChallengeResponse.replicated_challenge:type_name -> teleport.mfa.v2.ValidatedMFAChallenge
-	13, // 7: teleport.mfa.v2.VerifyValidatedMFAChallengeRequest.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
-	17, // 8: teleport.mfa.v2.CompleteBrowserMFAChallengeRequest.browser_mfa_response:type_name -> teleport.mfa.v2.BrowserMFAResponse
-	0,  // 9: teleport.mfa.v2.MFAService.CreateSessionChallenge:input_type -> teleport.mfa.v2.CreateSessionChallengeRequest
-	2,  // 10: teleport.mfa.v2.MFAService.ValidateSessionChallenge:input_type -> teleport.mfa.v2.ValidateSessionChallengeRequest
-	5,  // 11: teleport.mfa.v2.MFAService.ListValidatedMFAChallenges:input_type -> teleport.mfa.v2.ListValidatedMFAChallengesRequest
-	7,  // 12: teleport.mfa.v2.MFAService.ReplicateValidatedMFAChallenge:input_type -> teleport.mfa.v2.ReplicateValidatedMFAChallengeRequest
-	9,  // 13: teleport.mfa.v2.MFAService.VerifyValidatedMFAChallenge:input_type -> teleport.mfa.v2.VerifyValidatedMFAChallengeRequest
-	11, // 14: teleport.mfa.v2.MFAService.CompleteBrowserMFAChallenge:input_type -> teleport.mfa.v2.CompleteBrowserMFAChallengeRequest
-	1,  // 15: teleport.mfa.v2.MFAService.CreateSessionChallenge:output_type -> teleport.mfa.v2.CreateSessionChallengeResponse
-	3,  // 16: teleport.mfa.v2.MFAService.ValidateSessionChallenge:output_type -> teleport.mfa.v2.ValidateSessionChallengeResponse
-	6,  // 17: teleport.mfa.v2.MFAService.ListValidatedMFAChallenges:output_type -> teleport.mfa.v2.ListValidatedMFAChallengesResponse
-	8,  // 18: teleport.mfa.v2.MFAService.ReplicateValidatedMFAChallenge:output_type -> teleport.mfa.v2.ReplicateValidatedMFAChallengeResponse
-	10, // 19: teleport.mfa.v2.MFAService.VerifyValidatedMFAChallenge:output_type -> teleport.mfa.v2.VerifyValidatedMFAChallengeResponse
-	12, // 20: teleport.mfa.v2.MFAService.CompleteBrowserMFAChallenge:output_type -> teleport.mfa.v2.CompleteBrowserMFAChallengeResponse
-	15, // [15:21] is the sub-list for method output_type
-	9,  // [9:15] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	17, // 6: teleport.mfa.v2.ReplicateValidatedMFAChallengeRequest.mfa_device:type_name -> teleport.mfa.v2.MFADevice
+	16, // 7: teleport.mfa.v2.ReplicateValidatedMFAChallengeResponse.replicated_challenge:type_name -> teleport.mfa.v2.ValidatedMFAChallenge
+	13, // 8: teleport.mfa.v2.VerifyValidatedMFAChallengeRequest.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
+	17, // 9: teleport.mfa.v2.VerifyValidatedMFAChallengeResponse.mfa_device:type_name -> teleport.mfa.v2.MFADevice
+	18, // 10: teleport.mfa.v2.CompleteBrowserMFAChallengeRequest.browser_mfa_response:type_name -> teleport.mfa.v2.BrowserMFAResponse
+	0,  // 11: teleport.mfa.v2.MFAService.CreateSessionChallenge:input_type -> teleport.mfa.v2.CreateSessionChallengeRequest
+	2,  // 12: teleport.mfa.v2.MFAService.ValidateSessionChallenge:input_type -> teleport.mfa.v2.ValidateSessionChallengeRequest
+	5,  // 13: teleport.mfa.v2.MFAService.ListValidatedMFAChallenges:input_type -> teleport.mfa.v2.ListValidatedMFAChallengesRequest
+	7,  // 14: teleport.mfa.v2.MFAService.ReplicateValidatedMFAChallenge:input_type -> teleport.mfa.v2.ReplicateValidatedMFAChallengeRequest
+	9,  // 15: teleport.mfa.v2.MFAService.VerifyValidatedMFAChallenge:input_type -> teleport.mfa.v2.VerifyValidatedMFAChallengeRequest
+	11, // 16: teleport.mfa.v2.MFAService.CompleteBrowserMFAChallenge:input_type -> teleport.mfa.v2.CompleteBrowserMFAChallengeRequest
+	1,  // 17: teleport.mfa.v2.MFAService.CreateSessionChallenge:output_type -> teleport.mfa.v2.CreateSessionChallengeResponse
+	3,  // 18: teleport.mfa.v2.MFAService.ValidateSessionChallenge:output_type -> teleport.mfa.v2.ValidateSessionChallengeResponse
+	6,  // 19: teleport.mfa.v2.MFAService.ListValidatedMFAChallenges:output_type -> teleport.mfa.v2.ListValidatedMFAChallengesResponse
+	8,  // 20: teleport.mfa.v2.MFAService.ReplicateValidatedMFAChallenge:output_type -> teleport.mfa.v2.ReplicateValidatedMFAChallengeResponse
+	10, // 21: teleport.mfa.v2.MFAService.VerifyValidatedMFAChallenge:output_type -> teleport.mfa.v2.VerifyValidatedMFAChallengeResponse
+	12, // 22: teleport.mfa.v2.MFAService.CompleteBrowserMFAChallenge:output_type -> teleport.mfa.v2.CompleteBrowserMFAChallengeResponse
+	17, // [17:23] is the sub-list for method output_type
+	11, // [11:17] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_teleport_mfa_v2_service_proto_init() }

--- a/api/gen/proto/go/teleport/mfa/v2/service_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v2/service_protoopaque.pb.go
@@ -624,6 +624,7 @@ type ReplicateValidatedMFAChallengeRequest struct {
 	xxx_hidden_SourceCluster string                     `protobuf:"bytes,3,opt,name=source_cluster,json=sourceCluster,proto3"`
 	xxx_hidden_TargetCluster string                     `protobuf:"bytes,4,opt,name=target_cluster,json=targetCluster,proto3"`
 	xxx_hidden_Username      string                     `protobuf:"bytes,5,opt,name=username,proto3"`
+	xxx_hidden_DeviceId      string                     `protobuf:"bytes,6,opt,name=device_id,json=deviceId,proto3"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -688,6 +689,13 @@ func (x *ReplicateValidatedMFAChallengeRequest) GetUsername() string {
 	return ""
 }
 
+func (x *ReplicateValidatedMFAChallengeRequest) GetDeviceId() string {
+	if x != nil {
+		return x.xxx_hidden_DeviceId
+	}
+	return ""
+}
+
 func (x *ReplicateValidatedMFAChallengeRequest) SetName(v string) {
 	x.xxx_hidden_Name = v
 }
@@ -706,6 +714,10 @@ func (x *ReplicateValidatedMFAChallengeRequest) SetTargetCluster(v string) {
 
 func (x *ReplicateValidatedMFAChallengeRequest) SetUsername(v string) {
 	x.xxx_hidden_Username = v
+}
+
+func (x *ReplicateValidatedMFAChallengeRequest) SetDeviceId(v string) {
+	x.xxx_hidden_DeviceId = v
 }
 
 func (x *ReplicateValidatedMFAChallengeRequest) HasPayload() bool {
@@ -736,6 +748,9 @@ type ReplicateValidatedMFAChallengeRequest_builder struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified by source_cluster.
 	Username string
+	// ID of the MFA device that satisfied the challenge in the source cluster. Must match the device_id of the validated
+	// challenge being replicated so that mfa_device locks are enforced in the target cluster.
+	DeviceId string
 }
 
 func (b0 ReplicateValidatedMFAChallengeRequest_builder) Build() *ReplicateValidatedMFAChallengeRequest {
@@ -747,6 +762,7 @@ func (b0 ReplicateValidatedMFAChallengeRequest_builder) Build() *ReplicateValida
 	x.xxx_hidden_SourceCluster = b.SourceCluster
 	x.xxx_hidden_TargetCluster = b.TargetCluster
 	x.xxx_hidden_Username = b.Username
+	x.xxx_hidden_DeviceId = b.DeviceId
 	return m0
 }
 
@@ -943,9 +959,10 @@ func (b0 VerifyValidatedMFAChallengeRequest_builder) Build() *VerifyValidatedMFA
 
 // VerifyValidatedMFAChallengeResponse is the response message for VerifyValidatedMFAChallenge.
 type VerifyValidatedMFAChallengeResponse struct {
-	state         protoimpl.MessageState `protogen:"opaque.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state               protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_DeviceId string                 `protobuf:"bytes,1,opt,name=device_id,json=deviceId,proto3"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *VerifyValidatedMFAChallengeResponse) Reset() {
@@ -973,15 +990,30 @@ func (x *VerifyValidatedMFAChallengeResponse) ProtoReflect() protoreflect.Messag
 	return mi.MessageOf(x)
 }
 
+func (x *VerifyValidatedMFAChallengeResponse) GetDeviceId() string {
+	if x != nil {
+		return x.xxx_hidden_DeviceId
+	}
+	return ""
+}
+
+func (x *VerifyValidatedMFAChallengeResponse) SetDeviceId(v string) {
+	x.xxx_hidden_DeviceId = v
+}
+
 type VerifyValidatedMFAChallengeResponse_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
+	// ID of the MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for
+	// the session and MUST reject an empty value.
+	DeviceId string
 }
 
 func (b0 VerifyValidatedMFAChallengeResponse_builder) Build() *VerifyValidatedMFAChallengeResponse {
 	m0 := &VerifyValidatedMFAChallengeResponse{}
 	b, x := &b0, m0
 	_, _ = b, x
+	x.xxx_hidden_DeviceId = b.DeviceId
 	return m0
 }
 
@@ -1142,21 +1174,23 @@ const file_teleport_mfa_v2_service_proto_rawDesc = "" +
 	"\x06filter\x18\x03 \x01(\v21.teleport.mfa.v2.ListValidatedMFAChallengesFilterR\x06filter\"\xa7\x01\n" +
 	"\"ListValidatedMFAChallengesResponse\x12Y\n" +
 	"\x14validated_challenges\x18\x01 \x03(\v2&.teleport.mfa.v2.ValidatedMFAChallengeR\x13validatedChallenges\x12&\n" +
-	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\xeb\x01\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x88\x02\n" +
 	"%ReplicateValidatedMFAChallengeRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12D\n" +
 	"\apayload\x18\x02 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x03 \x01(\tR\rsourceCluster\x12%\n" +
 	"\x0etarget_cluster\x18\x04 \x01(\tR\rtargetCluster\x12\x1a\n" +
-	"\busername\x18\x05 \x01(\tR\busername\"\x83\x01\n" +
+	"\busername\x18\x05 \x01(\tR\busername\x12\x1b\n" +
+	"\tdevice_id\x18\x06 \x01(\tR\bdeviceId\"\x83\x01\n" +
 	"&ReplicateValidatedMFAChallengeResponse\x12Y\n" +
 	"\x14replicated_challenge\x18\x01 \x01(\v2&.teleport.mfa.v2.ValidatedMFAChallengeR\x13replicatedChallenge\"\xc1\x01\n" +
 	"\"VerifyValidatedMFAChallengeRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12D\n" +
 	"\apayload\x18\x02 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x03 \x01(\tR\rsourceCluster\x12\x1a\n" +
-	"\busername\x18\x04 \x01(\tR\busername\"%\n" +
-	"#VerifyValidatedMFAChallengeResponse\"{\n" +
+	"\busername\x18\x04 \x01(\tR\busername\"B\n" +
+	"#VerifyValidatedMFAChallengeResponse\x12\x1b\n" +
+	"\tdevice_id\x18\x01 \x01(\tR\bdeviceId\"{\n" +
 	"\"CompleteBrowserMFAChallengeRequest\x12U\n" +
 	"\x14browser_mfa_response\x18\x01 \x01(\v2#.teleport.mfa.v2.BrowserMFAResponseR\x12browserMfaResponse\"O\n" +
 	"#CompleteBrowserMFAChallengeResponse\x12(\n" +

--- a/api/gen/proto/go/teleport/mfa/v2/validated_challenge_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v2/validated_challenge_protohybrid.pb.go
@@ -194,7 +194,11 @@ type ValidatedMFAChallengeSpec struct {
 	TargetCluster string `protobuf:"bytes,3,opt,name=target_cluster,json=targetCluster,proto3" json:"target_cluster,omitempty"`
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified to source_cluster.
-	Username      string `protobuf:"bytes,4,opt,name=username,proto3" json:"username,omitempty"`
+	Username string `protobuf:"bytes,4,opt,name=username,proto3" json:"username,omitempty"`
+	// ID of the MFA device that satisfied the challenge, matching the ID of a device registered to username. For SSO MFA
+	// devices this is the auth connector ID rather than a generated UUID. Used as the mfa_device lock target when
+	// authorizing the session.
+	DeviceId      string `protobuf:"bytes,5,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -252,6 +256,13 @@ func (x *ValidatedMFAChallengeSpec) GetUsername() string {
 	return ""
 }
 
+func (x *ValidatedMFAChallengeSpec) GetDeviceId() string {
+	if x != nil {
+		return x.DeviceId
+	}
+	return ""
+}
+
 func (x *ValidatedMFAChallengeSpec) SetPayload(v *SessionIdentifyingPayload) {
 	x.Payload = v
 }
@@ -266,6 +277,10 @@ func (x *ValidatedMFAChallengeSpec) SetTargetCluster(v string) {
 
 func (x *ValidatedMFAChallengeSpec) SetUsername(v string) {
 	x.Username = v
+}
+
+func (x *ValidatedMFAChallengeSpec) SetDeviceId(v string) {
+	x.DeviceId = v
 }
 
 func (x *ValidatedMFAChallengeSpec) HasPayload() bool {
@@ -291,6 +306,10 @@ type ValidatedMFAChallengeSpec_builder struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified to source_cluster.
 	Username string
+	// ID of the MFA device that satisfied the challenge, matching the ID of a device registered to username. For SSO MFA
+	// devices this is the auth connector ID rather than a generated UUID. Used as the mfa_device lock target when
+	// authorizing the session.
+	DeviceId string
 }
 
 func (b0 ValidatedMFAChallengeSpec_builder) Build() *ValidatedMFAChallengeSpec {
@@ -301,6 +320,7 @@ func (b0 ValidatedMFAChallengeSpec_builder) Build() *ValidatedMFAChallengeSpec {
 	x.SourceCluster = b.SourceCluster
 	x.TargetCluster = b.TargetCluster
 	x.Username = b.Username
+	x.DeviceId = b.DeviceId
 	return m0
 }
 
@@ -504,12 +524,13 @@ const file_teleport_mfa_v2_validated_challenge_proto_rawDesc = "" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12>\n" +
-	"\x04spec\x18\x05 \x01(\v2*.teleport.mfa.v2.ValidatedMFAChallengeSpecR\x04spec\"\xcb\x01\n" +
+	"\x04spec\x18\x05 \x01(\v2*.teleport.mfa.v2.ValidatedMFAChallengeSpecR\x04spec\"\xe8\x01\n" +
 	"\x19ValidatedMFAChallengeSpec\x12D\n" +
 	"\apayload\x18\x01 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x02 \x01(\tR\rsourceCluster\x12%\n" +
 	"\x0etarget_cluster\x18\x03 \x01(\tR\rtargetCluster\x12\x1a\n" +
-	"\busername\x18\x04 \x01(\tR\busername\"v\n" +
+	"\busername\x18\x04 \x01(\tR\busername\x12\x1b\n" +
+	"\tdevice_id\x18\x05 \x01(\tR\bdeviceId\"v\n" +
 	"\x19SessionIdentifyingPayload\x12&\n" +
 	"\x0essh_session_id\x18\x01 \x01(\fH\x00R\fsshSessionId\x12&\n" +
 	"\x0etls_session_id\x18\x02 \x01(\fH\x00R\ftlsSessionIdB\t\n" +

--- a/api/gen/proto/go/teleport/mfa/v2/validated_challenge_protohybrid.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v2/validated_challenge_protohybrid.pb.go
@@ -195,10 +195,8 @@ type ValidatedMFAChallengeSpec struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified to source_cluster.
 	Username string `protobuf:"bytes,4,opt,name=username,proto3" json:"username,omitempty"`
-	// ID of the MFA device that satisfied the challenge, matching the ID of a device registered to username. For SSO MFA
-	// devices this is the auth connector ID rather than a generated UUID. Used as the mfa_device lock target when
-	// authorizing the session.
-	DeviceId      string `protobuf:"bytes,5,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
+	// MFA device that satisfied the challenge, as registered in source_cluster. Replicated verbatim to target_cluster.
+	MfaDevice     *MFADevice `protobuf:"bytes,5,opt,name=mfa_device,json=mfaDevice,proto3" json:"mfa_device,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -256,11 +254,11 @@ func (x *ValidatedMFAChallengeSpec) GetUsername() string {
 	return ""
 }
 
-func (x *ValidatedMFAChallengeSpec) GetDeviceId() string {
+func (x *ValidatedMFAChallengeSpec) GetMfaDevice() *MFADevice {
 	if x != nil {
-		return x.DeviceId
+		return x.MfaDevice
 	}
-	return ""
+	return nil
 }
 
 func (x *ValidatedMFAChallengeSpec) SetPayload(v *SessionIdentifyingPayload) {
@@ -279,8 +277,8 @@ func (x *ValidatedMFAChallengeSpec) SetUsername(v string) {
 	x.Username = v
 }
 
-func (x *ValidatedMFAChallengeSpec) SetDeviceId(v string) {
-	x.DeviceId = v
+func (x *ValidatedMFAChallengeSpec) SetMfaDevice(v *MFADevice) {
+	x.MfaDevice = v
 }
 
 func (x *ValidatedMFAChallengeSpec) HasPayload() bool {
@@ -290,8 +288,19 @@ func (x *ValidatedMFAChallengeSpec) HasPayload() bool {
 	return x.Payload != nil
 }
 
+func (x *ValidatedMFAChallengeSpec) HasMfaDevice() bool {
+	if x == nil {
+		return false
+	}
+	return x.MfaDevice != nil
+}
+
 func (x *ValidatedMFAChallengeSpec) ClearPayload() {
 	x.Payload = nil
+}
+
+func (x *ValidatedMFAChallengeSpec) ClearMfaDevice() {
+	x.MfaDevice = nil
 }
 
 type ValidatedMFAChallengeSpec_builder struct {
@@ -306,10 +315,8 @@ type ValidatedMFAChallengeSpec_builder struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified to source_cluster.
 	Username string
-	// ID of the MFA device that satisfied the challenge, matching the ID of a device registered to username. For SSO MFA
-	// devices this is the auth connector ID rather than a generated UUID. Used as the mfa_device lock target when
-	// authorizing the session.
-	DeviceId string
+	// MFA device that satisfied the challenge, as registered in source_cluster. Replicated verbatim to target_cluster.
+	MfaDevice *MFADevice
 }
 
 func (b0 ValidatedMFAChallengeSpec_builder) Build() *ValidatedMFAChallengeSpec {
@@ -320,7 +327,7 @@ func (b0 ValidatedMFAChallengeSpec_builder) Build() *ValidatedMFAChallengeSpec {
 	x.SourceCluster = b.SourceCluster
 	x.TargetCluster = b.TargetCluster
 	x.Username = b.Username
-	x.DeviceId = b.DeviceId
+	x.MfaDevice = b.MfaDevice
 	return m0
 }
 
@@ -514,6 +521,68 @@ func (*SessionIdentifyingPayload_SshSessionId) isSessionIdentifyingPayload_Paylo
 
 func (*SessionIdentifyingPayload_TlsSessionId) isSessionIdentifyingPayload_Payload() {}
 
+// MFADevice references the MFA device that satisfied a challenge.
+type MFADevice struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// ID of the MFA device, matching the ID of the device registered to the user. For SSO MFA devices this is the auth
+	// connector ID rather than a generated UUID. Used as the LockTarget.MFADevice when authorizing the session.
+	Id            string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MFADevice) Reset() {
+	*x = MFADevice{}
+	mi := &file_teleport_mfa_v2_validated_challenge_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MFADevice) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MFADevice) ProtoMessage() {}
+
+func (x *MFADevice) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_mfa_v2_validated_challenge_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *MFADevice) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *MFADevice) SetId(v string) {
+	x.Id = v
+}
+
+type MFADevice_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// ID of the MFA device, matching the ID of the device registered to the user. For SSO MFA devices this is the auth
+	// connector ID rather than a generated UUID. Used as the LockTarget.MFADevice when authorizing the session.
+	Id string
+}
+
+func (b0 MFADevice_builder) Build() *MFADevice {
+	m0 := &MFADevice{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Id = b.Id
+	return m0
+}
+
 var File_teleport_mfa_v2_validated_challenge_proto protoreflect.FileDescriptor
 
 const file_teleport_mfa_v2_validated_challenge_proto_rawDesc = "" +
@@ -524,34 +593,39 @@ const file_teleport_mfa_v2_validated_challenge_proto_rawDesc = "" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12>\n" +
-	"\x04spec\x18\x05 \x01(\v2*.teleport.mfa.v2.ValidatedMFAChallengeSpecR\x04spec\"\xe8\x01\n" +
+	"\x04spec\x18\x05 \x01(\v2*.teleport.mfa.v2.ValidatedMFAChallengeSpecR\x04spec\"\x86\x02\n" +
 	"\x19ValidatedMFAChallengeSpec\x12D\n" +
 	"\apayload\x18\x01 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x02 \x01(\tR\rsourceCluster\x12%\n" +
 	"\x0etarget_cluster\x18\x03 \x01(\tR\rtargetCluster\x12\x1a\n" +
-	"\busername\x18\x04 \x01(\tR\busername\x12\x1b\n" +
-	"\tdevice_id\x18\x05 \x01(\tR\bdeviceId\"v\n" +
+	"\busername\x18\x04 \x01(\tR\busername\x129\n" +
+	"\n" +
+	"mfa_device\x18\x05 \x01(\v2\x1a.teleport.mfa.v2.MFADeviceR\tmfaDevice\"v\n" +
 	"\x19SessionIdentifyingPayload\x12&\n" +
 	"\x0essh_session_id\x18\x01 \x01(\fH\x00R\fsshSessionId\x12&\n" +
 	"\x0etls_session_id\x18\x02 \x01(\fH\x00R\ftlsSessionIdB\t\n" +
-	"\apayloadBJZHgithub.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2;mfav2b\x06proto3"
+	"\apayload\"\x1b\n" +
+	"\tMFADevice\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02idBJZHgithub.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2;mfav2b\x06proto3"
 
-var file_teleport_mfa_v2_validated_challenge_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_teleport_mfa_v2_validated_challenge_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_teleport_mfa_v2_validated_challenge_proto_goTypes = []any{
 	(*ValidatedMFAChallenge)(nil),     // 0: teleport.mfa.v2.ValidatedMFAChallenge
 	(*ValidatedMFAChallengeSpec)(nil), // 1: teleport.mfa.v2.ValidatedMFAChallengeSpec
 	(*SessionIdentifyingPayload)(nil), // 2: teleport.mfa.v2.SessionIdentifyingPayload
-	(*v1.Metadata)(nil),               // 3: teleport.header.v1.Metadata
+	(*MFADevice)(nil),                 // 3: teleport.mfa.v2.MFADevice
+	(*v1.Metadata)(nil),               // 4: teleport.header.v1.Metadata
 }
 var file_teleport_mfa_v2_validated_challenge_proto_depIdxs = []int32{
-	3, // 0: teleport.mfa.v2.ValidatedMFAChallenge.metadata:type_name -> teleport.header.v1.Metadata
+	4, // 0: teleport.mfa.v2.ValidatedMFAChallenge.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.mfa.v2.ValidatedMFAChallenge.spec:type_name -> teleport.mfa.v2.ValidatedMFAChallengeSpec
 	2, // 2: teleport.mfa.v2.ValidatedMFAChallengeSpec.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	3, // 3: teleport.mfa.v2.ValidatedMFAChallengeSpec.mfa_device:type_name -> teleport.mfa.v2.MFADevice
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_teleport_mfa_v2_validated_challenge_proto_init() }
@@ -569,7 +643,7 @@ func file_teleport_mfa_v2_validated_challenge_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_mfa_v2_validated_challenge_proto_rawDesc), len(file_teleport_mfa_v2_validated_challenge_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/mfa/v2/validated_challenge_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v2/validated_challenge_protoopaque.pb.go
@@ -185,6 +185,7 @@ type ValidatedMFAChallengeSpec struct {
 	xxx_hidden_SourceCluster string                     `protobuf:"bytes,2,opt,name=source_cluster,json=sourceCluster,proto3"`
 	xxx_hidden_TargetCluster string                     `protobuf:"bytes,3,opt,name=target_cluster,json=targetCluster,proto3"`
 	xxx_hidden_Username      string                     `protobuf:"bytes,4,opt,name=username,proto3"`
+	xxx_hidden_DeviceId      string                     `protobuf:"bytes,5,opt,name=device_id,json=deviceId,proto3"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -242,6 +243,13 @@ func (x *ValidatedMFAChallengeSpec) GetUsername() string {
 	return ""
 }
 
+func (x *ValidatedMFAChallengeSpec) GetDeviceId() string {
+	if x != nil {
+		return x.xxx_hidden_DeviceId
+	}
+	return ""
+}
+
 func (x *ValidatedMFAChallengeSpec) SetPayload(v *SessionIdentifyingPayload) {
 	x.xxx_hidden_Payload = v
 }
@@ -256,6 +264,10 @@ func (x *ValidatedMFAChallengeSpec) SetTargetCluster(v string) {
 
 func (x *ValidatedMFAChallengeSpec) SetUsername(v string) {
 	x.xxx_hidden_Username = v
+}
+
+func (x *ValidatedMFAChallengeSpec) SetDeviceId(v string) {
+	x.xxx_hidden_DeviceId = v
 }
 
 func (x *ValidatedMFAChallengeSpec) HasPayload() bool {
@@ -281,6 +293,10 @@ type ValidatedMFAChallengeSpec_builder struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified to source_cluster.
 	Username string
+	// ID of the MFA device that satisfied the challenge, matching the ID of a device registered to username. For SSO MFA
+	// devices this is the auth connector ID rather than a generated UUID. Used as the mfa_device lock target when
+	// authorizing the session.
+	DeviceId string
 }
 
 func (b0 ValidatedMFAChallengeSpec_builder) Build() *ValidatedMFAChallengeSpec {
@@ -291,6 +307,7 @@ func (b0 ValidatedMFAChallengeSpec_builder) Build() *ValidatedMFAChallengeSpec {
 	x.xxx_hidden_SourceCluster = b.SourceCluster
 	x.xxx_hidden_TargetCluster = b.TargetCluster
 	x.xxx_hidden_Username = b.Username
+	x.xxx_hidden_DeviceId = b.DeviceId
 	return m0
 }
 
@@ -483,12 +500,13 @@ const file_teleport_mfa_v2_validated_challenge_proto_rawDesc = "" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12>\n" +
-	"\x04spec\x18\x05 \x01(\v2*.teleport.mfa.v2.ValidatedMFAChallengeSpecR\x04spec\"\xcb\x01\n" +
+	"\x04spec\x18\x05 \x01(\v2*.teleport.mfa.v2.ValidatedMFAChallengeSpecR\x04spec\"\xe8\x01\n" +
 	"\x19ValidatedMFAChallengeSpec\x12D\n" +
 	"\apayload\x18\x01 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x02 \x01(\tR\rsourceCluster\x12%\n" +
 	"\x0etarget_cluster\x18\x03 \x01(\tR\rtargetCluster\x12\x1a\n" +
-	"\busername\x18\x04 \x01(\tR\busername\"v\n" +
+	"\busername\x18\x04 \x01(\tR\busername\x12\x1b\n" +
+	"\tdevice_id\x18\x05 \x01(\tR\bdeviceId\"v\n" +
 	"\x19SessionIdentifyingPayload\x12&\n" +
 	"\x0essh_session_id\x18\x01 \x01(\fH\x00R\fsshSessionId\x12&\n" +
 	"\x0etls_session_id\x18\x02 \x01(\fH\x00R\ftlsSessionIdB\t\n" +

--- a/api/gen/proto/go/teleport/mfa/v2/validated_challenge_protoopaque.pb.go
+++ b/api/gen/proto/go/teleport/mfa/v2/validated_challenge_protoopaque.pb.go
@@ -185,7 +185,7 @@ type ValidatedMFAChallengeSpec struct {
 	xxx_hidden_SourceCluster string                     `protobuf:"bytes,2,opt,name=source_cluster,json=sourceCluster,proto3"`
 	xxx_hidden_TargetCluster string                     `protobuf:"bytes,3,opt,name=target_cluster,json=targetCluster,proto3"`
 	xxx_hidden_Username      string                     `protobuf:"bytes,4,opt,name=username,proto3"`
-	xxx_hidden_DeviceId      string                     `protobuf:"bytes,5,opt,name=device_id,json=deviceId,proto3"`
+	xxx_hidden_MfaDevice     *MFADevice                 `protobuf:"bytes,5,opt,name=mfa_device,json=mfaDevice,proto3"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -243,11 +243,11 @@ func (x *ValidatedMFAChallengeSpec) GetUsername() string {
 	return ""
 }
 
-func (x *ValidatedMFAChallengeSpec) GetDeviceId() string {
+func (x *ValidatedMFAChallengeSpec) GetMfaDevice() *MFADevice {
 	if x != nil {
-		return x.xxx_hidden_DeviceId
+		return x.xxx_hidden_MfaDevice
 	}
-	return ""
+	return nil
 }
 
 func (x *ValidatedMFAChallengeSpec) SetPayload(v *SessionIdentifyingPayload) {
@@ -266,8 +266,8 @@ func (x *ValidatedMFAChallengeSpec) SetUsername(v string) {
 	x.xxx_hidden_Username = v
 }
 
-func (x *ValidatedMFAChallengeSpec) SetDeviceId(v string) {
-	x.xxx_hidden_DeviceId = v
+func (x *ValidatedMFAChallengeSpec) SetMfaDevice(v *MFADevice) {
+	x.xxx_hidden_MfaDevice = v
 }
 
 func (x *ValidatedMFAChallengeSpec) HasPayload() bool {
@@ -277,8 +277,19 @@ func (x *ValidatedMFAChallengeSpec) HasPayload() bool {
 	return x.xxx_hidden_Payload != nil
 }
 
+func (x *ValidatedMFAChallengeSpec) HasMfaDevice() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_MfaDevice != nil
+}
+
 func (x *ValidatedMFAChallengeSpec) ClearPayload() {
 	x.xxx_hidden_Payload = nil
+}
+
+func (x *ValidatedMFAChallengeSpec) ClearMfaDevice() {
+	x.xxx_hidden_MfaDevice = nil
 }
 
 type ValidatedMFAChallengeSpec_builder struct {
@@ -293,10 +304,8 @@ type ValidatedMFAChallengeSpec_builder struct {
 	// Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
 	// login name) and must correspond to a user in the cluster specified to source_cluster.
 	Username string
-	// ID of the MFA device that satisfied the challenge, matching the ID of a device registered to username. For SSO MFA
-	// devices this is the auth connector ID rather than a generated UUID. Used as the mfa_device lock target when
-	// authorizing the session.
-	DeviceId string
+	// MFA device that satisfied the challenge, as registered in source_cluster. Replicated verbatim to target_cluster.
+	MfaDevice *MFADevice
 }
 
 func (b0 ValidatedMFAChallengeSpec_builder) Build() *ValidatedMFAChallengeSpec {
@@ -307,7 +316,7 @@ func (b0 ValidatedMFAChallengeSpec_builder) Build() *ValidatedMFAChallengeSpec {
 	x.xxx_hidden_SourceCluster = b.SourceCluster
 	x.xxx_hidden_TargetCluster = b.TargetCluster
 	x.xxx_hidden_Username = b.Username
-	x.xxx_hidden_DeviceId = b.DeviceId
+	x.xxx_hidden_MfaDevice = b.MfaDevice
 	return m0
 }
 
@@ -490,6 +499,66 @@ func (*sessionIdentifyingPayload_SshSessionId) isSessionIdentifyingPayload_Paylo
 
 func (*sessionIdentifyingPayload_TlsSessionId) isSessionIdentifyingPayload_Payload() {}
 
+// MFADevice references the MFA device that satisfied a challenge.
+type MFADevice struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Id string                 `protobuf:"bytes,1,opt,name=id,proto3"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MFADevice) Reset() {
+	*x = MFADevice{}
+	mi := &file_teleport_mfa_v2_validated_challenge_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MFADevice) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MFADevice) ProtoMessage() {}
+
+func (x *MFADevice) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_mfa_v2_validated_challenge_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *MFADevice) GetId() string {
+	if x != nil {
+		return x.xxx_hidden_Id
+	}
+	return ""
+}
+
+func (x *MFADevice) SetId(v string) {
+	x.xxx_hidden_Id = v
+}
+
+type MFADevice_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// ID of the MFA device, matching the ID of the device registered to the user. For SSO MFA devices this is the auth
+	// connector ID rather than a generated UUID. Used as the LockTarget.MFADevice when authorizing the session.
+	Id string
+}
+
+func (b0 MFADevice_builder) Build() *MFADevice {
+	m0 := &MFADevice{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Id = b.Id
+	return m0
+}
+
 var File_teleport_mfa_v2_validated_challenge_proto protoreflect.FileDescriptor
 
 const file_teleport_mfa_v2_validated_challenge_proto_rawDesc = "" +
@@ -500,34 +569,39 @@ const file_teleport_mfa_v2_validated_challenge_proto_rawDesc = "" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12>\n" +
-	"\x04spec\x18\x05 \x01(\v2*.teleport.mfa.v2.ValidatedMFAChallengeSpecR\x04spec\"\xe8\x01\n" +
+	"\x04spec\x18\x05 \x01(\v2*.teleport.mfa.v2.ValidatedMFAChallengeSpecR\x04spec\"\x86\x02\n" +
 	"\x19ValidatedMFAChallengeSpec\x12D\n" +
 	"\apayload\x18\x01 \x01(\v2*.teleport.mfa.v2.SessionIdentifyingPayloadR\apayload\x12%\n" +
 	"\x0esource_cluster\x18\x02 \x01(\tR\rsourceCluster\x12%\n" +
 	"\x0etarget_cluster\x18\x03 \x01(\tR\rtargetCluster\x12\x1a\n" +
-	"\busername\x18\x04 \x01(\tR\busername\x12\x1b\n" +
-	"\tdevice_id\x18\x05 \x01(\tR\bdeviceId\"v\n" +
+	"\busername\x18\x04 \x01(\tR\busername\x129\n" +
+	"\n" +
+	"mfa_device\x18\x05 \x01(\v2\x1a.teleport.mfa.v2.MFADeviceR\tmfaDevice\"v\n" +
 	"\x19SessionIdentifyingPayload\x12&\n" +
 	"\x0essh_session_id\x18\x01 \x01(\fH\x00R\fsshSessionId\x12&\n" +
 	"\x0etls_session_id\x18\x02 \x01(\fH\x00R\ftlsSessionIdB\t\n" +
-	"\apayloadBJZHgithub.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2;mfav2b\x06proto3"
+	"\apayload\"\x1b\n" +
+	"\tMFADevice\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02idBJZHgithub.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2;mfav2b\x06proto3"
 
-var file_teleport_mfa_v2_validated_challenge_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_teleport_mfa_v2_validated_challenge_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_teleport_mfa_v2_validated_challenge_proto_goTypes = []any{
 	(*ValidatedMFAChallenge)(nil),     // 0: teleport.mfa.v2.ValidatedMFAChallenge
 	(*ValidatedMFAChallengeSpec)(nil), // 1: teleport.mfa.v2.ValidatedMFAChallengeSpec
 	(*SessionIdentifyingPayload)(nil), // 2: teleport.mfa.v2.SessionIdentifyingPayload
-	(*v1.Metadata)(nil),               // 3: teleport.header.v1.Metadata
+	(*MFADevice)(nil),                 // 3: teleport.mfa.v2.MFADevice
+	(*v1.Metadata)(nil),               // 4: teleport.header.v1.Metadata
 }
 var file_teleport_mfa_v2_validated_challenge_proto_depIdxs = []int32{
-	3, // 0: teleport.mfa.v2.ValidatedMFAChallenge.metadata:type_name -> teleport.header.v1.Metadata
+	4, // 0: teleport.mfa.v2.ValidatedMFAChallenge.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.mfa.v2.ValidatedMFAChallenge.spec:type_name -> teleport.mfa.v2.ValidatedMFAChallengeSpec
 	2, // 2: teleport.mfa.v2.ValidatedMFAChallengeSpec.payload:type_name -> teleport.mfa.v2.SessionIdentifyingPayload
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	3, // 3: teleport.mfa.v2.ValidatedMFAChallengeSpec.mfa_device:type_name -> teleport.mfa.v2.MFADevice
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_teleport_mfa_v2_validated_challenge_proto_init() }
@@ -545,7 +619,7 @@ func file_teleport_mfa_v2_validated_challenge_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_mfa_v2_validated_challenge_proto_rawDesc), len(file_teleport_mfa_v2_validated_challenge_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/mfa/v2/service.proto
+++ b/api/proto/teleport/mfa/v2/service.proto
@@ -132,9 +132,9 @@ message ReplicateValidatedMFAChallengeRequest {
   // Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
   // login name) and must correspond to a user in the cluster specified by source_cluster.
   string username = 5;
-  // ID of the MFA device that satisfied the challenge in the source cluster. Must match the device_id of the validated
-  // challenge being replicated so that mfa_device locks are enforced in the target cluster.
-  string device_id = 6;
+  // MFA device that satisfied the challenge in source_cluster. Must match the mfa_device of the validated challenge
+  // being replicated so that mfa_device locks are enforced in the target cluster.
+  MFADevice mfa_device = 6;
 }
 
 // ReplicateValidatedMFAChallengeResponse is the response message for ReplicateValidatedMFAChallenge.
@@ -163,9 +163,9 @@ message VerifyValidatedMFAChallengeRequest {
 
 // VerifyValidatedMFAChallengeResponse is the response message for VerifyValidatedMFAChallenge.
 message VerifyValidatedMFAChallengeResponse {
-  // ID of the MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for
-  // the session and MUST reject an empty value.
-  string device_id = 1;
+  // MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for the
+  // session and MUST reject a nil or empty value.
+  MFADevice mfa_device = 1;
 }
 
 // CompleteBrowserMFAChallengeRequest is used to complete an MFA response

--- a/api/proto/teleport/mfa/v2/service.proto
+++ b/api/proto/teleport/mfa/v2/service.proto
@@ -132,6 +132,9 @@ message ReplicateValidatedMFAChallengeRequest {
   // Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
   // login name) and must correspond to a user in the cluster specified by source_cluster.
   string username = 5;
+  // ID of the MFA device that satisfied the challenge in the source cluster. Must match the device_id of the validated
+  // challenge being replicated so that mfa_device locks are enforced in the target cluster.
+  string device_id = 6;
 }
 
 // ReplicateValidatedMFAChallengeResponse is the response message for ReplicateValidatedMFAChallenge.
@@ -159,7 +162,11 @@ message VerifyValidatedMFAChallengeRequest {
 }
 
 // VerifyValidatedMFAChallengeResponse is the response message for VerifyValidatedMFAChallenge.
-message VerifyValidatedMFAChallengeResponse {}
+message VerifyValidatedMFAChallengeResponse {
+  // ID of the MFA device that satisfied the validated challenge. Callers MUST use this to enforce mfa_device locks for
+  // the session and MUST reject an empty value.
+  string device_id = 1;
+}
 
 // CompleteBrowserMFAChallengeRequest is used to complete an MFA response
 // during a browser-based MFA authentication flow.

--- a/api/proto/teleport/mfa/v2/validated_challenge.proto
+++ b/api/proto/teleport/mfa/v2/validated_challenge.proto
@@ -45,6 +45,10 @@ message ValidatedMFAChallengeSpec {
   // Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
   // login name) and must correspond to a user in the cluster specified to source_cluster.
   string username = 4;
+  // ID of the MFA device that satisfied the challenge, matching the ID of a device registered to username. For SSO MFA
+  // devices this is the auth connector ID rather than a generated UUID. Used as the mfa_device lock target when
+  // authorizing the session.
+  string device_id = 5;
 }
 
 // SessionIdentifyingPayload contains a value that uniquely identifies a user's session. It must be computed by the

--- a/api/proto/teleport/mfa/v2/validated_challenge.proto
+++ b/api/proto/teleport/mfa/v2/validated_challenge.proto
@@ -45,10 +45,8 @@ message ValidatedMFAChallengeSpec {
   // Username of the Teleport user for whom the challenge was issued. This should be the Teleport username (not the SSH
   // login name) and must correspond to a user in the cluster specified to source_cluster.
   string username = 4;
-  // ID of the MFA device that satisfied the challenge, matching the ID of a device registered to username. For SSO MFA
-  // devices this is the auth connector ID rather than a generated UUID. Used as the mfa_device lock target when
-  // authorizing the session.
-  string device_id = 5;
+  // MFA device that satisfied the challenge, as registered in source_cluster. Replicated verbatim to target_cluster.
+  MFADevice mfa_device = 5;
 }
 
 // SessionIdentifyingPayload contains a value that uniquely identifies a user's session. It must be computed by the
@@ -62,4 +60,11 @@ message SessionIdentifyingPayload {
     // this is the value from crypto/tls#ConnectionState.ExportKeyingMaterial().
     bytes tls_session_id = 2;
   }
+}
+
+// MFADevice references the MFA device that satisfied a challenge.
+message MFADevice {
+  // ID of the MFA device, matching the ID of the device registered to the user. For SSO MFA devices this is the auth
+  // connector ID rather than a generated UUID. Used as the LockTarget.MFADevice when authorizing the session.
+  string id = 1;
 }

--- a/lib/auth/mfa/mfav2/service.go
+++ b/lib/auth/mfa/mfav2/service.go
@@ -404,6 +404,7 @@ func (s *Service) ValidateSessionChallenge(
 				SourceCluster: details.SourceCluster,
 				TargetCluster: details.TargetCluster,
 				Username:      username,
+				DeviceId:      details.Device.Id,
 			}.Build(),
 		}.Build(),
 	)
@@ -503,6 +504,7 @@ func (s *Service) ReplicateValidatedMFAChallenge(
 			SourceCluster: req.GetSourceCluster(),
 			TargetCluster: req.GetTargetCluster(),
 			Username:      req.GetUsername(),
+			DeviceId:      req.GetDeviceId(),
 		}.Build(),
 	}.Build()
 
@@ -566,7 +568,9 @@ func (s *Service) VerifyValidatedMFAChallenge(
 		return nil, trace.AccessDenied("request payload does not match validated challenge payload")
 	}
 
-	return &mfav2.VerifyValidatedMFAChallengeResponse{}, nil
+	return mfav2.VerifyValidatedMFAChallengeResponse_builder{
+		DeviceId: chal.GetSpec().GetDeviceId(),
+	}.Build(), nil
 }
 
 func validateCreateSessionChallengeRequest(req *mfav2.CreateSessionChallengeRequest) error {
@@ -787,6 +791,9 @@ func checkReplicateValidatedMFAChallengeRequest(req *mfav2.ReplicateValidatedMFA
 
 	case req.GetUsername() == "":
 		return trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest username")
+
+	case req.GetDeviceId() == "":
+		return trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest device_id")
 	}
 
 	if err := checkPayload(req.GetPayload()); err != nil {

--- a/lib/auth/mfa/mfav2/service.go
+++ b/lib/auth/mfa/mfav2/service.go
@@ -404,7 +404,9 @@ func (s *Service) ValidateSessionChallenge(
 				SourceCluster: details.SourceCluster,
 				TargetCluster: details.TargetCluster,
 				Username:      username,
-				DeviceId:      details.Device.Id,
+				MfaDevice: mfav2.MFADevice_builder{
+					Id: details.Device.Id,
+				}.Build(),
 			}.Build(),
 		}.Build(),
 	)
@@ -504,7 +506,7 @@ func (s *Service) ReplicateValidatedMFAChallenge(
 			SourceCluster: req.GetSourceCluster(),
 			TargetCluster: req.GetTargetCluster(),
 			Username:      req.GetUsername(),
-			DeviceId:      req.GetDeviceId(),
+			MfaDevice:     req.GetMfaDevice(),
 		}.Build(),
 	}.Build()
 
@@ -569,7 +571,7 @@ func (s *Service) VerifyValidatedMFAChallenge(
 	}
 
 	return mfav2.VerifyValidatedMFAChallengeResponse_builder{
-		DeviceId: chal.GetSpec().GetDeviceId(),
+		MfaDevice: chal.GetSpec().GetMfaDevice(),
 	}.Build(), nil
 }
 
@@ -791,9 +793,6 @@ func checkReplicateValidatedMFAChallengeRequest(req *mfav2.ReplicateValidatedMFA
 
 	case req.GetUsername() == "":
 		return trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest username")
-
-	case req.GetDeviceId() == "":
-		return trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest device_id")
 	}
 
 	if err := checkPayload(req.GetPayload()); err != nil {

--- a/lib/auth/mfa/mfav2/service_test.go
+++ b/lib/auth/mfa/mfav2/service_test.go
@@ -47,6 +47,7 @@ const (
 	chalName      = "test-challenge"
 	sourceCluster = "test-cluster"
 	targetCluster = "test-cluster"
+	deviceID      = "test-device-id"
 )
 
 var payload = mfav2.SessionIdentifyingPayload_builder{
@@ -165,6 +166,7 @@ func testCreateValidateSessionChallengeWebauthn(t *testing.T, payload *mfav2.Ses
 			SourceCluster: sourceCluster,
 			TargetCluster: targetCluster,
 			Username:      user.GetName(),
+			DeviceId:      device.MFA.Id,
 		}.Build(),
 	}.Build()
 
@@ -190,6 +192,7 @@ func TestCreateValidateSessionChallenge_SSO(t *testing.T) {
 				Metadata: types.Metadata{
 					Name: "sso-device",
 				},
+				Id: deviceID,
 				Device: &types.MFADevice_Sso{
 					Sso: &types.SSOMFADevice{
 						DisplayName:   "test-display-name",
@@ -274,6 +277,7 @@ func TestCreateValidateSessionChallenge_SSO(t *testing.T) {
 			SourceCluster: sourceCluster,
 			TargetCluster: targetCluster,
 			Username:      user.GetName(),
+			DeviceId:      deviceID,
 		}.Build(),
 	}.Build()
 
@@ -696,6 +700,7 @@ func TestListValidatedMFAChallenges_Success(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
+				DeviceId:      deviceID,
 			}.Build(),
 		}.Build(),
 		mfav2.ValidatedMFAChallenge_builder{
@@ -709,6 +714,7 @@ func TestListValidatedMFAChallenges_Success(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
+				DeviceId:      deviceID,
 			}.Build(),
 		}.Build(),
 		mfav2.ValidatedMFAChallenge_builder{
@@ -722,6 +728,7 @@ func TestListValidatedMFAChallenges_Success(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
+				DeviceId:      deviceID,
 			}.Build(),
 		}.Build(),
 	}
@@ -832,6 +839,7 @@ func TestListValidatedMFAChallenges_FilterByTargetCluster(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
+				DeviceId:      deviceID,
 			}.Build(),
 		}.Build(),
 	}
@@ -882,6 +890,7 @@ func TestReplicateValidatedMFAChallenge_Success(t *testing.T) {
 		SourceCluster: sourceCluster,
 		TargetCluster: targetCluster,
 		Username:      user.GetName(),
+		DeviceId:      deviceID,
 	}.Build())
 	require.NoError(t, err)
 
@@ -897,6 +906,7 @@ func TestReplicateValidatedMFAChallenge_Success(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
+				DeviceId:      deviceID,
 			}.Build(),
 		}.Build(),
 	}.Build()
@@ -1016,6 +1026,7 @@ func TestReplicateValidatedMFAChallenge_TargetClusterMismatch(t *testing.T) {
 		SourceCluster: sourceCluster,
 		TargetCluster: "different-cluster",
 		Username:      "test-user",
+		DeviceId:      deviceID,
 	}.Build())
 	require.Error(t, err)
 	require.ErrorIs(t, err, trace.BadParameter(`target cluster "different-cluster" does not match current cluster "test-cluster"`))
@@ -1042,6 +1053,7 @@ func TestReplicateValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      "test-user",
+				DeviceId:      deviceID,
 			}.Build(),
 			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest name"),
 		},
@@ -1053,6 +1065,7 @@ func TestReplicateValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      "test-user",
+				DeviceId:      deviceID,
 			}.Build(),
 			expectedError: trace.BadParameter("missing SessionIdentifyingPayload in request"),
 		},
@@ -1064,6 +1077,7 @@ func TestReplicateValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 				SourceCluster: "",
 				TargetCluster: targetCluster,
 				Username:      "test-user",
+				DeviceId:      deviceID,
 			}.Build(),
 			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest source_cluster"),
 		},
@@ -1075,6 +1089,7 @@ func TestReplicateValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: "",
 				Username:      "test-user",
+				DeviceId:      deviceID,
 			}.Build(),
 			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest target_cluster"),
 		},
@@ -1086,8 +1101,21 @@ func TestReplicateValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      "",
+				DeviceId:      deviceID,
 			}.Build(),
 			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest username"),
+		},
+		{
+			name: "missing DeviceId",
+			req: mfav2.ReplicateValidatedMFAChallengeRequest_builder{
+				Name:          chalName,
+				Payload:       payload,
+				SourceCluster: sourceCluster,
+				TargetCluster: targetCluster,
+				Username:      "test-user",
+				DeviceId:      "",
+			}.Build(),
+			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest device_id"),
 		},
 		{
 			name: "empty SshSessionId in Payload",
@@ -1099,6 +1127,7 @@ func TestReplicateValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      "test-user",
+				DeviceId:      deviceID,
 			}.Build(),
 			expectedError: trace.BadParameter("ssh_session_id must not be empty"),
 		},
@@ -1157,6 +1186,7 @@ func TestVerifyValidatedMFAChallenge_Success(t *testing.T) {
 						SourceCluster: sourceCluster,
 						TargetCluster: targetCluster,
 						Username:      user.GetName(),
+						DeviceId:      deviceID,
 					}.Build(),
 				}.Build()
 
@@ -1185,6 +1215,10 @@ func TestVerifyValidatedMFAChallenge_Success(t *testing.T) {
 
 				if resp == nil {
 					return trace.BadParameter("expected non-nil response")
+				}
+
+				if resp.GetDeviceId() != deviceID {
+					return trace.BadParameter("device ID mismatch: got %q, expected %q", resp.GetDeviceId(), deviceID)
 				}
 
 				return nil
@@ -1234,6 +1268,7 @@ func TestVerifyValidatedMFAChallenge_PayloadMismatch(t *testing.T) {
 					SourceCluster: sourceCluster,
 					TargetCluster: targetCluster,
 					Username:      user.GetName(),
+					DeviceId:      deviceID,
 				}.Build(),
 			}.Build()
 
@@ -1273,6 +1308,7 @@ func TestVerifyValidatedMFAChallenge_SourceClusterMismatch(t *testing.T) {
 			SourceCluster: sourceCluster,
 			TargetCluster: targetCluster,
 			Username:      user.GetName(),
+			DeviceId:      deviceID,
 		}.Build(),
 	}.Build()
 	_, err := authServer.Auth().MFAService.CreateValidatedMFAChallenge(ctx, targetCluster, chal)

--- a/lib/auth/mfa/mfav2/service_test.go
+++ b/lib/auth/mfa/mfav2/service_test.go
@@ -48,6 +48,7 @@ const (
 	sourceCluster = "test-cluster"
 	targetCluster = "test-cluster"
 	deviceID      = "test-device-id"
+	username      = "test-user"
 )
 
 var payload = mfav2.SessionIdentifyingPayload_builder{
@@ -166,7 +167,9 @@ func testCreateValidateSessionChallengeWebauthn(t *testing.T, payload *mfav2.Ses
 			SourceCluster: sourceCluster,
 			TargetCluster: targetCluster,
 			Username:      user.GetName(),
-			DeviceId:      device.MFA.Id,
+			MfaDevice: mfav2.MFADevice_builder{
+				Id: device.MFA.Id,
+			}.Build(),
 		}.Build(),
 	}.Build()
 
@@ -277,7 +280,9 @@ func TestCreateValidateSessionChallenge_SSO(t *testing.T) {
 			SourceCluster: sourceCluster,
 			TargetCluster: targetCluster,
 			Username:      user.GetName(),
-			DeviceId:      deviceID,
+			MfaDevice: mfav2.MFADevice_builder{
+				Id: deviceID,
+			}.Build(),
 		}.Build(),
 	}.Build()
 
@@ -700,7 +705,9 @@ func TestListValidatedMFAChallenges_Success(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
-				DeviceId:      deviceID,
+				MfaDevice: mfav2.MFADevice_builder{
+					Id: deviceID,
+				}.Build(),
 			}.Build(),
 		}.Build(),
 		mfav2.ValidatedMFAChallenge_builder{
@@ -714,7 +721,9 @@ func TestListValidatedMFAChallenges_Success(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
-				DeviceId:      deviceID,
+				MfaDevice: mfav2.MFADevice_builder{
+					Id: deviceID,
+				}.Build(),
 			}.Build(),
 		}.Build(),
 		mfav2.ValidatedMFAChallenge_builder{
@@ -728,7 +737,9 @@ func TestListValidatedMFAChallenges_Success(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
-				DeviceId:      deviceID,
+				MfaDevice: mfav2.MFADevice_builder{
+					Id: deviceID,
+				}.Build(),
 			}.Build(),
 		}.Build(),
 	}
@@ -839,7 +850,9 @@ func TestListValidatedMFAChallenges_FilterByTargetCluster(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
-				DeviceId:      deviceID,
+				MfaDevice: mfav2.MFADevice_builder{
+					Id: deviceID,
+				}.Build(),
 			}.Build(),
 		}.Build(),
 	}
@@ -890,7 +903,9 @@ func TestReplicateValidatedMFAChallenge_Success(t *testing.T) {
 		SourceCluster: sourceCluster,
 		TargetCluster: targetCluster,
 		Username:      user.GetName(),
-		DeviceId:      deviceID,
+		MfaDevice: mfav2.MFADevice_builder{
+			Id: deviceID,
+		}.Build(),
 	}.Build())
 	require.NoError(t, err)
 
@@ -906,7 +921,9 @@ func TestReplicateValidatedMFAChallenge_Success(t *testing.T) {
 				SourceCluster: sourceCluster,
 				TargetCluster: targetCluster,
 				Username:      user.GetName(),
-				DeviceId:      deviceID,
+				MfaDevice: mfav2.MFADevice_builder{
+					Id: deviceID,
+				}.Build(),
 			}.Build(),
 		}.Build(),
 	}.Build()
@@ -935,7 +952,7 @@ func TestReplicateValidatedMFAChallenge_NonRemoteProxyDenied(t *testing.T) {
 		Payload:       payload,
 		SourceCluster: sourceCluster,
 		TargetCluster: targetCluster,
-		Username:      "test-user",
+		Username:      username,
 	}.Build())
 	require.Error(t, err)
 	require.ErrorIs(t, err, trace.AccessDenied("identity is not a remote builtin role, cannot be a remote proxy"))
@@ -974,7 +991,7 @@ func TestReplicateValidatedMFAChallenge_RemoteBuiltinWrongRoleDenied(t *testing.
 		Payload:       payload,
 		SourceCluster: sourceCluster,
 		TargetCluster: targetCluster,
-		Username:      "test-user",
+		Username:      username,
 	}.Build())
 	require.Error(t, err)
 	require.ErrorIs(
@@ -998,7 +1015,7 @@ func TestReplicateValidatedMFAChallenge_RemoteProxyWrongClusterDenied(t *testing
 		Payload:       payload,
 		SourceCluster: sourceCluster,
 		TargetCluster: targetCluster,
-		Username:      "test-user",
+		Username:      username,
 	}.Build())
 	require.Error(t, err)
 	require.ErrorIs(
@@ -1025,8 +1042,10 @@ func TestReplicateValidatedMFAChallenge_TargetClusterMismatch(t *testing.T) {
 		Payload:       payload,
 		SourceCluster: sourceCluster,
 		TargetCluster: "different-cluster",
-		Username:      "test-user",
-		DeviceId:      deviceID,
+		Username:      username,
+		MfaDevice: mfav2.MFADevice_builder{
+			Id: deviceID,
+		}.Build(),
 	}.Build())
 	require.Error(t, err)
 	require.ErrorIs(t, err, trace.BadParameter(`target cluster "different-cluster" does not match current cluster "test-cluster"`))
@@ -1040,6 +1059,15 @@ func TestReplicateValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 
 	ctx := authz.ContextWithUser(t.Context(), authtest.TestRemoteBuiltin(types.RoleProxy, targetCluster).I)
 
+	baseReq := mfav2.ReplicateValidatedMFAChallengeRequest_builder{
+		Name:          chalName,
+		Payload:       payload,
+		SourceCluster: sourceCluster,
+		TargetCluster: targetCluster,
+		Username:      username,
+		MfaDevice:     mfav2.MFADevice_builder{Id: deviceID}.Build(),
+	}
+
 	for _, testCase := range []struct {
 		name          string
 		req           *mfav2.ReplicateValidatedMFAChallengeRequest
@@ -1047,88 +1075,58 @@ func TestReplicateValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 	}{
 		{
 			name: "missing Name",
-			req: mfav2.ReplicateValidatedMFAChallengeRequest_builder{
-				Name:          "",
-				Payload:       payload,
-				SourceCluster: sourceCluster,
-				TargetCluster: targetCluster,
-				Username:      "test-user",
-				DeviceId:      deviceID,
-			}.Build(),
+			req: func() *mfav2.ReplicateValidatedMFAChallengeRequest {
+				req := baseReq
+				req.Name = ""
+				return req.Build()
+			}(),
 			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest name"),
 		},
 		{
 			name: "missing Payload",
-			req: mfav2.ReplicateValidatedMFAChallengeRequest_builder{
-				Name:          chalName,
-				Payload:       nil,
-				SourceCluster: sourceCluster,
-				TargetCluster: targetCluster,
-				Username:      "test-user",
-				DeviceId:      deviceID,
-			}.Build(),
+			req: func() *mfav2.ReplicateValidatedMFAChallengeRequest {
+				req := baseReq
+				req.Payload = nil
+				return req.Build()
+			}(),
 			expectedError: trace.BadParameter("missing SessionIdentifyingPayload in request"),
 		},
 		{
 			name: "missing SourceCluster",
-			req: mfav2.ReplicateValidatedMFAChallengeRequest_builder{
-				Name:          chalName,
-				Payload:       payload,
-				SourceCluster: "",
-				TargetCluster: targetCluster,
-				Username:      "test-user",
-				DeviceId:      deviceID,
-			}.Build(),
+			req: func() *mfav2.ReplicateValidatedMFAChallengeRequest {
+				req := baseReq
+				req.SourceCluster = ""
+				return req.Build()
+			}(),
 			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest source_cluster"),
 		},
 		{
 			name: "missing TargetCluster",
-			req: mfav2.ReplicateValidatedMFAChallengeRequest_builder{
-				Name:          chalName,
-				Payload:       payload,
-				SourceCluster: sourceCluster,
-				TargetCluster: "",
-				Username:      "test-user",
-				DeviceId:      deviceID,
-			}.Build(),
+			req: func() *mfav2.ReplicateValidatedMFAChallengeRequest {
+				req := baseReq
+				req.TargetCluster = ""
+				return req.Build()
+			}(),
 			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest target_cluster"),
 		},
 		{
 			name: "missing Username",
-			req: mfav2.ReplicateValidatedMFAChallengeRequest_builder{
-				Name:          chalName,
-				Payload:       payload,
-				SourceCluster: sourceCluster,
-				TargetCluster: targetCluster,
-				Username:      "",
-				DeviceId:      deviceID,
-			}.Build(),
+			req: func() *mfav2.ReplicateValidatedMFAChallengeRequest {
+				req := baseReq
+				req.Username = ""
+				return req.Build()
+			}(),
 			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest username"),
 		},
 		{
-			name: "missing DeviceId",
-			req: mfav2.ReplicateValidatedMFAChallengeRequest_builder{
-				Name:          chalName,
-				Payload:       payload,
-				SourceCluster: sourceCluster,
-				TargetCluster: targetCluster,
-				Username:      "test-user",
-				DeviceId:      "",
-			}.Build(),
-			expectedError: trace.BadParameter("missing ReplicateValidatedMFAChallengeRequest device_id"),
-		},
-		{
 			name: "empty SshSessionId in Payload",
-			req: mfav2.ReplicateValidatedMFAChallengeRequest_builder{
-				Name: chalName,
-				Payload: mfav2.SessionIdentifyingPayload_builder{
+			req: func() *mfav2.ReplicateValidatedMFAChallengeRequest {
+				req := baseReq
+				req.Payload = mfav2.SessionIdentifyingPayload_builder{
 					SshSessionId: []byte{},
-				}.Build(),
-				SourceCluster: sourceCluster,
-				TargetCluster: targetCluster,
-				Username:      "test-user",
-				DeviceId:      deviceID,
-			}.Build(),
+				}.Build()
+				return req.Build()
+			}(),
 			expectedError: trace.BadParameter("ssh_session_id must not be empty"),
 		},
 	} {
@@ -1186,7 +1184,9 @@ func TestVerifyValidatedMFAChallenge_Success(t *testing.T) {
 						SourceCluster: sourceCluster,
 						TargetCluster: targetCluster,
 						Username:      user.GetName(),
-						DeviceId:      deviceID,
+						MfaDevice: mfav2.MFADevice_builder{
+							Id: deviceID,
+						}.Build(),
 					}.Build(),
 				}.Build()
 
@@ -1217,8 +1217,8 @@ func TestVerifyValidatedMFAChallenge_Success(t *testing.T) {
 					return trace.BadParameter("expected non-nil response")
 				}
 
-				if resp.GetDeviceId() != deviceID {
-					return trace.BadParameter("device ID mismatch: got %q, expected %q", resp.GetDeviceId(), deviceID)
+				if resp.GetMfaDevice().GetId() != deviceID {
+					return trace.BadParameter("mfa_device.id mismatch: got %q, expected %q", resp.GetMfaDevice().GetId(), deviceID)
 				}
 
 				return nil
@@ -1268,7 +1268,9 @@ func TestVerifyValidatedMFAChallenge_PayloadMismatch(t *testing.T) {
 					SourceCluster: sourceCluster,
 					TargetCluster: targetCluster,
 					Username:      user.GetName(),
-					DeviceId:      deviceID,
+					MfaDevice: mfav2.MFADevice_builder{
+						Id: deviceID,
+					}.Build(),
 				}.Build(),
 			}.Build()
 
@@ -1308,7 +1310,9 @@ func TestVerifyValidatedMFAChallenge_SourceClusterMismatch(t *testing.T) {
 			SourceCluster: sourceCluster,
 			TargetCluster: targetCluster,
 			Username:      user.GetName(),
-			DeviceId:      deviceID,
+			MfaDevice: mfav2.MFADevice_builder{
+				Id: deviceID,
+			}.Build(),
 		}.Build(),
 	}.Build()
 	_, err := authServer.Auth().MFAService.CreateValidatedMFAChallenge(ctx, targetCluster, chal)
@@ -1371,7 +1375,7 @@ func TestVerifyValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 		{
 			name: "Missing name",
 			req: mfav2.VerifyValidatedMFAChallengeRequest_builder{
-				Username:      "test-user",
+				Username:      username,
 				Name:          "",
 				Payload:       payload,
 				SourceCluster: sourceCluster,
@@ -1381,7 +1385,7 @@ func TestVerifyValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 		{
 			name: "Missing payload",
 			req: mfav2.VerifyValidatedMFAChallengeRequest_builder{
-				Username:      "test-user",
+				Username:      username,
 				Name:          chalName,
 				Payload:       nil,
 				SourceCluster: sourceCluster,
@@ -1391,7 +1395,7 @@ func TestVerifyValidatedMFAChallenge_InvalidRequest(t *testing.T) {
 		{
 			name: "Empty SshSessionId",
 			req: mfav2.VerifyValidatedMFAChallengeRequest_builder{
-				Username:      "test-user",
+				Username:      username,
 				Name:          chalName,
 				Payload:       mfav2.SessionIdentifyingPayload_builder{SshSessionId: []byte{}}.Build(),
 				SourceCluster: sourceCluster,

--- a/lib/reversetunnel/leaf_cluster.go
+++ b/lib/reversetunnel/leaf_cluster.go
@@ -1203,7 +1203,7 @@ func (s *leafCluster) syncValidatedMFAChallenges(
 				SourceCluster: challenge.GetSpec().GetSourceCluster(),
 				TargetCluster: challenge.GetSpec().GetTargetCluster(),
 				Username:      challenge.GetSpec().GetUsername(),
-				DeviceId:      challenge.GetSpec().GetDeviceId(),
+				MfaDevice:     challenge.GetSpec().GetMfaDevice(),
 			}.Build(),
 		); err != nil && !trace.IsAlreadyExists(err) {
 			log.ErrorContext(

--- a/lib/reversetunnel/leaf_cluster.go
+++ b/lib/reversetunnel/leaf_cluster.go
@@ -1203,6 +1203,7 @@ func (s *leafCluster) syncValidatedMFAChallenges(
 				SourceCluster: challenge.GetSpec().GetSourceCluster(),
 				TargetCluster: challenge.GetSpec().GetTargetCluster(),
 				Username:      challenge.GetSpec().GetUsername(),
+				DeviceId:      challenge.GetSpec().GetDeviceId(),
 			}.Build(),
 		); err != nil && !trace.IsAlreadyExists(err) {
 			log.ErrorContext(

--- a/lib/reversetunnel/leaf_cluster_test.go
+++ b/lib/reversetunnel/leaf_cluster_test.go
@@ -487,6 +487,7 @@ func replicateValidatedMFAChallengeRequest(
 		SourceCluster: chal.GetSpec().GetSourceCluster(),
 		TargetCluster: chal.GetSpec().GetTargetCluster(),
 		Username:      chal.GetSpec().GetUsername(),
+		DeviceId:      chal.GetSpec().GetDeviceId(),
 	}.Build()
 }
 
@@ -507,6 +508,7 @@ func newValidatedMFAChallenge(name string) *mfav2.ValidatedMFAChallenge {
 			SourceCluster: "root.example.com",
 			TargetCluster: "leaf.example.com",
 			Username:      "alice",
+			DeviceId:      "test-device-id",
 		}.Build(),
 	}.Build()
 }

--- a/lib/reversetunnel/leaf_cluster_test.go
+++ b/lib/reversetunnel/leaf_cluster_test.go
@@ -487,7 +487,7 @@ func replicateValidatedMFAChallengeRequest(
 		SourceCluster: chal.GetSpec().GetSourceCluster(),
 		TargetCluster: chal.GetSpec().GetTargetCluster(),
 		Username:      chal.GetSpec().GetUsername(),
-		DeviceId:      chal.GetSpec().GetDeviceId(),
+		MfaDevice:     chal.GetSpec().GetMfaDevice(),
 	}.Build()
 }
 
@@ -508,7 +508,9 @@ func newValidatedMFAChallenge(name string) *mfav2.ValidatedMFAChallenge {
 			SourceCluster: "root.example.com",
 			TargetCluster: "leaf.example.com",
 			Username:      "alice",
-			DeviceId:      "test-device-id",
+			MfaDevice: mfav2.MFADevice_builder{
+				Id: "test-device-id",
+			}.Build(),
 		}.Build(),
 	}.Build()
 }

--- a/lib/reversetunnel/watcher_mfa_test.go
+++ b/lib/reversetunnel/watcher_mfa_test.go
@@ -261,6 +261,7 @@ func newValidatedMFAChallengeWithTargetCluster(name, targetCluster string) *mfav
 			SourceCluster: "root",
 			TargetCluster: targetCluster,
 			Username:      "alice",
+			DeviceId:      "device-id",
 		}.Build(),
 	}.Build()
 }

--- a/lib/reversetunnel/watcher_mfa_test.go
+++ b/lib/reversetunnel/watcher_mfa_test.go
@@ -261,7 +261,9 @@ func newValidatedMFAChallengeWithTargetCluster(name, targetCluster string) *mfav
 			SourceCluster: "root",
 			TargetCluster: targetCluster,
 			Username:      "alice",
-			DeviceId:      "device-id",
+			MfaDevice: mfav2.MFADevice_builder{
+				Id: "device-id",
+			}.Build(),
 		}.Build(),
 	}.Build()
 }

--- a/lib/services/local/events_test.go
+++ b/lib/services/local/events_test.go
@@ -472,6 +472,7 @@ func TestWatchers(t *testing.T) {
 							SourceCluster: "root.example.com",
 							TargetCluster: "leaf.example.com",
 							Username:      "alice",
+							DeviceId:      "device-id",
 						}.Build(),
 					}.Build(),
 				)
@@ -507,6 +508,7 @@ func TestWatchers(t *testing.T) {
 						SourceCluster: "root.example.com",
 						TargetCluster: "leaf.example.com",
 						Username:      "alice",
+						DeviceId:      "device-id",
 					}.Build(),
 				}.Build())
 				require.NoError(subtestT, err)

--- a/lib/services/local/events_test.go
+++ b/lib/services/local/events_test.go
@@ -472,7 +472,9 @@ func TestWatchers(t *testing.T) {
 							SourceCluster: "root.example.com",
 							TargetCluster: "leaf.example.com",
 							Username:      "alice",
-							DeviceId:      "device-id",
+							MfaDevice: mfav2.MFADevice_builder{
+								Id: "device-id",
+							}.Build(),
 						}.Build(),
 					}.Build(),
 				)
@@ -508,7 +510,9 @@ func TestWatchers(t *testing.T) {
 						SourceCluster: "root.example.com",
 						TargetCluster: "leaf.example.com",
 						Username:      "alice",
-						DeviceId:      "device-id",
+						MfaDevice: mfav2.MFADevice_builder{
+							Id: "device-id",
+						}.Build(),
 					}.Build(),
 				}.Build())
 				require.NoError(subtestT, err)

--- a/lib/services/local/mfa.go
+++ b/lib/services/local/mfa.go
@@ -217,8 +217,8 @@ func checkValidatedMFAChallenge(chal *mfav2.ValidatedMFAChallenge) error {
 		return trace.BadParameter("target_cluster must be set")
 	case chal.GetSpec().GetUsername() == "":
 		return trace.BadParameter("username must be set")
-	case chal.GetSpec().GetDeviceId() == "":
-		return trace.BadParameter("device_id must be set")
+	case chal.GetSpec().GetMfaDevice().GetId() == "":
+		return trace.BadParameter("mfa_device.id must be set")
 	}
 
 	switch chal.GetSpec().GetPayload().WhichPayload() {

--- a/lib/services/local/mfa.go
+++ b/lib/services/local/mfa.go
@@ -217,6 +217,8 @@ func checkValidatedMFAChallenge(chal *mfav2.ValidatedMFAChallenge) error {
 		return trace.BadParameter("target_cluster must be set")
 	case chal.GetSpec().GetUsername() == "":
 		return trace.BadParameter("username must be set")
+	case chal.GetSpec().GetDeviceId() == "":
+		return trace.BadParameter("device_id must be set")
 	}
 
 	switch chal.GetSpec().GetPayload().WhichPayload() {

--- a/lib/services/local/mfa_test.go
+++ b/lib/services/local/mfa_test.go
@@ -254,14 +254,14 @@ func TestMFAService_CreateValidatedMFAChallenge_Validation(t *testing.T) {
 			wantErr: trace.BadParameter("username must be set"),
 		},
 		{
-			name:          "missing device_id",
+			name:          "missing mfa_device.id",
 			targetCluster: &defaultTargetCluster,
 			chal: func() *mfav2.ValidatedMFAChallenge {
 				c := newValidatedMFAChallenge()
-				c.GetSpec().SetDeviceId("")
+				c.GetSpec().SetMfaDevice(mfav2.MFADevice_builder{Id: ""}.Build())
 				return c
 			}(),
-			wantErr: trace.BadParameter("device_id must be set"),
+			wantErr: trace.BadParameter("mfa_device.id must be set"),
 		},
 		{
 			name:          "request target_cluster mismatch",
@@ -411,7 +411,9 @@ func newValidatedMFAChallenge() *mfav2.ValidatedMFAChallenge {
 			SourceCluster: "src",
 			TargetCluster: "tgt",
 			Username:      "alice",
-			DeviceId:      "device-id",
+			MfaDevice: mfav2.MFADevice_builder{
+				Id: "device-id",
+			}.Build(),
 		}.Build(),
 	}.Build()
 }

--- a/lib/services/local/mfa_test.go
+++ b/lib/services/local/mfa_test.go
@@ -254,6 +254,16 @@ func TestMFAService_CreateValidatedMFAChallenge_Validation(t *testing.T) {
 			wantErr: trace.BadParameter("username must be set"),
 		},
 		{
+			name:          "missing device_id",
+			targetCluster: &defaultTargetCluster,
+			chal: func() *mfav2.ValidatedMFAChallenge {
+				c := newValidatedMFAChallenge()
+				c.GetSpec().SetDeviceId("")
+				return c
+			}(),
+			wantErr: trace.BadParameter("device_id must be set"),
+		},
+		{
 			name:          "request target_cluster mismatch",
 			targetCluster: &defaultTargetCluster,
 			chal: func() *mfav2.ValidatedMFAChallenge {
@@ -401,6 +411,7 @@ func newValidatedMFAChallenge() *mfav2.ValidatedMFAChallenge {
 			SourceCluster: "src",
 			TargetCluster: "tgt",
 			Username:      "alice",
+			DeviceId:      "device-id",
 		}.Build(),
 	}.Build()
 }


### PR DESCRIPTION
Part 1 of fix for https://github.com/gravitational/core/issues/146.

This change updates the MFA service to store the MFA device ID used to satisfy an MFA challenge. The MFA device ID is needed by the Teleport Agent gating SSH connections to enforce locks.

The MFA device ID is stored in the `ValidatedMFAChallenge` backend resource during the `ValidateSessionChallenge` RPC. The Teleport Agent will later call the `VerifyValidatedMFAChallenge` RPC ensure an MFA challenge was satisfied (pre-existing) and upon success, get the MFA device ID used to satisfy said challenge. The `ReplicateValidatedMFAChallengeRequest` RPC was also updated to account for replication to leaf clusters.