### PR TITLE
Fix bloat workflow for teleport-update signing guard

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -82,7 +82,7 @@ jobs:
         name: Build base
         id: build_base
         run: |
-          make WEBASSETS_SKIP_BUILD=1 BUILDDIR=base_build binaries
+          TELEPORT_UPDATE_DEV_BUILD=1 make WEBASSETS_SKIP_BUILD=1 BUILDDIR=base_build binaries
           cd .github/shared-workflows/bot && go run main.go -workflow=binary-sizes --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport,sessionhelper" --builddir="../../../base_build" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}"  > ~/teleport_base_build_stats
           echo "base_stats_file=~/teleport_base_build_stats" >> $GITHUB_OUTPUT
           echo "base_stats=$(cat ~/teleport_base_build_stats)" >> $GITHUB_ENV
@@ -117,7 +117,7 @@ jobs:
       - name: Build Binaries
         id: build_branch
         run: |
-          BUILD_SECRET=FAKE_SECRET make WEBASSETS_SKIP_BUILD=1 binaries
+          BUILD_SECRET=FAKE_SECRET TELEPORT_UPDATE_DEV_BUILD=1 make WEBASSETS_SKIP_BUILD=1 binaries
 
       - name: Check for Environment Leak
         id: check_branch_env_leak


### PR DESCRIPTION
## Summary
The new `teleport-update` build guard requires signing keys or `TELEPORT_UPDATE_DEV_BUILD=1`.

`bloat.yaml` runs plain Linux `make binaries`, which includes `teleport-update`, so it now needs the dev-build override. This change adds that override to the two affected build steps.

## Files changed
- `.github/workflows/bloat.yaml`

## Notes
This does not relax the release build requirement. It only marks the non-release bloat workflow as a dev build.

## Manual Test Plan
### Test Environment
Local

### Test Cases
- [x] make build/teleport-update -> fails
- [x] TELEPORT_UPDATE_DEV_BUILD=1 make build/teleport-update -> pass
