### PR TITLE
docs(upgrading/cloud-cluster): mention email notifications

### DIFF
--- a/docs/pages/upgrading/cloud-cluster-updates.mdx
+++ b/docs/pages/upgrading/cloud-cluster-updates.mdx
@@ -41,8 +41,7 @@ indicating that the update has finished.
 
 Teleport Enterprise (Cloud) users will receive email notifications for their
 verified [security and business contacts](../cloud-faq.mdx#how-do-i-update-my-security-and-business-contacts).
-Emails will be sent when a Teleport upgrade is planned or in the scenario
-that a Teleport upgrade is cancelled.
+Emails are sent when Teleport Cloud plans or cancels a Teleport upgrade.
 
 ## Expected impact
 

--- a/docs/pages/upgrading/cloud-cluster-updates.mdx
+++ b/docs/pages/upgrading/cloud-cluster-updates.mdx
@@ -23,6 +23,8 @@ release of a new major version. Minor version updates and patches occur more reg
 
 ## Notifications
 
+### Web UI
+
 Teleport Enterprise (Cloud) users will receive notification in the Web UI when
 a cluster update is scheduled. The notification will include the version
 and maintenance window during which the update will take place.
@@ -34,6 +36,13 @@ After the update has been completed, users will receive a new notification
 indicating that the update has finished.
 
 ![notification-complete](../../img/cloud/notification-complete.png)
+
+### Email
+
+Teleport Enterprise (Cloud) users will receive email notifications for their
+verified [security and business contacts](../cloud-faq.mdx#how-do-i-update-my-security-and-business-contacts).
+Emails will be sent when a Teleport upgrade is planned or in the scenario
+that a Teleport upgrade is cancelled.
 
 ## Expected impact
 

--- a/docs/pages/upgrading/cloud-cluster-updates.mdx
+++ b/docs/pages/upgrading/cloud-cluster-updates.mdx
@@ -41,7 +41,8 @@ indicating that the update has finished.
 
 Teleport Enterprise (Cloud) users will receive email notifications for their
 verified [security and business contacts](../cloud-faq.mdx#how-do-i-update-my-security-and-business-contacts).
-Emails are sent when Teleport Cloud plans or cancels a Teleport upgrade.
+Emails will be sent when a Teleport upgrade is planned or in the scenario
+that a Teleport upgrade is cancelled.
 
 ## Expected impact
 


### PR DESCRIPTION
Teleport Cloud has recently started supporting sending email notifications to Teleport Cloud users running Teleport v17 and v18.

This adds a blurb about email notifications and link to adding new business and security contacts.

Goal: https://github.com/gravitational/cloud/issues/13635
