### PR TITLE
Usage events send event_key for deduping event emission retries for the same event

### DIFF
--- a/gen/proto/go/prehog/v1alpha/teleport.pb.go
+++ b/gen/proto/go/prehog/v1alpha/teleport.pb.go
@@ -10717,6 +10717,11 @@ type SubmitEventRequest struct {
 	//
 	// PostHog property: tp.teleport_version
 	TeleportVersion string `protobuf:"bytes,95,opt,name=teleport_version,json=teleportVersion,proto3" json:"teleport_version,omitempty"`
+	// event_key is a UUID distinguishing one underlying event occurrence,
+	// allowing consumers to deduplicate resubmissions.
+	//
+	// PostHog property: tp.event_key
+	EventKey string `protobuf:"bytes,128,opt,name=event_key,json=eventKey,proto3" json:"event_key,omitempty"`
 	// the event being submitted
 	//
 	// Types that are valid to be assigned to Event:
@@ -10893,6 +10898,13 @@ func (x *SubmitEventRequest) GetTimestamp() *timestamppb.Timestamp {
 func (x *SubmitEventRequest) GetTeleportVersion() string {
 	if x != nil {
 		return x.TeleportVersion
+	}
+	return ""
+}
+
+func (x *SubmitEventRequest) GetEventKey() string {
+	if x != nil {
+		return x.EventKey
 	}
 	return ""
 }
@@ -13515,11 +13527,12 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"\x06params\x18\x04 \x03(\v2..prehog.v1alpha.UIInteractionEvent.ParamsEntryR\x06params\x1a9\n" +
 	"\vParamsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9di\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbbi\n" +
 	"\x12SubmitEventRequest\x12!\n" +
 	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x128\n" +
 	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12)\n" +
-	"\x10teleport_version\x18_ \x01(\tR\x0fteleportVersion\x12?\n" +
+	"\x10teleport_version\x18_ \x01(\tR\x0fteleportVersion\x12\x1c\n" +
+	"\tevent_key\x18\x80\x01 \x01(\tR\beventKey\x12?\n" +
 	"\n" +
 	"user_login\x18\x03 \x01(\v2\x1e.prehog.v1alpha.UserLoginEventH\x00R\tuserLogin\x12?\n" +
 	"\n" +

--- a/gen/proto/ts/prehog/v1alpha/teleport_pb.ts
+++ b/gen/proto/ts/prehog/v1alpha/teleport_pb.ts
@@ -3766,6 +3766,15 @@ export interface SubmitEventRequest {
      */
     teleportVersion: string;
     /**
+     * event_key is a UUID distinguishing one underlying event occurrence,
+     * allowing consumers to deduplicate resubmissions.
+     *
+     * PostHog property: tp.event_key
+     *
+     * @generated from protobuf field: string event_key = 128;
+     */
+    eventKey: string;
+    /**
      * @generated from protobuf oneof: event
      */
     event: {
@@ -13964,6 +13973,7 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
             { no: 1, name: "cluster_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "timestamp", kind: "message", T: () => Timestamp },
             { no: 95, name: "teleport_version", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 128, name: "event_key", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "user_login", kind: "message", oneof: "event", T: () => UserLoginEvent },
             { no: 4, name: "sso_create", kind: "message", oneof: "event", T: () => SSOCreateEvent },
             { no: 5, name: "resource_create", kind: "message", oneof: "event", T: () => ResourceCreateEvent },
@@ -14090,6 +14100,7 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.clusterName = "";
         message.teleportVersion = "";
+        message.eventKey = "";
         message.event = { oneofKind: undefined };
         if (value !== undefined)
             reflectionMergePartial<SubmitEventRequest>(this, message, value);
@@ -14108,6 +14119,9 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
                     break;
                 case /* string teleport_version */ 95:
                     message.teleportVersion = reader.string();
+                    break;
+                case /* string event_key */ 128:
+                    message.eventKey = reader.string();
                     break;
                 case /* prehog.v1alpha.UserLoginEvent user_login */ 3:
                     message.event = {
@@ -14850,6 +14864,9 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
         /* string teleport_version = 95; */
         if (message.teleportVersion !== "")
             writer.tag(95, WireType.LengthDelimited).string(message.teleportVersion);
+        /* string event_key = 128; */
+        if (message.eventKey !== "")
+            writer.tag(128, WireType.LengthDelimited).string(message.eventKey);
         /* prehog.v1alpha.UserLoginEvent user_login = 3; */
         if (message.event.oneofKind === "userLogin")
             UserLoginEvent.internalBinaryWrite(message.event.userLogin, writer.tag(3, WireType.LengthDelimited).fork(), options).join();

--- a/lib/usagereporter/teleport/usagereporter.go
+++ b/lib/usagereporter/teleport/usagereporter.go
@@ -30,7 +30,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
@@ -103,7 +102,6 @@ type StreamingUsageReporter struct {
 	// clusterName is the cluster's name, used for anonymization and as an event
 	// field.
 	clusterName types.ClusterName
-	clock       clockwork.Clock
 }
 
 var _ UsageReporter = (*StreamingUsageReporter)(nil)
@@ -117,7 +115,7 @@ func (t *StreamingUsageReporter) anonymize(events []Anonymizable) []*prehogv1a.S
 	reqs := make([]*prehogv1a.SubmitEventRequest, 0, len(events))
 	for _, e := range events {
 		req := e.Anonymize(t.anonymizer)
-		req.Timestamp = timestamppb.New(t.clock.Now())
+		req.Timestamp = timestamppb.Now()
 		req.ClusterName = t.anonymizer.AnonymizeString(t.clusterName.GetClusterName())
 		req.TeleportVersion = teleport.Version
 		// Deduping resubmitted events requires a stable key per event.
@@ -144,8 +142,6 @@ func NewStreamingUsageReporter(logger *slog.Logger, clusterName types.ClusterNam
 		return nil, trace.Wrap(err)
 	}
 
-	clock := clockwork.NewRealClock()
-
 	reporter := usagereporter.NewUsageReporter(&usagereporter.Options[prehogv1a.SubmitEventRequest]{
 		Logger:        logger,
 		Submit:        submitter,
@@ -155,14 +151,12 @@ func NewStreamingUsageReporter(logger *slog.Logger, clusterName types.ClusterNam
 		MaxBufferSize: usageReporterMaxBufferSize,
 		SubmitDelay:   usageReporterSubmitDelay,
 		RetryAttempts: usageReporterRetryAttempts,
-		Clock:         clock,
 	})
 
 	return &StreamingUsageReporter{
 		usageReporter: reporter,
 		anonymizer:    anonymizer,
 		clusterName:   clusterName,
-		clock:         clock,
 	}, nil
 }
 

--- a/lib/usagereporter/teleport/usagereporter.go
+++ b/lib/usagereporter/teleport/usagereporter.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -108,13 +109,23 @@ type StreamingUsageReporter struct {
 var _ UsageReporter = (*StreamingUsageReporter)(nil)
 
 func (t *StreamingUsageReporter) AnonymizeAndSubmit(events ...Anonymizable) {
+	t.usageReporter.AddEventsToQueue(t.anonymize(events)...)
+}
+
+// anonymize builds a submit request per event.
+func (t *StreamingUsageReporter) anonymize(events []Anonymizable) []*prehogv1a.SubmitEventRequest {
+	reqs := make([]*prehogv1a.SubmitEventRequest, 0, len(events))
 	for _, e := range events {
 		req := e.Anonymize(t.anonymizer)
 		req.Timestamp = timestamppb.New(t.clock.Now())
 		req.ClusterName = t.anonymizer.AnonymizeString(t.clusterName.GetClusterName())
 		req.TeleportVersion = teleport.Version
-		t.usageReporter.AddEventsToQueue(req)
+		// Deduping resubmitted events requires a stable key per event.
+		req.EventKey = uuid.NewString()
+		reqs = append(reqs, req)
 	}
+
+	return reqs
 }
 
 func (t *StreamingUsageReporter) Run(ctx context.Context) {

--- a/lib/usagereporter/teleport/usagereporter_test.go
+++ b/lib/usagereporter/teleport/usagereporter_test.go
@@ -22,11 +22,13 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/utils"
@@ -813,6 +815,40 @@ func TestConvertUsageEvent(t *testing.T) {
 
 			require.Equal(t, tt.expected, got)
 		})
+	}
+}
+
+func TestAnonymize(t *testing.T) {
+	t.Parallel()
+
+	anonymizer, err := utils.NewHMACAnonymizer(utils.AnonymizationKeyString("anon-key-or-cluster-id"))
+	require.NoError(t, err)
+
+	clusterName, err := types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: "test-cluster",
+		ClusterID:   "test-cluster-id",
+	})
+	require.NoError(t, err)
+
+	reporter := &StreamingUsageReporter{
+		anonymizer:  anonymizer,
+		clusterName: clusterName,
+		clock:       clockwork.NewFakeClock(),
+	}
+
+	reqs := reporter.anonymize([]Anonymizable{
+		&UserLoginEvent{UserName: "alice", ConnectorType: "local"},
+		&UserLoginEvent{UserName: "alice", ConnectorType: "local"},
+	})
+
+	require.Len(t, reqs, 2)
+	require.NotEmpty(t, reqs[0].EventKey)
+	require.NotEqual(t, reqs[0].EventKey, reqs[1].EventKey,
+		"identical events must not share an event key")
+
+	for _, req := range reqs {
+		require.Equal(t, anonymizer.AnonymizeString("test-cluster"), req.ClusterName)
+		require.Equal(t, teleport.Version, req.TeleportVersion)
 	}
 }
 

--- a/lib/usagereporter/teleport/usagereporter_test.go
+++ b/lib/usagereporter/teleport/usagereporter_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -833,7 +832,6 @@ func TestAnonymize(t *testing.T) {
 	reporter := &StreamingUsageReporter{
 		anonymizer:  anonymizer,
 		clusterName: clusterName,
-		clock:       clockwork.NewFakeClock(),
 	}
 
 	reqs := reporter.anonymize([]Anonymizable{

--- a/proto/prehog/v1alpha/teleport.proto
+++ b/proto/prehog/v1alpha/teleport.proto
@@ -2203,6 +2203,12 @@ message SubmitEventRequest {
   // PostHog property: tp.teleport_version
   string teleport_version = 95;
 
+  // event_key is a UUID distinguishing one underlying event occurrence,
+  // allowing consumers to deduplicate resubmissions.
+  //
+  // PostHog property: tp.event_key
+  string event_key = 128;
+
   // the event being submitted
   oneof event {
     UserLoginEvent user_login = 3;


### PR DESCRIPTION
Another fix while implementing DiscoveryConfigChangeEvent. Usage event submission has retry behavior, but no way to dedupe if multiple event submissions end up going through for the same event. This adds an `event_key` to use for deduplication on the backend.

## Manual Test Plan
### Test Environment
Local build.

### Test Cases
- [x] Check that `event_key` is filled when making prehog requests.
