### PR TITLE
DiscoveryConfigChangeEvent implementation

### DIFF
--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -39,6 +39,7 @@ import (
 	conv "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
@@ -220,6 +221,7 @@ func (s *Service) CreateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 	}
 
 	s.emitUsageEvent(resp, prehogv1a.DiscoveryConfigAction_DISCOVERY_CONFIG_ACTION_CREATE)
+	s.emitConfigChangedUsageEvent(ctx, resp, prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_CREATE)
 
 	return conv.ToProto(resp), nil
 }
@@ -268,6 +270,7 @@ func (s *Service) UpdateDiscoveryConfig(ctx context.Context, req *discoveryconfi
 	}
 
 	s.emitUsageEvent(resp, prehogv1a.DiscoveryConfigAction_DISCOVERY_CONFIG_ACTION_UPDATE)
+	s.emitConfigChangedUsageEvent(ctx, resp, prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UPDATE)
 
 	return conv.ToProto(resp), nil
 }
@@ -313,6 +316,7 @@ func (s *Service) UpsertDiscoveryConfig(ctx context.Context, req *discoveryconfi
 	}
 
 	s.emitUsageEvent(resp, prehogv1a.DiscoveryConfigAction_DISCOVERY_CONFIG_ACTION_CREATE)
+	s.emitConfigChangedUsageEvent(ctx, resp, prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT)
 
 	return conv.ToProto(resp), nil
 }
@@ -356,6 +360,7 @@ func (s *Service) DeleteDiscoveryConfig(ctx context.Context, req *discoveryconfi
 
 	if dc != nil {
 		s.emitUsageEvent(dc, prehogv1a.DiscoveryConfigAction_DISCOVERY_CONFIG_ACTION_DELETE)
+		s.emitConfigChangedUsageEvent(ctx, dc, prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_DELETE)
 	}
 
 	return &emptypb.Empty{}, nil
@@ -372,9 +377,15 @@ func (s *Service) DeleteAllDiscoveryConfigs(ctx context.Context, _ *discoverycon
 		return nil, trace.Wrap(err)
 	}
 
+	// The backend delete does not report which configs it removed, so the events
+	// are built first. Config changes during the deletion are missed.
+	usageEvents := s.buildDeleteUsageEvents(ctx)
+
 	if err := s.backend.DeleteAllDiscoveryConfigs(ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	s.usageReporter.AnonymizeAndSubmit(usageEvents...)
 
 	if err := s.emitter.EmitAuditEvent(ctx, &apievents.DiscoveryConfigDeleteAll{
 		Metadata: apievents.Metadata{
@@ -421,6 +432,27 @@ func (s *Service) UpdateDiscoveryConfigStatus(ctx context.Context, req *discover
 
 		return conv.ToProto(resp), nil
 	}
+}
+
+// buildDeleteUsageEvents builds a delete event per DiscoveryConfig.
+func (s *Service) buildDeleteUsageEvents(ctx context.Context) []usagereporter.Anonymizable {
+	var usageEvents []usagereporter.Anonymizable
+	for dc, err := range clientutils.Resources(ctx, s.backend.ListDiscoveryConfigs) {
+		if err != nil {
+			s.log.WarnContext(ctx, "Failed to list discovery configs, delete usage events will be missing for the remaining configs.",
+				"error", err)
+			break
+		}
+
+		usageEvents = append(usageEvents, usagereporter.NewDiscoveryConfigChangedEvent(ctx, dc,
+			prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_DELETE))
+	}
+
+	return usageEvents
+}
+
+func (s *Service) emitConfigChangedUsageEvent(ctx context.Context, dc *discoveryconfig.DiscoveryConfig, action prehogv1a.DiscoveryConfigChangeAction) {
+	s.usageReporter.AnonymizeAndSubmit(usagereporter.NewDiscoveryConfigChangedEvent(ctx, dc, action))
 }
 
 // emitUsageEvent emits a DiscoveryConfigEvent usage event.

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
@@ -26,14 +26,17 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	grpcmetadata "google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport"
 	discoveryconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	convert "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
 	"github.com/gravitational/teleport/api/types/header"
+	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/events"
@@ -548,7 +551,7 @@ func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *S
 		Backend:       localResourceService,
 		Authorizer:    authorizer,
 		Emitter:       emitter,
-		UsageReporter: usagereporter.DiscardUsageReporter{},
+		UsageReporter: &mockUsageReporter{},
 	})
 	require.NoError(t, err)
 
@@ -561,6 +564,128 @@ func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *S
 		IdentityService:        userSvc,
 		DiscoveryConfigService: localResourceService,
 	}, resourceSvc
+}
+
+type mockUsageReporter struct {
+	changedEvents []*usagereporter.DiscoveryConfigChangedEvent
+}
+
+func (m *mockUsageReporter) AnonymizeAndSubmit(events ...usagereporter.Anonymizable) {
+	for _, e := range events {
+		if changed, ok := e.(*usagereporter.DiscoveryConfigChangedEvent); ok {
+			m.changedEvents = append(m.changedEvents, changed)
+		}
+	}
+}
+
+func TestDiscoveryConfigChangedEvents(t *testing.T) {
+	clusterName := "test-cluster"
+	ctx, localClient, resourceSvc := initSvc(t, clusterName)
+	reporter := resourceSvc.usageReporter.(*mockUsageReporter)
+
+	userCtx := authorizerForDummyUser(t, ctx, types.RoleSpecV6{
+		Allow: types.RoleConditions{Rules: []types.Rule{{
+			Resources: []string{types.KindDiscoveryConfig},
+			Verbs:     []string{types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+		}}},
+	}, localClient)
+	userCtx = grpcmetadata.NewIncomingContext(userCtx,
+		grpcmetadata.Pairs("user-agent", teleport.ComponentWeb+"/19.0.0"))
+
+	// Each call varies the matcher type so an event built from the wrong version
+	// of the config is visible.
+	sampleDiscoveryConfig := func(name, matcherType string) *discoveryconfigpb.DiscoveryConfig {
+		dc, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: name},
+			discoveryconfig.Spec{
+				DiscoveryGroup: "some-group",
+				AWS: []types.AWSMatcher{{
+					Types:       []string{matcherType},
+					Regions:     []string{"us-west-2"},
+					Integration: "some-integration",
+					Params: &types.InstallerParams{
+						EnrollMode: types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+					},
+				}},
+			},
+		)
+		require.NoError(t, err)
+		return convert.ToProto(dc)
+	}
+
+	drain := func() []*usagereporter.DiscoveryConfigChangedEvent {
+		emitted := reporter.changedEvents
+		reporter.changedEvents = nil
+		return emitted
+	}
+
+	requireEvent := func(action prehogv1a.DiscoveryConfigChangeAction, name string, matcherType prehogv1a.DiscoveryMatcherType) {
+		t.Helper()
+		emitted := drain()
+		require.Len(t, emitted, 1)
+		require.Equal(t, action, emitted[0].Action)
+		require.Equal(t, name, emitted[0].DiscoveryConfigName)
+		require.Equal(t, prehogv1a.ClientKind_CLIENT_KIND_WEB_UI, emitted[0].ClientKind)
+		require.Equal(t, []prehogv1a.DiscoveryMatcherType{matcherType}, emitted[0].MatcherTypes)
+		require.Equal(t, []string{"some-integration"}, emitted[0].IntegrationNames)
+	}
+
+	dcName := uuid.NewString()
+
+	_, err := resourceSvc.CreateDiscoveryConfig(userCtx, discoveryconfigpb.CreateDiscoveryConfigRequest_builder{
+		DiscoveryConfig: sampleDiscoveryConfig(dcName, "ec2"),
+	}.Build())
+	require.NoError(t, err)
+	requireEvent(prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_CREATE, dcName,
+		prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EC2)
+
+	_, err = resourceSvc.UpdateDiscoveryConfig(userCtx, discoveryconfigpb.UpdateDiscoveryConfigRequest_builder{
+		DiscoveryConfig: sampleDiscoveryConfig(dcName, "eks"),
+	}.Build())
+	require.NoError(t, err)
+	requireEvent(prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UPDATE, dcName,
+		prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EKS)
+
+	_, err = resourceSvc.UpsertDiscoveryConfig(userCtx, discoveryconfigpb.UpsertDiscoveryConfigRequest_builder{
+		DiscoveryConfig: sampleDiscoveryConfig(dcName, "rds"),
+	}.Build())
+	require.NoError(t, err)
+	requireEvent(prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_UPSERT, dcName,
+		prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDS)
+
+	_, err = resourceSvc.DeleteDiscoveryConfig(userCtx,
+		discoveryconfigpb.DeleteDiscoveryConfigRequest_builder{Name: dcName}.Build())
+	require.NoError(t, err)
+	requireEvent(prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_DELETE, dcName,
+		prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_RDS)
+
+	_, err = resourceSvc.DeleteDiscoveryConfig(userCtx,
+		discoveryconfigpb.DeleteDiscoveryConfigRequest_builder{Name: uuid.NewString()}.Build())
+	require.True(t, trace.IsNotFound(err), "expected a NotFound error, got %v", err)
+	require.Empty(t, drain(), "deleting a missing config reported a change")
+
+	var deleteAllNames []string
+	for range 2 {
+		name := uuid.NewString()
+		deleteAllNames = append(deleteAllNames, name)
+
+		_, err = resourceSvc.CreateDiscoveryConfig(userCtx, discoveryconfigpb.CreateDiscoveryConfigRequest_builder{
+			DiscoveryConfig: sampleDiscoveryConfig(name, "ec2"),
+		}.Build())
+		require.NoError(t, err)
+	}
+	drain()
+
+	_, err = resourceSvc.DeleteAllDiscoveryConfigs(userCtx, &discoveryconfigpb.DeleteAllDiscoveryConfigsRequest{})
+	require.NoError(t, err)
+
+	var deleted []string
+	for _, e := range drain() {
+		require.Equal(t, prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_DELETE, e.Action)
+		require.Equal(t, []prehogv1a.DiscoveryMatcherType{prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EC2}, e.MatcherTypes)
+		deleted = append(deleted, e.DiscoveryConfigName)
+	}
+	require.ElementsMatch(t, deleteAllNames, deleted)
 }
 
 func TestExtractDiscoveryConfigMetadata(t *testing.T) {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6538,6 +6538,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Emitter:         cfg.Emitter,
 		Modules:         cfg.AuthServer.modules,
 		Logger:          cfg.AuthServer.logger.With(teleport.ComponentKey, "integrations.service"),
+		UsageReporter:   cfg.AuthServer.UsageReporter,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -32,11 +32,14 @@ import (
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	awsutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/modules"
+	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
@@ -108,7 +111,7 @@ func (s *Service) deleteAWSOIDCAssociatedResources(ctx context.Context, authCtx 
 
 	// Delete discovery_configs created by this integration
 	var configsRequireCleanup []string
-	var configsToDelete []string
+	var configsToDelete []*discoveryconfig.DiscoveryConfig
 
 	for config, err := range clientutils.Resources(ctx, s.cache.ListDiscoveryConfigs) {
 		if err != nil {
@@ -127,7 +130,7 @@ func (s *Service) deleteAWSOIDCAssociatedResources(ctx context.Context, authCtx 
 			_, err := uuid.Parse(config.GetName())
 
 			if err == nil {
-				configsToDelete = append(configsToDelete, config.GetName())
+				configsToDelete = append(configsToDelete, config)
 				continue
 			}
 		}
@@ -142,16 +145,22 @@ func (s *Service) deleteAWSOIDCAssociatedResources(ctx context.Context, authCtx 
 			ig.GetName(), strings.Join(configsRequireCleanup, ", "))
 	}
 
-	for _, configName := range configsToDelete {
+	for _, config := range configsToDelete {
 		s.logger.DebugContext(ctx, "Deleting discovery_config associated with integration",
-			"discovery_config", configName,
+			"discovery_config", config.GetName(),
 			"integration", ig.GetName())
 
-		err := s.backend.DeleteDiscoveryConfig(ctx, configName)
+		err := s.backend.DeleteDiscoveryConfig(ctx, config.GetName())
 
-		if err != nil && !trace.IsNotFound(err) {
-			return trace.Wrap(err)
+		if err != nil {
+			if !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+			continue
 		}
+
+		s.usageReporter.AnonymizeAndSubmit(usagereporter.NewDiscoveryConfigChangedEvent(ctx, config,
+			prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_DELETE))
 	}
 
 	// Delete AWS access app_server associated with this integration

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
+	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -110,6 +111,7 @@ type ServiceConfig struct {
 	Clock           clockwork.Clock
 	Emitter         apievents.Emitter
 	Modules         modules.Modules
+	UsageReporter   usagereporter.UsageReporter
 
 	// awsRolesAnywhereCreateSessionFn is a function that creates an AWS Roles Anywhere session.
 	// This is used to allow mocking in tests, because the real implementation does
@@ -144,6 +146,11 @@ func (s *ServiceConfig) CheckAndSetDefaults() error {
 	if s.Modules == nil {
 		return trace.BadParameter("modules is required")
 	}
+
+	if s.UsageReporter == nil {
+		return trace.BadParameter("usage reporter is required")
+	}
+
 	if s.Logger == nil {
 		s.Logger = slog.With(teleport.ComponentKey, "integrations.service")
 	}
@@ -166,6 +173,7 @@ type Service struct {
 	clock           clockwork.Clock
 	emitter         apievents.Emitter
 	modules         modules.Modules
+	usageReporter   usagereporter.UsageReporter
 
 	awsRolesAnywhereCreateSessionFn func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error)
 }
@@ -185,6 +193,7 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 		clock:           cfg.Clock,
 		emitter:         cfg.Emitter,
 		modules:         cfg.Modules,
+		usageReporter:   cfg.UsageReporter,
 
 		awsRolesAnywhereCreateSessionFn: cfg.awsRolesAnywhereCreateSessionFn,
 	}, nil

--- a/lib/auth/integration/integrationv1/service_test.go
+++ b/lib/auth/integration/integrationv1/service_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/header"
+	prehogv1a "github.com/gravitational/teleport/gen/proto/go/prehog/v1alpha"
 	"github.com/gravitational/teleport/lib/auth/integration/credentials"
 	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -53,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
+	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -1106,6 +1108,61 @@ func TestIntegrationCRUD(t *testing.T) {
 	}
 }
 
+type mockUsageReporter struct {
+	changedEvents []*usagereporter.DiscoveryConfigChangedEvent
+}
+
+func (m *mockUsageReporter) AnonymizeAndSubmit(events ...usagereporter.Anonymizable) {
+	for _, e := range events {
+		if changed, ok := e.(*usagereporter.DiscoveryConfigChangedEvent); ok {
+			m.changedEvents = append(m.changedEvents, changed)
+		}
+	}
+}
+
+func TestIntegrationDeleteEmitsConfigChange(t *testing.T) {
+	t.Parallel()
+	clusterName := "test-cluster"
+
+	ca := newCertAuthority(t, types.HostCA, clusterName)
+	ctx, localClient, resourceSvc := initSvc(t, ca, clusterName, "127.0.0.1.nip.io")
+	reporter := resourceSvc.usageReporter.(*mockUsageReporter)
+
+	igName := uuid.NewString()
+	ig, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: igName},
+		&types.AWSOIDCIntegrationSpecV1{RoleARN: "arn:aws:iam::123456789012:role/OpsTeam"},
+	)
+	require.NoError(t, err)
+	_, err = localClient.CreateIntegration(ctx, ig)
+	require.NoError(t, err)
+
+	_, err = localClient.CreateDiscoveryConfig(ctx, mustMakeDiscoveryConfig(t, ig))
+	require.NoError(t, err)
+
+	adminCtx := authorizerForAdminUser(t, ctx, cascadeDeleteRole, localClient)
+
+	_, err = resourceSvc.DeleteIntegration(adminCtx, integrationpb.DeleteIntegrationRequest_builder{
+		Name:                      igName,
+		DeleteAssociatedResources: true,
+	}.Build())
+	require.NoError(t, err)
+
+	require.Equal(t, []*usagereporter.DiscoveryConfigChangedEvent{{
+		DiscoveryConfigName: igName,
+		DiscoveryGroup:      igName,
+		IntegrationNames:    []string{igName},
+		Action:              prehogv1a.DiscoveryConfigChangeAction_DISCOVERY_CONFIG_CHANGE_ACTION_DELETE,
+		MatcherTypes: []prehogv1a.DiscoveryMatcherType{
+			prehogv1a.DiscoveryMatcherType_DISCOVERY_MATCHER_TYPE_AWS_EC2,
+		},
+		MatcherProviders: []prehogv1a.CloudProvider{
+			prehogv1a.CloudProvider_CLOUD_PROVIDER_AWS,
+		},
+		ClientKind: prehogv1a.ClientKind_CLIENT_KIND_UNKNOWN,
+	}}, reporter.changedEvents)
+}
+
 // authorizerForDummyUser creates a user context without admin MFA verification.
 func authorizerForDummyUser(t *testing.T, ctx context.Context, roleSpec types.RoleSpecV6, localClient localClient) context.Context {
 	t.Helper()
@@ -1342,6 +1399,7 @@ func initSvc(t *testing.T, ca types.CertAuthority, clusterName string, proxyPubl
 		KeyStoreManager: keystoreManager,
 		Emitter:         events.NewDiscardEmitter(),
 		Modules:         modulestest.EnterpriseModules(),
+		UsageReporter:   &mockUsageReporter{},
 		awsRolesAnywhereCreateSessionFn: func(ctx context.Context, req createsession.CreateSessionRequest) (*createsession.CreateSessionResponse, error) {
 			return &createsession.CreateSessionResponse{
 				Version:         1,


### PR DESCRIPTION
Implementation of new DiscoveryConfigChangeEvent defined in https://github.com/gravitational/teleport/pull/69626

This implementation will replace the old DiscoveryConfigEvent. I made a new event since merging into the old event would result in a lot of confusing variations of fields. The new events carries more information that will be useful for product analysis.

- which client kind made it
- setup attempt ID so frontend events can be correlated all the way through to backend resource events.
- separate cloud providers and cloud resource types for easier joining and aggregation.
- enum types instead of strings

I'm planning to delete the old event in a follow-up PR.

setup_attempt_id will get plumbed through with the frontend events work in a follow-up PR.

## Manual Test Plan

### Test Environment

Locally

### Test Cases

- [x] New event is emitted with the expected fields
