### PR TITLE
Discovery new DiscoveryConfigChangeEvent definition

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1060,6 +1060,9 @@ const (
 	IACToolLabel = TeleportNamespace + "/iac-tool"
 	// IACToolTerraform identifies that a IAC tool is Terraform.
 	IACToolTerraform = "terraform"
+	// SetupAttemptIDLabel is a resource metadata label that identifies the setup
+	// attempt that created the resource.
+	SetupAttemptIDLabel = TeleportNamespace + "/setup-attempt-id"
 
 	// ReqAnnotationApproveSchedulesLabel is the request annotation key at which schedules are stored for access plugins.
 	ReqAnnotationApproveSchedulesLabel = "/schedules"

--- a/gen/proto/go/prehog/v1alpha/teleport.pb.go
+++ b/gen/proto/go/prehog/v1alpha/teleport.pb.go
@@ -1386,6 +1386,296 @@ func (DiscoveryConfigAction) EnumDescriptor() ([]byte, []int) {
 	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{17}
 }
 
+// DiscoveryMatcherType is a resource type a discovery config's matchers select.
+type DiscoveryMatcherType int32
+
+const (
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_UNSPECIFIED                DiscoveryMatcherType = 0
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EC2                    DiscoveryMatcherType = 1
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EKS                    DiscoveryMatcherType = 2
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDS                    DiscoveryMatcherType = 3
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDSPROXY               DiscoveryMatcherType = 4
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT               DiscoveryMatcherType = 5
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT_SERVERLESS    DiscoveryMatcherType = 6
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE            DiscoveryMatcherType = 7
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE_SERVERLESS DiscoveryMatcherType = 8
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_MEMORYDB               DiscoveryMatcherType = 9
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_OPENSEARCH             DiscoveryMatcherType = 10
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_DOCDB                  DiscoveryMatcherType = 11
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_VM                   DiscoveryMatcherType = 12
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_AKS                  DiscoveryMatcherType = 13
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_MYSQL                DiscoveryMatcherType = 14
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_POSTGRES             DiscoveryMatcherType = 15
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_REDIS                DiscoveryMatcherType = 16
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_SQLSERVER            DiscoveryMatcherType = 17
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_WINDOWS_VM           DiscoveryMatcherType = 18
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_GCP_GKE                    DiscoveryMatcherType = 19
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_GCP_GCE                    DiscoveryMatcherType = 20
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_GCP_CLOUDSQL               DiscoveryMatcherType = 21
+	DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_KUBE_APP                   DiscoveryMatcherType = 22
+)
+
+// Enum value maps for DiscoveryMatcherType.
+var (
+	DiscoveryMatcherType_name = map[int32]string{
+		0:  "DISCOVERY_MATCHER_TYPE_UNSPECIFIED",
+		1:  "DISCOVERY_MATCHER_TYPE_AWS_EC2",
+		2:  "DISCOVERY_MATCHER_TYPE_AWS_EKS",
+		3:  "DISCOVERY_MATCHER_TYPE_AWS_RDS",
+		4:  "DISCOVERY_MATCHER_TYPE_AWS_RDSPROXY",
+		5:  "DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT",
+		6:  "DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT_SERVERLESS",
+		7:  "DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE",
+		8:  "DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE_SERVERLESS",
+		9:  "DISCOVERY_MATCHER_TYPE_AWS_MEMORYDB",
+		10: "DISCOVERY_MATCHER_TYPE_AWS_OPENSEARCH",
+		11: "DISCOVERY_MATCHER_TYPE_AWS_DOCDB",
+		12: "DISCOVERY_MATCHER_TYPE_AZURE_VM",
+		13: "DISCOVERY_MATCHER_TYPE_AZURE_AKS",
+		14: "DISCOVERY_MATCHER_TYPE_AZURE_MYSQL",
+		15: "DISCOVERY_MATCHER_TYPE_AZURE_POSTGRES",
+		16: "DISCOVERY_MATCHER_TYPE_AZURE_REDIS",
+		17: "DISCOVERY_MATCHER_TYPE_AZURE_SQLSERVER",
+		18: "DISCOVERY_MATCHER_TYPE_AZURE_WINDOWS_VM",
+		19: "DISCOVERY_MATCHER_TYPE_GCP_GKE",
+		20: "DISCOVERY_MATCHER_TYPE_GCP_GCE",
+		21: "DISCOVERY_MATCHER_TYPE_GCP_CLOUDSQL",
+		22: "DISCOVERY_MATCHER_TYPE_KUBE_APP",
+	}
+	DiscoveryMatcherType_value = map[string]int32{
+		"DISCOVERY_MATCHER_TYPE_UNSPECIFIED":                0,
+		"DISCOVERY_MATCHER_TYPE_AWS_EC2":                    1,
+		"DISCOVERY_MATCHER_TYPE_AWS_EKS":                    2,
+		"DISCOVERY_MATCHER_TYPE_AWS_RDS":                    3,
+		"DISCOVERY_MATCHER_TYPE_AWS_RDSPROXY":               4,
+		"DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT":               5,
+		"DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT_SERVERLESS":    6,
+		"DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE":            7,
+		"DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE_SERVERLESS": 8,
+		"DISCOVERY_MATCHER_TYPE_AWS_MEMORYDB":               9,
+		"DISCOVERY_MATCHER_TYPE_AWS_OPENSEARCH":             10,
+		"DISCOVERY_MATCHER_TYPE_AWS_DOCDB":                  11,
+		"DISCOVERY_MATCHER_TYPE_AZURE_VM":                   12,
+		"DISCOVERY_MATCHER_TYPE_AZURE_AKS":                  13,
+		"DISCOVERY_MATCHER_TYPE_AZURE_MYSQL":                14,
+		"DISCOVERY_MATCHER_TYPE_AZURE_POSTGRES":             15,
+		"DISCOVERY_MATCHER_TYPE_AZURE_REDIS":                16,
+		"DISCOVERY_MATCHER_TYPE_AZURE_SQLSERVER":            17,
+		"DISCOVERY_MATCHER_TYPE_AZURE_WINDOWS_VM":           18,
+		"DISCOVERY_MATCHER_TYPE_GCP_GKE":                    19,
+		"DISCOVERY_MATCHER_TYPE_GCP_GCE":                    20,
+		"DISCOVERY_MATCHER_TYPE_GCP_CLOUDSQL":               21,
+		"DISCOVERY_MATCHER_TYPE_KUBE_APP":                   22,
+	}
+)
+
+func (x DiscoveryMatcherType) Enum() *DiscoveryMatcherType {
+	p := new(DiscoveryMatcherType)
+	*p = x
+	return p
+}
+
+func (x DiscoveryMatcherType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DiscoveryMatcherType) Descriptor() protoreflect.EnumDescriptor {
+	return file_prehog_v1alpha_teleport_proto_enumTypes[18].Descriptor()
+}
+
+func (DiscoveryMatcherType) Type() protoreflect.EnumType {
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[18]
+}
+
+func (x DiscoveryMatcherType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DiscoveryMatcherType.Descriptor instead.
+func (DiscoveryMatcherType) EnumDescriptor() ([]byte, []int) {
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{18}
+}
+
+// CloudProvider is a platform a discovery config selects resources from.
+type CloudProvider int32
+
+const (
+	CloudProvider_CLOUD_PROVIDER_UNSPECIFIED CloudProvider = 0
+	CloudProvider_CLOUD_PROVIDER_AWS         CloudProvider = 1
+	CloudProvider_CLOUD_PROVIDER_AZURE       CloudProvider = 2
+	CloudProvider_CLOUD_PROVIDER_GCP         CloudProvider = 3
+	CloudProvider_CLOUD_PROVIDER_KUBERNETES  CloudProvider = 4
+)
+
+// Enum value maps for CloudProvider.
+var (
+	CloudProvider_name = map[int32]string{
+		0: "CLOUD_PROVIDER_UNSPECIFIED",
+		1: "CLOUD_PROVIDER_AWS",
+		2: "CLOUD_PROVIDER_AZURE",
+		3: "CLOUD_PROVIDER_GCP",
+		4: "CLOUD_PROVIDER_KUBERNETES",
+	}
+	CloudProvider_value = map[string]int32{
+		"CLOUD_PROVIDER_UNSPECIFIED": 0,
+		"CLOUD_PROVIDER_AWS":         1,
+		"CLOUD_PROVIDER_AZURE":       2,
+		"CLOUD_PROVIDER_GCP":         3,
+		"CLOUD_PROVIDER_KUBERNETES":  4,
+	}
+)
+
+func (x CloudProvider) Enum() *CloudProvider {
+	p := new(CloudProvider)
+	*p = x
+	return p
+}
+
+func (x CloudProvider) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CloudProvider) Descriptor() protoreflect.EnumDescriptor {
+	return file_prehog_v1alpha_teleport_proto_enumTypes[19].Descriptor()
+}
+
+func (CloudProvider) Type() protoreflect.EnumType {
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[19]
+}
+
+func (x CloudProvider) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CloudProvider.Descriptor instead.
+func (CloudProvider) EnumDescriptor() ([]byte, []int) {
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{19}
+}
+
+// ClientKind is the tool that made a configuration change, read from the
+// request's user agent.
+type ClientKind int32
+
+const (
+	// The event's producer does not report a client.
+	ClientKind_CLIENT_KIND_UNSPECIFIED ClientKind = 0
+	// The user agent did not match a known tool.
+	ClientKind_CLIENT_KIND_UNKNOWN            ClientKind = 1
+	ClientKind_CLIENT_KIND_WEB_UI             ClientKind = 2
+	ClientKind_CLIENT_KIND_TCTL               ClientKind = 3
+	ClientKind_CLIENT_KIND_TSH                ClientKind = 4
+	ClientKind_CLIENT_KIND_TBOT               ClientKind = 5
+	ClientKind_CLIENT_KIND_TERRAFORM_PROVIDER ClientKind = 6
+	ClientKind_CLIENT_KIND_KUBE_OPERATOR      ClientKind = 7
+)
+
+// Enum value maps for ClientKind.
+var (
+	ClientKind_name = map[int32]string{
+		0: "CLIENT_KIND_UNSPECIFIED",
+		1: "CLIENT_KIND_UNKNOWN",
+		2: "CLIENT_KIND_WEB_UI",
+		3: "CLIENT_KIND_TCTL",
+		4: "CLIENT_KIND_TSH",
+		5: "CLIENT_KIND_TBOT",
+		6: "CLIENT_KIND_TERRAFORM_PROVIDER",
+		7: "CLIENT_KIND_KUBE_OPERATOR",
+	}
+	ClientKind_value = map[string]int32{
+		"CLIENT_KIND_UNSPECIFIED":        0,
+		"CLIENT_KIND_UNKNOWN":            1,
+		"CLIENT_KIND_WEB_UI":             2,
+		"CLIENT_KIND_TCTL":               3,
+		"CLIENT_KIND_TSH":                4,
+		"CLIENT_KIND_TBOT":               5,
+		"CLIENT_KIND_TERRAFORM_PROVIDER": 6,
+		"CLIENT_KIND_KUBE_OPERATOR":      7,
+	}
+)
+
+func (x ClientKind) Enum() *ClientKind {
+	p := new(ClientKind)
+	*p = x
+	return p
+}
+
+func (x ClientKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ClientKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_prehog_v1alpha_teleport_proto_enumTypes[20].Descriptor()
+}
+
+func (ClientKind) Type() protoreflect.EnumType {
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[20]
+}
+
+func (x ClientKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ClientKind.Descriptor instead.
+func (ClientKind) EnumDescriptor() ([]byte, []int) {
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{20}
+}
+
+// DiscoveryConfigChangeAction is the change made to a discovery config.
+type DiscoveryConfigChangeAction int32
+
+const (
+	DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UNSPECIFIED DiscoveryConfigChangeAction = 0
+	DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_CREATE      DiscoveryConfigChangeAction = 1
+	DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UPDATE      DiscoveryConfigChangeAction = 2
+	DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT      DiscoveryConfigChangeAction = 3
+	DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_DELETE      DiscoveryConfigChangeAction = 4
+)
+
+// Enum value maps for DiscoveryConfigChangeAction.
+var (
+	DiscoveryConfigChangeAction_name = map[int32]string{
+		0: "DISCOVERY_CONFIG_CHANGE_ACTION_UNSPECIFIED",
+		1: "DISCOVERY_CONFIG_CHANGE_ACTION_CREATE",
+		2: "DISCOVERY_CONFIG_CHANGE_ACTION_UPDATE",
+		3: "DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT",
+		4: "DISCOVERY_CONFIG_CHANGE_ACTION_DELETE",
+	}
+	DiscoveryConfigChangeAction_value = map[string]int32{
+		"DISCOVERY_CONFIG_CHANGE_ACTION_UNSPECIFIED": 0,
+		"DISCOVERY_CONFIG_CHANGE_ACTION_CREATE":      1,
+		"DISCOVERY_CONFIG_CHANGE_ACTION_UPDATE":      2,
+		"DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT":      3,
+		"DISCOVERY_CONFIG_CHANGE_ACTION_DELETE":      4,
+	}
+)
+
+func (x DiscoveryConfigChangeAction) Enum() *DiscoveryConfigChangeAction {
+	p := new(DiscoveryConfigChangeAction)
+	*p = x
+	return p
+}
+
+func (x DiscoveryConfigChangeAction) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DiscoveryConfigChangeAction) Descriptor() protoreflect.EnumDescriptor {
+	return file_prehog_v1alpha_teleport_proto_enumTypes[21].Descriptor()
+}
+
+func (DiscoveryConfigChangeAction) Type() protoreflect.EnumType {
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[21]
+}
+
+func (x DiscoveryConfigChangeAction) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DiscoveryConfigChangeAction.Descriptor instead.
+func (DiscoveryConfigChangeAction) EnumDescriptor() ([]byte, []int) {
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{21}
+}
+
 // AccessListStatus represents a access list wizard step outcome.
 type AccessListStatus int32
 
@@ -1431,11 +1721,11 @@ func (x AccessListStatus) String() string {
 }
 
 func (AccessListStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[18].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[22].Descriptor()
 }
 
 func (AccessListStatus) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[18]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[22]
 }
 
 func (x AccessListStatus) Number() protoreflect.EnumNumber {
@@ -1444,7 +1734,7 @@ func (x AccessListStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AccessListStatus.Descriptor instead.
 func (AccessListStatus) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{18}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{22}
 }
 
 // AccessListPreset represents the access list preset type.
@@ -1481,11 +1771,11 @@ func (x AccessListPreset) String() string {
 }
 
 func (AccessListPreset) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[19].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[23].Descriptor()
 }
 
 func (AccessListPreset) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[19]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[23]
 }
 
 func (x AccessListPreset) Number() protoreflect.EnumNumber {
@@ -1494,7 +1784,7 @@ func (x AccessListPreset) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AccessListPreset.Descriptor instead.
 func (AccessListPreset) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{19}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{23}
 }
 
 // AccessListIntegrate describes what integration user
@@ -1530,11 +1820,11 @@ func (x AccessListIntegrate) String() string {
 }
 
 func (AccessListIntegrate) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[20].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[24].Descriptor()
 }
 
 func (AccessListIntegrate) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[20]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[24]
 }
 
 func (x AccessListIntegrate) Number() protoreflect.EnumNumber {
@@ -1543,7 +1833,7 @@ func (x AccessListIntegrate) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AccessListIntegrate.Descriptor instead.
 func (AccessListIntegrate) EnumDescriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{20}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{24}
 }
 
 // DeployMethod describes the method used to deploy a service.
@@ -1584,11 +1874,11 @@ func (x UIDiscoverDeployServiceEvent_DeployMethod) String() string {
 }
 
 func (UIDiscoverDeployServiceEvent_DeployMethod) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[21].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[25].Descriptor()
 }
 
 func (UIDiscoverDeployServiceEvent_DeployMethod) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[21]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[25]
 }
 
 func (x UIDiscoverDeployServiceEvent_DeployMethod) Number() protoreflect.EnumNumber {
@@ -1640,11 +1930,11 @@ func (x UIDiscoverDeployServiceEvent_DeployType) String() string {
 }
 
 func (UIDiscoverDeployServiceEvent_DeployType) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[22].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[26].Descriptor()
 }
 
 func (UIDiscoverDeployServiceEvent_DeployType) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[22]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[26]
 }
 
 func (x UIDiscoverDeployServiceEvent_DeployType) Number() protoreflect.EnumNumber {
@@ -1701,11 +1991,11 @@ func (x UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) String() string {
 }
 
 func (UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[23].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[27].Descriptor()
 }
 
 func (UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[23]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[27]
 }
 
 func (x UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod) Number() protoreflect.EnumNumber {
@@ -1754,11 +2044,11 @@ func (x AccessRequestReviewEvent_ProposedState) String() string {
 }
 
 func (AccessRequestReviewEvent_ProposedState) Descriptor() protoreflect.EnumDescriptor {
-	return file_prehog_v1alpha_teleport_proto_enumTypes[24].Descriptor()
+	return file_prehog_v1alpha_teleport_proto_enumTypes[28].Descriptor()
 }
 
 func (AccessRequestReviewEvent_ProposedState) Type() protoreflect.EnumType {
-	return &file_prehog_v1alpha_teleport_proto_enumTypes[24]
+	return &file_prehog_v1alpha_teleport_proto_enumTypes[28]
 }
 
 func (x AccessRequestReviewEvent_ProposedState) Number() protoreflect.EnumNumber {
@@ -9941,6 +10231,158 @@ func (x *DiscoveryConfigEvent) GetCreationMethod() string {
 	return ""
 }
 
+// DiscoveryConfigChangedEvent is emitted when a discovery config is created,
+// updated, upserted, or deleted.
+//
+// PostHog event: tp.discovery.config.changed
+type DiscoveryConfigChangedEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// discovery_config_id is the anonymized name of the discovery config.
+	//
+	// PostHog property: tp.discovery.discovery_config_id
+	DiscoveryConfigId string `protobuf:"bytes,1,opt,name=discovery_config_id,json=discoveryConfigId,proto3" json:"discovery_config_id,omitempty"`
+	// integration_ids are the anonymized names of the integrations the config's
+	// matchers use, deduplicated.
+	//
+	// PostHog property: tp.discovery.integration_ids
+	IntegrationIds []string `protobuf:"bytes,2,rep,name=integration_ids,json=integrationIds,proto3" json:"integration_ids,omitempty"`
+	// setup_attempt_id is the anonymized setup attempt ID the config carries as a
+	// label.
+	//
+	// PostHog property: tp.discovery.setup_attempt_id
+	SetupAttemptId string `protobuf:"bytes,3,opt,name=setup_attempt_id,json=setupAttemptId,proto3" json:"setup_attempt_id,omitempty"`
+	// PostHog property: tp.discovery.action
+	Action DiscoveryConfigChangeAction `protobuf:"varint,4,opt,name=action,proto3,enum=prehog.v1alpha.DiscoveryConfigChangeAction" json:"action,omitempty"`
+	// matcher_types are the resource types the config's matchers select, sorted
+	// and deduplicated.
+	//
+	// PostHog property: tp.discovery.matcher_types
+	MatcherTypes []DiscoveryMatcherType `protobuf:"varint,5,rep,packed,name=matcher_types,json=matcherTypes,proto3,enum=prehog.v1alpha.DiscoveryMatcherType" json:"matcher_types,omitempty"`
+	// PostHog property: tp.discovery.client_kind
+	ClientKind ClientKind `protobuf:"varint,6,opt,name=client_kind,json=clientKind,proto3,enum=prehog.v1alpha.ClientKind" json:"client_kind,omitempty"`
+	// access_graph_integration_ids are the anonymized names of the integrations
+	// the config's Access Graph syncs use, deduplicated.
+	//
+	// PostHog property: tp.discovery.access_graph_integration_ids
+	AccessGraphIntegrationIds []string `protobuf:"bytes,7,rep,name=access_graph_integration_ids,json=accessGraphIntegrationIds,proto3" json:"access_graph_integration_ids,omitempty"`
+	// access_graph_sync_providers are the clouds the config syncs into Access
+	// Graph, sorted and deduplicated.
+	//
+	// PostHog property: tp.discovery.access_graph_sync_providers
+	AccessGraphSyncProviders []CloudProvider `protobuf:"varint,8,rep,packed,name=access_graph_sync_providers,json=accessGraphSyncProviders,proto3,enum=prehog.v1alpha.CloudProvider" json:"access_graph_sync_providers,omitempty"`
+	// matcher_providers are the platforms the config's matchers select resources
+	// from, sorted and deduplicated.
+	//
+	// PostHog property: tp.discovery.matcher_providers
+	MatcherProviders []CloudProvider `protobuf:"varint,9,rep,packed,name=matcher_providers,json=matcherProviders,proto3,enum=prehog.v1alpha.CloudProvider" json:"matcher_providers,omitempty"`
+	// discovery_group_id is the anonymized discovery group that runs the config.
+	//
+	// PostHog property: tp.discovery.discovery_group_id
+	DiscoveryGroupId string `protobuf:"bytes,10,opt,name=discovery_group_id,json=discoveryGroupId,proto3" json:"discovery_group_id,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *DiscoveryConfigChangedEvent) Reset() {
+	*x = DiscoveryConfigChangedEvent{}
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[120]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoveryConfigChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoveryConfigChangedEvent) ProtoMessage() {}
+
+func (x *DiscoveryConfigChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[120]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoveryConfigChangedEvent.ProtoReflect.Descriptor instead.
+func (*DiscoveryConfigChangedEvent) Descriptor() ([]byte, []int) {
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{120}
+}
+
+func (x *DiscoveryConfigChangedEvent) GetDiscoveryConfigId() string {
+	if x != nil {
+		return x.DiscoveryConfigId
+	}
+	return ""
+}
+
+func (x *DiscoveryConfigChangedEvent) GetIntegrationIds() []string {
+	if x != nil {
+		return x.IntegrationIds
+	}
+	return nil
+}
+
+func (x *DiscoveryConfigChangedEvent) GetSetupAttemptId() string {
+	if x != nil {
+		return x.SetupAttemptId
+	}
+	return ""
+}
+
+func (x *DiscoveryConfigChangedEvent) GetAction() DiscoveryConfigChangeAction {
+	if x != nil {
+		return x.Action
+	}
+	return DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UNSPECIFIED
+}
+
+func (x *DiscoveryConfigChangedEvent) GetMatcherTypes() []DiscoveryMatcherType {
+	if x != nil {
+		return x.MatcherTypes
+	}
+	return nil
+}
+
+func (x *DiscoveryConfigChangedEvent) GetClientKind() ClientKind {
+	if x != nil {
+		return x.ClientKind
+	}
+	return ClientKind_CLIENT_KIND_UNSPECIFIED
+}
+
+func (x *DiscoveryConfigChangedEvent) GetAccessGraphIntegrationIds() []string {
+	if x != nil {
+		return x.AccessGraphIntegrationIds
+	}
+	return nil
+}
+
+func (x *DiscoveryConfigChangedEvent) GetAccessGraphSyncProviders() []CloudProvider {
+	if x != nil {
+		return x.AccessGraphSyncProviders
+	}
+	return nil
+}
+
+func (x *DiscoveryConfigChangedEvent) GetMatcherProviders() []CloudProvider {
+	if x != nil {
+		return x.MatcherProviders
+	}
+	return nil
+}
+
+func (x *DiscoveryConfigChangedEvent) GetDiscoveryGroupId() string {
+	if x != nil {
+		return x.DiscoveryGroupId
+	}
+	return ""
+}
+
 // IdentitySecurityGraphSizeEvent is emitted by Access Graph whenever the access graph
 // for a provider is updated.
 type IdentitySecurityGraphSizeEvent struct {
@@ -9958,7 +10400,7 @@ type IdentitySecurityGraphSizeEvent struct {
 
 func (x *IdentitySecurityGraphSizeEvent) Reset() {
 	*x = IdentitySecurityGraphSizeEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[120]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9970,7 +10412,7 @@ func (x *IdentitySecurityGraphSizeEvent) String() string {
 func (*IdentitySecurityGraphSizeEvent) ProtoMessage() {}
 
 func (x *IdentitySecurityGraphSizeEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[120]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9983,7 +10425,7 @@ func (x *IdentitySecurityGraphSizeEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdentitySecurityGraphSizeEvent.ProtoReflect.Descriptor instead.
 func (*IdentitySecurityGraphSizeEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{120}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *IdentitySecurityGraphSizeEvent) GetProvider() string {
@@ -10022,7 +10464,7 @@ type IdentitySecurityAuditLogsIngestedEvent struct {
 
 func (x *IdentitySecurityAuditLogsIngestedEvent) Reset() {
 	*x = IdentitySecurityAuditLogsIngestedEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[121]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10034,7 +10476,7 @@ func (x *IdentitySecurityAuditLogsIngestedEvent) String() string {
 func (*IdentitySecurityAuditLogsIngestedEvent) ProtoMessage() {}
 
 func (x *IdentitySecurityAuditLogsIngestedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[121]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10047,7 +10489,7 @@ func (x *IdentitySecurityAuditLogsIngestedEvent) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use IdentitySecurityAuditLogsIngestedEvent.ProtoReflect.Descriptor instead.
 func (*IdentitySecurityAuditLogsIngestedEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{121}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *IdentitySecurityAuditLogsIngestedEvent) GetProvider() string {
@@ -10077,7 +10519,7 @@ type AccessListStepStatus struct {
 
 func (x *AccessListStepStatus) Reset() {
 	*x = AccessListStepStatus{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[122]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10089,7 +10531,7 @@ func (x *AccessListStepStatus) String() string {
 func (*AccessListStepStatus) ProtoMessage() {}
 
 func (x *AccessListStepStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[122]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10102,7 +10544,7 @@ func (x *AccessListStepStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListStepStatus.ProtoReflect.Descriptor instead.
 func (*AccessListStepStatus) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{122}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *AccessListStepStatus) GetStatus() AccessListStatus {
@@ -10131,7 +10573,7 @@ type UIAccessListDefineAccessEvent struct {
 
 func (x *UIAccessListDefineAccessEvent) Reset() {
 	*x = UIAccessListDefineAccessEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[123]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10143,7 +10585,7 @@ func (x *UIAccessListDefineAccessEvent) String() string {
 func (*UIAccessListDefineAccessEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineAccessEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[123]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10156,7 +10598,7 @@ func (x *UIAccessListDefineAccessEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListDefineAccessEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineAccessEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{123}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *UIAccessListDefineAccessEvent) GetMetadata() *AccessListMetadata {
@@ -10185,7 +10627,7 @@ type UIAccessListDefineIdentitiesEvent struct {
 
 func (x *UIAccessListDefineIdentitiesEvent) Reset() {
 	*x = UIAccessListDefineIdentitiesEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[124]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10197,7 +10639,7 @@ func (x *UIAccessListDefineIdentitiesEvent) String() string {
 func (*UIAccessListDefineIdentitiesEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineIdentitiesEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[124]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10210,7 +10652,7 @@ func (x *UIAccessListDefineIdentitiesEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use UIAccessListDefineIdentitiesEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineIdentitiesEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{124}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *UIAccessListDefineIdentitiesEvent) GetMetadata() *AccessListMetadata {
@@ -10239,7 +10681,7 @@ type UIAccessListDefineBasicInfoEvent struct {
 
 func (x *UIAccessListDefineBasicInfoEvent) Reset() {
 	*x = UIAccessListDefineBasicInfoEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[125]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10251,7 +10693,7 @@ func (x *UIAccessListDefineBasicInfoEvent) String() string {
 func (*UIAccessListDefineBasicInfoEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineBasicInfoEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[125]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10264,7 +10706,7 @@ func (x *UIAccessListDefineBasicInfoEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListDefineBasicInfoEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineBasicInfoEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{125}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *UIAccessListDefineBasicInfoEvent) GetMetadata() *AccessListMetadata {
@@ -10293,7 +10735,7 @@ type UIAccessListDefineMembersEvent struct {
 
 func (x *UIAccessListDefineMembersEvent) Reset() {
 	*x = UIAccessListDefineMembersEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[126]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10305,7 +10747,7 @@ func (x *UIAccessListDefineMembersEvent) String() string {
 func (*UIAccessListDefineMembersEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineMembersEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[126]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10318,7 +10760,7 @@ func (x *UIAccessListDefineMembersEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListDefineMembersEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineMembersEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{126}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *UIAccessListDefineMembersEvent) GetMetadata() *AccessListMetadata {
@@ -10347,7 +10789,7 @@ type UIAccessListDefineOwnersEvent struct {
 
 func (x *UIAccessListDefineOwnersEvent) Reset() {
 	*x = UIAccessListDefineOwnersEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[127]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10359,7 +10801,7 @@ func (x *UIAccessListDefineOwnersEvent) String() string {
 func (*UIAccessListDefineOwnersEvent) ProtoMessage() {}
 
 func (x *UIAccessListDefineOwnersEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[127]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10372,7 +10814,7 @@ func (x *UIAccessListDefineOwnersEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListDefineOwnersEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListDefineOwnersEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{127}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *UIAccessListDefineOwnersEvent) GetMetadata() *AccessListMetadata {
@@ -10401,7 +10843,7 @@ type UIAccessListStartEvent struct {
 
 func (x *UIAccessListStartEvent) Reset() {
 	*x = UIAccessListStartEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[128]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10413,7 +10855,7 @@ func (x *UIAccessListStartEvent) String() string {
 func (*UIAccessListStartEvent) ProtoMessage() {}
 
 func (x *UIAccessListStartEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[128]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10426,7 +10868,7 @@ func (x *UIAccessListStartEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListStartEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListStartEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{128}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *UIAccessListStartEvent) GetMetadata() *AccessListMetadata {
@@ -10455,7 +10897,7 @@ type UIAccessListCustomEvent struct {
 
 func (x *UIAccessListCustomEvent) Reset() {
 	*x = UIAccessListCustomEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[129]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10467,7 +10909,7 @@ func (x *UIAccessListCustomEvent) String() string {
 func (*UIAccessListCustomEvent) ProtoMessage() {}
 
 func (x *UIAccessListCustomEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[129]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10480,7 +10922,7 @@ func (x *UIAccessListCustomEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListCustomEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListCustomEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{129}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *UIAccessListCustomEvent) GetMetadata() *AccessListMetadata {
@@ -10512,7 +10954,7 @@ type UIAccessListCompleteEvent struct {
 
 func (x *UIAccessListCompleteEvent) Reset() {
 	*x = UIAccessListCompleteEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[130]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10524,7 +10966,7 @@ func (x *UIAccessListCompleteEvent) String() string {
 func (*UIAccessListCompleteEvent) ProtoMessage() {}
 
 func (x *UIAccessListCompleteEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[130]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10537,7 +10979,7 @@ func (x *UIAccessListCompleteEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListCompleteEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListCompleteEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{130}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *UIAccessListCompleteEvent) GetMetadata() *AccessListMetadata {
@@ -10573,7 +11015,7 @@ type UIAccessListIntegrateEvent struct {
 
 func (x *UIAccessListIntegrateEvent) Reset() {
 	*x = UIAccessListIntegrateEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[131]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10585,7 +11027,7 @@ func (x *UIAccessListIntegrateEvent) String() string {
 func (*UIAccessListIntegrateEvent) ProtoMessage() {}
 
 func (x *UIAccessListIntegrateEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[131]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10598,7 +11040,7 @@ func (x *UIAccessListIntegrateEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIAccessListIntegrateEvent.ProtoReflect.Descriptor instead.
 func (*UIAccessListIntegrateEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{131}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *UIAccessListIntegrateEvent) GetMetadata() *AccessListMetadata {
@@ -10645,7 +11087,7 @@ type UIInteractionEvent struct {
 
 func (x *UIInteractionEvent) Reset() {
 	*x = UIInteractionEvent{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[132]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10657,7 +11099,7 @@ func (x *UIInteractionEvent) String() string {
 func (*UIInteractionEvent) ProtoMessage() {}
 
 func (x *UIInteractionEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[132]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10670,7 +11112,7 @@ func (x *UIInteractionEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UIInteractionEvent.ProtoReflect.Descriptor instead.
 func (*UIInteractionEvent) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{132}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *UIInteractionEvent) GetUserName() string {
@@ -10846,6 +11288,7 @@ type SubmitEventRequest struct {
 	//	*SubmitEventRequest_BeamsDestroyed
 	//	*SubmitEventRequest_BeamsPublished
 	//	*SubmitEventRequest_BeamsUnpublished
+	//	*SubmitEventRequest_DiscoveryConfigChanged
 	Event         isSubmitEventRequest_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -10853,7 +11296,7 @@ type SubmitEventRequest struct {
 
 func (x *SubmitEventRequest) Reset() {
 	*x = SubmitEventRequest{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[133]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10865,7 +11308,7 @@ func (x *SubmitEventRequest) String() string {
 func (*SubmitEventRequest) ProtoMessage() {}
 
 func (x *SubmitEventRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[133]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10878,7 +11321,7 @@ func (x *SubmitEventRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitEventRequest.ProtoReflect.Descriptor instead.
 func (*SubmitEventRequest) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{133}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *SubmitEventRequest) GetClusterName() string {
@@ -11996,6 +12439,15 @@ func (x *SubmitEventRequest) GetBeamsUnpublished() *BeamsUnpublishedEvent {
 	return nil
 }
 
+func (x *SubmitEventRequest) GetDiscoveryConfigChanged() *DiscoveryConfigChangedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*SubmitEventRequest_DiscoveryConfigChanged); ok {
+			return x.DiscoveryConfigChanged
+		}
+	}
+	return nil
+}
+
 type isSubmitEventRequest_Event interface {
 	isSubmitEventRequest_Event()
 }
@@ -12485,6 +12937,10 @@ type SubmitEventRequest_BeamsUnpublished struct {
 	BeamsUnpublished *BeamsUnpublishedEvent `protobuf:"bytes,126,opt,name=beams_unpublished,json=beamsUnpublished,proto3,oneof"`
 }
 
+type SubmitEventRequest_DiscoveryConfigChanged struct {
+	DiscoveryConfigChanged *DiscoveryConfigChangedEvent `protobuf:"bytes,127,opt,name=discovery_config_changed,json=discoveryConfigChanged,proto3,oneof"`
+}
+
 func (*SubmitEventRequest_UserLogin) isSubmitEventRequest_Event() {}
 
 func (*SubmitEventRequest_SsoCreate) isSubmitEventRequest_Event() {}
@@ -12727,6 +13183,8 @@ func (*SubmitEventRequest_BeamsPublished) isSubmitEventRequest_Event() {}
 
 func (*SubmitEventRequest_BeamsUnpublished) isSubmitEventRequest_Event() {}
 
+func (*SubmitEventRequest_DiscoveryConfigChanged) isSubmitEventRequest_Event() {}
+
 type SubmitEventResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -12735,7 +13193,7 @@ type SubmitEventResponse struct {
 
 func (x *SubmitEventResponse) Reset() {
 	*x = SubmitEventResponse{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[134]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12747,7 +13205,7 @@ func (x *SubmitEventResponse) String() string {
 func (*SubmitEventResponse) ProtoMessage() {}
 
 func (x *SubmitEventResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[134]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12760,7 +13218,7 @@ func (x *SubmitEventResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitEventResponse.ProtoReflect.Descriptor instead.
 func (*SubmitEventResponse) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{134}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{135}
 }
 
 type SubmitEventsRequest struct {
@@ -12773,7 +13231,7 @@ type SubmitEventsRequest struct {
 
 func (x *SubmitEventsRequest) Reset() {
 	*x = SubmitEventsRequest{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[135]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12785,7 +13243,7 @@ func (x *SubmitEventsRequest) String() string {
 func (*SubmitEventsRequest) ProtoMessage() {}
 
 func (x *SubmitEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[135]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12798,7 +13256,7 @@ func (x *SubmitEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitEventsRequest.ProtoReflect.Descriptor instead.
 func (*SubmitEventsRequest) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{135}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *SubmitEventsRequest) GetEvents() []*SubmitEventRequest {
@@ -12816,7 +13274,7 @@ type SubmitEventsResponse struct {
 
 func (x *SubmitEventsResponse) Reset() {
 	*x = SubmitEventsResponse{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[136]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12828,7 +13286,7 @@ func (x *SubmitEventsResponse) String() string {
 func (*SubmitEventsResponse) ProtoMessage() {}
 
 func (x *SubmitEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[136]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12841,7 +13299,7 @@ func (x *SubmitEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubmitEventsResponse.ProtoReflect.Descriptor instead.
 func (*SubmitEventsResponse) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{136}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{137}
 }
 
 type HelloTeleportRequest struct {
@@ -12852,7 +13310,7 @@ type HelloTeleportRequest struct {
 
 func (x *HelloTeleportRequest) Reset() {
 	*x = HelloTeleportRequest{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[137]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12864,7 +13322,7 @@ func (x *HelloTeleportRequest) String() string {
 func (*HelloTeleportRequest) ProtoMessage() {}
 
 func (x *HelloTeleportRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[137]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12877,7 +13335,7 @@ func (x *HelloTeleportRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HelloTeleportRequest.ProtoReflect.Descriptor instead.
 func (*HelloTeleportRequest) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{137}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{138}
 }
 
 type HelloTeleportResponse struct {
@@ -12888,7 +13346,7 @@ type HelloTeleportResponse struct {
 
 func (x *HelloTeleportResponse) Reset() {
 	*x = HelloTeleportResponse{}
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[138]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12900,7 +13358,7 @@ func (x *HelloTeleportResponse) String() string {
 func (*HelloTeleportResponse) ProtoMessage() {}
 
 func (x *HelloTeleportResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[138]
+	mi := &file_prehog_v1alpha_teleport_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12913,7 +13371,7 @@ func (x *HelloTeleportResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HelloTeleportResponse.ProtoReflect.Descriptor instead.
 func (*HelloTeleportResponse) Descriptor() ([]byte, []int) {
-	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{138}
+	return file_prehog_v1alpha_teleport_proto_rawDescGZIP(), []int{139}
 }
 
 var File_prehog_v1alpha_teleport_proto protoreflect.FileDescriptor
@@ -13481,7 +13939,20 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"\x15discovery_config_name\x18\x02 \x01(\tR\x13discoveryConfigName\x12%\n" +
 	"\x0eresource_types\x18\x03 \x03(\tR\rresourceTypes\x12'\n" +
 	"\x0fcloud_providers\x18\x04 \x03(\tR\x0ecloudProviders\x12'\n" +
-	"\x0fcreation_method\x18\x05 \x01(\tR\x0ecreationMethod\"\x90\x01\n" +
+	"\x0fcreation_method\x18\x05 \x01(\tR\x0ecreationMethod\"\x86\x05\n" +
+	"\x1bDiscoveryConfigChangedEvent\x12.\n" +
+	"\x13discovery_config_id\x18\x01 \x01(\tR\x11discoveryConfigId\x12'\n" +
+	"\x0fintegration_ids\x18\x02 \x03(\tR\x0eintegrationIds\x12(\n" +
+	"\x10setup_attempt_id\x18\x03 \x01(\tR\x0esetupAttemptId\x12C\n" +
+	"\x06action\x18\x04 \x01(\x0e2+.prehog.v1alpha.DiscoveryConfigChangeActionR\x06action\x12I\n" +
+	"\rmatcher_types\x18\x05 \x03(\x0e2$.prehog.v1alpha.DiscoveryMatcherTypeR\fmatcherTypes\x12;\n" +
+	"\vclient_kind\x18\x06 \x01(\x0e2\x1a.prehog.v1alpha.ClientKindR\n" +
+	"clientKind\x12?\n" +
+	"\x1caccess_graph_integration_ids\x18\a \x03(\tR\x19accessGraphIntegrationIds\x12\\\n" +
+	"\x1baccess_graph_sync_providers\x18\b \x03(\x0e2\x1d.prehog.v1alpha.CloudProviderR\x18accessGraphSyncProviders\x12J\n" +
+	"\x11matcher_providers\x18\t \x03(\x0e2\x1d.prehog.v1alpha.CloudProviderR\x10matcherProviders\x12,\n" +
+	"\x12discovery_group_id\x18\n" +
+	" \x01(\tR\x10discoveryGroupId\"\x90\x01\n" +
 	"\x1eIdentitySecurityGraphSizeEvent\x12\x1a\n" +
 	"\bprovider\x18\x01 \x01(\tR\bprovider\x12)\n" +
 	"\x10total_identities\x18\x02 \x01(\x04R\x0ftotalIdentities\x12'\n" +
@@ -13527,7 +13998,7 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"\x06params\x18\x04 \x03(\v2..prehog.v1alpha.UIInteractionEvent.ParamsEntryR\x06params\x1a9\n" +
 	"\vParamsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbbi\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xa4j\n" +
 	"\x12SubmitEventRequest\x12!\n" +
 	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x128\n" +
 	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12)\n" +
@@ -13658,7 +14129,8 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"\rbeams_created\x18{ \x01(\v2!.prehog.v1alpha.BeamsCreatedEventH\x00R\fbeamsCreated\x12N\n" +
 	"\x0fbeams_destroyed\x18| \x01(\v2#.prehog.v1alpha.BeamsDestroyedEventH\x00R\x0ebeamsDestroyed\x12N\n" +
 	"\x0fbeams_published\x18} \x01(\v2#.prehog.v1alpha.BeamsPublishedEventH\x00R\x0ebeamsPublished\x12T\n" +
-	"\x11beams_unpublished\x18~ \x01(\v2%.prehog.v1alpha.BeamsUnpublishedEventH\x00R\x10beamsUnpublishedB\a\n" +
+	"\x11beams_unpublished\x18~ \x01(\v2%.prehog.v1alpha.BeamsUnpublishedEventH\x00R\x10beamsUnpublished\x12g\n" +
+	"\x18discovery_config_changed\x18\x7f \x01(\v2+.prehog.v1alpha.DiscoveryConfigChangedEventH\x00R\x16discoveryConfigChangedB\a\n" +
 	"\x05eventJ\x04\b\b\x10\tJ\x04\ba\x10bJ\x04\bb\x10cR\x1cui_onboard_get_started_clickR\x1baccess_request_create_eventR\x1baccess_request_review_event\"\x15\n" +
 	"\x13SubmitEventResponse\"Q\n" +
 	"\x13SubmitEventsRequest\x12:\n" +
@@ -13864,7 +14336,54 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"#DISCOVERY_CONFIG_ACTION_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eDISCOVERY_CONFIG_ACTION_CREATE\x10\x01\x12\"\n" +
 	"\x1eDISCOVERY_CONFIG_ACTION_UPDATE\x10\x02\x12\"\n" +
-	"\x1eDISCOVERY_CONFIG_ACTION_DELETE\x10\x03*\xb4\x01\n" +
+	"\x1eDISCOVERY_CONFIG_ACTION_DELETE\x10\x03*\xc2\a\n" +
+	"\x14DiscoveryMatcherType\x12&\n" +
+	"\"DISCOVERY_MATCHER_TYPE_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eDISCOVERY_MATCHER_TYPE_AWS_EC2\x10\x01\x12\"\n" +
+	"\x1eDISCOVERY_MATCHER_TYPE_AWS_EKS\x10\x02\x12\"\n" +
+	"\x1eDISCOVERY_MATCHER_TYPE_AWS_RDS\x10\x03\x12'\n" +
+	"#DISCOVERY_MATCHER_TYPE_AWS_RDSPROXY\x10\x04\x12'\n" +
+	"#DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT\x10\x05\x122\n" +
+	".DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT_SERVERLESS\x10\x06\x12*\n" +
+	"&DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE\x10\a\x125\n" +
+	"1DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE_SERVERLESS\x10\b\x12'\n" +
+	"#DISCOVERY_MATCHER_TYPE_AWS_MEMORYDB\x10\t\x12)\n" +
+	"%DISCOVERY_MATCHER_TYPE_AWS_OPENSEARCH\x10\n" +
+	"\x12$\n" +
+	" DISCOVERY_MATCHER_TYPE_AWS_DOCDB\x10\v\x12#\n" +
+	"\x1fDISCOVERY_MATCHER_TYPE_AZURE_VM\x10\f\x12$\n" +
+	" DISCOVERY_MATCHER_TYPE_AZURE_AKS\x10\r\x12&\n" +
+	"\"DISCOVERY_MATCHER_TYPE_AZURE_MYSQL\x10\x0e\x12)\n" +
+	"%DISCOVERY_MATCHER_TYPE_AZURE_POSTGRES\x10\x0f\x12&\n" +
+	"\"DISCOVERY_MATCHER_TYPE_AZURE_REDIS\x10\x10\x12*\n" +
+	"&DISCOVERY_MATCHER_TYPE_AZURE_SQLSERVER\x10\x11\x12+\n" +
+	"'DISCOVERY_MATCHER_TYPE_AZURE_WINDOWS_VM\x10\x12\x12\"\n" +
+	"\x1eDISCOVERY_MATCHER_TYPE_GCP_GKE\x10\x13\x12\"\n" +
+	"\x1eDISCOVERY_MATCHER_TYPE_GCP_GCE\x10\x14\x12'\n" +
+	"#DISCOVERY_MATCHER_TYPE_GCP_CLOUDSQL\x10\x15\x12#\n" +
+	"\x1fDISCOVERY_MATCHER_TYPE_KUBE_APP\x10\x16*\x98\x01\n" +
+	"\rCloudProvider\x12\x1e\n" +
+	"\x1aCLOUD_PROVIDER_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12CLOUD_PROVIDER_AWS\x10\x01\x12\x18\n" +
+	"\x14CLOUD_PROVIDER_AZURE\x10\x02\x12\x16\n" +
+	"\x12CLOUD_PROVIDER_GCP\x10\x03\x12\x1d\n" +
+	"\x19CLOUD_PROVIDER_KUBERNETES\x10\x04*\xde\x01\n" +
+	"\n" +
+	"ClientKind\x12\x1b\n" +
+	"\x17CLIENT_KIND_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13CLIENT_KIND_UNKNOWN\x10\x01\x12\x16\n" +
+	"\x12CLIENT_KIND_WEB_UI\x10\x02\x12\x14\n" +
+	"\x10CLIENT_KIND_TCTL\x10\x03\x12\x13\n" +
+	"\x0fCLIENT_KIND_TSH\x10\x04\x12\x14\n" +
+	"\x10CLIENT_KIND_TBOT\x10\x05\x12\"\n" +
+	"\x1eCLIENT_KIND_TERRAFORM_PROVIDER\x10\x06\x12\x1d\n" +
+	"\x19CLIENT_KIND_KUBE_OPERATOR\x10\a*\xf9\x01\n" +
+	"\x1bDiscoveryConfigChangeAction\x12.\n" +
+	"*DISCOVERY_CONFIG_CHANGE_ACTION_UNSPECIFIED\x10\x00\x12)\n" +
+	"%DISCOVERY_CONFIG_CHANGE_ACTION_CREATE\x10\x01\x12)\n" +
+	"%DISCOVERY_CONFIG_CHANGE_ACTION_UPDATE\x10\x02\x12)\n" +
+	"%DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT\x10\x03\x12)\n" +
+	"%DISCOVERY_CONFIG_CHANGE_ACTION_DELETE\x10\x04*\xb4\x01\n" +
 	"\x10AccessListStatus\x12\"\n" +
 	"\x1eACCESS_LIST_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aACCESS_LIST_STATUS_SUCCESS\x10\x01\x12\x1e\n" +
@@ -13896,8 +14415,8 @@ func file_prehog_v1alpha_teleport_proto_rawDescGZIP() []byte {
 	return file_prehog_v1alpha_teleport_proto_rawDescData
 }
 
-var file_prehog_v1alpha_teleport_proto_enumTypes = make([]protoimpl.EnumInfo, 25)
-var file_prehog_v1alpha_teleport_proto_msgTypes = make([]protoimpl.MessageInfo, 140)
+var file_prehog_v1alpha_teleport_proto_enumTypes = make([]protoimpl.EnumInfo, 29)
+var file_prehog_v1alpha_teleport_proto_msgTypes = make([]protoimpl.MessageInfo, 141)
 var file_prehog_v1alpha_teleport_proto_goTypes = []any{
 	(UserOrigin)(0),                                           // 0: prehog.v1alpha.UserOrigin
 	(ResourceKind)(0),                                         // 1: prehog.v1alpha.ResourceKind
@@ -13917,427 +14436,438 @@ var file_prehog_v1alpha_teleport_proto_goTypes = []any{
 	(FeatureRecommendationStatus)(0),                          // 15: prehog.v1alpha.FeatureRecommendationStatus
 	(LicenseLimit)(0),                                         // 16: prehog.v1alpha.LicenseLimit
 	(DiscoveryConfigAction)(0),                                // 17: prehog.v1alpha.DiscoveryConfigAction
-	(AccessListStatus)(0),                                     // 18: prehog.v1alpha.AccessListStatus
-	(AccessListPreset)(0),                                     // 19: prehog.v1alpha.AccessListPreset
-	(AccessListIntegrate)(0),                                  // 20: prehog.v1alpha.AccessListIntegrate
-	(UIDiscoverDeployServiceEvent_DeployMethod)(0),            // 21: prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployMethod
-	(UIDiscoverDeployServiceEvent_DeployType)(0),              // 22: prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployType
-	(UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod)(0),    // 23: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.ConfigMethod
-	(AccessRequestReviewEvent_ProposedState)(0),               // 24: prehog.v1alpha.AccessRequestReviewEvent.ProposedState
-	(*UserLoginEvent)(nil),                                    // 25: prehog.v1alpha.UserLoginEvent
-	(*MFAAuthenticationEvent)(nil),                            // 26: prehog.v1alpha.MFAAuthenticationEvent
-	(*SSOCreateEvent)(nil),                                    // 27: prehog.v1alpha.SSOCreateEvent
-	(*ResourceCreateEvent)(nil),                               // 28: prehog.v1alpha.ResourceCreateEvent
-	(*DiscoveredDatabaseMetadata)(nil),                        // 29: prehog.v1alpha.DiscoveredDatabaseMetadata
-	(*ResourceHeartbeatEvent)(nil),                            // 30: prehog.v1alpha.ResourceHeartbeatEvent
-	(*SessionStartEvent)(nil),                                 // 31: prehog.v1alpha.SessionStartEvent
-	(*SessionStartDatabaseMetadata)(nil),                      // 32: prehog.v1alpha.SessionStartDatabaseMetadata
-	(*SessionStartDesktopMetadata)(nil),                       // 33: prehog.v1alpha.SessionStartDesktopMetadata
-	(*SessionStartAppMetadata)(nil),                           // 34: prehog.v1alpha.SessionStartAppMetadata
-	(*SessionStartGitMetadata)(nil),                           // 35: prehog.v1alpha.SessionStartGitMetadata
-	(*SessionStartMCPMetadata)(nil),                           // 36: prehog.v1alpha.SessionStartMCPMetadata
-	(*SessionStartBeamMetadata)(nil),                          // 37: prehog.v1alpha.SessionStartBeamMetadata
-	(*BeamsCreatedEvent)(nil),                                 // 38: prehog.v1alpha.BeamsCreatedEvent
-	(*BeamsDestroyedEvent)(nil),                               // 39: prehog.v1alpha.BeamsDestroyedEvent
-	(*BeamsPublishedEvent)(nil),                               // 40: prehog.v1alpha.BeamsPublishedEvent
-	(*BeamsUnpublishedEvent)(nil),                             // 41: prehog.v1alpha.BeamsUnpublishedEvent
-	(*UserCertificateIssuedEvent)(nil),                        // 42: prehog.v1alpha.UserCertificateIssuedEvent
-	(*SPIFFESVIDIssuedEvent)(nil),                             // 43: prehog.v1alpha.SPIFFESVIDIssuedEvent
-	(*UIBannerClickEvent)(nil),                                // 44: prehog.v1alpha.UIBannerClickEvent
-	(*UIOnboardCompleteGoToDashboardClickEvent)(nil),          // 45: prehog.v1alpha.UIOnboardCompleteGoToDashboardClickEvent
-	(*UIOnboardAddFirstResourceClickEvent)(nil),               // 46: prehog.v1alpha.UIOnboardAddFirstResourceClickEvent
-	(*UIOnboardAddFirstResourceLaterClickEvent)(nil),          // 47: prehog.v1alpha.UIOnboardAddFirstResourceLaterClickEvent
-	(*UIOnboardSetCredentialSubmitEvent)(nil),                 // 48: prehog.v1alpha.UIOnboardSetCredentialSubmitEvent
-	(*UIOnboardRegisterChallengeSubmitEvent)(nil),             // 49: prehog.v1alpha.UIOnboardRegisterChallengeSubmitEvent
-	(*UIOnboardQuestionnaireSubmitEvent)(nil),                 // 50: prehog.v1alpha.UIOnboardQuestionnaireSubmitEvent
-	(*UIRecoveryCodesContinueClickEvent)(nil),                 // 51: prehog.v1alpha.UIRecoveryCodesContinueClickEvent
-	(*UIRecoveryCodesCopyClickEvent)(nil),                     // 52: prehog.v1alpha.UIRecoveryCodesCopyClickEvent
-	(*UIRecoveryCodesPrintClickEvent)(nil),                    // 53: prehog.v1alpha.UIRecoveryCodesPrintClickEvent
-	(*DiscoverMetadata)(nil),                                  // 54: prehog.v1alpha.DiscoverMetadata
-	(*DiscoverResourceMetadata)(nil),                          // 55: prehog.v1alpha.DiscoverResourceMetadata
-	(*DiscoverStepStatus)(nil),                                // 56: prehog.v1alpha.DiscoverStepStatus
-	(*UIDiscoverStartedEvent)(nil),                            // 57: prehog.v1alpha.UIDiscoverStartedEvent
-	(*UIDiscoverResourceSelectionEvent)(nil),                  // 58: prehog.v1alpha.UIDiscoverResourceSelectionEvent
-	(*UIDiscoverIntegrationAWSOIDCConnectEvent)(nil),          // 59: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent
-	(*UIDiscoverDatabaseRDSEnrollEvent)(nil),                  // 60: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent
-	(*UIDiscoverKubeEKSEnrollEvent)(nil),                      // 61: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent
-	(*UIDiscoverDeployServiceEvent)(nil),                      // 62: prehog.v1alpha.UIDiscoverDeployServiceEvent
-	(*UIDiscoverCreateDiscoveryConfigEvent)(nil),              // 63: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent
-	(*UIDiscoverDatabaseRegisterEvent)(nil),                   // 64: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent
-	(*UIDiscoverDatabaseConfigureMTLSEvent)(nil),              // 65: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent
-	(*UIDiscoverDesktopActiveDirectoryToolsInstallEvent)(nil), // 66: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent
-	(*UIDiscoverDesktopActiveDirectoryConfigureEvent)(nil),    // 67: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent
-	(*UIDiscoverAutoDiscoveredResourcesEvent)(nil),            // 68: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent
-	(*UIDiscoverEC2InstanceSelectionEvent)(nil),               // 69: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent
-	(*UIDiscoverDeployEICEEvent)(nil),                         // 70: prehog.v1alpha.UIDiscoverDeployEICEEvent
-	(*UIDiscoverCreateNodeEvent)(nil),                         // 71: prehog.v1alpha.UIDiscoverCreateNodeEvent
-	(*UIDiscoverCreateAppServerEvent)(nil),                    // 72: prehog.v1alpha.UIDiscoverCreateAppServerEvent
-	(*UIDiscoverDatabaseConfigureIAMPolicyEvent)(nil),         // 73: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent
-	(*UIDiscoverPrincipalsConfigureEvent)(nil),                // 74: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent
-	(*UIDiscoverTestConnectionEvent)(nil),                     // 75: prehog.v1alpha.UIDiscoverTestConnectionEvent
-	(*UIDiscoverCompletedEvent)(nil),                          // 76: prehog.v1alpha.UIDiscoverCompletedEvent
-	(*RoleCreateEvent)(nil),                                   // 77: prehog.v1alpha.RoleCreateEvent
-	(*BotCreateEvent)(nil),                                    // 78: prehog.v1alpha.BotCreateEvent
-	(*BotJoinEvent)(nil),                                      // 79: prehog.v1alpha.BotJoinEvent
-	(*UICreateNewRoleClickEvent)(nil),                         // 80: prehog.v1alpha.UICreateNewRoleClickEvent
-	(*UICreateNewRoleSaveClickEvent)(nil),                     // 81: prehog.v1alpha.UICreateNewRoleSaveClickEvent
-	(*UICreateNewRoleCancelClickEvent)(nil),                   // 82: prehog.v1alpha.UICreateNewRoleCancelClickEvent
-	(*UICreateNewRoleViewDocumentationClickEvent)(nil),        // 83: prehog.v1alpha.UICreateNewRoleViewDocumentationClickEvent
-	(*UICallToActionClickEvent)(nil),                          // 84: prehog.v1alpha.UICallToActionClickEvent
-	(*KubeRequestEvent)(nil),                                  // 85: prehog.v1alpha.KubeRequestEvent
-	(*SFTPEvent)(nil),                                         // 86: prehog.v1alpha.SFTPEvent
-	(*AgentMetadataEvent)(nil),                                // 87: prehog.v1alpha.AgentMetadataEvent
-	(*AssistCompletionEvent)(nil),                             // 88: prehog.v1alpha.AssistCompletionEvent
-	(*AssistExecutionEvent)(nil),                              // 89: prehog.v1alpha.AssistExecutionEvent
-	(*AssistNewConversationEvent)(nil),                        // 90: prehog.v1alpha.AssistNewConversationEvent
-	(*AssistAccessRequestEvent)(nil),                          // 91: prehog.v1alpha.AssistAccessRequestEvent
-	(*AssistActionEvent)(nil),                                 // 92: prehog.v1alpha.AssistActionEvent
-	(*AccessListMetadata)(nil),                                // 93: prehog.v1alpha.AccessListMetadata
-	(*AccessListCreateEvent)(nil),                             // 94: prehog.v1alpha.AccessListCreateEvent
-	(*AccessListUpdateEvent)(nil),                             // 95: prehog.v1alpha.AccessListUpdateEvent
-	(*AccessListDeleteEvent)(nil),                             // 96: prehog.v1alpha.AccessListDeleteEvent
-	(*AccessListMemberCreateEvent)(nil),                       // 97: prehog.v1alpha.AccessListMemberCreateEvent
-	(*AccessListMemberUpdateEvent)(nil),                       // 98: prehog.v1alpha.AccessListMemberUpdateEvent
-	(*AccessListMemberDeleteEvent)(nil),                       // 99: prehog.v1alpha.AccessListMemberDeleteEvent
-	(*AccessListGrantsToUserEvent)(nil),                       // 100: prehog.v1alpha.AccessListGrantsToUserEvent
-	(*AccessListReviewCreateEvent)(nil),                       // 101: prehog.v1alpha.AccessListReviewCreateEvent
-	(*AccessListReviewDeleteEvent)(nil),                       // 102: prehog.v1alpha.AccessListReviewDeleteEvent
-	(*AccessListReviewComplianceEvent)(nil),                   // 103: prehog.v1alpha.AccessListReviewComplianceEvent
-	(*IntegrationEnrollMetadata)(nil),                         // 104: prehog.v1alpha.IntegrationEnrollMetadata
-	(*UIIntegrationEnrollStartEvent)(nil),                     // 105: prehog.v1alpha.UIIntegrationEnrollStartEvent
-	(*UIIntegrationEnrollCompleteEvent)(nil),                  // 106: prehog.v1alpha.UIIntegrationEnrollCompleteEvent
-	(*IntegrationEnrollStepStatus)(nil),                       // 107: prehog.v1alpha.IntegrationEnrollStepStatus
-	(*UIIntegrationEnrollStepEvent)(nil),                      // 108: prehog.v1alpha.UIIntegrationEnrollStepEvent
-	(*UIIntegrationEnrollSectionOpenEvent)(nil),               // 109: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent
-	(*UIIntegrationEnrollFieldCompleteEvent)(nil),             // 110: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent
-	(*UIIntegrationEnrollCodeCopyEvent)(nil),                  // 111: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent
-	(*UIIntegrationEnrollLinkClickEvent)(nil),                 // 112: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent
-	(*EditorChangeEvent)(nil),                                 // 113: prehog.v1alpha.EditorChangeEvent
-	(*DeviceAuthenticateEvent)(nil),                           // 114: prehog.v1alpha.DeviceAuthenticateEvent
-	(*DeviceEnrollEvent)(nil),                                 // 115: prehog.v1alpha.DeviceEnrollEvent
-	(*FeatureRecommendationEvent)(nil),                        // 116: prehog.v1alpha.FeatureRecommendationEvent
-	(*LicenseLimitEvent)(nil),                                 // 117: prehog.v1alpha.LicenseLimitEvent
-	(*DesktopDirectoryShareEvent)(nil),                        // 118: prehog.v1alpha.DesktopDirectoryShareEvent
-	(*DesktopClipboardEvent)(nil),                             // 119: prehog.v1alpha.DesktopClipboardEvent
-	(*TAGExecuteQueryEvent)(nil),                              // 120: prehog.v1alpha.TAGExecuteQueryEvent
-	(*AccessGraphSecretsScanAuthorizedKeysEvent)(nil),         // 121: prehog.v1alpha.AccessGraphSecretsScanAuthorizedKeysEvent
-	(*AccessGraphSecretsScanSSHPrivateKeysEvent)(nil),         // 122: prehog.v1alpha.AccessGraphSecretsScanSSHPrivateKeysEvent
-	(*AccessGraphGitlabScanEvent)(nil),                        // 123: prehog.v1alpha.AccessGraphGitlabScanEvent
-	(*AccessGraphAWSScanEvent)(nil),                           // 124: prehog.v1alpha.AccessGraphAWSScanEvent
-	(*AccessGraphAccessPathChangedEvent)(nil),                 // 125: prehog.v1alpha.AccessGraphAccessPathChangedEvent
-	(*UIAccessGraphCrownJewelDiffViewEvent)(nil),              // 126: prehog.v1alpha.UIAccessGraphCrownJewelDiffViewEvent
-	(*UIPageViewEvent)(nil),                                   // 127: prehog.v1alpha.UIPageViewEvent
-	(*UIUsageReportingAlertCtaClickEvent)(nil),                // 128: prehog.v1alpha.UIUsageReportingAlertCtaClickEvent
-	(*AccessGraphCrownJewelCreateEvent)(nil),                  // 129: prehog.v1alpha.AccessGraphCrownJewelCreateEvent
-	(*ExternalAuditStorageAuthenticateEvent)(nil),             // 130: prehog.v1alpha.ExternalAuditStorageAuthenticateEvent
-	(*SecurityReportGetResultEvent)(nil),                      // 131: prehog.v1alpha.SecurityReportGetResultEvent
-	(*AuditQueryRunEvent)(nil),                                // 132: prehog.v1alpha.AuditQueryRunEvent
-	(*DiscoveryFetchEvent)(nil),                               // 133: prehog.v1alpha.DiscoveryFetchEvent
-	(*OktaAccessListSyncEvent)(nil),                           // 134: prehog.v1alpha.OktaAccessListSyncEvent
-	(*DatabaseUserCreatedEvent)(nil),                          // 135: prehog.v1alpha.DatabaseUserCreatedEvent
-	(*DatabaseUserPermissionsUpdateEvent)(nil),                // 136: prehog.v1alpha.DatabaseUserPermissionsUpdateEvent
-	(*SessionRecordingAccessEvent)(nil),                       // 137: prehog.v1alpha.SessionRecordingAccessEvent
-	(*UserTaskStateEvent)(nil),                                // 138: prehog.v1alpha.UserTaskStateEvent
-	(*AccessRequestCreateEvent)(nil),                          // 139: prehog.v1alpha.AccessRequestCreateEvent
-	(*AccessRequestReviewEvent)(nil),                          // 140: prehog.v1alpha.AccessRequestReviewEvent
-	(*SessionSummaryAccessEvent)(nil),                         // 141: prehog.v1alpha.SessionSummaryAccessEvent
-	(*SessionSummaryCreateEvent)(nil),                         // 142: prehog.v1alpha.SessionSummaryCreateEvent
-	(*SessionSummarySearchEvent)(nil),                         // 143: prehog.v1alpha.SessionSummarySearchEvent
-	(*DiscoveryConfigEvent)(nil),                              // 144: prehog.v1alpha.DiscoveryConfigEvent
-	(*IdentitySecurityGraphSizeEvent)(nil),                    // 145: prehog.v1alpha.IdentitySecurityGraphSizeEvent
-	(*IdentitySecurityAuditLogsIngestedEvent)(nil),            // 146: prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
-	(*AccessListStepStatus)(nil),                              // 147: prehog.v1alpha.AccessListStepStatus
-	(*UIAccessListDefineAccessEvent)(nil),                     // 148: prehog.v1alpha.UIAccessListDefineAccessEvent
-	(*UIAccessListDefineIdentitiesEvent)(nil),                 // 149: prehog.v1alpha.UIAccessListDefineIdentitiesEvent
-	(*UIAccessListDefineBasicInfoEvent)(nil),                  // 150: prehog.v1alpha.UIAccessListDefineBasicInfoEvent
-	(*UIAccessListDefineMembersEvent)(nil),                    // 151: prehog.v1alpha.UIAccessListDefineMembersEvent
-	(*UIAccessListDefineOwnersEvent)(nil),                     // 152: prehog.v1alpha.UIAccessListDefineOwnersEvent
-	(*UIAccessListStartEvent)(nil),                            // 153: prehog.v1alpha.UIAccessListStartEvent
-	(*UIAccessListCustomEvent)(nil),                           // 154: prehog.v1alpha.UIAccessListCustomEvent
-	(*UIAccessListCompleteEvent)(nil),                         // 155: prehog.v1alpha.UIAccessListCompleteEvent
-	(*UIAccessListIntegrateEvent)(nil),                        // 156: prehog.v1alpha.UIAccessListIntegrateEvent
-	(*UIInteractionEvent)(nil),                                // 157: prehog.v1alpha.UIInteractionEvent
-	(*SubmitEventRequest)(nil),                                // 158: prehog.v1alpha.SubmitEventRequest
-	(*SubmitEventResponse)(nil),                               // 159: prehog.v1alpha.SubmitEventResponse
-	(*SubmitEventsRequest)(nil),                               // 160: prehog.v1alpha.SubmitEventsRequest
-	(*SubmitEventsResponse)(nil),                              // 161: prehog.v1alpha.SubmitEventsResponse
-	(*HelloTeleportRequest)(nil),                              // 162: prehog.v1alpha.HelloTeleportRequest
-	(*HelloTeleportResponse)(nil),                             // 163: prehog.v1alpha.HelloTeleportResponse
-	nil,                                                       // 164: prehog.v1alpha.UIInteractionEvent.ParamsEntry
-	(*durationpb.Duration)(nil),                               // 165: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                             // 166: google.protobuf.Timestamp
+	(DiscoveryMatcherType)(0),                                 // 18: prehog.v1alpha.DiscoveryMatcherType
+	(CloudProvider)(0),                                        // 19: prehog.v1alpha.CloudProvider
+	(ClientKind)(0),                                           // 20: prehog.v1alpha.ClientKind
+	(DiscoveryConfigChangeAction)(0),                          // 21: prehog.v1alpha.DiscoveryConfigChangeAction
+	(AccessListStatus)(0),                                     // 22: prehog.v1alpha.AccessListStatus
+	(AccessListPreset)(0),                                     // 23: prehog.v1alpha.AccessListPreset
+	(AccessListIntegrate)(0),                                  // 24: prehog.v1alpha.AccessListIntegrate
+	(UIDiscoverDeployServiceEvent_DeployMethod)(0),            // 25: prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployMethod
+	(UIDiscoverDeployServiceEvent_DeployType)(0),              // 26: prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployType
+	(UIDiscoverCreateDiscoveryConfigEvent_ConfigMethod)(0),    // 27: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.ConfigMethod
+	(AccessRequestReviewEvent_ProposedState)(0),               // 28: prehog.v1alpha.AccessRequestReviewEvent.ProposedState
+	(*UserLoginEvent)(nil),                                    // 29: prehog.v1alpha.UserLoginEvent
+	(*MFAAuthenticationEvent)(nil),                            // 30: prehog.v1alpha.MFAAuthenticationEvent
+	(*SSOCreateEvent)(nil),                                    // 31: prehog.v1alpha.SSOCreateEvent
+	(*ResourceCreateEvent)(nil),                               // 32: prehog.v1alpha.ResourceCreateEvent
+	(*DiscoveredDatabaseMetadata)(nil),                        // 33: prehog.v1alpha.DiscoveredDatabaseMetadata
+	(*ResourceHeartbeatEvent)(nil),                            // 34: prehog.v1alpha.ResourceHeartbeatEvent
+	(*SessionStartEvent)(nil),                                 // 35: prehog.v1alpha.SessionStartEvent
+	(*SessionStartDatabaseMetadata)(nil),                      // 36: prehog.v1alpha.SessionStartDatabaseMetadata
+	(*SessionStartDesktopMetadata)(nil),                       // 37: prehog.v1alpha.SessionStartDesktopMetadata
+	(*SessionStartAppMetadata)(nil),                           // 38: prehog.v1alpha.SessionStartAppMetadata
+	(*SessionStartGitMetadata)(nil),                           // 39: prehog.v1alpha.SessionStartGitMetadata
+	(*SessionStartMCPMetadata)(nil),                           // 40: prehog.v1alpha.SessionStartMCPMetadata
+	(*SessionStartBeamMetadata)(nil),                          // 41: prehog.v1alpha.SessionStartBeamMetadata
+	(*BeamsCreatedEvent)(nil),                                 // 42: prehog.v1alpha.BeamsCreatedEvent
+	(*BeamsDestroyedEvent)(nil),                               // 43: prehog.v1alpha.BeamsDestroyedEvent
+	(*BeamsPublishedEvent)(nil),                               // 44: prehog.v1alpha.BeamsPublishedEvent
+	(*BeamsUnpublishedEvent)(nil),                             // 45: prehog.v1alpha.BeamsUnpublishedEvent
+	(*UserCertificateIssuedEvent)(nil),                        // 46: prehog.v1alpha.UserCertificateIssuedEvent
+	(*SPIFFESVIDIssuedEvent)(nil),                             // 47: prehog.v1alpha.SPIFFESVIDIssuedEvent
+	(*UIBannerClickEvent)(nil),                                // 48: prehog.v1alpha.UIBannerClickEvent
+	(*UIOnboardCompleteGoToDashboardClickEvent)(nil),          // 49: prehog.v1alpha.UIOnboardCompleteGoToDashboardClickEvent
+	(*UIOnboardAddFirstResourceClickEvent)(nil),               // 50: prehog.v1alpha.UIOnboardAddFirstResourceClickEvent
+	(*UIOnboardAddFirstResourceLaterClickEvent)(nil),          // 51: prehog.v1alpha.UIOnboardAddFirstResourceLaterClickEvent
+	(*UIOnboardSetCredentialSubmitEvent)(nil),                 // 52: prehog.v1alpha.UIOnboardSetCredentialSubmitEvent
+	(*UIOnboardRegisterChallengeSubmitEvent)(nil),             // 53: prehog.v1alpha.UIOnboardRegisterChallengeSubmitEvent
+	(*UIOnboardQuestionnaireSubmitEvent)(nil),                 // 54: prehog.v1alpha.UIOnboardQuestionnaireSubmitEvent
+	(*UIRecoveryCodesContinueClickEvent)(nil),                 // 55: prehog.v1alpha.UIRecoveryCodesContinueClickEvent
+	(*UIRecoveryCodesCopyClickEvent)(nil),                     // 56: prehog.v1alpha.UIRecoveryCodesCopyClickEvent
+	(*UIRecoveryCodesPrintClickEvent)(nil),                    // 57: prehog.v1alpha.UIRecoveryCodesPrintClickEvent
+	(*DiscoverMetadata)(nil),                                  // 58: prehog.v1alpha.DiscoverMetadata
+	(*DiscoverResourceMetadata)(nil),                          // 59: prehog.v1alpha.DiscoverResourceMetadata
+	(*DiscoverStepStatus)(nil),                                // 60: prehog.v1alpha.DiscoverStepStatus
+	(*UIDiscoverStartedEvent)(nil),                            // 61: prehog.v1alpha.UIDiscoverStartedEvent
+	(*UIDiscoverResourceSelectionEvent)(nil),                  // 62: prehog.v1alpha.UIDiscoverResourceSelectionEvent
+	(*UIDiscoverIntegrationAWSOIDCConnectEvent)(nil),          // 63: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent
+	(*UIDiscoverDatabaseRDSEnrollEvent)(nil),                  // 64: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent
+	(*UIDiscoverKubeEKSEnrollEvent)(nil),                      // 65: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent
+	(*UIDiscoverDeployServiceEvent)(nil),                      // 66: prehog.v1alpha.UIDiscoverDeployServiceEvent
+	(*UIDiscoverCreateDiscoveryConfigEvent)(nil),              // 67: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent
+	(*UIDiscoverDatabaseRegisterEvent)(nil),                   // 68: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent
+	(*UIDiscoverDatabaseConfigureMTLSEvent)(nil),              // 69: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent
+	(*UIDiscoverDesktopActiveDirectoryToolsInstallEvent)(nil), // 70: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent
+	(*UIDiscoverDesktopActiveDirectoryConfigureEvent)(nil),    // 71: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent
+	(*UIDiscoverAutoDiscoveredResourcesEvent)(nil),            // 72: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent
+	(*UIDiscoverEC2InstanceSelectionEvent)(nil),               // 73: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent
+	(*UIDiscoverDeployEICEEvent)(nil),                         // 74: prehog.v1alpha.UIDiscoverDeployEICEEvent
+	(*UIDiscoverCreateNodeEvent)(nil),                         // 75: prehog.v1alpha.UIDiscoverCreateNodeEvent
+	(*UIDiscoverCreateAppServerEvent)(nil),                    // 76: prehog.v1alpha.UIDiscoverCreateAppServerEvent
+	(*UIDiscoverDatabaseConfigureIAMPolicyEvent)(nil),         // 77: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent
+	(*UIDiscoverPrincipalsConfigureEvent)(nil),                // 78: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent
+	(*UIDiscoverTestConnectionEvent)(nil),                     // 79: prehog.v1alpha.UIDiscoverTestConnectionEvent
+	(*UIDiscoverCompletedEvent)(nil),                          // 80: prehog.v1alpha.UIDiscoverCompletedEvent
+	(*RoleCreateEvent)(nil),                                   // 81: prehog.v1alpha.RoleCreateEvent
+	(*BotCreateEvent)(nil),                                    // 82: prehog.v1alpha.BotCreateEvent
+	(*BotJoinEvent)(nil),                                      // 83: prehog.v1alpha.BotJoinEvent
+	(*UICreateNewRoleClickEvent)(nil),                         // 84: prehog.v1alpha.UICreateNewRoleClickEvent
+	(*UICreateNewRoleSaveClickEvent)(nil),                     // 85: prehog.v1alpha.UICreateNewRoleSaveClickEvent
+	(*UICreateNewRoleCancelClickEvent)(nil),                   // 86: prehog.v1alpha.UICreateNewRoleCancelClickEvent
+	(*UICreateNewRoleViewDocumentationClickEvent)(nil),        // 87: prehog.v1alpha.UICreateNewRoleViewDocumentationClickEvent
+	(*UICallToActionClickEvent)(nil),                          // 88: prehog.v1alpha.UICallToActionClickEvent
+	(*KubeRequestEvent)(nil),                                  // 89: prehog.v1alpha.KubeRequestEvent
+	(*SFTPEvent)(nil),                                         // 90: prehog.v1alpha.SFTPEvent
+	(*AgentMetadataEvent)(nil),                                // 91: prehog.v1alpha.AgentMetadataEvent
+	(*AssistCompletionEvent)(nil),                             // 92: prehog.v1alpha.AssistCompletionEvent
+	(*AssistExecutionEvent)(nil),                              // 93: prehog.v1alpha.AssistExecutionEvent
+	(*AssistNewConversationEvent)(nil),                        // 94: prehog.v1alpha.AssistNewConversationEvent
+	(*AssistAccessRequestEvent)(nil),                          // 95: prehog.v1alpha.AssistAccessRequestEvent
+	(*AssistActionEvent)(nil),                                 // 96: prehog.v1alpha.AssistActionEvent
+	(*AccessListMetadata)(nil),                                // 97: prehog.v1alpha.AccessListMetadata
+	(*AccessListCreateEvent)(nil),                             // 98: prehog.v1alpha.AccessListCreateEvent
+	(*AccessListUpdateEvent)(nil),                             // 99: prehog.v1alpha.AccessListUpdateEvent
+	(*AccessListDeleteEvent)(nil),                             // 100: prehog.v1alpha.AccessListDeleteEvent
+	(*AccessListMemberCreateEvent)(nil),                       // 101: prehog.v1alpha.AccessListMemberCreateEvent
+	(*AccessListMemberUpdateEvent)(nil),                       // 102: prehog.v1alpha.AccessListMemberUpdateEvent
+	(*AccessListMemberDeleteEvent)(nil),                       // 103: prehog.v1alpha.AccessListMemberDeleteEvent
+	(*AccessListGrantsToUserEvent)(nil),                       // 104: prehog.v1alpha.AccessListGrantsToUserEvent
+	(*AccessListReviewCreateEvent)(nil),                       // 105: prehog.v1alpha.AccessListReviewCreateEvent
+	(*AccessListReviewDeleteEvent)(nil),                       // 106: prehog.v1alpha.AccessListReviewDeleteEvent
+	(*AccessListReviewComplianceEvent)(nil),                   // 107: prehog.v1alpha.AccessListReviewComplianceEvent
+	(*IntegrationEnrollMetadata)(nil),                         // 108: prehog.v1alpha.IntegrationEnrollMetadata
+	(*UIIntegrationEnrollStartEvent)(nil),                     // 109: prehog.v1alpha.UIIntegrationEnrollStartEvent
+	(*UIIntegrationEnrollCompleteEvent)(nil),                  // 110: prehog.v1alpha.UIIntegrationEnrollCompleteEvent
+	(*IntegrationEnrollStepStatus)(nil),                       // 111: prehog.v1alpha.IntegrationEnrollStepStatus
+	(*UIIntegrationEnrollStepEvent)(nil),                      // 112: prehog.v1alpha.UIIntegrationEnrollStepEvent
+	(*UIIntegrationEnrollSectionOpenEvent)(nil),               // 113: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent
+	(*UIIntegrationEnrollFieldCompleteEvent)(nil),             // 114: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent
+	(*UIIntegrationEnrollCodeCopyEvent)(nil),                  // 115: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent
+	(*UIIntegrationEnrollLinkClickEvent)(nil),                 // 116: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent
+	(*EditorChangeEvent)(nil),                                 // 117: prehog.v1alpha.EditorChangeEvent
+	(*DeviceAuthenticateEvent)(nil),                           // 118: prehog.v1alpha.DeviceAuthenticateEvent
+	(*DeviceEnrollEvent)(nil),                                 // 119: prehog.v1alpha.DeviceEnrollEvent
+	(*FeatureRecommendationEvent)(nil),                        // 120: prehog.v1alpha.FeatureRecommendationEvent
+	(*LicenseLimitEvent)(nil),                                 // 121: prehog.v1alpha.LicenseLimitEvent
+	(*DesktopDirectoryShareEvent)(nil),                        // 122: prehog.v1alpha.DesktopDirectoryShareEvent
+	(*DesktopClipboardEvent)(nil),                             // 123: prehog.v1alpha.DesktopClipboardEvent
+	(*TAGExecuteQueryEvent)(nil),                              // 124: prehog.v1alpha.TAGExecuteQueryEvent
+	(*AccessGraphSecretsScanAuthorizedKeysEvent)(nil),         // 125: prehog.v1alpha.AccessGraphSecretsScanAuthorizedKeysEvent
+	(*AccessGraphSecretsScanSSHPrivateKeysEvent)(nil),         // 126: prehog.v1alpha.AccessGraphSecretsScanSSHPrivateKeysEvent
+	(*AccessGraphGitlabScanEvent)(nil),                        // 127: prehog.v1alpha.AccessGraphGitlabScanEvent
+	(*AccessGraphAWSScanEvent)(nil),                           // 128: prehog.v1alpha.AccessGraphAWSScanEvent
+	(*AccessGraphAccessPathChangedEvent)(nil),                 // 129: prehog.v1alpha.AccessGraphAccessPathChangedEvent
+	(*UIAccessGraphCrownJewelDiffViewEvent)(nil),              // 130: prehog.v1alpha.UIAccessGraphCrownJewelDiffViewEvent
+	(*UIPageViewEvent)(nil),                                   // 131: prehog.v1alpha.UIPageViewEvent
+	(*UIUsageReportingAlertCtaClickEvent)(nil),                // 132: prehog.v1alpha.UIUsageReportingAlertCtaClickEvent
+	(*AccessGraphCrownJewelCreateEvent)(nil),                  // 133: prehog.v1alpha.AccessGraphCrownJewelCreateEvent
+	(*ExternalAuditStorageAuthenticateEvent)(nil),             // 134: prehog.v1alpha.ExternalAuditStorageAuthenticateEvent
+	(*SecurityReportGetResultEvent)(nil),                      // 135: prehog.v1alpha.SecurityReportGetResultEvent
+	(*AuditQueryRunEvent)(nil),                                // 136: prehog.v1alpha.AuditQueryRunEvent
+	(*DiscoveryFetchEvent)(nil),                               // 137: prehog.v1alpha.DiscoveryFetchEvent
+	(*OktaAccessListSyncEvent)(nil),                           // 138: prehog.v1alpha.OktaAccessListSyncEvent
+	(*DatabaseUserCreatedEvent)(nil),                          // 139: prehog.v1alpha.DatabaseUserCreatedEvent
+	(*DatabaseUserPermissionsUpdateEvent)(nil),                // 140: prehog.v1alpha.DatabaseUserPermissionsUpdateEvent
+	(*SessionRecordingAccessEvent)(nil),                       // 141: prehog.v1alpha.SessionRecordingAccessEvent
+	(*UserTaskStateEvent)(nil),                                // 142: prehog.v1alpha.UserTaskStateEvent
+	(*AccessRequestCreateEvent)(nil),                          // 143: prehog.v1alpha.AccessRequestCreateEvent
+	(*AccessRequestReviewEvent)(nil),                          // 144: prehog.v1alpha.AccessRequestReviewEvent
+	(*SessionSummaryAccessEvent)(nil),                         // 145: prehog.v1alpha.SessionSummaryAccessEvent
+	(*SessionSummaryCreateEvent)(nil),                         // 146: prehog.v1alpha.SessionSummaryCreateEvent
+	(*SessionSummarySearchEvent)(nil),                         // 147: prehog.v1alpha.SessionSummarySearchEvent
+	(*DiscoveryConfigEvent)(nil),                              // 148: prehog.v1alpha.DiscoveryConfigEvent
+	(*DiscoveryConfigChangedEvent)(nil),                       // 149: prehog.v1alpha.DiscoveryConfigChangedEvent
+	(*IdentitySecurityGraphSizeEvent)(nil),                    // 150: prehog.v1alpha.IdentitySecurityGraphSizeEvent
+	(*IdentitySecurityAuditLogsIngestedEvent)(nil),            // 151: prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
+	(*AccessListStepStatus)(nil),                              // 152: prehog.v1alpha.AccessListStepStatus
+	(*UIAccessListDefineAccessEvent)(nil),                     // 153: prehog.v1alpha.UIAccessListDefineAccessEvent
+	(*UIAccessListDefineIdentitiesEvent)(nil),                 // 154: prehog.v1alpha.UIAccessListDefineIdentitiesEvent
+	(*UIAccessListDefineBasicInfoEvent)(nil),                  // 155: prehog.v1alpha.UIAccessListDefineBasicInfoEvent
+	(*UIAccessListDefineMembersEvent)(nil),                    // 156: prehog.v1alpha.UIAccessListDefineMembersEvent
+	(*UIAccessListDefineOwnersEvent)(nil),                     // 157: prehog.v1alpha.UIAccessListDefineOwnersEvent
+	(*UIAccessListStartEvent)(nil),                            // 158: prehog.v1alpha.UIAccessListStartEvent
+	(*UIAccessListCustomEvent)(nil),                           // 159: prehog.v1alpha.UIAccessListCustomEvent
+	(*UIAccessListCompleteEvent)(nil),                         // 160: prehog.v1alpha.UIAccessListCompleteEvent
+	(*UIAccessListIntegrateEvent)(nil),                        // 161: prehog.v1alpha.UIAccessListIntegrateEvent
+	(*UIInteractionEvent)(nil),                                // 162: prehog.v1alpha.UIInteractionEvent
+	(*SubmitEventRequest)(nil),                                // 163: prehog.v1alpha.SubmitEventRequest
+	(*SubmitEventResponse)(nil),                               // 164: prehog.v1alpha.SubmitEventResponse
+	(*SubmitEventsRequest)(nil),                               // 165: prehog.v1alpha.SubmitEventsRequest
+	(*SubmitEventsResponse)(nil),                              // 166: prehog.v1alpha.SubmitEventsResponse
+	(*HelloTeleportRequest)(nil),                              // 167: prehog.v1alpha.HelloTeleportRequest
+	(*HelloTeleportResponse)(nil),                             // 168: prehog.v1alpha.HelloTeleportResponse
+	nil,                                                       // 169: prehog.v1alpha.UIInteractionEvent.ParamsEntry
+	(*durationpb.Duration)(nil),                               // 170: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                             // 171: google.protobuf.Timestamp
 }
 var file_prehog_v1alpha_teleport_proto_depIdxs = []int32{
 	0,   // 0: prehog.v1alpha.UserLoginEvent.user_origin:type_name -> prehog.v1alpha.UserOrigin
-	29,  // 1: prehog.v1alpha.ResourceCreateEvent.database:type_name -> prehog.v1alpha.DiscoveredDatabaseMetadata
+	33,  // 1: prehog.v1alpha.ResourceCreateEvent.database:type_name -> prehog.v1alpha.DiscoveredDatabaseMetadata
 	1,   // 2: prehog.v1alpha.ResourceHeartbeatEvent.resource_kind:type_name -> prehog.v1alpha.ResourceKind
-	32,  // 3: prehog.v1alpha.SessionStartEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
-	33,  // 4: prehog.v1alpha.SessionStartEvent.desktop:type_name -> prehog.v1alpha.SessionStartDesktopMetadata
+	36,  // 3: prehog.v1alpha.SessionStartEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
+	37,  // 4: prehog.v1alpha.SessionStartEvent.desktop:type_name -> prehog.v1alpha.SessionStartDesktopMetadata
 	2,   // 5: prehog.v1alpha.SessionStartEvent.user_kind:type_name -> prehog.v1alpha.UserKind
-	34,  // 6: prehog.v1alpha.SessionStartEvent.app:type_name -> prehog.v1alpha.SessionStartAppMetadata
-	35,  // 7: prehog.v1alpha.SessionStartEvent.git:type_name -> prehog.v1alpha.SessionStartGitMetadata
-	36,  // 8: prehog.v1alpha.SessionStartEvent.mcp:type_name -> prehog.v1alpha.SessionStartMCPMetadata
-	37,  // 9: prehog.v1alpha.SessionStartEvent.beam:type_name -> prehog.v1alpha.SessionStartBeamMetadata
+	38,  // 6: prehog.v1alpha.SessionStartEvent.app:type_name -> prehog.v1alpha.SessionStartAppMetadata
+	39,  // 7: prehog.v1alpha.SessionStartEvent.git:type_name -> prehog.v1alpha.SessionStartGitMetadata
+	40,  // 8: prehog.v1alpha.SessionStartEvent.mcp:type_name -> prehog.v1alpha.SessionStartMCPMetadata
+	41,  // 9: prehog.v1alpha.SessionStartEvent.beam:type_name -> prehog.v1alpha.SessionStartBeamMetadata
 	3,   // 10: prehog.v1alpha.BeamsDestroyedEvent.reason:type_name -> prehog.v1alpha.BeamDestroyReason
-	165, // 11: prehog.v1alpha.UserCertificateIssuedEvent.ttl:type_name -> google.protobuf.Duration
+	170, // 11: prehog.v1alpha.UserCertificateIssuedEvent.ttl:type_name -> google.protobuf.Duration
 	2,   // 12: prehog.v1alpha.SPIFFESVIDIssuedEvent.user_kind:type_name -> prehog.v1alpha.UserKind
 	4,   // 13: prehog.v1alpha.DiscoverResourceMetadata.resource:type_name -> prehog.v1alpha.DiscoverResource
 	5,   // 14: prehog.v1alpha.DiscoverStepStatus.status:type_name -> prehog.v1alpha.DiscoverStatus
-	54,  // 15: prehog.v1alpha.UIDiscoverStartedEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	56,  // 16: prehog.v1alpha.UIDiscoverStartedEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 17: prehog.v1alpha.UIDiscoverResourceSelectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 18: prehog.v1alpha.UIDiscoverResourceSelectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 19: prehog.v1alpha.UIDiscoverResourceSelectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 20: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 21: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 22: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 23: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 24: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 25: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 26: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 27: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 28: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 29: prehog.v1alpha.UIDiscoverDeployServiceEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 30: prehog.v1alpha.UIDiscoverDeployServiceEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 31: prehog.v1alpha.UIDiscoverDeployServiceEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	21,  // 32: prehog.v1alpha.UIDiscoverDeployServiceEvent.deploy_method:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployMethod
-	22,  // 33: prehog.v1alpha.UIDiscoverDeployServiceEvent.deploy_type:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployType
-	54,  // 34: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 35: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 36: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	23,  // 37: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.config_method:type_name -> prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.ConfigMethod
-	54,  // 38: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 39: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 40: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 41: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 42: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 43: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 44: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 45: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 46: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 47: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 48: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 49: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 50: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 51: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 52: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 53: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 54: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 55: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 56: prehog.v1alpha.UIDiscoverDeployEICEEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 57: prehog.v1alpha.UIDiscoverDeployEICEEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 58: prehog.v1alpha.UIDiscoverDeployEICEEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 59: prehog.v1alpha.UIDiscoverCreateNodeEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 60: prehog.v1alpha.UIDiscoverCreateNodeEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 61: prehog.v1alpha.UIDiscoverCreateNodeEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 62: prehog.v1alpha.UIDiscoverCreateAppServerEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 63: prehog.v1alpha.UIDiscoverCreateAppServerEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 64: prehog.v1alpha.UIDiscoverCreateAppServerEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 65: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 66: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 67: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 68: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 69: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 70: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 71: prehog.v1alpha.UIDiscoverTestConnectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 72: prehog.v1alpha.UIDiscoverTestConnectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 73: prehog.v1alpha.UIDiscoverTestConnectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
-	54,  // 74: prehog.v1alpha.UIDiscoverCompletedEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
-	55,  // 75: prehog.v1alpha.UIDiscoverCompletedEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
-	56,  // 76: prehog.v1alpha.UIDiscoverCompletedEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 15: prehog.v1alpha.UIDiscoverStartedEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	60,  // 16: prehog.v1alpha.UIDiscoverStartedEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 17: prehog.v1alpha.UIDiscoverResourceSelectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 18: prehog.v1alpha.UIDiscoverResourceSelectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 19: prehog.v1alpha.UIDiscoverResourceSelectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 20: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 21: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 22: prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 23: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 24: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 25: prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 26: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 27: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 28: prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 29: prehog.v1alpha.UIDiscoverDeployServiceEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 30: prehog.v1alpha.UIDiscoverDeployServiceEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 31: prehog.v1alpha.UIDiscoverDeployServiceEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	25,  // 32: prehog.v1alpha.UIDiscoverDeployServiceEvent.deploy_method:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployMethod
+	26,  // 33: prehog.v1alpha.UIDiscoverDeployServiceEvent.deploy_type:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent.DeployType
+	58,  // 34: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 35: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 36: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	27,  // 37: prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.config_method:type_name -> prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent.ConfigMethod
+	58,  // 38: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 39: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 40: prehog.v1alpha.UIDiscoverDatabaseRegisterEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 41: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 42: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 43: prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 44: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 45: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 46: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 47: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 48: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 49: prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 50: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 51: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 52: prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 53: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 54: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 55: prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 56: prehog.v1alpha.UIDiscoverDeployEICEEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 57: prehog.v1alpha.UIDiscoverDeployEICEEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 58: prehog.v1alpha.UIDiscoverDeployEICEEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 59: prehog.v1alpha.UIDiscoverCreateNodeEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 60: prehog.v1alpha.UIDiscoverCreateNodeEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 61: prehog.v1alpha.UIDiscoverCreateNodeEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 62: prehog.v1alpha.UIDiscoverCreateAppServerEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 63: prehog.v1alpha.UIDiscoverCreateAppServerEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 64: prehog.v1alpha.UIDiscoverCreateAppServerEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 65: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 66: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 67: prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 68: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 69: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 70: prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 71: prehog.v1alpha.UIDiscoverTestConnectionEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 72: prehog.v1alpha.UIDiscoverTestConnectionEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 73: prehog.v1alpha.UIDiscoverTestConnectionEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
+	58,  // 74: prehog.v1alpha.UIDiscoverCompletedEvent.metadata:type_name -> prehog.v1alpha.DiscoverMetadata
+	59,  // 75: prehog.v1alpha.UIDiscoverCompletedEvent.resource:type_name -> prehog.v1alpha.DiscoverResourceMetadata
+	60,  // 76: prehog.v1alpha.UIDiscoverCompletedEvent.status:type_name -> prehog.v1alpha.DiscoverStepStatus
 	6,   // 77: prehog.v1alpha.UICallToActionClickEvent.cta:type_name -> prehog.v1alpha.CTA
 	2,   // 78: prehog.v1alpha.KubeRequestEvent.user_kind:type_name -> prehog.v1alpha.UserKind
 	2,   // 79: prehog.v1alpha.SFTPEvent.user_kind:type_name -> prehog.v1alpha.UserKind
-	19,  // 80: prehog.v1alpha.AccessListMetadata.preset:type_name -> prehog.v1alpha.AccessListPreset
-	93,  // 81: prehog.v1alpha.AccessListCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	93,  // 82: prehog.v1alpha.AccessListUpdateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	93,  // 83: prehog.v1alpha.AccessListDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	93,  // 84: prehog.v1alpha.AccessListMemberCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	93,  // 85: prehog.v1alpha.AccessListMemberUpdateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	93,  // 86: prehog.v1alpha.AccessListMemberDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	93,  // 87: prehog.v1alpha.AccessListReviewCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	93,  // 88: prehog.v1alpha.AccessListReviewDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	23,  // 80: prehog.v1alpha.AccessListMetadata.preset:type_name -> prehog.v1alpha.AccessListPreset
+	97,  // 81: prehog.v1alpha.AccessListCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	97,  // 82: prehog.v1alpha.AccessListUpdateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	97,  // 83: prehog.v1alpha.AccessListDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	97,  // 84: prehog.v1alpha.AccessListMemberCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	97,  // 85: prehog.v1alpha.AccessListMemberUpdateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	97,  // 86: prehog.v1alpha.AccessListMemberDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	97,  // 87: prehog.v1alpha.AccessListReviewCreateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	97,  // 88: prehog.v1alpha.AccessListReviewDeleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
 	7,   // 89: prehog.v1alpha.IntegrationEnrollMetadata.kind:type_name -> prehog.v1alpha.IntegrationEnrollKind
-	104, // 90: prehog.v1alpha.UIIntegrationEnrollStartEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
-	104, // 91: prehog.v1alpha.UIIntegrationEnrollCompleteEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	108, // 90: prehog.v1alpha.UIIntegrationEnrollStartEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	108, // 91: prehog.v1alpha.UIIntegrationEnrollCompleteEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
 	9,   // 92: prehog.v1alpha.IntegrationEnrollStepStatus.code:type_name -> prehog.v1alpha.IntegrationEnrollStatusCode
-	104, // 93: prehog.v1alpha.UIIntegrationEnrollStepEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	108, // 93: prehog.v1alpha.UIIntegrationEnrollStepEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
 	8,   // 94: prehog.v1alpha.UIIntegrationEnrollStepEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
-	107, // 95: prehog.v1alpha.UIIntegrationEnrollStepEvent.status:type_name -> prehog.v1alpha.IntegrationEnrollStepStatus
-	104, // 96: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	111, // 95: prehog.v1alpha.UIIntegrationEnrollStepEvent.status:type_name -> prehog.v1alpha.IntegrationEnrollStepStatus
+	108, // 96: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
 	8,   // 97: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
 	10,  // 98: prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent.section:type_name -> prehog.v1alpha.IntegrationEnrollSection
-	104, // 99: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	108, // 99: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
 	8,   // 100: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
 	11,  // 101: prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent.field:type_name -> prehog.v1alpha.IntegrationEnrollField
-	104, // 102: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	108, // 102: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
 	8,   // 103: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
 	12,  // 104: prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent.type:type_name -> prehog.v1alpha.IntegrationEnrollCodeType
-	104, // 105: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
+	108, // 105: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent.metadata:type_name -> prehog.v1alpha.IntegrationEnrollMetadata
 	8,   // 106: prehog.v1alpha.UIIntegrationEnrollLinkClickEvent.step:type_name -> prehog.v1alpha.IntegrationEnrollStep
 	13,  // 107: prehog.v1alpha.EditorChangeEvent.status:type_name -> prehog.v1alpha.EditorChangeStatus
 	14,  // 108: prehog.v1alpha.FeatureRecommendationEvent.feature:type_name -> prehog.v1alpha.Feature
 	15,  // 109: prehog.v1alpha.FeatureRecommendationEvent.feature_recommendation_status:type_name -> prehog.v1alpha.FeatureRecommendationStatus
 	16,  // 110: prehog.v1alpha.LicenseLimitEvent.license_limit:type_name -> prehog.v1alpha.LicenseLimit
-	32,  // 111: prehog.v1alpha.DatabaseUserCreatedEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
-	32,  // 112: prehog.v1alpha.DatabaseUserPermissionsUpdateEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
-	24,  // 113: prehog.v1alpha.AccessRequestReviewEvent.proposed_state:type_name -> prehog.v1alpha.AccessRequestReviewEvent.ProposedState
+	36,  // 111: prehog.v1alpha.DatabaseUserCreatedEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
+	36,  // 112: prehog.v1alpha.DatabaseUserPermissionsUpdateEvent.database:type_name -> prehog.v1alpha.SessionStartDatabaseMetadata
+	28,  // 113: prehog.v1alpha.AccessRequestReviewEvent.proposed_state:type_name -> prehog.v1alpha.AccessRequestReviewEvent.ProposedState
 	2,   // 114: prehog.v1alpha.SessionSummaryAccessEvent.user_kind:type_name -> prehog.v1alpha.UserKind
 	2,   // 115: prehog.v1alpha.SessionSummarySearchEvent.user_kind:type_name -> prehog.v1alpha.UserKind
 	17,  // 116: prehog.v1alpha.DiscoveryConfigEvent.action:type_name -> prehog.v1alpha.DiscoveryConfigAction
-	18,  // 117: prehog.v1alpha.AccessListStepStatus.status:type_name -> prehog.v1alpha.AccessListStatus
-	93,  // 118: prehog.v1alpha.UIAccessListDefineAccessEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	147, // 119: prehog.v1alpha.UIAccessListDefineAccessEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	93,  // 120: prehog.v1alpha.UIAccessListDefineIdentitiesEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	147, // 121: prehog.v1alpha.UIAccessListDefineIdentitiesEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	93,  // 122: prehog.v1alpha.UIAccessListDefineBasicInfoEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	147, // 123: prehog.v1alpha.UIAccessListDefineBasicInfoEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	93,  // 124: prehog.v1alpha.UIAccessListDefineMembersEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	147, // 125: prehog.v1alpha.UIAccessListDefineMembersEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	93,  // 126: prehog.v1alpha.UIAccessListDefineOwnersEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	147, // 127: prehog.v1alpha.UIAccessListDefineOwnersEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	93,  // 128: prehog.v1alpha.UIAccessListStartEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	147, // 129: prehog.v1alpha.UIAccessListStartEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	93,  // 130: prehog.v1alpha.UIAccessListCustomEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	147, // 131: prehog.v1alpha.UIAccessListCustomEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	93,  // 132: prehog.v1alpha.UIAccessListCompleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	147, // 133: prehog.v1alpha.UIAccessListCompleteEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
-	93,  // 134: prehog.v1alpha.UIAccessListIntegrateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
-	20,  // 135: prehog.v1alpha.UIAccessListIntegrateEvent.integrate:type_name -> prehog.v1alpha.AccessListIntegrate
-	164, // 136: prehog.v1alpha.UIInteractionEvent.params:type_name -> prehog.v1alpha.UIInteractionEvent.ParamsEntry
-	166, // 137: prehog.v1alpha.SubmitEventRequest.timestamp:type_name -> google.protobuf.Timestamp
-	25,  // 138: prehog.v1alpha.SubmitEventRequest.user_login:type_name -> prehog.v1alpha.UserLoginEvent
-	27,  // 139: prehog.v1alpha.SubmitEventRequest.sso_create:type_name -> prehog.v1alpha.SSOCreateEvent
-	28,  // 140: prehog.v1alpha.SubmitEventRequest.resource_create:type_name -> prehog.v1alpha.ResourceCreateEvent
-	31,  // 141: prehog.v1alpha.SubmitEventRequest.session_start:type_name -> prehog.v1alpha.SessionStartEvent
-	44,  // 142: prehog.v1alpha.SubmitEventRequest.ui_banner_click:type_name -> prehog.v1alpha.UIBannerClickEvent
-	45,  // 143: prehog.v1alpha.SubmitEventRequest.ui_onboard_complete_go_to_dashboard_click:type_name -> prehog.v1alpha.UIOnboardCompleteGoToDashboardClickEvent
-	46,  // 144: prehog.v1alpha.SubmitEventRequest.ui_onboard_add_first_resource_click:type_name -> prehog.v1alpha.UIOnboardAddFirstResourceClickEvent
-	47,  // 145: prehog.v1alpha.SubmitEventRequest.ui_onboard_add_first_resource_later_click:type_name -> prehog.v1alpha.UIOnboardAddFirstResourceLaterClickEvent
-	48,  // 146: prehog.v1alpha.SubmitEventRequest.ui_onboard_set_credential_submit:type_name -> prehog.v1alpha.UIOnboardSetCredentialSubmitEvent
-	49,  // 147: prehog.v1alpha.SubmitEventRequest.ui_onboard_register_challenge_submit:type_name -> prehog.v1alpha.UIOnboardRegisterChallengeSubmitEvent
-	51,  // 148: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_continue_click:type_name -> prehog.v1alpha.UIRecoveryCodesContinueClickEvent
-	52,  // 149: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_copy_click:type_name -> prehog.v1alpha.UIRecoveryCodesCopyClickEvent
-	53,  // 150: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_print_click:type_name -> prehog.v1alpha.UIRecoveryCodesPrintClickEvent
-	57,  // 151: prehog.v1alpha.SubmitEventRequest.ui_discover_started_event:type_name -> prehog.v1alpha.UIDiscoverStartedEvent
-	58,  // 152: prehog.v1alpha.SubmitEventRequest.ui_discover_resource_selection_event:type_name -> prehog.v1alpha.UIDiscoverResourceSelectionEvent
-	42,  // 153: prehog.v1alpha.SubmitEventRequest.user_certificate_issued_event:type_name -> prehog.v1alpha.UserCertificateIssuedEvent
-	31,  // 154: prehog.v1alpha.SubmitEventRequest.session_start_v2:type_name -> prehog.v1alpha.SessionStartEvent
-	62,  // 155: prehog.v1alpha.SubmitEventRequest.ui_discover_deploy_service_event:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent
-	64,  // 156: prehog.v1alpha.SubmitEventRequest.ui_discover_database_register_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseRegisterEvent
-	65,  // 157: prehog.v1alpha.SubmitEventRequest.ui_discover_database_configure_mtls_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent
-	66,  // 158: prehog.v1alpha.SubmitEventRequest.ui_discover_desktop_active_directory_tools_install_event:type_name -> prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent
-	67,  // 159: prehog.v1alpha.SubmitEventRequest.ui_discover_desktop_active_directory_configure_event:type_name -> prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent
-	68,  // 160: prehog.v1alpha.SubmitEventRequest.ui_discover_auto_discovered_resources_event:type_name -> prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent
-	73,  // 161: prehog.v1alpha.SubmitEventRequest.ui_discover_database_configure_iam_policy_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent
-	74,  // 162: prehog.v1alpha.SubmitEventRequest.ui_discover_principals_configure_event:type_name -> prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent
-	75,  // 163: prehog.v1alpha.SubmitEventRequest.ui_discover_test_connection_event:type_name -> prehog.v1alpha.UIDiscoverTestConnectionEvent
-	76,  // 164: prehog.v1alpha.SubmitEventRequest.ui_discover_completed_event:type_name -> prehog.v1alpha.UIDiscoverCompletedEvent
-	77,  // 165: prehog.v1alpha.SubmitEventRequest.role_create:type_name -> prehog.v1alpha.RoleCreateEvent
-	80,  // 166: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_click:type_name -> prehog.v1alpha.UICreateNewRoleClickEvent
-	81,  // 167: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_save_click:type_name -> prehog.v1alpha.UICreateNewRoleSaveClickEvent
-	82,  // 168: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_cancel_click:type_name -> prehog.v1alpha.UICreateNewRoleCancelClickEvent
-	83,  // 169: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_view_documentation_click:type_name -> prehog.v1alpha.UICreateNewRoleViewDocumentationClickEvent
-	85,  // 170: prehog.v1alpha.SubmitEventRequest.kube_request:type_name -> prehog.v1alpha.KubeRequestEvent
-	86,  // 171: prehog.v1alpha.SubmitEventRequest.sftp:type_name -> prehog.v1alpha.SFTPEvent
-	87,  // 172: prehog.v1alpha.SubmitEventRequest.agent_metadata_event:type_name -> prehog.v1alpha.AgentMetadataEvent
-	30,  // 173: prehog.v1alpha.SubmitEventRequest.resource_heartbeat:type_name -> prehog.v1alpha.ResourceHeartbeatEvent
-	59,  // 174: prehog.v1alpha.SubmitEventRequest.ui_discover_integration_aws_oidc_connect_event:type_name -> prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent
-	60,  // 175: prehog.v1alpha.SubmitEventRequest.ui_discover_database_rds_enroll_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent
-	84,  // 176: prehog.v1alpha.SubmitEventRequest.ui_call_to_action_click_event:type_name -> prehog.v1alpha.UICallToActionClickEvent
-	88,  // 177: prehog.v1alpha.SubmitEventRequest.assist_completion:type_name -> prehog.v1alpha.AssistCompletionEvent
-	105, // 178: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_start_event:type_name -> prehog.v1alpha.UIIntegrationEnrollStartEvent
-	106, // 179: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_complete_event:type_name -> prehog.v1alpha.UIIntegrationEnrollCompleteEvent
-	113, // 180: prehog.v1alpha.SubmitEventRequest.editor_change_event:type_name -> prehog.v1alpha.EditorChangeEvent
-	78,  // 181: prehog.v1alpha.SubmitEventRequest.bot_create:type_name -> prehog.v1alpha.BotCreateEvent
-	50,  // 182: prehog.v1alpha.SubmitEventRequest.ui_onboard_questionnaire_submit:type_name -> prehog.v1alpha.UIOnboardQuestionnaireSubmitEvent
-	79,  // 183: prehog.v1alpha.SubmitEventRequest.bot_join:type_name -> prehog.v1alpha.BotJoinEvent
-	89,  // 184: prehog.v1alpha.SubmitEventRequest.assist_execution:type_name -> prehog.v1alpha.AssistExecutionEvent
-	90,  // 185: prehog.v1alpha.SubmitEventRequest.assist_new_conversation:type_name -> prehog.v1alpha.AssistNewConversationEvent
-	114, // 186: prehog.v1alpha.SubmitEventRequest.device_authenticate_event:type_name -> prehog.v1alpha.DeviceAuthenticateEvent
-	116, // 187: prehog.v1alpha.SubmitEventRequest.feature_recommendation_event:type_name -> prehog.v1alpha.FeatureRecommendationEvent
-	91,  // 188: prehog.v1alpha.SubmitEventRequest.assist_access_request:type_name -> prehog.v1alpha.AssistAccessRequestEvent
-	92,  // 189: prehog.v1alpha.SubmitEventRequest.assist_action:type_name -> prehog.v1alpha.AssistActionEvent
-	115, // 190: prehog.v1alpha.SubmitEventRequest.device_enroll_event:type_name -> prehog.v1alpha.DeviceEnrollEvent
-	117, // 191: prehog.v1alpha.SubmitEventRequest.license_limit_event:type_name -> prehog.v1alpha.LicenseLimitEvent
-	94,  // 192: prehog.v1alpha.SubmitEventRequest.access_list_create:type_name -> prehog.v1alpha.AccessListCreateEvent
-	95,  // 193: prehog.v1alpha.SubmitEventRequest.access_list_update:type_name -> prehog.v1alpha.AccessListUpdateEvent
-	96,  // 194: prehog.v1alpha.SubmitEventRequest.access_list_delete:type_name -> prehog.v1alpha.AccessListDeleteEvent
-	97,  // 195: prehog.v1alpha.SubmitEventRequest.access_list_member_create:type_name -> prehog.v1alpha.AccessListMemberCreateEvent
-	98,  // 196: prehog.v1alpha.SubmitEventRequest.access_list_member_update:type_name -> prehog.v1alpha.AccessListMemberUpdateEvent
-	99,  // 197: prehog.v1alpha.SubmitEventRequest.access_list_member_delete:type_name -> prehog.v1alpha.AccessListMemberDeleteEvent
-	100, // 198: prehog.v1alpha.SubmitEventRequest.access_list_grants_to_user:type_name -> prehog.v1alpha.AccessListGrantsToUserEvent
-	69,  // 199: prehog.v1alpha.SubmitEventRequest.ui_discover_ec2_instance_selection:type_name -> prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent
-	70,  // 200: prehog.v1alpha.SubmitEventRequest.ui_discover_deploy_eice:type_name -> prehog.v1alpha.UIDiscoverDeployEICEEvent
-	71,  // 201: prehog.v1alpha.SubmitEventRequest.ui_discover_create_node:type_name -> prehog.v1alpha.UIDiscoverCreateNodeEvent
-	118, // 202: prehog.v1alpha.SubmitEventRequest.desktop_directory_share:type_name -> prehog.v1alpha.DesktopDirectoryShareEvent
-	119, // 203: prehog.v1alpha.SubmitEventRequest.desktop_clipboard_transfer:type_name -> prehog.v1alpha.DesktopClipboardEvent
-	120, // 204: prehog.v1alpha.SubmitEventRequest.tag_execute_query:type_name -> prehog.v1alpha.TAGExecuteQueryEvent
-	130, // 205: prehog.v1alpha.SubmitEventRequest.external_audit_storage_authenticate:type_name -> prehog.v1alpha.ExternalAuditStorageAuthenticateEvent
-	131, // 206: prehog.v1alpha.SubmitEventRequest.security_report_get_result:type_name -> prehog.v1alpha.SecurityReportGetResultEvent
-	132, // 207: prehog.v1alpha.SubmitEventRequest.audit_query_run:type_name -> prehog.v1alpha.AuditQueryRunEvent
-	133, // 208: prehog.v1alpha.SubmitEventRequest.discovery_fetch_event:type_name -> prehog.v1alpha.DiscoveryFetchEvent
-	101, // 209: prehog.v1alpha.SubmitEventRequest.access_list_review_create:type_name -> prehog.v1alpha.AccessListReviewCreateEvent
-	102, // 210: prehog.v1alpha.SubmitEventRequest.access_list_review_delete:type_name -> prehog.v1alpha.AccessListReviewDeleteEvent
-	103, // 211: prehog.v1alpha.SubmitEventRequest.access_list_review_compliance:type_name -> prehog.v1alpha.AccessListReviewComplianceEvent
-	26,  // 212: prehog.v1alpha.SubmitEventRequest.mfa_authentication_event:type_name -> prehog.v1alpha.MFAAuthenticationEvent
-	43,  // 213: prehog.v1alpha.SubmitEventRequest.spiffe_svid_issued:type_name -> prehog.v1alpha.SPIFFESVIDIssuedEvent
-	134, // 214: prehog.v1alpha.SubmitEventRequest.okta_access_list_sync:type_name -> prehog.v1alpha.OktaAccessListSyncEvent
-	135, // 215: prehog.v1alpha.SubmitEventRequest.database_user_created:type_name -> prehog.v1alpha.DatabaseUserCreatedEvent
-	136, // 216: prehog.v1alpha.SubmitEventRequest.database_user_permissions_updated:type_name -> prehog.v1alpha.DatabaseUserPermissionsUpdateEvent
-	63,  // 217: prehog.v1alpha.SubmitEventRequest.ui_discover_create_discovery_config:type_name -> prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent
-	61,  // 218: prehog.v1alpha.SubmitEventRequest.ui_discover_kube_eks_enroll_event:type_name -> prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent
-	72,  // 219: prehog.v1alpha.SubmitEventRequest.ui_discover_create_app_server_event:type_name -> prehog.v1alpha.UIDiscoverCreateAppServerEvent
-	123, // 220: prehog.v1alpha.SubmitEventRequest.access_graph_gitlab_scan:type_name -> prehog.v1alpha.AccessGraphGitlabScanEvent
-	121, // 221: prehog.v1alpha.SubmitEventRequest.access_graph_secrets_scan_authorized_keys:type_name -> prehog.v1alpha.AccessGraphSecretsScanAuthorizedKeysEvent
-	122, // 222: prehog.v1alpha.SubmitEventRequest.access_graph_secrets_scan_ssh_private_keys:type_name -> prehog.v1alpha.AccessGraphSecretsScanSSHPrivateKeysEvent
-	124, // 223: prehog.v1alpha.SubmitEventRequest.access_graph_aws_scan:type_name -> prehog.v1alpha.AccessGraphAWSScanEvent
-	125, // 224: prehog.v1alpha.SubmitEventRequest.access_graph_access_path_changed:type_name -> prehog.v1alpha.AccessGraphAccessPathChangedEvent
-	129, // 225: prehog.v1alpha.SubmitEventRequest.access_graph_crown_jewel_create:type_name -> prehog.v1alpha.AccessGraphCrownJewelCreateEvent
-	126, // 226: prehog.v1alpha.SubmitEventRequest.ui_access_graph_crown_jewel_diff_view:type_name -> prehog.v1alpha.UIAccessGraphCrownJewelDiffViewEvent
-	137, // 227: prehog.v1alpha.SubmitEventRequest.session_recording_access:type_name -> prehog.v1alpha.SessionRecordingAccessEvent
-	138, // 228: prehog.v1alpha.SubmitEventRequest.user_task_state:type_name -> prehog.v1alpha.UserTaskStateEvent
-	108, // 229: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_step_event:type_name -> prehog.v1alpha.UIIntegrationEnrollStepEvent
-	139, // 230: prehog.v1alpha.SubmitEventRequest.access_request_create:type_name -> prehog.v1alpha.AccessRequestCreateEvent
-	140, // 231: prehog.v1alpha.SubmitEventRequest.access_request_review:type_name -> prehog.v1alpha.AccessRequestReviewEvent
-	109, // 232: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_section_open_event:type_name -> prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent
-	110, // 233: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_field_complete_event:type_name -> prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent
-	111, // 234: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_code_copy_event:type_name -> prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent
-	112, // 235: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_link_click_event:type_name -> prehog.v1alpha.UIIntegrationEnrollLinkClickEvent
-	142, // 236: prehog.v1alpha.SubmitEventRequest.session_summary_create_event:type_name -> prehog.v1alpha.SessionSummaryCreateEvent
-	141, // 237: prehog.v1alpha.SubmitEventRequest.session_summary_access_event:type_name -> prehog.v1alpha.SessionSummaryAccessEvent
-	144, // 238: prehog.v1alpha.SubmitEventRequest.discovery_config:type_name -> prehog.v1alpha.DiscoveryConfigEvent
-	145, // 239: prehog.v1alpha.SubmitEventRequest.identity_security_graph_size_event:type_name -> prehog.v1alpha.IdentitySecurityGraphSizeEvent
-	146, // 240: prehog.v1alpha.SubmitEventRequest.identity_security_audit_logs_ingested_event:type_name -> prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
-	148, // 241: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_access_event:type_name -> prehog.v1alpha.UIAccessListDefineAccessEvent
-	149, // 242: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_identities_event:type_name -> prehog.v1alpha.UIAccessListDefineIdentitiesEvent
-	150, // 243: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_basic_info_event:type_name -> prehog.v1alpha.UIAccessListDefineBasicInfoEvent
-	151, // 244: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_members_event:type_name -> prehog.v1alpha.UIAccessListDefineMembersEvent
-	152, // 245: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_owners_event:type_name -> prehog.v1alpha.UIAccessListDefineOwnersEvent
-	153, // 246: prehog.v1alpha.SubmitEventRequest.ui_access_list_start_event:type_name -> prehog.v1alpha.UIAccessListStartEvent
-	155, // 247: prehog.v1alpha.SubmitEventRequest.ui_access_list_complete_event:type_name -> prehog.v1alpha.UIAccessListCompleteEvent
-	156, // 248: prehog.v1alpha.SubmitEventRequest.ui_access_list_integrate_event:type_name -> prehog.v1alpha.UIAccessListIntegrateEvent
-	154, // 249: prehog.v1alpha.SubmitEventRequest.ui_access_list_custom_event:type_name -> prehog.v1alpha.UIAccessListCustomEvent
-	127, // 250: prehog.v1alpha.SubmitEventRequest.ui_page_view:type_name -> prehog.v1alpha.UIPageViewEvent
-	128, // 251: prehog.v1alpha.SubmitEventRequest.ui_usage_reporting_alert_cta_click:type_name -> prehog.v1alpha.UIUsageReportingAlertCtaClickEvent
-	143, // 252: prehog.v1alpha.SubmitEventRequest.session_summary_search_event:type_name -> prehog.v1alpha.SessionSummarySearchEvent
-	157, // 253: prehog.v1alpha.SubmitEventRequest.ui_interaction:type_name -> prehog.v1alpha.UIInteractionEvent
-	38,  // 254: prehog.v1alpha.SubmitEventRequest.beams_created:type_name -> prehog.v1alpha.BeamsCreatedEvent
-	39,  // 255: prehog.v1alpha.SubmitEventRequest.beams_destroyed:type_name -> prehog.v1alpha.BeamsDestroyedEvent
-	40,  // 256: prehog.v1alpha.SubmitEventRequest.beams_published:type_name -> prehog.v1alpha.BeamsPublishedEvent
-	41,  // 257: prehog.v1alpha.SubmitEventRequest.beams_unpublished:type_name -> prehog.v1alpha.BeamsUnpublishedEvent
-	158, // 258: prehog.v1alpha.SubmitEventsRequest.events:type_name -> prehog.v1alpha.SubmitEventRequest
-	158, // 259: prehog.v1alpha.TeleportReportingService.SubmitEvent:input_type -> prehog.v1alpha.SubmitEventRequest
-	160, // 260: prehog.v1alpha.TeleportReportingService.SubmitEvents:input_type -> prehog.v1alpha.SubmitEventsRequest
-	162, // 261: prehog.v1alpha.TeleportReportingService.HelloTeleport:input_type -> prehog.v1alpha.HelloTeleportRequest
-	159, // 262: prehog.v1alpha.TeleportReportingService.SubmitEvent:output_type -> prehog.v1alpha.SubmitEventResponse
-	161, // 263: prehog.v1alpha.TeleportReportingService.SubmitEvents:output_type -> prehog.v1alpha.SubmitEventsResponse
-	163, // 264: prehog.v1alpha.TeleportReportingService.HelloTeleport:output_type -> prehog.v1alpha.HelloTeleportResponse
-	262, // [262:265] is the sub-list for method output_type
-	259, // [259:262] is the sub-list for method input_type
-	259, // [259:259] is the sub-list for extension type_name
-	259, // [259:259] is the sub-list for extension extendee
-	0,   // [0:259] is the sub-list for field type_name
+	21,  // 117: prehog.v1alpha.DiscoveryConfigChangedEvent.action:type_name -> prehog.v1alpha.DiscoveryConfigChangeAction
+	18,  // 118: prehog.v1alpha.DiscoveryConfigChangedEvent.matcher_types:type_name -> prehog.v1alpha.DiscoveryMatcherType
+	20,  // 119: prehog.v1alpha.DiscoveryConfigChangedEvent.client_kind:type_name -> prehog.v1alpha.ClientKind
+	19,  // 120: prehog.v1alpha.DiscoveryConfigChangedEvent.access_graph_sync_providers:type_name -> prehog.v1alpha.CloudProvider
+	19,  // 121: prehog.v1alpha.DiscoveryConfigChangedEvent.matcher_providers:type_name -> prehog.v1alpha.CloudProvider
+	22,  // 122: prehog.v1alpha.AccessListStepStatus.status:type_name -> prehog.v1alpha.AccessListStatus
+	97,  // 123: prehog.v1alpha.UIAccessListDefineAccessEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	152, // 124: prehog.v1alpha.UIAccessListDefineAccessEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	97,  // 125: prehog.v1alpha.UIAccessListDefineIdentitiesEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	152, // 126: prehog.v1alpha.UIAccessListDefineIdentitiesEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	97,  // 127: prehog.v1alpha.UIAccessListDefineBasicInfoEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	152, // 128: prehog.v1alpha.UIAccessListDefineBasicInfoEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	97,  // 129: prehog.v1alpha.UIAccessListDefineMembersEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	152, // 130: prehog.v1alpha.UIAccessListDefineMembersEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	97,  // 131: prehog.v1alpha.UIAccessListDefineOwnersEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	152, // 132: prehog.v1alpha.UIAccessListDefineOwnersEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	97,  // 133: prehog.v1alpha.UIAccessListStartEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	152, // 134: prehog.v1alpha.UIAccessListStartEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	97,  // 135: prehog.v1alpha.UIAccessListCustomEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	152, // 136: prehog.v1alpha.UIAccessListCustomEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	97,  // 137: prehog.v1alpha.UIAccessListCompleteEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	152, // 138: prehog.v1alpha.UIAccessListCompleteEvent.status:type_name -> prehog.v1alpha.AccessListStepStatus
+	97,  // 139: prehog.v1alpha.UIAccessListIntegrateEvent.metadata:type_name -> prehog.v1alpha.AccessListMetadata
+	24,  // 140: prehog.v1alpha.UIAccessListIntegrateEvent.integrate:type_name -> prehog.v1alpha.AccessListIntegrate
+	169, // 141: prehog.v1alpha.UIInteractionEvent.params:type_name -> prehog.v1alpha.UIInteractionEvent.ParamsEntry
+	171, // 142: prehog.v1alpha.SubmitEventRequest.timestamp:type_name -> google.protobuf.Timestamp
+	29,  // 143: prehog.v1alpha.SubmitEventRequest.user_login:type_name -> prehog.v1alpha.UserLoginEvent
+	31,  // 144: prehog.v1alpha.SubmitEventRequest.sso_create:type_name -> prehog.v1alpha.SSOCreateEvent
+	32,  // 145: prehog.v1alpha.SubmitEventRequest.resource_create:type_name -> prehog.v1alpha.ResourceCreateEvent
+	35,  // 146: prehog.v1alpha.SubmitEventRequest.session_start:type_name -> prehog.v1alpha.SessionStartEvent
+	48,  // 147: prehog.v1alpha.SubmitEventRequest.ui_banner_click:type_name -> prehog.v1alpha.UIBannerClickEvent
+	49,  // 148: prehog.v1alpha.SubmitEventRequest.ui_onboard_complete_go_to_dashboard_click:type_name -> prehog.v1alpha.UIOnboardCompleteGoToDashboardClickEvent
+	50,  // 149: prehog.v1alpha.SubmitEventRequest.ui_onboard_add_first_resource_click:type_name -> prehog.v1alpha.UIOnboardAddFirstResourceClickEvent
+	51,  // 150: prehog.v1alpha.SubmitEventRequest.ui_onboard_add_first_resource_later_click:type_name -> prehog.v1alpha.UIOnboardAddFirstResourceLaterClickEvent
+	52,  // 151: prehog.v1alpha.SubmitEventRequest.ui_onboard_set_credential_submit:type_name -> prehog.v1alpha.UIOnboardSetCredentialSubmitEvent
+	53,  // 152: prehog.v1alpha.SubmitEventRequest.ui_onboard_register_challenge_submit:type_name -> prehog.v1alpha.UIOnboardRegisterChallengeSubmitEvent
+	55,  // 153: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_continue_click:type_name -> prehog.v1alpha.UIRecoveryCodesContinueClickEvent
+	56,  // 154: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_copy_click:type_name -> prehog.v1alpha.UIRecoveryCodesCopyClickEvent
+	57,  // 155: prehog.v1alpha.SubmitEventRequest.ui_recovery_codes_print_click:type_name -> prehog.v1alpha.UIRecoveryCodesPrintClickEvent
+	61,  // 156: prehog.v1alpha.SubmitEventRequest.ui_discover_started_event:type_name -> prehog.v1alpha.UIDiscoverStartedEvent
+	62,  // 157: prehog.v1alpha.SubmitEventRequest.ui_discover_resource_selection_event:type_name -> prehog.v1alpha.UIDiscoverResourceSelectionEvent
+	46,  // 158: prehog.v1alpha.SubmitEventRequest.user_certificate_issued_event:type_name -> prehog.v1alpha.UserCertificateIssuedEvent
+	35,  // 159: prehog.v1alpha.SubmitEventRequest.session_start_v2:type_name -> prehog.v1alpha.SessionStartEvent
+	66,  // 160: prehog.v1alpha.SubmitEventRequest.ui_discover_deploy_service_event:type_name -> prehog.v1alpha.UIDiscoverDeployServiceEvent
+	68,  // 161: prehog.v1alpha.SubmitEventRequest.ui_discover_database_register_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseRegisterEvent
+	69,  // 162: prehog.v1alpha.SubmitEventRequest.ui_discover_database_configure_mtls_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseConfigureMTLSEvent
+	70,  // 163: prehog.v1alpha.SubmitEventRequest.ui_discover_desktop_active_directory_tools_install_event:type_name -> prehog.v1alpha.UIDiscoverDesktopActiveDirectoryToolsInstallEvent
+	71,  // 164: prehog.v1alpha.SubmitEventRequest.ui_discover_desktop_active_directory_configure_event:type_name -> prehog.v1alpha.UIDiscoverDesktopActiveDirectoryConfigureEvent
+	72,  // 165: prehog.v1alpha.SubmitEventRequest.ui_discover_auto_discovered_resources_event:type_name -> prehog.v1alpha.UIDiscoverAutoDiscoveredResourcesEvent
+	77,  // 166: prehog.v1alpha.SubmitEventRequest.ui_discover_database_configure_iam_policy_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseConfigureIAMPolicyEvent
+	78,  // 167: prehog.v1alpha.SubmitEventRequest.ui_discover_principals_configure_event:type_name -> prehog.v1alpha.UIDiscoverPrincipalsConfigureEvent
+	79,  // 168: prehog.v1alpha.SubmitEventRequest.ui_discover_test_connection_event:type_name -> prehog.v1alpha.UIDiscoverTestConnectionEvent
+	80,  // 169: prehog.v1alpha.SubmitEventRequest.ui_discover_completed_event:type_name -> prehog.v1alpha.UIDiscoverCompletedEvent
+	81,  // 170: prehog.v1alpha.SubmitEventRequest.role_create:type_name -> prehog.v1alpha.RoleCreateEvent
+	84,  // 171: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_click:type_name -> prehog.v1alpha.UICreateNewRoleClickEvent
+	85,  // 172: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_save_click:type_name -> prehog.v1alpha.UICreateNewRoleSaveClickEvent
+	86,  // 173: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_cancel_click:type_name -> prehog.v1alpha.UICreateNewRoleCancelClickEvent
+	87,  // 174: prehog.v1alpha.SubmitEventRequest.ui_create_new_role_view_documentation_click:type_name -> prehog.v1alpha.UICreateNewRoleViewDocumentationClickEvent
+	89,  // 175: prehog.v1alpha.SubmitEventRequest.kube_request:type_name -> prehog.v1alpha.KubeRequestEvent
+	90,  // 176: prehog.v1alpha.SubmitEventRequest.sftp:type_name -> prehog.v1alpha.SFTPEvent
+	91,  // 177: prehog.v1alpha.SubmitEventRequest.agent_metadata_event:type_name -> prehog.v1alpha.AgentMetadataEvent
+	34,  // 178: prehog.v1alpha.SubmitEventRequest.resource_heartbeat:type_name -> prehog.v1alpha.ResourceHeartbeatEvent
+	63,  // 179: prehog.v1alpha.SubmitEventRequest.ui_discover_integration_aws_oidc_connect_event:type_name -> prehog.v1alpha.UIDiscoverIntegrationAWSOIDCConnectEvent
+	64,  // 180: prehog.v1alpha.SubmitEventRequest.ui_discover_database_rds_enroll_event:type_name -> prehog.v1alpha.UIDiscoverDatabaseRDSEnrollEvent
+	88,  // 181: prehog.v1alpha.SubmitEventRequest.ui_call_to_action_click_event:type_name -> prehog.v1alpha.UICallToActionClickEvent
+	92,  // 182: prehog.v1alpha.SubmitEventRequest.assist_completion:type_name -> prehog.v1alpha.AssistCompletionEvent
+	109, // 183: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_start_event:type_name -> prehog.v1alpha.UIIntegrationEnrollStartEvent
+	110, // 184: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_complete_event:type_name -> prehog.v1alpha.UIIntegrationEnrollCompleteEvent
+	117, // 185: prehog.v1alpha.SubmitEventRequest.editor_change_event:type_name -> prehog.v1alpha.EditorChangeEvent
+	82,  // 186: prehog.v1alpha.SubmitEventRequest.bot_create:type_name -> prehog.v1alpha.BotCreateEvent
+	54,  // 187: prehog.v1alpha.SubmitEventRequest.ui_onboard_questionnaire_submit:type_name -> prehog.v1alpha.UIOnboardQuestionnaireSubmitEvent
+	83,  // 188: prehog.v1alpha.SubmitEventRequest.bot_join:type_name -> prehog.v1alpha.BotJoinEvent
+	93,  // 189: prehog.v1alpha.SubmitEventRequest.assist_execution:type_name -> prehog.v1alpha.AssistExecutionEvent
+	94,  // 190: prehog.v1alpha.SubmitEventRequest.assist_new_conversation:type_name -> prehog.v1alpha.AssistNewConversationEvent
+	118, // 191: prehog.v1alpha.SubmitEventRequest.device_authenticate_event:type_name -> prehog.v1alpha.DeviceAuthenticateEvent
+	120, // 192: prehog.v1alpha.SubmitEventRequest.feature_recommendation_event:type_name -> prehog.v1alpha.FeatureRecommendationEvent
+	95,  // 193: prehog.v1alpha.SubmitEventRequest.assist_access_request:type_name -> prehog.v1alpha.AssistAccessRequestEvent
+	96,  // 194: prehog.v1alpha.SubmitEventRequest.assist_action:type_name -> prehog.v1alpha.AssistActionEvent
+	119, // 195: prehog.v1alpha.SubmitEventRequest.device_enroll_event:type_name -> prehog.v1alpha.DeviceEnrollEvent
+	121, // 196: prehog.v1alpha.SubmitEventRequest.license_limit_event:type_name -> prehog.v1alpha.LicenseLimitEvent
+	98,  // 197: prehog.v1alpha.SubmitEventRequest.access_list_create:type_name -> prehog.v1alpha.AccessListCreateEvent
+	99,  // 198: prehog.v1alpha.SubmitEventRequest.access_list_update:type_name -> prehog.v1alpha.AccessListUpdateEvent
+	100, // 199: prehog.v1alpha.SubmitEventRequest.access_list_delete:type_name -> prehog.v1alpha.AccessListDeleteEvent
+	101, // 200: prehog.v1alpha.SubmitEventRequest.access_list_member_create:type_name -> prehog.v1alpha.AccessListMemberCreateEvent
+	102, // 201: prehog.v1alpha.SubmitEventRequest.access_list_member_update:type_name -> prehog.v1alpha.AccessListMemberUpdateEvent
+	103, // 202: prehog.v1alpha.SubmitEventRequest.access_list_member_delete:type_name -> prehog.v1alpha.AccessListMemberDeleteEvent
+	104, // 203: prehog.v1alpha.SubmitEventRequest.access_list_grants_to_user:type_name -> prehog.v1alpha.AccessListGrantsToUserEvent
+	73,  // 204: prehog.v1alpha.SubmitEventRequest.ui_discover_ec2_instance_selection:type_name -> prehog.v1alpha.UIDiscoverEC2InstanceSelectionEvent
+	74,  // 205: prehog.v1alpha.SubmitEventRequest.ui_discover_deploy_eice:type_name -> prehog.v1alpha.UIDiscoverDeployEICEEvent
+	75,  // 206: prehog.v1alpha.SubmitEventRequest.ui_discover_create_node:type_name -> prehog.v1alpha.UIDiscoverCreateNodeEvent
+	122, // 207: prehog.v1alpha.SubmitEventRequest.desktop_directory_share:type_name -> prehog.v1alpha.DesktopDirectoryShareEvent
+	123, // 208: prehog.v1alpha.SubmitEventRequest.desktop_clipboard_transfer:type_name -> prehog.v1alpha.DesktopClipboardEvent
+	124, // 209: prehog.v1alpha.SubmitEventRequest.tag_execute_query:type_name -> prehog.v1alpha.TAGExecuteQueryEvent
+	134, // 210: prehog.v1alpha.SubmitEventRequest.external_audit_storage_authenticate:type_name -> prehog.v1alpha.ExternalAuditStorageAuthenticateEvent
+	135, // 211: prehog.v1alpha.SubmitEventRequest.security_report_get_result:type_name -> prehog.v1alpha.SecurityReportGetResultEvent
+	136, // 212: prehog.v1alpha.SubmitEventRequest.audit_query_run:type_name -> prehog.v1alpha.AuditQueryRunEvent
+	137, // 213: prehog.v1alpha.SubmitEventRequest.discovery_fetch_event:type_name -> prehog.v1alpha.DiscoveryFetchEvent
+	105, // 214: prehog.v1alpha.SubmitEventRequest.access_list_review_create:type_name -> prehog.v1alpha.AccessListReviewCreateEvent
+	106, // 215: prehog.v1alpha.SubmitEventRequest.access_list_review_delete:type_name -> prehog.v1alpha.AccessListReviewDeleteEvent
+	107, // 216: prehog.v1alpha.SubmitEventRequest.access_list_review_compliance:type_name -> prehog.v1alpha.AccessListReviewComplianceEvent
+	30,  // 217: prehog.v1alpha.SubmitEventRequest.mfa_authentication_event:type_name -> prehog.v1alpha.MFAAuthenticationEvent
+	47,  // 218: prehog.v1alpha.SubmitEventRequest.spiffe_svid_issued:type_name -> prehog.v1alpha.SPIFFESVIDIssuedEvent
+	138, // 219: prehog.v1alpha.SubmitEventRequest.okta_access_list_sync:type_name -> prehog.v1alpha.OktaAccessListSyncEvent
+	139, // 220: prehog.v1alpha.SubmitEventRequest.database_user_created:type_name -> prehog.v1alpha.DatabaseUserCreatedEvent
+	140, // 221: prehog.v1alpha.SubmitEventRequest.database_user_permissions_updated:type_name -> prehog.v1alpha.DatabaseUserPermissionsUpdateEvent
+	67,  // 222: prehog.v1alpha.SubmitEventRequest.ui_discover_create_discovery_config:type_name -> prehog.v1alpha.UIDiscoverCreateDiscoveryConfigEvent
+	65,  // 223: prehog.v1alpha.SubmitEventRequest.ui_discover_kube_eks_enroll_event:type_name -> prehog.v1alpha.UIDiscoverKubeEKSEnrollEvent
+	76,  // 224: prehog.v1alpha.SubmitEventRequest.ui_discover_create_app_server_event:type_name -> prehog.v1alpha.UIDiscoverCreateAppServerEvent
+	127, // 225: prehog.v1alpha.SubmitEventRequest.access_graph_gitlab_scan:type_name -> prehog.v1alpha.AccessGraphGitlabScanEvent
+	125, // 226: prehog.v1alpha.SubmitEventRequest.access_graph_secrets_scan_authorized_keys:type_name -> prehog.v1alpha.AccessGraphSecretsScanAuthorizedKeysEvent
+	126, // 227: prehog.v1alpha.SubmitEventRequest.access_graph_secrets_scan_ssh_private_keys:type_name -> prehog.v1alpha.AccessGraphSecretsScanSSHPrivateKeysEvent
+	128, // 228: prehog.v1alpha.SubmitEventRequest.access_graph_aws_scan:type_name -> prehog.v1alpha.AccessGraphAWSScanEvent
+	129, // 229: prehog.v1alpha.SubmitEventRequest.access_graph_access_path_changed:type_name -> prehog.v1alpha.AccessGraphAccessPathChangedEvent
+	133, // 230: prehog.v1alpha.SubmitEventRequest.access_graph_crown_jewel_create:type_name -> prehog.v1alpha.AccessGraphCrownJewelCreateEvent
+	130, // 231: prehog.v1alpha.SubmitEventRequest.ui_access_graph_crown_jewel_diff_view:type_name -> prehog.v1alpha.UIAccessGraphCrownJewelDiffViewEvent
+	141, // 232: prehog.v1alpha.SubmitEventRequest.session_recording_access:type_name -> prehog.v1alpha.SessionRecordingAccessEvent
+	142, // 233: prehog.v1alpha.SubmitEventRequest.user_task_state:type_name -> prehog.v1alpha.UserTaskStateEvent
+	112, // 234: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_step_event:type_name -> prehog.v1alpha.UIIntegrationEnrollStepEvent
+	143, // 235: prehog.v1alpha.SubmitEventRequest.access_request_create:type_name -> prehog.v1alpha.AccessRequestCreateEvent
+	144, // 236: prehog.v1alpha.SubmitEventRequest.access_request_review:type_name -> prehog.v1alpha.AccessRequestReviewEvent
+	113, // 237: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_section_open_event:type_name -> prehog.v1alpha.UIIntegrationEnrollSectionOpenEvent
+	114, // 238: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_field_complete_event:type_name -> prehog.v1alpha.UIIntegrationEnrollFieldCompleteEvent
+	115, // 239: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_code_copy_event:type_name -> prehog.v1alpha.UIIntegrationEnrollCodeCopyEvent
+	116, // 240: prehog.v1alpha.SubmitEventRequest.ui_integration_enroll_link_click_event:type_name -> prehog.v1alpha.UIIntegrationEnrollLinkClickEvent
+	146, // 241: prehog.v1alpha.SubmitEventRequest.session_summary_create_event:type_name -> prehog.v1alpha.SessionSummaryCreateEvent
+	145, // 242: prehog.v1alpha.SubmitEventRequest.session_summary_access_event:type_name -> prehog.v1alpha.SessionSummaryAccessEvent
+	148, // 243: prehog.v1alpha.SubmitEventRequest.discovery_config:type_name -> prehog.v1alpha.DiscoveryConfigEvent
+	150, // 244: prehog.v1alpha.SubmitEventRequest.identity_security_graph_size_event:type_name -> prehog.v1alpha.IdentitySecurityGraphSizeEvent
+	151, // 245: prehog.v1alpha.SubmitEventRequest.identity_security_audit_logs_ingested_event:type_name -> prehog.v1alpha.IdentitySecurityAuditLogsIngestedEvent
+	153, // 246: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_access_event:type_name -> prehog.v1alpha.UIAccessListDefineAccessEvent
+	154, // 247: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_identities_event:type_name -> prehog.v1alpha.UIAccessListDefineIdentitiesEvent
+	155, // 248: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_basic_info_event:type_name -> prehog.v1alpha.UIAccessListDefineBasicInfoEvent
+	156, // 249: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_members_event:type_name -> prehog.v1alpha.UIAccessListDefineMembersEvent
+	157, // 250: prehog.v1alpha.SubmitEventRequest.ui_access_list_define_owners_event:type_name -> prehog.v1alpha.UIAccessListDefineOwnersEvent
+	158, // 251: prehog.v1alpha.SubmitEventRequest.ui_access_list_start_event:type_name -> prehog.v1alpha.UIAccessListStartEvent
+	160, // 252: prehog.v1alpha.SubmitEventRequest.ui_access_list_complete_event:type_name -> prehog.v1alpha.UIAccessListCompleteEvent
+	161, // 253: prehog.v1alpha.SubmitEventRequest.ui_access_list_integrate_event:type_name -> prehog.v1alpha.UIAccessListIntegrateEvent
+	159, // 254: prehog.v1alpha.SubmitEventRequest.ui_access_list_custom_event:type_name -> prehog.v1alpha.UIAccessListCustomEvent
+	131, // 255: prehog.v1alpha.SubmitEventRequest.ui_page_view:type_name -> prehog.v1alpha.UIPageViewEvent
+	132, // 256: prehog.v1alpha.SubmitEventRequest.ui_usage_reporting_alert_cta_click:type_name -> prehog.v1alpha.UIUsageReportingAlertCtaClickEvent
+	147, // 257: prehog.v1alpha.SubmitEventRequest.session_summary_search_event:type_name -> prehog.v1alpha.SessionSummarySearchEvent
+	162, // 258: prehog.v1alpha.SubmitEventRequest.ui_interaction:type_name -> prehog.v1alpha.UIInteractionEvent
+	42,  // 259: prehog.v1alpha.SubmitEventRequest.beams_created:type_name -> prehog.v1alpha.BeamsCreatedEvent
+	43,  // 260: prehog.v1alpha.SubmitEventRequest.beams_destroyed:type_name -> prehog.v1alpha.BeamsDestroyedEvent
+	44,  // 261: prehog.v1alpha.SubmitEventRequest.beams_published:type_name -> prehog.v1alpha.BeamsPublishedEvent
+	45,  // 262: prehog.v1alpha.SubmitEventRequest.beams_unpublished:type_name -> prehog.v1alpha.BeamsUnpublishedEvent
+	149, // 263: prehog.v1alpha.SubmitEventRequest.discovery_config_changed:type_name -> prehog.v1alpha.DiscoveryConfigChangedEvent
+	163, // 264: prehog.v1alpha.SubmitEventsRequest.events:type_name -> prehog.v1alpha.SubmitEventRequest
+	163, // 265: prehog.v1alpha.TeleportReportingService.SubmitEvent:input_type -> prehog.v1alpha.SubmitEventRequest
+	165, // 266: prehog.v1alpha.TeleportReportingService.SubmitEvents:input_type -> prehog.v1alpha.SubmitEventsRequest
+	167, // 267: prehog.v1alpha.TeleportReportingService.HelloTeleport:input_type -> prehog.v1alpha.HelloTeleportRequest
+	164, // 268: prehog.v1alpha.TeleportReportingService.SubmitEvent:output_type -> prehog.v1alpha.SubmitEventResponse
+	166, // 269: prehog.v1alpha.TeleportReportingService.SubmitEvents:output_type -> prehog.v1alpha.SubmitEventsResponse
+	168, // 270: prehog.v1alpha.TeleportReportingService.HelloTeleport:output_type -> prehog.v1alpha.HelloTeleportResponse
+	268, // [268:271] is the sub-list for method output_type
+	265, // [265:268] is the sub-list for method input_type
+	265, // [265:265] is the sub-list for extension type_name
+	265, // [265:265] is the sub-list for extension extendee
+	0,   // [0:265] is the sub-list for field type_name
 }
 
 func init() { file_prehog_v1alpha_teleport_proto_init() }
@@ -14345,7 +14875,7 @@ func file_prehog_v1alpha_teleport_proto_init() {
 	if File_prehog_v1alpha_teleport_proto != nil {
 		return
 	}
-	file_prehog_v1alpha_teleport_proto_msgTypes[133].OneofWrappers = []any{
+	file_prehog_v1alpha_teleport_proto_msgTypes[134].OneofWrappers = []any{
 		(*SubmitEventRequest_UserLogin)(nil),
 		(*SubmitEventRequest_SsoCreate)(nil),
 		(*SubmitEventRequest_ResourceCreate)(nil),
@@ -14466,14 +14996,15 @@ func file_prehog_v1alpha_teleport_proto_init() {
 		(*SubmitEventRequest_BeamsDestroyed)(nil),
 		(*SubmitEventRequest_BeamsPublished)(nil),
 		(*SubmitEventRequest_BeamsUnpublished)(nil),
+		(*SubmitEventRequest_DiscoveryConfigChanged)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_prehog_v1alpha_teleport_proto_rawDesc), len(file_prehog_v1alpha_teleport_proto_rawDesc)),
-			NumEnums:      25,
-			NumMessages:   140,
+			NumEnums:      29,
+			NumMessages:   141,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/ts/prehog/v1alpha/teleport_pb.ts
+++ b/gen/proto/ts/prehog/v1alpha/teleport_pb.ts
@@ -3472,6 +3472,98 @@ export interface DiscoveryConfigEvent {
     creationMethod: string;
 }
 /**
+ * DiscoveryConfigChangedEvent is emitted when a discovery config is created,
+ * updated, upserted, or deleted.
+ *
+ * PostHog event: tp.discovery.config.changed
+ *
+ * @generated from protobuf message prehog.v1alpha.DiscoveryConfigChangedEvent
+ */
+export interface DiscoveryConfigChangedEvent {
+    /**
+     * discovery_config_id is the anonymized name of the discovery config.
+     *
+     * PostHog property: tp.discovery.discovery_config_id
+     *
+     * @generated from protobuf field: string discovery_config_id = 1;
+     */
+    discoveryConfigId: string;
+    /**
+     * integration_ids are the anonymized names of the integrations the config's
+     * matchers use, deduplicated.
+     *
+     * PostHog property: tp.discovery.integration_ids
+     *
+     * @generated from protobuf field: repeated string integration_ids = 2;
+     */
+    integrationIds: string[];
+    /**
+     * setup_attempt_id is the anonymized setup attempt ID the config carries as a
+     * label.
+     *
+     * PostHog property: tp.discovery.setup_attempt_id
+     *
+     * @generated from protobuf field: string setup_attempt_id = 3;
+     */
+    setupAttemptId: string;
+    /**
+     * PostHog property: tp.discovery.action
+     *
+     * @generated from protobuf field: prehog.v1alpha.DiscoveryConfigChangeAction action = 4;
+     */
+    action: DiscoveryConfigChangeAction;
+    /**
+     * matcher_types are the resource types the config's matchers select, sorted
+     * and deduplicated.
+     *
+     * PostHog property: tp.discovery.matcher_types
+     *
+     * @generated from protobuf field: repeated prehog.v1alpha.DiscoveryMatcherType matcher_types = 5;
+     */
+    matcherTypes: DiscoveryMatcherType[];
+    /**
+     * PostHog property: tp.discovery.client_kind
+     *
+     * @generated from protobuf field: prehog.v1alpha.ClientKind client_kind = 6;
+     */
+    clientKind: ClientKind;
+    /**
+     * access_graph_integration_ids are the anonymized names of the integrations
+     * the config's Access Graph syncs use, deduplicated.
+     *
+     * PostHog property: tp.discovery.access_graph_integration_ids
+     *
+     * @generated from protobuf field: repeated string access_graph_integration_ids = 7;
+     */
+    accessGraphIntegrationIds: string[];
+    /**
+     * access_graph_sync_providers are the clouds the config syncs into Access
+     * Graph, sorted and deduplicated.
+     *
+     * PostHog property: tp.discovery.access_graph_sync_providers
+     *
+     * @generated from protobuf field: repeated prehog.v1alpha.CloudProvider access_graph_sync_providers = 8;
+     */
+    accessGraphSyncProviders: CloudProvider[];
+    /**
+     * matcher_providers are the platforms the config's matchers select resources
+     * from, sorted and deduplicated.
+     *
+     * PostHog property: tp.discovery.matcher_providers
+     *
+     * @generated from protobuf field: repeated prehog.v1alpha.CloudProvider matcher_providers = 9;
+     */
+    matcherProviders: CloudProvider[];
+    /**
+     * discovery_group_id is the anonymized discovery group that runs the config.
+     *
+     * PostHog property: tp.discovery.discovery_group_id
+     *
+     * @generated from protobuf field: string discovery_group_id = 10;
+     */
+    discoveryGroupId: string;
+}
+/**
  * IdentitySecurityGraphSizeEvent is emitted by Access Graph whenever the access graph
  * for a provider is updated.
  *
@@ -4507,6 +4599,12 @@ export interface SubmitEventRequest {
          */
         beamsUnpublished: BeamsUnpublishedEvent;
     } | {
+        oneofKind: "discoveryConfigChanged";
+        /**
+         * @generated from protobuf field: prehog.v1alpha.DiscoveryConfigChangedEvent discovery_config_changed = 127;
+         */
+        discoveryConfigChanged: DiscoveryConfigChangedEvent;
+    } | {
         oneofKind: undefined;
     };
 }
@@ -5491,6 +5589,203 @@ export enum DiscoveryConfigAction {
      * @generated from protobuf enum value: DISCOVERY_CONFIG_ACTION_DELETE = 3;
      */
     DELETE = 3
+}
+/**
+ * DiscoveryMatcherType is a resource type a discovery config's matchers select.
+ *
+ * @generated from protobuf enum prehog.v1alpha.DiscoveryMatcherType
+ */
+export enum DiscoveryMatcherType {
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_UNSPECIFIED = 0;
+     */
+    UNSPECIFIED = 0,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_EC2 = 1;
+     */
+    AWS_EC2 = 1,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_EKS = 2;
+     */
+    AWS_EKS = 2,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_RDS = 3;
+     */
+    AWS_RDS = 3,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_RDSPROXY = 4;
+     */
+    AWS_RDSPROXY = 4,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT = 5;
+     */
+    AWS_REDSHIFT = 5,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT_SERVERLESS = 6;
+     */
+    AWS_REDSHIFT_SERVERLESS = 6,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE = 7;
+     */
+    AWS_ELASTICACHE = 7,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE_SERVERLESS = 8;
+     */
+    AWS_ELASTICACHE_SERVERLESS = 8,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_MEMORYDB = 9;
+     */
+    AWS_MEMORYDB = 9,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_OPENSEARCH = 10;
+     */
+    AWS_OPENSEARCH = 10,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AWS_DOCDB = 11;
+     */
+    AWS_DOCDB = 11,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AZURE_VM = 12;
+     */
+    AZURE_VM = 12,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AZURE_AKS = 13;
+     */
+    AZURE_AKS = 13,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AZURE_MYSQL = 14;
+     */
+    AZURE_MYSQL = 14,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AZURE_POSTGRES = 15;
+     */
+    AZURE_POSTGRES = 15,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AZURE_REDIS = 16;
+     */
+    AZURE_REDIS = 16,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AZURE_SQLSERVER = 17;
+     */
+    AZURE_SQLSERVER = 17,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_AZURE_WINDOWS_VM = 18;
+     */
+    AZURE_WINDOWS_VM = 18,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_GCP_GKE = 19;
+     */
+    GCP_GKE = 19,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_GCP_GCE = 20;
+     */
+    GCP_GCE = 20,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_GCP_CLOUDSQL = 21;
+     */
+    GCP_CLOUDSQL = 21,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_MATCHER_TYPE_KUBE_APP = 22;
+     */
+    KUBE_APP = 22
+}
+/**
+ * CloudProvider is a platform a discovery config selects resources from.
+ *
+ * @generated from protobuf enum prehog.v1alpha.CloudProvider
+ */
+export enum CloudProvider {
+    /**
+     * @generated from protobuf enum value: CLOUD_PROVIDER_UNSPECIFIED = 0;
+     */
+    UNSPECIFIED = 0,
+    /**
+     * @generated from protobuf enum value: CLOUD_PROVIDER_AWS = 1;
+     */
+    AWS = 1,
+    /**
+     * @generated from protobuf enum value: CLOUD_PROVIDER_AZURE = 2;
+     */
+    AZURE = 2,
+    /**
+     * @generated from protobuf enum value: CLOUD_PROVIDER_GCP = 3;
+     */
+    GCP = 3,
+    /**
+     * @generated from protobuf enum value: CLOUD_PROVIDER_KUBERNETES = 4;
+     */
+    KUBERNETES = 4
+}
+/**
+ * ClientKind is the tool that made a configuration change, read from the
+ * request's user agent.
+ *
+ * @generated from protobuf enum prehog.v1alpha.ClientKind
+ */
+export enum ClientKind {
+    /**
+     * The event's producer does not report a client.
+     *
+     * @generated from protobuf enum value: CLIENT_KIND_UNSPECIFIED = 0;
+     */
+    UNSPECIFIED = 0,
+    /**
+     * The user agent did not match a known tool.
+     *
+     * @generated from protobuf enum value: CLIENT_KIND_UNKNOWN = 1;
+     */
+    UNKNOWN = 1,
+    /**
+     * @generated from protobuf enum value: CLIENT_KIND_WEB_UI = 2;
+     */
+    WEB_UI = 2,
+    /**
+     * @generated from protobuf enum value: CLIENT_KIND_TCTL = 3;
+     */
+    TCTL = 3,
+    /**
+     * @generated from protobuf enum value: CLIENT_KIND_TSH = 4;
+     */
+    TSH = 4,
+    /**
+     * @generated from protobuf enum value: CLIENT_KIND_TBOT = 5;
+     */
+    TBOT = 5,
+    /**
+     * @generated from protobuf enum value: CLIENT_KIND_TERRAFORM_PROVIDER = 6;
+     */
+    TERRAFORM_PROVIDER = 6,
+    /**
+     * @generated from protobuf enum value: CLIENT_KIND_KUBE_OPERATOR = 7;
+     */
+    KUBE_OPERATOR = 7
+}
+/**
+ * DiscoveryConfigChangeAction is the change made to a discovery config.
+ *
+ * @generated from protobuf enum prehog.v1alpha.DiscoveryConfigChangeAction
+ */
+export enum DiscoveryConfigChangeAction {
+    /**
+     * @generated from protobuf enum value: DISCOVERY_CONFIG_CHANGE_ACTION_UNSPECIFIED = 0;
+     */
+    UNSPECIFIED = 0,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_CONFIG_CHANGE_ACTION_CREATE = 1;
+     */
+    CREATE = 1,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_CONFIG_CHANGE_ACTION_UPDATE = 2;
+     */
+    UPDATE = 2,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT = 3;
+     */
+    UPSERT = 3,
+    /**
+     * @generated from protobuf enum value: DISCOVERY_CONFIG_CHANGE_ACTION_DELETE = 4;
+     */
+    DELETE = 4
 }
 /**
  * AccessListStatus represents a access list wizard step outcome.
@@ -13221,6 +13516,149 @@ class DiscoveryConfigEvent$Type extends MessageType<DiscoveryConfigEvent> {
  */
 export const DiscoveryConfigEvent = new DiscoveryConfigEvent$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class DiscoveryConfigChangedEvent$Type extends MessageType<DiscoveryConfigChangedEvent> {
+    constructor() {
+        super("prehog.v1alpha.DiscoveryConfigChangedEvent", [
+            { no: 1, name: "discovery_config_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "integration_ids", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "setup_attempt_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "action", kind: "enum", T: () => ["prehog.v1alpha.DiscoveryConfigChangeAction", DiscoveryConfigChangeAction, "DISCOVERY_CONFIG_CHANGE_ACTION_"] },
+            { no: 5, name: "matcher_types", kind: "enum", repeat: 1 /*RepeatType.PACKED*/, T: () => ["prehog.v1alpha.DiscoveryMatcherType", DiscoveryMatcherType, "DISCOVERY_MATCHER_TYPE_"] },
+            { no: 6, name: "client_kind", kind: "enum", T: () => ["prehog.v1alpha.ClientKind", ClientKind, "CLIENT_KIND_"] },
+            { no: 7, name: "access_graph_integration_ids", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 8, name: "access_graph_sync_providers", kind: "enum", repeat: 1 /*RepeatType.PACKED*/, T: () => ["prehog.v1alpha.CloudProvider", CloudProvider, "CLOUD_PROVIDER_"] },
+            { no: 9, name: "matcher_providers", kind: "enum", repeat: 1 /*RepeatType.PACKED*/, T: () => ["prehog.v1alpha.CloudProvider", CloudProvider, "CLOUD_PROVIDER_"] },
+            { no: 10, name: "discovery_group_id", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<DiscoveryConfigChangedEvent>): DiscoveryConfigChangedEvent {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.discoveryConfigId = "";
+        message.integrationIds = [];
+        message.setupAttemptId = "";
+        message.action = 0;
+        message.matcherTypes = [];
+        message.clientKind = 0;
+        message.accessGraphIntegrationIds = [];
+        message.accessGraphSyncProviders = [];
+        message.matcherProviders = [];
+        message.discoveryGroupId = "";
+        if (value !== undefined)
+            reflectionMergePartial<DiscoveryConfigChangedEvent>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: DiscoveryConfigChangedEvent): DiscoveryConfigChangedEvent {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string discovery_config_id */ 1:
+                    message.discoveryConfigId = reader.string();
+                    break;
+                case /* repeated string integration_ids */ 2:
+                    message.integrationIds.push(reader.string());
+                    break;
+                case /* string setup_attempt_id */ 3:
+                    message.setupAttemptId = reader.string();
+                    break;
+                case /* prehog.v1alpha.DiscoveryConfigChangeAction action */ 4:
+                    message.action = reader.int32();
+                    break;
+                case /* repeated prehog.v1alpha.DiscoveryMatcherType matcher_types */ 5:
+                    if (wireType === WireType.LengthDelimited)
+                        for (let e = reader.int32() + reader.pos; reader.pos < e;)
+                            message.matcherTypes.push(reader.int32());
+                    else
+                        message.matcherTypes.push(reader.int32());
+                    break;
+                case /* prehog.v1alpha.ClientKind client_kind */ 6:
+                    message.clientKind = reader.int32();
+                    break;
+                case /* repeated string access_graph_integration_ids */ 7:
+                    message.accessGraphIntegrationIds.push(reader.string());
+                    break;
+                case /* repeated prehog.v1alpha.CloudProvider access_graph_sync_providers */ 8:
+                    if (wireType === WireType.LengthDelimited)
+                        for (let e = reader.int32() + reader.pos; reader.pos < e;)
+                            message.accessGraphSyncProviders.push(reader.int32());
+                    else
+                        message.accessGraphSyncProviders.push(reader.int32());
+                    break;
+                case /* repeated prehog.v1alpha.CloudProvider matcher_providers */ 9:
+                    if (wireType === WireType.LengthDelimited)
+                        for (let e = reader.int32() + reader.pos; reader.pos < e;)
+                            message.matcherProviders.push(reader.int32());
+                    else
+                        message.matcherProviders.push(reader.int32());
+                    break;
+                case /* string discovery_group_id */ 10:
+                    message.discoveryGroupId = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: DiscoveryConfigChangedEvent, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string discovery_config_id = 1; */
+        if (message.discoveryConfigId !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.discoveryConfigId);
+        /* repeated string integration_ids = 2; */
+        for (let i = 0; i < message.integrationIds.length; i++)
+            writer.tag(2, WireType.LengthDelimited).string(message.integrationIds[i]);
+        /* string setup_attempt_id = 3; */
+        if (message.setupAttemptId !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.setupAttemptId);
+        /* prehog.v1alpha.DiscoveryConfigChangeAction action = 4; */
+        if (message.action !== 0)
+            writer.tag(4, WireType.Varint).int32(message.action);
+        /* repeated prehog.v1alpha.DiscoveryMatcherType matcher_types = 5; */
+        if (message.matcherTypes.length) {
+            writer.tag(5, WireType.LengthDelimited).fork();
+            for (let i = 0; i < message.matcherTypes.length; i++)
+                writer.int32(message.matcherTypes[i]);
+            writer.join();
+        }
+        /* prehog.v1alpha.ClientKind client_kind = 6; */
+        if (message.clientKind !== 0)
+            writer.tag(6, WireType.Varint).int32(message.clientKind);
+        /* repeated string access_graph_integration_ids = 7; */
+        for (let i = 0; i < message.accessGraphIntegrationIds.length; i++)
+            writer.tag(7, WireType.LengthDelimited).string(message.accessGraphIntegrationIds[i]);
+        /* repeated prehog.v1alpha.CloudProvider access_graph_sync_providers = 8; */
+        if (message.accessGraphSyncProviders.length) {
+            writer.tag(8, WireType.LengthDelimited).fork();
+            for (let i = 0; i < message.accessGraphSyncProviders.length; i++)
+                writer.int32(message.accessGraphSyncProviders[i]);
+            writer.join();
+        }
+        /* repeated prehog.v1alpha.CloudProvider matcher_providers = 9; */
+        if (message.matcherProviders.length) {
+            writer.tag(9, WireType.LengthDelimited).fork();
+            for (let i = 0; i < message.matcherProviders.length; i++)
+                writer.int32(message.matcherProviders[i]);
+            writer.join();
+        }
+        /* string discovery_group_id = 10; */
+        if (message.discoveryGroupId !== "")
+            writer.tag(10, WireType.LengthDelimited).string(message.discoveryGroupId);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message prehog.v1alpha.DiscoveryConfigChangedEvent
+ */
+export const DiscoveryConfigChangedEvent = new DiscoveryConfigChangedEvent$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class IdentitySecurityGraphSizeEvent$Type extends MessageType<IdentitySecurityGraphSizeEvent> {
     constructor() {
         super("prehog.v1alpha.IdentitySecurityGraphSizeEvent", [
@@ -14093,7 +14531,8 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
             { no: 123, name: "beams_created", kind: "message", oneof: "event", T: () => BeamsCreatedEvent },
             { no: 124, name: "beams_destroyed", kind: "message", oneof: "event", T: () => BeamsDestroyedEvent },
             { no: 125, name: "beams_published", kind: "message", oneof: "event", T: () => BeamsPublishedEvent },
-            { no: 126, name: "beams_unpublished", kind: "message", oneof: "event", T: () => BeamsUnpublishedEvent }
+            { no: 126, name: "beams_unpublished", kind: "message", oneof: "event", T: () => BeamsUnpublishedEvent },
+            { no: 127, name: "discovery_config_changed", kind: "message", oneof: "event", T: () => DiscoveryConfigChangedEvent }
         ]);
     }
     create(value?: PartialMessage<SubmitEventRequest>): SubmitEventRequest {
@@ -14843,6 +15282,12 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
                         beamsUnpublished: BeamsUnpublishedEvent.internalBinaryRead(reader, reader.uint32(), options, (message.event as any).beamsUnpublished)
                     };
                     break;
+                case /* prehog.v1alpha.DiscoveryConfigChangedEvent discovery_config_changed */ 127:
+                    message.event = {
+                        oneofKind: "discoveryConfigChanged",
+                        discoveryConfigChanged: DiscoveryConfigChangedEvent.internalBinaryRead(reader, reader.uint32(), options, (message.event as any).discoveryConfigChanged)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -15227,6 +15672,9 @@ class SubmitEventRequest$Type extends MessageType<SubmitEventRequest> {
         /* prehog.v1alpha.BeamsUnpublishedEvent beams_unpublished = 126; */
         if (message.event.oneofKind === "beamsUnpublished")
             BeamsUnpublishedEvent.internalBinaryWrite(message.event.beamsUnpublished, writer.tag(126, WireType.LengthDelimited).fork(), options).join();
+        /* prehog.v1alpha.DiscoveryConfigChangedEvent discovery_config_changed = 127; */
+        if (message.event.oneofKind === "discoveryConfigChanged")
+            DiscoveryConfigChangedEvent.internalBinaryWrite(message.event.discoveryConfigChanged, writer.tag(127, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/usagereporter/teleport/discoveryconfig.go
+++ b/lib/usagereporter/teleport/discoveryconfig.go
@@ -1,0 +1,217 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package usagereporter
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/metadata"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
+)
+
+var (
+	awsMatcherTypes = map[string]prehogv1a.DiscoveryMatcherType{
+		types.AWSMatcherEC2:                   prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EC2,
+		types.AWSMatcherEKS:                   prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EKS,
+		types.AWSMatcherRDS:                   prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDS,
+		types.AWSMatcherRDSProxy:              prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDSPROXY,
+		types.AWSMatcherRedshift:              prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT,
+		types.AWSMatcherRedshiftServerless:    prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT_SERVERLESS,
+		types.AWSMatcherElastiCache:           prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE,
+		types.AWSMatcherElastiCacheServerless: prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE_SERVERLESS,
+		types.AWSMatcherMemoryDB:              prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_MEMORYDB,
+		types.AWSMatcherOpenSearch:            prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_OPENSEARCH,
+		types.AWSMatcherDocumentDB:            prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_DOCDB,
+	}
+	azureMatcherTypes = map[string]prehogv1a.DiscoveryMatcherType{
+		types.AzureMatcherVM:         prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_VM,
+		types.AzureMatcherKubernetes: prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_AKS,
+		types.AzureMatcherMySQL:      prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_MYSQL,
+		types.AzureMatcherPostgres:   prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_POSTGRES,
+		types.AzureMatcherRedis:      prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_REDIS,
+		types.AzureMatcherSQLServer:  prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_SQLSERVER,
+		types.AzureMatcherWindowsVM:  prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_WINDOWS_VM,
+	}
+	gcpMatcherTypes = map[string]prehogv1a.DiscoveryMatcherType{
+		types.GCPMatcherKubernetes: prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_GCP_GKE,
+		types.GCPMatcherCompute:    prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_GCP_GCE,
+		types.GCPMatcherCloudSQL:   prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_GCP_CLOUDSQL,
+	}
+	kubeMatcherTypes = map[string]prehogv1a.DiscoveryMatcherType{
+		types.KubernetesMatchersApp: prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_KUBE_APP,
+	}
+)
+
+// matcherTypes returns the distinct resource types a config's matchers select,
+// sorted.
+func matcherTypes(spec discoveryconfig.Spec) []prehogv1a.DiscoveryMatcherType {
+	var found []prehogv1a.DiscoveryMatcherType
+	for _, m := range spec.AWS {
+		for _, matcherType := range m.Types {
+			if t, ok := awsMatcherTypes[matcherType]; ok {
+				found = append(found, t)
+			}
+		}
+	}
+	for _, m := range spec.Azure {
+		for _, matcherType := range m.Types {
+			if t, ok := azureMatcherTypes[matcherType]; ok {
+				found = append(found, t)
+			}
+		}
+	}
+	for _, m := range spec.GCP {
+		for _, matcherType := range m.Types {
+			if t, ok := gcpMatcherTypes[matcherType]; ok {
+				found = append(found, t)
+			}
+		}
+	}
+	for _, m := range spec.Kube {
+		for _, matcherType := range m.Types {
+			if t, ok := kubeMatcherTypes[matcherType]; ok {
+				found = append(found, t)
+			}
+		}
+	}
+
+	slices.Sort(found)
+	return slices.Compact(found)
+}
+
+// integrationNames returns the distinct integrations a config's matchers use,
+// sorted.
+func integrationNames(spec discoveryconfig.Spec) []string {
+	var found []string
+	for _, m := range spec.AWS {
+		if m.Integration != "" {
+			found = append(found, m.Integration)
+		}
+	}
+	for _, m := range spec.Azure {
+		if m.Integration != "" {
+			found = append(found, m.Integration)
+		}
+	}
+
+	slices.Sort(found)
+	return slices.Compact(found)
+}
+
+// accessGraphIntegrationNames returns the distinct integrations a config's
+// Access Graph syncs use, sorted.
+func accessGraphIntegrationNames(spec discoveryconfig.Spec) []string {
+	if spec.AccessGraph == nil {
+		return nil
+	}
+
+	var found []string
+	for _, sync := range spec.AccessGraph.AWS {
+		if sync != nil && sync.Integration != "" {
+			found = append(found, sync.Integration)
+		}
+	}
+	for _, sync := range spec.AccessGraph.Azure {
+		if sync != nil && sync.Integration != "" {
+			found = append(found, sync.Integration)
+		}
+	}
+
+	slices.Sort(found)
+	return slices.Compact(found)
+}
+
+// matcherProviders returns the platforms a config's matchers select resources
+// from.
+func matcherProviders(spec discoveryconfig.Spec) []prehogv1a.CloudProvider {
+	var found []prehogv1a.CloudProvider
+	if len(spec.AWS) > 0 {
+		found = append(found, prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS)
+	}
+	if len(spec.Azure) > 0 {
+		found = append(found, prehogv1a.CloudProvider_CLOUD_PROVIDER_AZURE)
+	}
+	if len(spec.GCP) > 0 {
+		found = append(found, prehogv1a.CloudProvider_CLOUD_PROVIDER_GCP)
+	}
+	if len(spec.Kube) > 0 {
+		found = append(found, prehogv1a.CloudProvider_CLOUD_PROVIDER_KUBERNETES)
+	}
+
+	return found
+}
+
+// accessGraphSyncProviders returns the clouds a config syncs into Access Graph.
+func accessGraphSyncProviders(spec discoveryconfig.Spec) []prehogv1a.CloudProvider {
+	if spec.AccessGraph == nil {
+		return nil
+	}
+
+	var found []prehogv1a.CloudProvider
+	if len(spec.AccessGraph.AWS) > 0 {
+		found = append(found, prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS)
+	}
+	if len(spec.AccessGraph.Azure) > 0 {
+		found = append(found, prehogv1a.CloudProvider_CLOUD_PROVIDER_AZURE)
+	}
+
+	return found
+}
+
+var userAgentClientKinds = map[string]prehogv1a.ClientKind{
+	teleport.ComponentWeb:               prehogv1a.ClientKind_CLIENT_KIND_WEB_UI,
+	teleport.ComponentTCTL:              prehogv1a.ClientKind_CLIENT_KIND_TCTL,
+	teleport.ComponentTSH:               prehogv1a.ClientKind_CLIENT_KIND_TSH,
+	teleport.ComponentTBot:              prehogv1a.ClientKind_CLIENT_KIND_TBOT,
+	teleport.ComponentTerraformProvider: prehogv1a.ClientKind_CLIENT_KIND_TERRAFORM_PROVIDER,
+	teleport.ComponentKubeOperator:      prehogv1a.ClientKind_CLIENT_KIND_KUBE_OPERATOR,
+}
+
+// clientKindFromContext returns the tool that made the request.
+func clientKindFromContext(ctx context.Context) prehogv1a.ClientKind {
+	userAgent := metadata.UserAgentFromContext(ctx)
+	for component, kind := range userAgentClientKinds {
+		if strings.HasPrefix(userAgent, component+"/") {
+			return kind
+		}
+	}
+	return prehogv1a.ClientKind_CLIENT_KIND_UNKNOWN
+}
+
+// NewDiscoveryConfigChangedEvent builds the event for one change to one
+// discovery config.
+func NewDiscoveryConfigChangedEvent(ctx context.Context, dc *discoveryconfig.DiscoveryConfig, action prehogv1a.DiscoveryConfigChangeAction) *DiscoveryConfigChangedEvent {
+	return &DiscoveryConfigChangedEvent{
+		DiscoveryConfigName:         dc.GetName(),
+		DiscoveryGroup:              dc.Spec.DiscoveryGroup,
+		IntegrationNames:            integrationNames(dc.Spec),
+		AccessGraphIntegrationNames: accessGraphIntegrationNames(dc.Spec),
+		AccessGraphSyncProviders:    accessGraphSyncProviders(dc.Spec),
+		SetupAttemptID:              dc.GetMetadata().Labels[types.SetupAttemptIDLabel],
+		Action:                      action,
+		MatcherTypes:                matcherTypes(dc.Spec),
+		MatcherProviders:            matcherProviders(dc.Spec),
+		ClientKind:                  clientKindFromContext(ctx),
+	}
+}

--- a/lib/usagereporter/teleport/discoveryconfig_test.go
+++ b/lib/usagereporter/teleport/discoveryconfig_test.go
@@ -1,0 +1,562 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package usagereporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	grpcmetadata "google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/api/types/header"
+	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestMatcherTypeMaps(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		prefix    string
+		supported []string
+		mapping   map[string]prehogv1a.DiscoveryMatcherType
+	}{
+		{"aws", "DISCOVERY_MATCHER_TYPE_AWS_", types.SupportedAWSMatchers, awsMatcherTypes},
+		{"azure", "DISCOVERY_MATCHER_TYPE_AZURE_", types.SupportedAzureMatchers, azureMatcherTypes},
+		{"gcp", "DISCOVERY_MATCHER_TYPE_GCP_", types.SupportedGCPMatchers, gcpMatcherTypes},
+		{"kube", "DISCOVERY_MATCHER_TYPE_KUBE_", types.SupportedKubernetesMatchers, kubeMatcherTypes},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Len(t, tt.mapping, len(tt.supported))
+
+			for _, matcher := range tt.supported {
+				got, ok := tt.mapping[matcher]
+				require.True(t, ok, "matcher %q has no matcher type", matcher)
+
+				want := tt.prefix + strings.ToUpper(strings.ReplaceAll(matcher, "-", "_"))
+				require.Equal(t, want, got.String(), "matcher %q maps to the wrong matcher type", matcher)
+			}
+		})
+	}
+
+	t.Run("every matcher type is produced", func(t *testing.T) {
+		produced := make(map[prehogv1a.DiscoveryMatcherType]string)
+		for _, mapping := range []map[string]prehogv1a.DiscoveryMatcherType{
+			awsMatcherTypes, azureMatcherTypes, gcpMatcherTypes, kubeMatcherTypes,
+		} {
+			for matcher, matcherType := range mapping {
+				other, ok := produced[matcherType]
+				require.False(t, ok, "matchers %q and %q both map to %s", matcher, other, matcherType)
+				produced[matcherType] = matcher
+			}
+		}
+
+		for value, name := range prehogv1a.DiscoveryMatcherType_name {
+			if prehogv1a.DiscoveryMatcherType(value) == prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_UNSPECIFIED {
+				continue
+			}
+			require.Contains(t, produced, prehogv1a.DiscoveryMatcherType(value), "no matcher maps to %s", name)
+		}
+	})
+}
+
+func TestMatcherTypes(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		spec discoveryconfig.Spec
+		want []prehogv1a.DiscoveryMatcherType
+	}{
+		{
+			name: "sorted and deduplicated",
+			spec: discoveryconfig.Spec{
+				AWS: []types.AWSMatcher{
+					{Types: []string{types.AWSMatcherRDS, types.AWSMatcherEC2}},
+					{Types: []string{types.AWSMatcherRDS}},
+				},
+			},
+			want: []prehogv1a.DiscoveryMatcherType{
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EC2,
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDS,
+			},
+		},
+		{
+			name: "every cloud",
+			spec: discoveryconfig.Spec{
+				AWS:   []types.AWSMatcher{{Types: []string{types.AWSMatcherEC2}}},
+				Azure: []types.AzureMatcher{{Types: []string{types.AzureMatcherSQLServer, types.AzureMatcherVM}}},
+				GCP:   []types.GCPMatcher{{Types: []string{types.GCPMatcherKubernetes}}},
+				Kube:  []types.KubernetesMatcher{{Types: []string{types.KubernetesMatchersApp}}},
+			},
+			want: []prehogv1a.DiscoveryMatcherType{
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EC2,
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_VM,
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AZURE_SQLSERVER,
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_GCP_GKE,
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_KUBE_APP,
+			},
+		},
+		{
+			name: "access graph syncs excluded",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					AWS:   []*types.AccessGraphAWSSync{{Integration: "aws-sync"}},
+					Azure: []*types.AccessGraphAzureSync{{Integration: "azure-sync"}},
+				},
+			},
+		},
+		{
+			name: "unmapped matcher type skipped",
+			spec: discoveryconfig.Spec{
+				AWS: []types.AWSMatcher{
+					{Types: []string{"from-a-newer-version", types.AWSMatcherEC2}},
+				},
+			},
+			want: []prehogv1a.DiscoveryMatcherType{
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EC2,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, matcherTypes(tt.spec))
+		})
+	}
+}
+
+func TestIntegrationNames(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		spec discoveryconfig.Spec
+		want []string
+	}{
+		{
+			name: "no integrations",
+			spec: discoveryconfig.Spec{
+				AWS: []types.AWSMatcher{{Types: []string{types.AWSMatcherEC2}}},
+			},
+		},
+		{
+			name: "aws and azure matchers",
+			spec: discoveryconfig.Spec{
+				AWS:   []types.AWSMatcher{{Integration: "aws-matcher"}},
+				Azure: []types.AzureMatcher{{Integration: "azure-matcher"}},
+			},
+			want: []string{"aws-matcher", "azure-matcher"},
+		},
+		{
+			name: "sorted and deduplicated",
+			spec: discoveryconfig.Spec{
+				AWS: []types.AWSMatcher{
+					{Integration: "zeta"},
+					{Integration: "alpha"},
+					{Integration: "zeta"},
+				},
+			},
+			want: []string{"alpha", "zeta"},
+		},
+		{
+			name: "access graph syncs excluded",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					AWS:   []*types.AccessGraphAWSSync{{Integration: "aws-sync"}},
+					Azure: []*types.AccessGraphAzureSync{{Integration: "azure-sync"}},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, integrationNames(tt.spec))
+		})
+	}
+}
+
+func TestAccessGraphIntegrationNames(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		spec discoveryconfig.Spec
+		want []string
+	}{
+		{
+			name: "no access graph",
+			spec: discoveryconfig.Spec{
+				AWS: []types.AWSMatcher{{Integration: "aws-matcher"}},
+			},
+		},
+		{
+			name: "aws and azure syncs",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					AWS:   []*types.AccessGraphAWSSync{{Integration: "aws-sync"}},
+					Azure: []*types.AccessGraphAzureSync{{Integration: "azure-sync"}},
+				},
+			},
+			want: []string{"aws-sync", "azure-sync"},
+		},
+		{
+			name: "sync on ambient credentials",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{{Regions: []string{"us-east-1"}}},
+				},
+			},
+		},
+		{
+			name: "sorted and deduplicated",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{
+						{Integration: "zeta"},
+						{Integration: "alpha"},
+						{Integration: "zeta"},
+					},
+				},
+			},
+			want: []string{"alpha", "zeta"},
+		},
+		{
+			name: "matcher integrations excluded",
+			spec: discoveryconfig.Spec{
+				AWS:         []types.AWSMatcher{{Integration: "aws-matcher"}},
+				AccessGraph: &types.AccessGraphSync{},
+			},
+		},
+		{
+			name: "nil entries",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					AWS:   []*types.AccessGraphAWSSync{nil},
+					Azure: []*types.AccessGraphAzureSync{nil},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, accessGraphIntegrationNames(tt.spec))
+		})
+	}
+}
+
+func TestAccessGraphSyncProviders(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		spec discoveryconfig.Spec
+		want []prehogv1a.CloudProvider
+	}{
+		{
+			name: "no access graph",
+			spec: discoveryconfig.Spec{
+				AWS: []types.AWSMatcher{{Types: []string{types.AWSMatcherEC2}}},
+			},
+		},
+		{
+			name: "aws only",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{{Regions: []string{"us-east-1"}}},
+				},
+			},
+			want: []prehogv1a.CloudProvider{prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS},
+		},
+		{
+			name: "azure only",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					Azure: []*types.AccessGraphAzureSync{{SubscriptionID: "sub"}},
+				},
+			},
+			want: []prehogv1a.CloudProvider{prehogv1a.CloudProvider_CLOUD_PROVIDER_AZURE},
+		},
+		{
+			name: "both clouds",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					AWS:   []*types.AccessGraphAWSSync{{Regions: []string{"us-east-1"}}},
+					Azure: []*types.AccessGraphAzureSync{{SubscriptionID: "sub"}},
+				},
+			},
+			want: []prehogv1a.CloudProvider{
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS,
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_AZURE,
+			},
+		},
+		{
+			name: "access graph with no syncs",
+			spec: discoveryconfig.Spec{AccessGraph: &types.AccessGraphSync{}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, accessGraphSyncProviders(tt.spec))
+		})
+	}
+}
+
+func TestMatcherProviders(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		spec discoveryconfig.Spec
+		want []prehogv1a.CloudProvider
+	}{
+		{
+			name: "no matchers",
+			spec: discoveryconfig.Spec{
+				AccessGraph: &types.AccessGraphSync{
+					AWS: []*types.AccessGraphAWSSync{{Regions: []string{"us-east-1"}}},
+				},
+			},
+		},
+		{
+			name: "aws only",
+			spec: discoveryconfig.Spec{
+				AWS: []types.AWSMatcher{{Types: []string{types.AWSMatcherEC2}}},
+			},
+			want: []prehogv1a.CloudProvider{prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS},
+		},
+		{
+			name: "kubernetes only",
+			spec: discoveryconfig.Spec{
+				Kube: []types.KubernetesMatcher{{Types: []string{types.KubernetesMatchersApp}}},
+			},
+			want: []prehogv1a.CloudProvider{prehogv1a.CloudProvider_CLOUD_PROVIDER_KUBERNETES},
+		},
+		{
+			name: "every provider",
+			spec: discoveryconfig.Spec{
+				AWS:   []types.AWSMatcher{{Types: []string{types.AWSMatcherEC2}}},
+				Azure: []types.AzureMatcher{{Types: []string{types.AzureMatcherVM}}},
+				GCP:   []types.GCPMatcher{{Types: []string{types.GCPMatcherKubernetes}}},
+				Kube:  []types.KubernetesMatcher{{Types: []string{types.KubernetesMatchersApp}}},
+			},
+			want: []prehogv1a.CloudProvider{
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS,
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_AZURE,
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_GCP,
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_KUBERNETES,
+			},
+		},
+		{
+			name: "many matchers for one provider report it once",
+			spec: discoveryconfig.Spec{
+				AWS: []types.AWSMatcher{
+					{Types: []string{types.AWSMatcherEC2}},
+					{Types: []string{types.AWSMatcherRDS}},
+				},
+			},
+			want: []prehogv1a.CloudProvider{prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, matcherProviders(tt.spec))
+		})
+	}
+}
+
+func TestClientKind(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		userAgent string
+		want      prehogv1a.ClientKind
+	}{
+		{
+			name: "no user agent",
+			want: prehogv1a.ClientKind_CLIENT_KIND_UNKNOWN,
+		},
+		{
+			name:      "unrecognized client",
+			userAgent: "curl/8.7.1",
+			want:      prehogv1a.ClientKind_CLIENT_KIND_UNKNOWN,
+		},
+		{
+			name:      "component without a version",
+			userAgent: teleport.ComponentTSH,
+			want:      prehogv1a.ClientKind_CLIENT_KIND_UNKNOWN,
+		},
+		{
+			name:      "recognized client",
+			userAgent: teleport.ComponentTerraformProvider + "/19.0.0",
+			want:      prehogv1a.ClientKind_CLIENT_KIND_TERRAFORM_PROVIDER,
+		},
+		{
+			name:      "grpc-go appends its own version",
+			userAgent: teleport.ComponentWeb + "/19.0.0 grpc-go/1.76.0",
+			want:      prehogv1a.ClientKind_CLIENT_KIND_WEB_UI,
+		},
+		{
+			name:      "tctl",
+			userAgent: teleport.ComponentTCTL + "/19.0.0",
+			want:      prehogv1a.ClientKind_CLIENT_KIND_TCTL,
+		},
+		{
+			name:      "tsh",
+			userAgent: teleport.ComponentTSH + "/19.0.0",
+			want:      prehogv1a.ClientKind_CLIENT_KIND_TSH,
+		},
+		{
+			name:      "tbot",
+			userAgent: teleport.ComponentTBot + "/19.0.0",
+			want:      prehogv1a.ClientKind_CLIENT_KIND_TBOT,
+		},
+		{
+			name:      "kube operator",
+			userAgent: teleport.ComponentKubeOperator + "/19.0.0",
+			want:      prehogv1a.ClientKind_CLIENT_KIND_KUBE_OPERATOR,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.userAgent != "" {
+				ctx = grpcmetadata.NewIncomingContext(ctx,
+					grpcmetadata.Pairs("user-agent", tt.userAgent))
+			}
+
+			require.Equal(t, tt.want, clientKindFromContext(ctx))
+		})
+	}
+
+	t.Run("every client kind is produced", func(t *testing.T) {
+		produced := make(map[prehogv1a.ClientKind]string)
+		for component, kind := range userAgentClientKinds {
+			other, ok := produced[kind]
+			require.False(t, ok, "components %q and %q both map to %s", component, other, kind)
+			produced[kind] = component
+		}
+
+		for value, name := range prehogv1a.ClientKind_name {
+			kind := prehogv1a.ClientKind(value)
+			if kind == prehogv1a.ClientKind_CLIENT_KIND_UNSPECIFIED || kind == prehogv1a.ClientKind_CLIENT_KIND_UNKNOWN {
+				continue
+			}
+			require.Contains(t, produced, kind, "no user agent maps to %s", name)
+		}
+	})
+}
+
+func TestNewDiscoveryConfigChangedEvent(t *testing.T) {
+	dc, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{
+			Name:   "dc-name",
+			Labels: map[string]string{types.SetupAttemptIDLabel: "attempt-id"},
+		},
+		discoveryconfig.Spec{
+			DiscoveryGroup: "dg",
+			AWS: []types.AWSMatcher{{
+				Types:       []string{types.AWSMatcherRDS},
+				Integration: "aws-integration",
+				Regions:     []string{"us-east-1"},
+			}},
+			AccessGraph: &types.AccessGraphSync{
+				AWS: []*types.AccessGraphAWSSync{{
+					Integration: "sync-integration",
+					Regions:     []string{"us-east-1"},
+				}},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	ctx := grpcmetadata.NewIncomingContext(context.Background(),
+		grpcmetadata.Pairs("user-agent", teleport.ComponentWeb+"/19.0.0"))
+
+	require.Equal(t, &DiscoveryConfigChangedEvent{
+		DiscoveryConfigName:         "dc-name",
+		DiscoveryGroup:              "dg",
+		IntegrationNames:            []string{"aws-integration"},
+		AccessGraphIntegrationNames: []string{"sync-integration"},
+		AccessGraphSyncProviders: []prehogv1a.CloudProvider{
+			prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS,
+		},
+		SetupAttemptID: "attempt-id",
+		Action:         prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_CREATE,
+		MatcherTypes: []prehogv1a.DiscoveryMatcherType{
+			prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDS,
+		},
+		MatcherProviders: []prehogv1a.CloudProvider{
+			prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS,
+		},
+		ClientKind: prehogv1a.ClientKind_CLIENT_KIND_WEB_UI,
+	}, NewDiscoveryConfigChangedEvent(ctx, dc,
+		prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_CREATE))
+}
+
+func TestDiscoveryConfigChangedEventAnonymize(t *testing.T) {
+	anonymizer, err := utils.NewHMACAnonymizer(utils.AnonymizationKeyString("anon-key-or-cluster-id"))
+	require.NoError(t, err)
+
+	t.Run("every field", func(t *testing.T) {
+		event := &DiscoveryConfigChangedEvent{
+			DiscoveryConfigName:         "dc-name",
+			DiscoveryGroup:              "dg",
+			IntegrationNames:            []string{"aws-integration", "azure-integration"},
+			AccessGraphIntegrationNames: []string{"sync-integration"},
+			AccessGraphSyncProviders: []prehogv1a.CloudProvider{
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS,
+			},
+			SetupAttemptID: "attempt-id",
+			Action:         prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT,
+			MatcherTypes: []prehogv1a.DiscoveryMatcherType{
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDS,
+			},
+			MatcherProviders: []prehogv1a.CloudProvider{
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS,
+			},
+			ClientKind: prehogv1a.ClientKind_CLIENT_KIND_TCTL,
+		}
+
+		want := &prehogv1a.DiscoveryConfigChangedEvent{
+			DiscoveryConfigId: anonymizer.AnonymizeString("dc-name"),
+			DiscoveryGroupId:  anonymizer.AnonymizeString("dg"),
+			IntegrationIds: []string{
+				anonymizer.AnonymizeString("aws-integration"),
+				anonymizer.AnonymizeString("azure-integration"),
+			},
+			AccessGraphIntegrationIds: []string{anonymizer.AnonymizeString("sync-integration")},
+			AccessGraphSyncProviders: []prehogv1a.CloudProvider{
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS,
+			},
+			SetupAttemptId: anonymizer.AnonymizeString("attempt-id"),
+			Action:         prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT,
+			MatcherTypes: []prehogv1a.DiscoveryMatcherType{
+				prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDS,
+			},
+			MatcherProviders: []prehogv1a.CloudProvider{
+				prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS,
+			},
+			ClientKind: prehogv1a.ClientKind_CLIENT_KIND_TCTL,
+		}
+
+		got := event.Anonymize(anonymizer).GetDiscoveryConfigChanged()
+		require.Empty(t, cmp.Diff(want, got, protocmp.Transform()))
+	})
+
+	t.Run("no setup attempt", func(t *testing.T) {
+		event := &DiscoveryConfigChangedEvent{DiscoveryConfigName: "dc-name"}
+
+		require.Empty(t, event.Anonymize(anonymizer).GetDiscoveryConfigChanged().GetSetupAttemptId())
+	})
+
+	t.Run("no discovery group", func(t *testing.T) {
+		event := &DiscoveryConfigChangedEvent{DiscoveryConfigName: "dc-name"}
+
+		require.Empty(t, event.Anonymize(anonymizer).GetDiscoveryConfigChanged().GetDiscoveryGroupId())
+	})
+}

--- a/lib/usagereporter/teleport/types.go
+++ b/lib/usagereporter/teleport/types.go
@@ -2319,6 +2319,62 @@ func (e *DiscoveryConfigEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEv
 	}
 }
 
+// DiscoveryConfigChangedEvent is emitted when a DiscoveryConfig is created,
+// updated, upserted, or deleted.
+type DiscoveryConfigChangedEvent struct {
+	// DiscoveryConfigName is the name of the DiscoveryConfig that changed.
+	DiscoveryConfigName string
+	// DiscoveryGroup is the group of Discovery Services that load the config.
+	DiscoveryGroup string
+	// IntegrationNames are the integrations the config's matchers use.
+	IntegrationNames []string
+	// AccessGraphIntegrationNames are the integrations the config's Access Graph
+	// syncs use.
+	AccessGraphIntegrationNames []string
+	// AccessGraphSyncProviders are the clouds the config syncs into Access Graph.
+	AccessGraphSyncProviders []prehogv1a.CloudProvider
+	// SetupAttemptID is the setup attempt ID the config carries as a label.
+	SetupAttemptID string
+	// Action is the change made to the config.
+	Action prehogv1a.DiscoveryConfigChangeAction
+	// MatcherTypes are the resource types the config's matchers select.
+	MatcherTypes []prehogv1a.DiscoveryMatcherType
+	// MatcherProviders are the platforms the config's matchers select from.
+	MatcherProviders []prehogv1a.CloudProvider
+	// ClientKind is the tool that made the request.
+	ClientKind prehogv1a.ClientKind
+}
+
+// Anonymize anonymizes the event.
+func (e *DiscoveryConfigChangedEvent) Anonymize(a utils.Anonymizer) *prehogv1a.SubmitEventRequest {
+	var setupAttemptID string
+	if e.SetupAttemptID != "" {
+		setupAttemptID = a.AnonymizeString(e.SetupAttemptID)
+	}
+
+	var discoveryGroupID string
+	if e.DiscoveryGroup != "" {
+		discoveryGroupID = a.AnonymizeString(e.DiscoveryGroup)
+	}
+
+	return &prehogv1a.SubmitEventRequest{
+		Event: &prehogv1a.SubmitEventRequest_DiscoveryConfigChanged{
+			DiscoveryConfigChanged: &prehogv1a.DiscoveryConfigChangedEvent{
+				DiscoveryConfigId:         a.AnonymizeString(e.DiscoveryConfigName),
+				DiscoveryGroupId:          discoveryGroupID,
+				IntegrationIds:            utils.AnonymizeStrings(a, e.IntegrationNames),
+				AccessGraphIntegrationIds: utils.AnonymizeStrings(a, e.AccessGraphIntegrationNames),
+				AccessGraphSyncProviders:  e.AccessGraphSyncProviders,
+				SetupAttemptId:            setupAttemptID,
+				Action:                    e.Action,
+				MatcherTypes:              e.MatcherTypes,
+				MatcherProviders:          e.MatcherProviders,
+				ClientKind:                e.ClientKind,
+			},
+		},
+	}
+}
+
 // IdentitySecurityGraphSizeEvent is emitted when the size of a providers access graph is updated.
 type IdentitySecurityGraphSizeEvent prehogv1a.IdentitySecurityGraphSizeEvent
 

--- a/lib/utils/anonymizer.go
+++ b/lib/utils/anonymizer.go
@@ -40,6 +40,15 @@ type Anonymizer interface {
 	AnonymizeNonEmpty(s string) []byte
 }
 
+// AnonymizeStrings anonymizes every string in s.
+func AnonymizeStrings(a Anonymizer, s []string) []string {
+	anonymized := make([]string, 0, len(s))
+	for _, v := range s {
+		anonymized = append(anonymized, a.AnonymizeString(v))
+	}
+	return anonymized
+}
+
 var _ AnonymizationKeyProvider = (AnonymizationKeyString)("")
 
 // AnonymizationKeyString is a simple implementation of AnonymizationKeyProvider that uses a string as the key.

--- a/proto/prehog/v1alpha/teleport.proto
+++ b/proto/prehog/v1alpha/teleport.proto
@@ -2032,6 +2032,128 @@ message DiscoveryConfigEvent {
   string creation_method = 5;
 }
 
+// DiscoveryMatcherType is a resource type a discovery config's matchers select.
+enum DiscoveryMatcherType {
+  DISCOVERY_MATCHER_TYPE_UNSPECIFIED = 0;
+
+  DISCOVERY_MATCHER_TYPE_AWS_EC2 = 1;
+  DISCOVERY_MATCHER_TYPE_AWS_EKS = 2;
+  DISCOVERY_MATCHER_TYPE_AWS_RDS = 3;
+  DISCOVERY_MATCHER_TYPE_AWS_RDSPROXY = 4;
+  DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT = 5;
+  DISCOVERY_MATCHER_TYPE_AWS_REDSHIFT_SERVERLESS = 6;
+  DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE = 7;
+  DISCOVERY_MATCHER_TYPE_AWS_ELASTICACHE_SERVERLESS = 8;
+  DISCOVERY_MATCHER_TYPE_AWS_MEMORYDB = 9;
+  DISCOVERY_MATCHER_TYPE_AWS_OPENSEARCH = 10;
+  DISCOVERY_MATCHER_TYPE_AWS_DOCDB = 11;
+
+  DISCOVERY_MATCHER_TYPE_AZURE_VM = 12;
+  DISCOVERY_MATCHER_TYPE_AZURE_AKS = 13;
+  DISCOVERY_MATCHER_TYPE_AZURE_MYSQL = 14;
+  DISCOVERY_MATCHER_TYPE_AZURE_POSTGRES = 15;
+  DISCOVERY_MATCHER_TYPE_AZURE_REDIS = 16;
+  DISCOVERY_MATCHER_TYPE_AZURE_SQLSERVER = 17;
+  DISCOVERY_MATCHER_TYPE_AZURE_WINDOWS_VM = 18;
+
+  DISCOVERY_MATCHER_TYPE_GCP_GKE = 19;
+  DISCOVERY_MATCHER_TYPE_GCP_GCE = 20;
+  DISCOVERY_MATCHER_TYPE_GCP_CLOUDSQL = 21;
+
+  DISCOVERY_MATCHER_TYPE_KUBE_APP = 22;
+}
+
+// CloudProvider is a platform a discovery config selects resources from.
+enum CloudProvider {
+  CLOUD_PROVIDER_UNSPECIFIED = 0;
+  CLOUD_PROVIDER_AWS = 1;
+  CLOUD_PROVIDER_AZURE = 2;
+  CLOUD_PROVIDER_GCP = 3;
+  CLOUD_PROVIDER_KUBERNETES = 4;
+}
+
+// ClientKind is the tool that made a configuration change, read from the
+// request's user agent.
+enum ClientKind {
+  // The event's producer does not report a client.
+  CLIENT_KIND_UNSPECIFIED = 0;
+  // The user agent did not match a known tool.
+  CLIENT_KIND_UNKNOWN = 1;
+  CLIENT_KIND_WEB_UI = 2;
+  CLIENT_KIND_TCTL = 3;
+  CLIENT_KIND_TSH = 4;
+  CLIENT_KIND_TBOT = 5;
+  CLIENT_KIND_TERRAFORM_PROVIDER = 6;
+  CLIENT_KIND_KUBE_OPERATOR = 7;
+}
+
+// DiscoveryConfigChangeAction is the change made to a discovery config.
+enum DiscoveryConfigChangeAction {
+  DISCOVERY_CONFIG_CHANGE_ACTION_UNSPECIFIED = 0;
+  DISCOVERY_CONFIG_CHANGE_ACTION_CREATE = 1;
+  DISCOVERY_CONFIG_CHANGE_ACTION_UPDATE = 2;
+  DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT = 3;
+  DISCOVERY_CONFIG_CHANGE_ACTION_DELETE = 4;
+}
+
+// DiscoveryConfigChangedEvent is emitted when a discovery config is created,
+// updated, upserted, or deleted.
+//
+// PostHog event: tp.discovery.config.changed
+message DiscoveryConfigChangedEvent {
+  // discovery_config_id is the anonymized name of the discovery config.
+  //
+  // PostHog property: tp.discovery.discovery_config_id
+  string discovery_config_id = 1;
+
+  // integration_ids are the anonymized names of the integrations the config's
+  // matchers use, deduplicated.
+  //
+  // PostHog property: tp.discovery.integration_ids
+  repeated string integration_ids = 2;
+
+  // setup_attempt_id is the anonymized setup attempt ID the config carries as a
+  // label.
+  //
+  // PostHog property: tp.discovery.setup_attempt_id
+  string setup_attempt_id = 3;
+
+  // PostHog property: tp.discovery.action
+  DiscoveryConfigChangeAction action = 4;
+
+  // matcher_types are the resource types the config's matchers select, sorted
+  // and deduplicated.
+  //
+  // PostHog property: tp.discovery.matcher_types
+  repeated DiscoveryMatcherType matcher_types = 5;
+
+  // PostHog property: tp.discovery.client_kind
+  ClientKind client_kind = 6;
+
+  // access_graph_integration_ids are the anonymized names of the integrations
+  // the config's Access Graph syncs use, deduplicated.
+  //
+  // PostHog property: tp.discovery.access_graph_integration_ids
+  repeated string access_graph_integration_ids = 7;
+
+  // access_graph_sync_providers are the clouds the config syncs into Access
+  // Graph, sorted and deduplicated.
+  //
+  // PostHog property: tp.discovery.access_graph_sync_providers
+  repeated CloudProvider access_graph_sync_providers = 8;
+
+  // matcher_providers are the platforms the config's matchers select resources
+  // from, sorted and deduplicated.
+  //
+  // PostHog property: tp.discovery.matcher_providers
+  repeated CloudProvider matcher_providers = 9;
+
+  // discovery_group_id is the anonymized discovery group that runs the config.
+  //
+  // PostHog property: tp.discovery.discovery_group_id
+  string discovery_group_id = 10;
+}
+
 // IdentitySecurityGraphSizeEvent is emitted by Access Graph whenever the access graph
 // for a provider is updated.
 message IdentitySecurityGraphSizeEvent {
@@ -2395,6 +2517,8 @@ message SubmitEventRequest {
     BeamsDestroyedEvent beams_destroyed = 124;
     BeamsPublishedEvent beams_published = 125;
     BeamsUnpublishedEvent beams_unpublished = 126;
+
+    DiscoveryConfigChangedEvent discovery_config_changed = 127;
   }
 
   reserved 8; // UIOnboardGetStartedClickEvent


### PR DESCRIPTION
This implementation will replace the old DiscoveryConfigEvent. I made a new event since merging into the old event would result in a lot of confusing variations of fields. The new events carries more information that will be useful for product analysis.

- which client kind made it
- setup attempt ID so frontend events can be correlated all the way through to backend resource events.
- separate cloud providers and cloud resource types for easier joining and aggregation.
- enum types instead of strings

I'm planning to delete the old event in a follow-up PR.

setup_attempt_id will get plumbed through with the frontend events work in a follow-up PR.

## Manual Test Plan

### Test Environment

Locally

### Test Cases

- [x] New event is emitted with the expected fields
