### PR TITLE
Return error on `tctl create` with no file or stdin input

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -362,6 +362,10 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client
 
 	var reader io.Reader
 	if rc.filename == "" {
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) != 0 {
+			return trace.BadParameter("no file specified or input via stdin")
+		}
 		reader = os.Stdin
 	} else {
 		f, err := utils.OpenFileAllowingUnsafeLinks(rc.filename)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -362,7 +362,10 @@ func (rc *ResourceCommand) Create(ctx context.Context, client *authclient.Client
 
 	var reader io.Reader
 	if rc.filename == "" {
-		stat, _ := os.Stdin.Stat()
+		stat, err := os.Stdin.Stat()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		if (stat.Mode() & os.ModeCharDevice) != 0 {
 			return trace.BadParameter("no file specified or input via stdin")
 		}

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -2490,6 +2490,10 @@ func TestCreateResources(t *testing.T) {
 			create: testCreateWithEmptyDocument,
 		},
 		{
+			kind:   "no-file-or-input",
+			create: testCreateWithNoFileOrInput,
+		},
+		{
 			kind:   types.KindDatabaseObjectImportRule,
 			create: testCreateDatabaseObjectImportRule,
 		},
@@ -2778,6 +2782,15 @@ spec:
 	require.NoError(t, os.WriteFile(userYAMLPath, []byte(userYAML), 0644))
 	_, err := runResourceCommand(t, clt, []string{"create", userYAMLPath})
 	require.NoError(t, err)
+}
+
+func testCreateWithNoFileOrInput(t *testing.T, clt *authclient.Client) {
+	prevStdin := os.Stdin
+	os.Stdin, _ = os.Open(os.DevNull)
+	t.Cleanup(func() { os.Stdin = prevStdin })
+
+	_, err := runResourceCommand(t, clt, []string{"create"})
+	require.ErrorContains(t, err, "no file specified or input via stdin")
 }
 
 func testCreateUser(t *testing.T, clt *authclient.Client) {


### PR DESCRIPTION
Close #14791



<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: Fixed a bug where `tctl create` would hang indefinitely instead of returning an error when run without a file or stdin input.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

### Test Cases
- [ ] 
