### PR TITLE
docs: google cloud enrollment guides - agent blockers

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -67,11 +67,29 @@ guide.
 
 - (!docs/pages/includes/tctl.mdx!)
 
+<Admonition type="tip" title="Discover your project ID">
+
+If you do not know your Google Cloud project ID, run:
+
+```code
+$ gcloud projects list --format="table(projectId,name,projectNumber)"
+```
+
+Set it as an environment variable for use throughout this guide:
+
+```code
+$ export GCP_PROJECT="your-project-id"
+```
+
+</Admonition>
+
 ## Step 1/4. Configure Google Cloud
 
 The Teleport Application Service needs permissions from Google Cloud to proxy
 requests from Teleport users to Google Cloud's APIs. In this step, you will
 configure these permissions before you launch the Teleport Application Service.
+
+**Run the commands in this step on your local workstation** (where `gcloud` is authenticated).
 
 When setting up Google Cloud API access with Teleport, you will configure
 service accounts with two different functions:
@@ -86,6 +104,20 @@ service accounts with two different functions:
   `teleport-vm-viewer`, and you can follow the same steps to enable access to
   other target service accounts.
 
+<Admonition type="tip" title="Choosing an authentication method">
+
+The Application Service authenticates to Google Cloud using the service account
+attached to its Compute Engine VM. This is the recommended approach because:
+- No credential files need to be managed or rotated.
+- The VM's identity is cryptographically verified by Google Cloud.
+
+If you cannot use a Compute Engine VM, you can alternatively create a service account
+key file and reference it via the `GOOGLE_APPLICATION_CREDENTIALS` environment variable
+on the Application Service host. However, this approach requires manual key rotation
+and secure storage of the key file.
+
+</Admonition>
+
 ### Create a service account for the Application Service
 
 The Application Service uses the controlling service account to access Google
@@ -96,12 +128,15 @@ Cloud. This way, local Google Cloud CLI tools have no access to these tokens.
 In this section, we will create a controlling service account for the
 Application Service and assign permissions to it.
 
+**Run on your local workstation:**
+
 Create a service account called `teleport-google-cloud-cli`:
 
 ```code
 $ gcloud iam service-accounts create teleport-google-cloud-cli \
   --description="Google Cloud CLI access" \
-  --display-name="teleport-google-cloud-cli"
+  --display-name="teleport-google-cloud-cli" \
+  --project="$GCP_PROJECT"
 ```
 
 ### Set up a service account that Teleport users can access
@@ -125,20 +160,23 @@ section](#enable-teleport-google-cloud-cli-to-impersonate-target-service-account
 
 </Admonition>
 
+**Run on your local workstation:**
+
 Create a target service account:
 
 ```code
 $ gcloud iam service-accounts create teleport-vm-viewer \
   --description="Sample service account to demonstrate Teleport" \
-  --display-name="teleport-vm-viewer"
+  --display-name="teleport-vm-viewer" \
+  --project="$GCP_PROJECT"
 ```
 
 Bind this service account to the predefined "Compute Viewer" role, which allows
 users with the role to list Google Compute Engine resources:
 
 ```code
-$ gcloud projects add-iam-policy-binding <Var name="google-cloud-project" /> \
-   --member="serviceAccount:teleport-vm-viewer@<Var name="google-cloud-project" />.iam.gserviceaccount.com" \
+$ gcloud projects add-iam-policy-binding "$GCP_PROJECT" \
+   --member="serviceAccount:teleport-vm-viewer@${GCP_PROJECT}.iam.gserviceaccount.com" \
    --role="roles/compute.viewer"
 ```
 
@@ -156,12 +194,38 @@ run this command for each service account.
 
 </Admonition>
 
+**Run on your local workstation:**
+
 ```code
 $ gcloud iam service-accounts add-iam-policy-binding \
- teleport-vm-viewer@<Var name="google-cloud-project" />.iam.gserviceaccount.com \
- --member=serviceAccount:teleport-google-cloud-cli@<Var name="google-cloud-project" />.iam.gserviceaccount.com \
+ "teleport-vm-viewer@${GCP_PROJECT}.iam.gserviceaccount.com" \
+ --member="serviceAccount:teleport-google-cloud-cli@${GCP_PROJECT}.iam.gserviceaccount.com" \
   --role="roles/iam.serviceAccountTokenCreator"
 ```
+
+<Checkpoint>
+
+Verify both service accounts exist:
+
+```code
+$ gcloud iam service-accounts list --project="$GCP_PROJECT" \
+  --filter="email:(teleport-google-cloud-cli OR teleport-vm-viewer)" \
+  --format="table(email,displayName)"
+```
+
+You should see both `teleport-google-cloud-cli` and `teleport-vm-viewer` listed.
+
+Verify the impersonation binding:
+
+```code
+$ gcloud iam service-accounts get-iam-policy \
+  "teleport-vm-viewer@${GCP_PROJECT}.iam.gserviceaccount.com" \
+  --format="table(bindings.role,bindings.members)"
+```
+
+You should see `roles/iam.serviceAccountTokenCreator` with the controlling service account as a member.
+
+</Checkpoint>
 
 ## Step 2/4. Deploy the Teleport Application Service
 
@@ -180,21 +244,24 @@ Application Service. The instructions depend on whether you are using a
 pre-existing virtual machine for the Teleport Application Service or launching a
 new one:
 
+**Run on your local workstation:**
+
 <Tabs>
 
 <TabItem label="New Virtual Machine">
 
-Create a new virtual machine with the `teleport-google-cloud` service account
+Create a new virtual machine with the `teleport-google-cloud-cli` service account
 attached. In this example, we are using the latest machine image that supports
 Debian 12:
 
 ```code
 $ IMAGE=$(gcloud --format json compute images describe-from-family debian-12 --project debian-cloud | jq -r '.selfLink')
 $ gcloud compute instances create teleport-app-service \
-   --service-account=teleport-google-cloud-cli@<Var name="google-cloud-project" />.iam.gserviceaccount.com \
+   --service-account="teleport-google-cloud-cli@${GCP_PROJECT}.iam.gserviceaccount.com" \
    --scopes=cloud-platform \
    --zone=<Var name="google-cloud-zone" /> \
-   --image="$IMAGE"
+   --image="$IMAGE" \
+   --project="$GCP_PROJECT"
 ```
 
 You must use the `service-account` and `scopes` flags as we list them here,
@@ -209,16 +276,19 @@ the needs of your environment.
 Stop your VM so you can attach your service account to it:
 
 ```code
-$ gcloud compute instances stop <Var name="vm-name" /> --zone=<Var name="google-cloud-zone" />
+$ gcloud compute instances stop <Var name="vm-name" /> \
+  --zone=<Var name="google-cloud-zone" /> \
+  --project="$GCP_PROJECT"
 ```
 
 Attach your service account to the instance:
 
 ```code
 $ gcloud compute instances set-service-account <Var name="vm-name" /> \
-   --service-account teleport-google-cloud-cli@<Var name="google-cloud-project" />.iam.gserviceaccount.com \
-   --zone <Var name="google-cloud-zone" /> \
-   --scopes=cloud-platform
+   --service-account="teleport-google-cloud-cli@${GCP_PROJECT}.iam.gserviceaccount.com" \
+   --zone=<Var name="google-cloud-zone" /> \
+   --scopes=cloud-platform \
+   --project="$GCP_PROJECT"
 ```
 
 <Admonition type="warning">
@@ -232,15 +302,74 @@ obtain the required authorization to access Google Cloud.
 Once you have attached the service account, restart your VM:
 
 ```code
-$ gcloud compute instances start <Var name="vm-name" /> --zone <Var name="google-cloud-zone" />
+$ gcloud compute instances start <Var name="vm-name" /> \
+  --zone=<Var name="google-cloud-zone" /> \
+  --project="$GCP_PROJECT"
 ```
 
 </TabItem>
 </Tabs>
 
+<Admonition type="tip" title="Connecting to the Application Service host">
+
+To SSH into the VM where you will run the Teleport Application Service, use:
+
+```code
+$ gcloud compute ssh teleport-app-service \
+  --zone=<Var name="google-cloud-zone" /> \
+  --project="$GCP_PROJECT"
+```
+
+Replace `teleport-app-service` with your VM name if using an existing VM.
+
+</Admonition>
+
 (!docs/pages/includes/application-access/app-service-join-token.mdx!)
 
+<Admonition type="tip" title="Transferring the join token to the VM">
+
+If you generated the join token on your local workstation and need to transfer it to the
+Application Service VM, you can either:
+
+1. Generate the token directly on the VM (if `tctl` is available there):
+
+   **Run on the Application Service host:**
+
+   ```code
+   $ tctl tokens add --type=app --ttl=1h > /tmp/token
+   ```
+
+2. Use `scp` via `gcloud` to copy a token file from your workstation:
+
+   **Run on your local workstation:**
+
+   ```code
+   $ gcloud compute scp /tmp/token teleport-app-service:/tmp/token \
+     --zone=<Var name="google-cloud-zone" /> \
+     --project="$GCP_PROJECT"
+   ```
+
+3. Use `tctl` on your workstation and paste the token value directly:
+
+   **Run on your local workstation:**
+
+   ```code
+   $ tctl tokens add --type=app --ttl=1h --format=text
+   ```
+
+   Then on the VM, write the token to a file:
+
+   **Run on the Application Service host:**
+
+   ```code
+   $ echo "the-token-value" > /tmp/token
+   ```
+
+</Admonition>
+
 ### Install the Teleport Application Service
+
+**Run the following commands on the Application Service host.**
 
 Follow the instructions below on the host where you will install the Teleport
 Application Service.
@@ -248,6 +377,8 @@ Application Service.
 (!docs/pages/includes/install-linux.mdx!)
 
 ### Configure the Teleport Application Service
+
+**Run on the Application Service host:**
 
 On the host where you will run the Teleport Application Service, create a file
 at `/etc/teleport.yaml` with the following content:
@@ -286,13 +417,41 @@ Cloud.
 
 ### Run the Teleport Application Service
 
+**Run on the Application Service host:**
+
 On the host where you will run the Teleport Application Service, execute the
 following command, depending on whether you installed Teleport using a package
 manager or via a TAR archive:
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Application Service"!)
 
+<Checkpoint>
+
+Verify the Application Service has connected to the cluster. **Run on your local workstation:**
+
+```code
+$ tsh apps ls
+```
+
+You should see the `google-cloud-cli` application listed:
+
+```text
+Application      Description Type Public Address                        Labels
+---------------- ----------- ---- ------------------------------------- -------------------
+google-cloud-cli             HTTP google-cloud-cli.teleport.example.com teleport.dev/origin
+```
+
+If the application does not appear, check the Teleport Application Service logs on the VM:
+
+```code
+$ journalctl -u teleport --no-pager -n 50
+```
+
+</Checkpoint>
+
 ## Step 3/4. Enable your user to access Google Cloud CLIs
+
+**Run the commands in this step on your local workstation** (where `tctl` is available).
 
 The next step is to authorize your Teleport user to access a target service
 account and execute Google Cloud CLI commands via Teleport. You will protect
@@ -351,7 +510,7 @@ account) to your Teleport user by running the following command, setting
 
 ```code
 $ tctl users update <Var name="teleport-user" /> \
---set-gcp-service-accounts teleport-vm-viewer@<Var name="google-cloud-project" />.iam.gserviceaccount.com
+--set-gcp-service-accounts "teleport-vm-viewer@${GCP_PROJECT}.iam.gserviceaccount.com"
 ```
 
 This command uses the `--set-gcp-service-accounts` flag to add Google Cloud
@@ -493,6 +652,8 @@ evaluating a user's roles.
 
 ## Step 4/4. Use Google Cloud CLIs with Teleport
 
+**Run the commands in this step on your local workstation.**
+
 Now that you have started the Teleport Application Service and authorized your
 Teleport user to access Google Cloud CLIs, you can run Google Cloud CLI commands
 through Teleport.
@@ -560,6 +721,21 @@ ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 ERROR: exit status 1
 ```
 
+<Checkpoint>
+
+Verify that Google Cloud CLI access works through Teleport:
+
+```code
+$ tsh gcloud compute instances list
+```
+
+You should see a list of VMs. If you get an authentication error, verify that:
+1. The Application Service VM has the `teleport-google-cloud-cli` service account attached.
+2. The `teleport-google-cloud-cli` service account has `roles/iam.serviceAccountTokenCreator` on the target service account.
+3. Your Teleport user has the `google-cloud-cli-access` role assigned.
+
+</Checkpoint>
+
 ### Use Google Cloud CLI applications without `tsh`
 
 In addition to running `gcloud` commands via `tsh`, you can grant secure access
@@ -570,6 +746,8 @@ application to the Teleport Application Service. The Application Service uses
 the `teleport-google-cloud-cli` service account we created earlier to fetch an
 authentication token from Google Cloud. Your CLI application uses this token to
 authenticate requests to Google Cloud's APIs.
+
+**Run on your local workstation:**
 
 To start the local proxy, run the following `tsh` command:
 
@@ -652,4 +830,3 @@ in the background and uses it to execute the command.
   command with Teleport. Users can execute `gsutil` commands with `tsh gsutil`.
   For more information, see the `tsh gsutil` entry in the [CLI
   Reference](../../../reference/cli/tsh.mdx#tsh-gsutil).
-

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/gke-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/gke-discovery.mdx
@@ -49,6 +49,28 @@ account to discover GKE clusters and manage access from Teleport users. In this
 step, you will create a service account and download a credentials file for the
 Teleport Discovery Service.
 
+### Discover your Google Cloud project and zones
+
+Before creating resources, identify the project ID and available zones where
+your GKE clusters run:
+
+```code
+$ gcloud config get-value project
+$ gcloud container clusters list --format="table(name,location,status)"
+```
+
+If you have not set a default project, list available projects:
+
+```code
+$ gcloud projects list --format="table(projectId,name)"
+```
+
+To list available zones:
+
+```code
+$ gcloud compute zones list --format="table(name,region,status)"
+```
+
 ### Create an IAM role for the Discovery Service
 
 The Teleport Discovery Service needs permissions to retrieve GKE clusters
@@ -171,7 +193,9 @@ Kubernetes Service and Discovery Service on Google Cloud or some other way
 (e.g., via Amazon EC2 or on a local network).
 
 <Tabs>
-<TabItem label="Google Cloud">
+<TabItem label="Google Cloud (VM service account)">
+
+This approach requires stopping the VM to attach the service account.
 
 Stop your VM so you can attach your service account to it:
 
@@ -180,7 +204,7 @@ $ gcloud compute instances stop <Var name="vm-name" /> --zone=<Var name="google-
 ```
 
 Attach your service account to the instance, assigning the name of your VM to <Var name="vm-name" />
-and the name of your Google Cloud region to <Var name="google-cloud-region" />:
+and the name of your Google Cloud zone to <Var name="google-cloud-region" />:
 
 ```code
 $ gcloud compute instances set-service-account <Var name="vm-name" /> \
@@ -231,6 +255,40 @@ Once you have attached the service account, restart your VM:
 $ gcloud compute instances start <Var name="vm-name" /> --zone <Var name="google-cloud-region" />
 ```
 </TabItem>
+<TabItem label="Google Cloud (Workload Identity - GKE-hosted)">
+
+If the Discovery Service runs inside a GKE cluster, use GKE Workload Identity
+instead of attaching a service account to a VM. This avoids the need to stop
+and restart a VM.
+
+Create a Kubernetes service account for the Teleport pod:
+
+```code
+$ kubectl create serviceaccount teleport-discovery -n teleport
+```
+
+Bind the Kubernetes service account to the Google Cloud service account:
+
+```code
+$ PROJECT_ID=<Var name="google-cloud-project" />
+$ gcloud iam service-accounts add-iam-policy-binding \
+   teleport-discovery-kubernetes@${PROJECT_ID?}.iam.gserviceaccount.com \
+   --role roles/iam.workloadIdentityUser \
+   --member "serviceAccount:${PROJECT_ID?}.svc.id.goog[teleport/teleport-discovery]"
+```
+
+Annotate the Kubernetes service account:
+
+```code
+$ kubectl annotate serviceaccount teleport-discovery \
+   -n teleport \
+   iam.gke.io/gcp-service-account=teleport-discovery-kubernetes@${PROJECT_ID?}.iam.gserviceaccount.com
+```
+
+When deploying Teleport, configure the pod to use the `teleport-discovery`
+Kubernetes service account. No credentials file is needed with this approach.
+
+</TabItem>
 <TabItem label="Other Platform">
 
 Download a credentials file for the service account used by the Discovery
@@ -274,6 +332,37 @@ guide.
 
 </TabItem>
 </Tabs>
+
+<Checkpoint>
+Verify that the service account has been attached and has the correct roles.
+
+For VM-based deployments, confirm the service account is attached:
+
+```code
+$ gcloud compute instances describe <Var name="vm-name" /> \
+   --zone <Var name="google-cloud-region" /> \
+   --format="yaml(serviceAccounts)"
+```
+
+The output should show `teleport-discovery-kubernetes@<project>.iam.gserviceaccount.com`.
+
+For credential-file-based deployments, confirm the file exists:
+
+```code
+$ ls -la /var/lib/teleport/google-cloud-credentials.json
+```
+
+Verify the service account roles are bound correctly:
+
+```code
+$ gcloud projects get-iam-policy ${PROJECT_ID?} \
+   --flatten="bindings[].members" \
+   --filter="bindings.members:teleport-discovery-kubernetes@${PROJECT_ID?}.iam.gserviceaccount.com" \
+   --format="table(bindings.role)"
+```
+
+You should see both `GKEKubernetesAutoDisc` and `GKEAccessManager` roles listed.
+</Checkpoint>
 
 ## Step 2/3. Configure Teleport to discover GKE clusters
 
@@ -468,6 +557,12 @@ value, `gke`.
 
 In your matcher, replace `myproject` with the ID of your Google Cloud project.
 
+You can discover your project ID by running:
+
+```code
+$ gcloud config get-value project
+```
+
 Ensure that the `project_ids` field follows these rules:
 - It must include at least one value.
 - It must not combine the wildcard character (`*`) with other values.
@@ -485,6 +580,12 @@ Ensure that the `project_ids` field follows these rules:
 Each matcher's `locations` field contains an array of Google Cloud region or
 zone names that the matcher will search for GKE clusters. The wildcard
 character, `*`, configures the matcher to search all locations.
+
+To discover what locations your GKE clusters are running in:
+
+```code
+$ gcloud container clusters list --format="value(location)" | sort -u
+```
 
 #### `discovery_service.gcp[0].tags`
 
@@ -607,9 +708,34 @@ $ kubectl config use-context CONTEXT_NAME
 Switched to context CONTEXT_NAME
 ```
 
+You can also fetch GKE credentials directly:
+
+```code
+$ gcloud container clusters get-credentials <Var name="cluster-name" /> \
+   --zone <Var name="google-cloud-region" /> \
+   --project <Var name="google-cloud-project" />
+```
+
 </details>
 
 (!docs/pages/includes/kubernetes-access/rbac.mdx!)
+
+<Admonition type="tip">
+
+If you have multiple discovered clusters and want to apply RBAC to all of them,
+use the following script to loop over every GKE cluster in your project:
+
+```code
+$ for CLUSTER in $(gcloud container clusters list --format="value(name)"); do
+   LOCATION=$(gcloud container clusters list --filter="name=$CLUSTER" --format="value(location)")
+   gcloud container clusters get-credentials $CLUSTER --zone $LOCATION --project ${PROJECT_ID?}
+   kubectl apply -f crb.yaml
+done
+```
+
+Replace `crb.yaml` with the path to your `ClusterRoleBinding` manifest.
+
+</Admonition>
 
 ### Access your cluster
 
@@ -652,6 +778,31 @@ you listed previously:
 $ tsh kube login mycluster-gke
 Logged into kubernetes cluster "mycluster-gke". Try 'kubectl version' to test the connection.
 ```
+
+<Checkpoint>
+Verify end-to-end discovery and access are working.
+
+Confirm that the Discovery Service found and registered your cluster:
+
+```code
+$ tctl get kube_clusters --format=json | jq '.[].metadata.name'
+```
+
+The output should include your GKE cluster name(s).
+
+Confirm that you can run kubectl commands through the Teleport proxy:
+
+```code
+$ kubectl version
+$ kubectl get namespaces
+```
+
+If the cluster does not appear, check the Discovery Service logs:
+
+```code
+$ sudo journalctl -u teleport --grep "discovery" --since "10 minutes ago"
+```
+</Checkpoint>
 
 As you can see, Teleport GKE Auto-Discovery enabled you to access a GKE cluster
 in your Google Cloud account without requiring you to register that cluster

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -71,9 +71,7 @@ spec:
         service_accounts: ["my-sa@my-project-id.iam.gserviceaccount.com"]
 ```
 
-<Admonition type="tip">
-
-To discover the values needed for this token configuration:
+To discover the values needed for this token configuration, run:
 
 ```code
 # Get your project ID
@@ -85,8 +83,6 @@ $ gcloud compute instances list --format="value(zone)" | sort -u
 # List service accounts attached to your instances
 $ gcloud compute instances list --format="value(serviceAccounts[0].email)" | sort -u
 ```
-
-</Admonition>
 
 Add your instance's project ID(s) to the `project_ids` field.
 Add the token to the Teleport cluster with:
@@ -197,9 +193,7 @@ at least one entry under `serviceAccounts`:
 $ gcloud compute instances describe --format="yaml(name,serviceAccounts)" <Var name="instance_name" description="Instance name" />
 ```
 
-<Admonition type="tip">
-
-To check all instances in your project at once for service account attachment:
+To check all instances in your project at once for service account attachment, run:
 
 ```code
 $ gcloud compute instances list \
@@ -209,8 +203,6 @@ $ gcloud compute instances list \
 
 Instances without a service account will show an empty `SERVICE_ACCOUNT` column
 and cannot be discovered by Teleport.
-
-</Admonition>
 
 ### Enable guest attributes on instances
 
@@ -272,14 +264,10 @@ will automatically be populated with the instance's host keys. If guest
 attributes were enabled after the instance was created, you must manually add
 the host keys to the guest attributes.
 
-<Admonition type="note">
-
 This is a one-time operation per instance. Once host keys are written to guest
 attributes, they persist across reboots. If you enabled guest attributes
 project-wide before creating instances, new instances will automatically
 populate their host keys and no manual action is needed.
-
-</Admonition>
 
 <Tabs>
 <TabItem label="Batch (all instances)">
@@ -310,10 +298,8 @@ populate their host keys and no manual action is needed.
   --metadata-from-file=startup-script="add-host-keys.sh"
   ```
 
-  <Admonition type="note">
   The startup script runs on each boot. After the host keys have been
   populated, you can remove it or leave it in place (it is idempotent).
-  </Admonition>
 </TabItem>
 <TabItem label="SSH (single instance)">
   Run the following command to add the host keys over SSH:
@@ -419,9 +405,7 @@ Static configuration while simpler at first, has less flexibility because enroll
           "env": "prod" # Match virtual machines where label:env=prod
   ```
 
-  <Admonition type="tip">
-
-  To discover the values needed for the matcher configuration:
+  To discover the values needed for the matcher configuration, run:
 
   ```code
   # Get your project ID
@@ -433,8 +417,6 @@ Static configuration while simpler at first, has less flexibility because enroll
   # List service accounts attached to target instances
   $ gcloud compute instances list --filter="labels.env=prod" --format="value(serviceAccounts[0].email)" | sort -u
   ```
-
-  </Admonition>
 
   Adjust the keys under `spec.gcp` to match your GCP environment,
   specifically the project IDs, locations, service accounts and labels you want to associate with the Discovery Service.

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -35,6 +35,13 @@ other Linux distributions, you can install Teleport manually.)
 When discovering GCP compute instances, Teleport makes use of GCP invite tokens for
 authenticating joining SSH Service instances.
 
+First, discover your project ID and the zones where your instances run:
+
+```code
+$ gcloud config get-value project
+$ gcloud compute instances list --format="table(name,zone,status,serviceAccounts.email)"
+```
+
 Create a file called `token.yaml`:
 
 ```yaml
@@ -55,14 +62,31 @@ spec:
   gcp:
     allow:
       # The GCP project ID(s) that VMs can join from.
-      - project_ids: []
+      - project_ids: ["my-project-id"]
         # (Optional) The locations that VMs can join from. Note: both regions and
         # zones are accepted.
-        locations: []
+        locations: ["us-central1-a", "us-east1-b"]
         # (Optional) The email addresses of service accounts that VMs can join
         # with.
-        service_accounts: []
+        service_accounts: ["my-sa@my-project-id.iam.gserviceaccount.com"]
 ```
+
+<Admonition type="tip">
+
+To discover the values needed for this token configuration:
+
+```code
+# Get your project ID
+$ gcloud config get-value project
+
+# List zones where your instances run
+$ gcloud compute instances list --format="value(zone)" | sort -u
+
+# List service accounts attached to your instances
+$ gcloud compute instances list --format="value(serviceAccounts[0].email)" | sort -u
+```
+
+</Admonition>
 
 Add your instance's project ID(s) to the `project_ids` field.
 Add the token to the Teleport cluster with:
@@ -173,6 +197,21 @@ at least one entry under `serviceAccounts`:
 $ gcloud compute instances describe --format="yaml(name,serviceAccounts)" <Var name="instance_name" description="Instance name" />
 ```
 
+<Admonition type="tip">
+
+To check all instances in your project at once for service account attachment:
+
+```code
+$ gcloud compute instances list \
+  --format="table(name,zone,serviceAccounts[0].email:label=SERVICE_ACCOUNT)" \
+  --filter="labels.env=prod"
+```
+
+Instances without a service account will show an empty `SERVICE_ACCOUNT` column
+and cannot be discovered by Teleport.
+
+</Admonition>
+
 ### Enable guest attributes on instances
 
 Guest attributes (a subset of custom metadata used for infrequently updated data)
@@ -180,18 +219,82 @@ must be enabled on instances to be discovered so Teleport can access their SSH
 host keys. Enable guest attributes by setting `enable-guest-attributes` to
 `TRUE` in the instance's metadata.
 
+You can enable guest attributes for a single instance:
+
 ```code
 $ gcloud compute instances add-metadata <Var name="instance_name" description="Instance name" /> \
 --metadata=enable-guest-attributes=True
 ```
 
+To enable guest attributes project-wide so all current and future instances
+inherit the setting:
+
+```code
+$ gcloud compute project-info add-metadata \
+--metadata=enable-guest-attributes=True
+```
+
+To enable guest attributes in batch for all instances matching a label filter:
+
+```code
+$ for INSTANCE in $(gcloud compute instances list --filter="labels.env=prod" --format="value(name,zone)" | tr '\t' ','); do
+  NAME=$(echo $INSTANCE | cut -d',' -f1)
+  ZONE=$(echo $INSTANCE | cut -d',' -f2)
+  gcloud compute instances add-metadata $NAME --zone=$ZONE --metadata=enable-guest-attributes=True
+done
+```
+
+<Checkpoint>
+Verify that guest attributes are enabled on your target instances.
+
+Check an individual instance:
+
+```code
+$ gcloud compute instances describe <Var name="instance_name" /> \
+  --format="value(metadata.items[enable-guest-attributes])"
+```
+
+The output should be `True`.
+
+Check the project-wide setting (if you applied it project-wide):
+
+```code
+$ gcloud compute project-info describe \
+  --format="value(commonInstanceMetadata.items[enable-guest-attributes])"
+```
+
+</Checkpoint>
+
+### Populate host keys in guest attributes
+
 If guest attributes are enabled during instance creation, the guest attributes
 will automatically be populated with the instance's host keys. If guest
-attributes were enabled after the instance was created, you can manually add
-the host keys to the guest attributes below:
+attributes were enabled after the instance was created, you must manually add
+the host keys to the guest attributes.
+
+<Admonition type="note">
+
+This is a one-time operation per instance. Once host keys are written to guest
+attributes, they persist across reboots. If you enabled guest attributes
+project-wide before creating instances, new instances will automatically
+populate their host keys and no manual action is needed.
+
+</Admonition>
 
 <Tabs>
-<TabItem label="Startup script">
+<TabItem label="Batch (all instances)">
+  Use the following script to populate host keys on all instances matching a
+  label filter. Run this from a machine with `gcloud` access:
+
+  ```code
+  $ for INSTANCE in $(gcloud compute instances list --filter="labels.env=prod" --format="value(name,zone)" | tr '\t' ','); do
+    NAME=$(echo $INSTANCE | cut -d',' -f1)
+    ZONE=$(echo $INSTANCE | cut -d',' -f2)
+    gcloud compute ssh $NAME --zone=$ZONE --command='for file in /etc/ssh/ssh_host_*_key.pub; do KEY_TYPE=$(awk '\''{print $1}'\'' $file); KEY=$(awk '\''{print $2}'\'' $file); curl -sX PUT --data "$KEY" "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/hostkeys/$KEY_TYPE" -H "Metadata-Flavor: Google"; done'
+  done
+  ```
+</TabItem>
+<TabItem label="Startup script (single instance)">
   Create a file named `add-host-keys.sh` and copy the following into it:
   ```sh
   #!/usr/bin/env bash
@@ -206,15 +309,29 @@ the host keys to the guest attributes below:
   $ gcloud compute instances add-metadata <Var name="instance_name" description="Instance name" /> \
   --metadata-from-file=startup-script="add-host-keys.sh"
   ```
+
+  <Admonition type="note">
+  The startup script runs on each boot. After the host keys have been
+  populated, you can remove it or leave it in place (it is idempotent).
+  </Admonition>
 </TabItem>
-<TabItem label="SSH">
+<TabItem label="SSH (single instance)">
   Run the following command to add the host keys over SSH:
   ```code
   $ gcloud compute ssh <Var name="instance_name" description="Instance name" /> \
-  --command='for file in /etc/ssh/ssh_host_*_key.pub; do KEY_TYPE=$(awk '\''{print $1}'\'' $file); KEY=$(awk '\''{print $2}'\''  $file); curl -X PUT --data "$KEY" "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/hostkeys/$KEY_TYPE" -H "Metadata-Flavor: Google"; done'
+  --command='for file in /etc/ssh/ssh_host_*_key.pub; do KEY_TYPE=$(awk '\''{print $1}'\'' $file); KEY=$(awk '\''{print $2}'\'' $file); curl -X PUT --data "$KEY" "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/hostkeys/$KEY_TYPE" -H "Metadata-Flavor: Google"; done'
   ```
 </TabItem>
 </Tabs>
+
+Verify that host keys are populated in guest attributes:
+
+```code
+$ gcloud compute instances get-guest-attributes <Var name="instance_name" /> \
+  --query-path="hostkeys/"
+```
+
+The output should list one or more entries (e.g., `ssh-rsa`, `ecdsa-sha2-nistp256`, `ssh-ed25519`).
 
 ## Step 4/5. Install the Teleport Discovery Service
 
@@ -290,17 +407,35 @@ Static configuration while simpler at first, has less flexibility because enroll
     gcp:
       - types: ["gce"]
         # The IDs of GCP projects that VMs can join from.
-        project_ids: []
+        project_ids: ["my-project-id"]
         # (Optional) The locations that VMs can join from. Note: both regions and
         # zones are accepted.
-        locations: []
+        locations: ["us-central1-a", "us-east1-b"]
         # (Optional) The email addresses of service accounts that VMs can join
         # with.
-        service_accounts: []
+        service_accounts: ["my-sa@my-project-id.iam.gserviceaccount.com"]
         # (Optional) Labels that joining VMs must have.
         labels:
           "env": "prod" # Match virtual machines where label:env=prod
   ```
+
+  <Admonition type="tip">
+
+  To discover the values needed for the matcher configuration:
+
+  ```code
+  # Get your project ID
+  $ gcloud config get-value project
+
+  # List zones where your target instances run
+  $ gcloud compute instances list --filter="labels.env=prod" --format="value(zone)" | sort -u
+
+  # List service accounts attached to target instances
+  $ gcloud compute instances list --filter="labels.env=prod" --format="value(serviceAccounts[0].email)" | sort -u
+  ```
+
+  </Admonition>
+
   Adjust the keys under `spec.gcp` to match your GCP environment,
   specifically the project IDs, locations, service accounts and labels you want to associate with the Discovery Service.
 
@@ -327,13 +462,13 @@ Static configuration while simpler at first, has less flexibility because enroll
     gcp:
       - types: ["gce"]
         # The IDs of GCP projects that VMs can join from.
-        project_ids: []
+        project_ids: ["my-project-id"]
         # (Optional) The locations that VMs can join from. Note: both regions and
         # zones are accepted.
-        locations: []
+        locations: ["us-central1-a", "us-east1-b"]
         # (Optional) The email addresses of service accounts that VMs can join
         # with.
-        service_accounts: []
+        service_accounts: ["my-sa@my-project-id.iam.gserviceaccount.com"]
         # (Optional) Labels that joining VMs must have.
         labels:
           "env": "prod" # Match virtual machines where label:env=prod
@@ -355,6 +490,44 @@ The easiest way to ensure that is to run the Discovery Service on a GCP
 instance and assign the service account to that instance. Refer to
 [Set Up Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
 for details on alternate methods.
+
+### Start and verify the Discovery Service
+
+Start the Discovery Service:
+
+```code
+$ sudo systemctl start teleport
+```
+
+<Checkpoint>
+Verify that the Discovery Service is running and discovering instances.
+
+Check the service status:
+
+```code
+$ sudo systemctl status teleport
+```
+
+After a few moments, verify that discovered nodes appear in the cluster:
+
+```code
+$ tctl get nodes --format=json | jq '.[].metadata.name'
+```
+
+If no nodes appear after a few minutes, check the Discovery Service logs for
+errors:
+
+```code
+$ sudo journalctl -u teleport --grep "discovery\|gcp" --since "5 minutes ago" --no-pager
+```
+
+Common issues:
+- Missing guest attributes: the instance host keys have not been written.
+- No service account on target instance: the instance cannot authenticate via
+  the GCP join method.
+- Permission denied: the Discovery Service service account is missing required
+  IAM permissions.
+</Checkpoint>
 
 ## Auto-discovery labels
 

--- a/docs/pages/enroll-resources/automatic-labels/gcp-tags.mdx
+++ b/docs/pages/enroll-resources/automatic-labels/gcp-tags.mdx
@@ -48,7 +48,7 @@ fakehost.example.com 127.0.0.1:3022 gcp/label/testing=yes,gcp/tag/environment=st
 - One Teleport Agent running on a GCP Compute instance. See
   [our guides](../../installation/agents/agents.mdx) for how to set up Teleport Agents.
 
-## Configure service account on instances with Teleport nodes
+## Step 1/3. Create the IAM role and service account
 
 Create a service account that will give Teleport the IAM permissions needed
 to import tags and labels. Copy the following and paste it into a file called
@@ -61,6 +61,12 @@ stage: "ALPHA"
 includedPermissions:
 - compute.instances.get
 - compute.instances.listEffectiveTags
+```
+
+First, discover your project ID:
+
+```code
+$ gcloud config get-value project
 ```
 
 Then run the following command to create the role:
@@ -87,3 +93,131 @@ $ gcloud projects add-iam-policy-binding <Var name="project_id" description="GCP
 If you want to only import labels or only import tags, you can leave
 `compute.instances.listEffectiveTags` or `compute.instances.get`
 out of your created service account's permissions, respectively.
+
+## Step 2/3. Attach the service account to your instance
+
+The Teleport Agent must run on an instance that has the `teleport-labels`
+service account attached. Without this attachment, the agent cannot call the
+GCP APIs needed to fetch tags and labels.
+
+<Admonition type="warning">
+
+Attaching or changing a service account on an existing VM requires stopping the
+VM first. Plan for a brief interruption.
+
+</Admonition>
+
+<Tabs>
+<TabItem label="gcloud CLI">
+
+Stop the instance, attach the service account, and restart it:
+
+```code
+$ gcloud compute instances stop <Var name="instance_name" description="Name of the VM running the Teleport Agent" /> \
+  --zone=<Var name="zone" description="GCP zone of the instance" />
+$ gcloud compute instances set-service-account <Var name="instance_name" /> \
+  --service-account=teleport-labels@<Var name="project_id" />.iam.gserviceaccount.com \
+  --scopes=cloud-platform \
+  --zone=<Var name="zone" />
+$ gcloud compute instances start <Var name="instance_name" /> \
+  --zone=<Var name="zone" />
+```
+
+</TabItem>
+<TabItem label="Console">
+
+1. Go to [Compute Engine > VM instances](https://console.cloud.google.com/compute/instances).
+2. Click on the instance name.
+3. Click **Stop** and wait for the instance to stop.
+4. Click **Edit**.
+5. Under **Service account**, select `teleport-labels`.
+6. Under **Access scopes**, select **Allow full access to all Cloud APIs** (or at minimum, ensure Compute Engine Read Only is enabled).
+7. Click **Save**.
+8. Click **Start/Resume**.
+
+</TabItem>
+</Tabs>
+
+<Checkpoint>
+Verify that the service account is attached to the instance.
+
+Run the following command and confirm the output shows the `teleport-labels`
+service account:
+
+```code
+$ gcloud compute instances describe <Var name="instance_name" /> \
+  --zone=<Var name="zone" /> \
+  --format="yaml(serviceAccounts)"
+```
+
+Expected output:
+
+```
+serviceAccounts:
+- email: teleport-labels@<project_id>.iam.gserviceaccount.com
+  scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+```
+
+If the `serviceAccounts` field is empty or shows a different account, repeat the
+steps above.
+</Checkpoint>
+
+## Step 3/3. Verify labels appear in Teleport
+
+After attaching the service account, restart the Teleport Agent on the instance
+so it picks up the new credentials:
+
+```code
+$ sudo systemctl restart teleport
+```
+
+Wait a moment for the agent to start and fetch labels from the GCP API, then
+verify that GCP labels and tags are visible:
+
+```code
+$ tsh ls --format=json | jq '.[].metadata.labels | with_entries(select(.key | startswith("gcp/")))'
+```
+
+You can also verify the labels on a specific node:
+
+```code
+$ tctl get nodes --format=json | jq '.[] | select(.spec.hostname == "<Var name="instance_name" />") | .metadata.labels'
+```
+
+To confirm which labels and tags are set on the GCP instance itself:
+
+```code
+$ gcloud compute instances describe <Var name="instance_name" /> \
+  --zone=<Var name="zone" /> \
+  --format="yaml(labels,tags)"
+```
+
+<Checkpoint>
+Verify that GCP labels appear as Teleport labels on the node.
+
+Run the following command:
+
+```code
+$ tsh ls
+```
+
+The output should show labels prefixed with `gcp/label/` and `gcp/tag/` for
+your instance. For example:
+
+```
+Node Name            Address        Labels
+-------------------- -------------- ---------------------------------------------------------
+myhost.example.com   127.0.0.1:3022 gcp/label/env=prod,gcp/tag/team=platform
+```
+
+If no `gcp/` labels appear:
+- Confirm the service account is attached (Step 2).
+- Check that the Teleport Agent process restarted after the service account was
+  attached.
+- Review the Teleport Agent logs for permission errors:
+
+```code
+$ sudo journalctl -u teleport --grep "gcp\|label" --since "5 minutes ago" --no-pager
+```
+</Checkpoint>

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/alloydb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/alloydb.mdx
@@ -27,6 +27,18 @@ page_type: how-to
 - A host (e.g., a Compute Engine instance) to run the Teleport Database Service.
 - (!docs/pages/includes/tctl.mdx!)
 
+<Admonition type="tip" title="Discover your GCP project and AlloyDB resources">
+If you are unsure of your GCP project ID or AlloyDB cluster/instance names, run:
+
+```code
+$ gcloud config get-value project
+$ gcloud alloydb clusters list --format="table(name,state)" --region=<Var name="region" />
+$ gcloud alloydb instances list --cluster=<Var name="cluster-name" /> --region=<Var name="region" /> \
+    --format="table(name,instanceType,state)"
+```
+
+</Admonition>
+
 ## Step 1/4. Configure IAM and create a database user
 
 In this step, you will create two required service accounts.
@@ -102,6 +114,29 @@ $ gcloud iam service-accounts add-iam-policy-binding \
 </TabItem>
 </Tabs>
 
+<Checkpoint
+  title="Verify service account impersonation"
+  description="Confirm that the Database Service account can impersonate the database user account."
+>
+
+Run:
+
+```code
+$ gcloud iam service-accounts get-iam-policy \
+    alloydb-user@<Var name="project-id" />.iam.gserviceaccount.com
+```
+
+The output should include a binding that pairs `teleport-db-service` with `roles/iam.serviceAccountTokenCreator`:
+
+```yaml
+bindings:
+- members:
+  - serviceAccount:teleport-db-service@<project-id>.iam.gserviceaccount.com
+  role: roles/iam.serviceAccountTokenCreator
+```
+
+</Checkpoint>
+
 ### Add the IAM database user to AlloyDB
 
 <Admonition type="note">
@@ -166,6 +201,31 @@ $ gcloud alloydb users create alloydb-user@<Var name="project-id" />.iam \
 </TabItem>
 </Tabs>
 
+<Admonition type="note" title="AlloyDB IAM user naming convention">
+For AlloyDB (PostgreSQL-compatible), IAM database users use a `.iam` suffix when
+connecting. The database user name is the service account email with
+`.gserviceaccount.com` replaced by `.iam`. For example,
+`alloydb-user@my-project.iam.gserviceaccount.com` becomes
+`alloydb-user@my-project.iam` as the database user name.
+</Admonition>
+
+<Checkpoint
+  title="Verify IAM database user"
+  description="Confirm that the IAM user was created on the AlloyDB instance."
+>
+
+```code
+$ gcloud alloydb users list \
+    --cluster=<Var name="cluster-name" /> \
+    --region=<Var name="region" /> \
+    --project=<Var name="project-id" /> \
+    --format="table(name,userType)"
+```
+
+You should see a user with type `IAM_BASED` for your service account.
+
+</Checkpoint>
+
 ## Step 2/4. Create a Teleport Database Service host
 
 The Teleport Database Service must run on a host that can reach the AlloyDB instance and authenticate with GCP.
@@ -199,19 +259,19 @@ Set the variables:
 ```code
 # The instance must be stopped before modifying the service account
 # 1. Stop the instance
-gcloud compute instances stop <Var name="instance-name" /> \
+$ gcloud compute instances stop <Var name="instance-name" /> \
     --project=<Var name="project-id" /> \
     --zone=<Var name="zone" />
 
 # 2. Update the Service Account and Scopes
-gcloud compute instances set-service-account <Var name="instance-name" /> \
+$ gcloud compute instances set-service-account <Var name="instance-name" /> \
     --service-account=teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com \
     --scopes=https://www.googleapis.com/auth/cloud-platform \
     --project=<Var name="project-id" /> \
     --zone=<Var name="zone" />
 
 # 3. Restart the instance
-gcloud compute instances start <Var name="instance-name" /> \
+$ gcloud compute instances start <Var name="instance-name" /> \
     --project=<Var name="project-id" /> \
     --zone=<Var name="zone" />
 ```
@@ -249,6 +309,10 @@ See [Google Cloud authentication docs](https://cloud.google.com/docs/authenticat
 
 In this step, you will configure the Teleport Database Service to connect to AlloyDB and handle authentication and access on behalf of users.
 
+<Admonition type="note" title="Where to run commands">
+Run the commands in this step on the host where you will run the Teleport Database Service (the GCE instance from Step 2).
+</Admonition>
+
 ### Install the Teleport Database Service
 
 (!docs/pages/includes/install-linux.mdx!)
@@ -267,6 +331,19 @@ The connection URI has the format `projects/PROJECT-ID/locations/REGION/clusters
 You can copy it from the AlloyDB instance details page in the Google Cloud console.
 
 ![AlloyDB Connection URI](../../../../../img/database-access/guides/alloydb/connection-uri.png)
+
+<Admonition type="tip" title="Discover the AlloyDB connection URI components">
+You can discover the components of the connection URI using these commands:
+
+```code
+$ gcloud config get-value project
+$ gcloud alloydb clusters list --region=<Var name="region" /> --format="table(name,state)"
+$ gcloud alloydb instances list --cluster=<Var name="cluster-name" /> --region=<Var name="region" /> \
+    --format="table(name,instanceType,state)"
+```
+
+Assemble the URI as: `projects/<project-id>/locations/<region>/clusters/<cluster-name>/instances/<instance-name>`
+</Admonition>
 
 Run the command as follows. Make sure to include the mandatory `alloydb://` prefix in the specified URI.
 
@@ -323,6 +400,27 @@ $ tctl create -f alloydb.yaml
 Start the Database Service:
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
+
+<Checkpoint
+  title="Verify the Database Service joined the cluster"
+  description="Confirm that the Teleport Database Service is running and the AlloyDB database appears."
+>
+
+```code
+$ tsh db ls
+```
+
+You should see your AlloyDB database in the output:
+
+```
+Name    Description Labels
+------- ----------- -------
+alloydb GCP AlloyDB env=dev
+```
+
+If the database does not appear, verify your Teleport role permissions. See the [RBAC](../../../../zero-trust-access/rbac-get-started/rbac-get-started.mdx) guide.
+
+</Checkpoint>
 
 ## Step 4/4. Connect to your database
 
@@ -427,4 +525,3 @@ serviceusage.services.use
 * Learn more about [IAM authentication for AlloyDB](https://cloud.google.com/alloydb/docs/database-users/manage-iam-auth).
 * Learn more about [service account authentication](https://cloud.google.com/docs/authentication#service-accounts) in Google Cloud.
 * Learn more about AlloyDB [Auth Proxy permissions](https://cloud.google.com/alloydb/docs/auth-proxy/connect#required-iam-permissions).
-

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/mysql-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/mysql-cloudsql.mdx
@@ -34,21 +34,17 @@ page_type: how-to
   Service
 - (!docs/pages/includes/tctl.mdx!)
 
-<Admonition type="tip" title="Discover your GCP project ID">
-If you are unsure of your GCP project ID, run:
+To find your GCP project ID, run:
 
 ```code
 $ gcloud config get-value project
 ```
 
-</Admonition>
-
 ## Step 1/9. Create a service account for the Teleport Database Service
 
 (!docs/pages/includes/database-access/cloudsql-create-service-account-for-db-service.mdx !)
 
-<Admonition type="tip" title="CLI alternative">
-You can create the service account using the `gcloud` CLI instead of the Cloud Console:
+Alternatively, create the service account using the `gcloud` CLI:
 
 ```code
 $ gcloud iam service-accounts create teleport-db-service \
@@ -56,14 +52,11 @@ $ gcloud iam service-accounts create teleport-db-service \
     --project=<Var name="project-id" />
 ```
 
-</Admonition>
-
 ### (Optional) Grant permissions
 
 (!docs/pages/includes/database-access/cloudsql_grant_db_service_account.mdx!)
 
-<Admonition type="tip" title="CLI alternative">
-Grant the required Cloud SQL permissions to the Database Service account using the CLI:
+Alternatively, grant the required Cloud SQL permissions to the Database Service account using the `gcloud` CLI:
 
 ```code
 $ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
@@ -74,8 +67,6 @@ $ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
     --member="serviceAccount:teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com" \
     --role="roles/cloudsql.instanceUser"
 ```
-
-</Admonition>
 
 ### (Optional) Grant permission to check user type
 
@@ -101,16 +92,13 @@ The pre-defined "Cloud SQL Viewer" role has this permission, but also has other
 permissions that are not needed. Define and bind a custom role to the service
 account to follow the principle of least privilege.
 
-<Admonition type="tip" title="CLI alternative">
-To grant the Cloud SQL Viewer role (or a custom role with `cloudsql.users.get`):
+Alternatively, grant the Cloud SQL Viewer role (or a custom role with `cloudsql.users.get`) using the `gcloud` CLI:
 
 ```code
 $ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
     --member="serviceAccount:teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com" \
     --role="roles/cloudsql.viewer"
 ```
-
-</Admonition>
 
 <Admonition type="note">
 Support for legacy one-time password authentication will be deprecated.
@@ -125,8 +113,7 @@ Teleport uses service accounts to connect to Cloud SQL databases.
 
 (!docs/pages/includes/database-access/cloudsql_create_db_user_account.mdx!)
 
-<Admonition type="tip" title="CLI alternative">
-Create the database user service account using the CLI:
+Alternatively, create the database user service account using the `gcloud` CLI:
 
 ```code
 $ gcloud iam service-accounts create cloudsql-user \
@@ -134,12 +121,9 @@ $ gcloud iam service-accounts create cloudsql-user \
     --project=<Var name="project-id" />
 ```
 
-</Admonition>
-
 (!docs/pages/includes/database-access/cloudsql_grant_db_user.mdx!)
 
-<Admonition type="tip" title="CLI alternative">
-Grant the Cloud SQL Instance User role to the database user service account:
+Alternatively, grant the Cloud SQL Instance User role to the database user service account using the `gcloud` CLI:
 
 ```code
 $ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
@@ -147,12 +131,9 @@ $ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
     --role="roles/cloudsql.instanceUser"
 ```
 
-</Admonition>
-
 (!docs/pages/includes/database-access/cloudsql-grant-impersonation.mdx!)
 
-<Admonition type="tip" title="CLI alternative">
-Grant the Database Service account permission to impersonate the database user account:
+Alternatively, grant the Database Service account permission to impersonate the database user account using the `gcloud` CLI:
 
 ```code
 $ gcloud iam service-accounts add-iam-policy-binding \
@@ -160,8 +141,6 @@ $ gcloud iam service-accounts add-iam-policy-binding \
     --member="serviceAccount:teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com" \
     --role="roles/iam.serviceAccountTokenCreator"
 ```
-
-</Admonition>
 
 <Checkpoint
   title="Verify service account impersonation"
@@ -196,15 +175,12 @@ with Cloud SQL MySQL instances.
 
 (!docs/pages/includes/database-access/cloudsql_enable_iam_auth.mdx type="MySQL" flag="cloudsql_iam_authentication" !)
 
-<Admonition type="tip" title="CLI alternative">
-Enable IAM authentication on your Cloud SQL MySQL instance:
+Alternatively, enable IAM authentication on your Cloud SQL MySQL instance using the `gcloud` CLI:
 
 ```code
 $ gcloud sql instances patch <Var name="instance-name" /> \
     --database-flags=cloudsql_iam_authentication=on
 ```
-
-</Admonition>
 
 ### (Optional) SSL mode "require trusted client certificates"
 
@@ -248,14 +224,11 @@ $ gcloud sql users create cloudsql-user@<Var name="project-id" />.iam.gserviceac
     --type=CLOUD_IAM_SERVICE_ACCOUNT
 ```
 
-<Admonition type="tip" title="Discover your Cloud SQL instance name">
-List your Cloud SQL instances:
+To find your Cloud SQL instance name, run:
 
 ```code
 $ gcloud sql instances list --format="table(name,databaseVersion,region,state)"
 ```
-
-</Admonition>
 
 </TabItem>
 </Tabs>
@@ -280,9 +253,7 @@ You should see a user with type `CLOUD_IAM_SERVICE_ACCOUNT` for your service acc
 
 ## Step 5/9. Configure the Teleport Database Service
 
-<Admonition type="note" title="Where to run commands">
 Run the commands in this step on the host where you will run the Teleport Database Service (e.g., a Compute Engine instance).
-</Admonition>
 
 ### Create a join token
 

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/mysql-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/mysql-cloudsql.mdx
@@ -34,13 +34,48 @@ page_type: how-to
   Service
 - (!docs/pages/includes/tctl.mdx!)
 
+<Admonition type="tip" title="Discover your GCP project ID">
+If you are unsure of your GCP project ID, run:
+
+```code
+$ gcloud config get-value project
+```
+
+</Admonition>
+
 ## Step 1/9. Create a service account for the Teleport Database Service
 
 (!docs/pages/includes/database-access/cloudsql-create-service-account-for-db-service.mdx !)
 
+<Admonition type="tip" title="CLI alternative">
+You can create the service account using the `gcloud` CLI instead of the Cloud Console:
+
+```code
+$ gcloud iam service-accounts create teleport-db-service \
+    --display-name="Teleport Database Service" \
+    --project=<Var name="project-id" />
+```
+
+</Admonition>
+
 ### (Optional) Grant permissions
 
 (!docs/pages/includes/database-access/cloudsql_grant_db_service_account.mdx!)
+
+<Admonition type="tip" title="CLI alternative">
+Grant the required Cloud SQL permissions to the Database Service account using the CLI:
+
+```code
+$ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
+    --member="serviceAccount:teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com" \
+    --role="roles/cloudsql.client"
+
+$ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
+    --member="serviceAccount:teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com" \
+    --role="roles/cloudsql.instanceUser"
+```
+
+</Admonition>
 
 ### (Optional) Grant permission to check user type
 
@@ -66,6 +101,17 @@ The pre-defined "Cloud SQL Viewer" role has this permission, but also has other
 permissions that are not needed. Define and bind a custom role to the service
 account to follow the principle of least privilege.
 
+<Admonition type="tip" title="CLI alternative">
+To grant the Cloud SQL Viewer role (or a custom role with `cloudsql.users.get`):
+
+```code
+$ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
+    --member="serviceAccount:teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com" \
+    --role="roles/cloudsql.viewer"
+```
+
+</Admonition>
+
 <Admonition type="note">
 Support for legacy one-time password authentication will be deprecated.
 If you are following this guide and have already set up Teleport prior to the
@@ -79,9 +125,66 @@ Teleport uses service accounts to connect to Cloud SQL databases.
 
 (!docs/pages/includes/database-access/cloudsql_create_db_user_account.mdx!)
 
+<Admonition type="tip" title="CLI alternative">
+Create the database user service account using the CLI:
+
+```code
+$ gcloud iam service-accounts create cloudsql-user \
+    --display-name="Cloud SQL Database User" \
+    --project=<Var name="project-id" />
+```
+
+</Admonition>
+
 (!docs/pages/includes/database-access/cloudsql_grant_db_user.mdx!)
 
+<Admonition type="tip" title="CLI alternative">
+Grant the Cloud SQL Instance User role to the database user service account:
+
+```code
+$ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
+    --member="serviceAccount:cloudsql-user@<Var name="project-id" />.iam.gserviceaccount.com" \
+    --role="roles/cloudsql.instanceUser"
+```
+
+</Admonition>
+
 (!docs/pages/includes/database-access/cloudsql-grant-impersonation.mdx!)
+
+<Admonition type="tip" title="CLI alternative">
+Grant the Database Service account permission to impersonate the database user account:
+
+```code
+$ gcloud iam service-accounts add-iam-policy-binding \
+    cloudsql-user@<Var name="project-id" />.iam.gserviceaccount.com \
+    --member="serviceAccount:teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com" \
+    --role="roles/iam.serviceAccountTokenCreator"
+```
+
+</Admonition>
+
+<Checkpoint
+  title="Verify service account impersonation"
+  description="Confirm that the Database Service account can impersonate the database user account."
+>
+
+Run:
+
+```code
+$ gcloud iam service-accounts get-iam-policy \
+    cloudsql-user@<Var name="project-id" />.iam.gserviceaccount.com
+```
+
+The output should include a binding that pairs `teleport-db-service` with `roles/iam.serviceAccountTokenCreator`:
+
+```yaml
+bindings:
+- members:
+  - serviceAccount:teleport-db-service@<project-id>.iam.gserviceaccount.com
+  role: roles/iam.serviceAccountTokenCreator
+```
+
+</Checkpoint>
 
 ## Step 3/9. Configure your Cloud SQL database
 
@@ -92,6 +195,16 @@ authentication](https://cloud.google.com/sql/docs/mysql/iam-authentication)
 with Cloud SQL MySQL instances.
 
 (!docs/pages/includes/database-access/cloudsql_enable_iam_auth.mdx type="MySQL" flag="cloudsql_iam_authentication" !)
+
+<Admonition type="tip" title="CLI alternative">
+Enable IAM authentication on your Cloud SQL MySQL instance:
+
+```code
+$ gcloud sql instances patch <Var name="instance-name" /> \
+    --database-flags=cloudsql_iam_authentication=on
+```
+
+</Admonition>
 
 ### (Optional) SSL mode "require trusted client certificates"
 
@@ -110,6 +223,9 @@ setting.
 
 ### Create a database user
 
+<Tabs>
+<TabItem label="Google Cloud console">
+
 Now go back to the Users page of your Cloud SQL instance and add a new user
 account. In the sidebar, choose "Cloud IAM" authentication type and add the
 "cloudsql-user" service account you created in
@@ -121,11 +237,52 @@ Press "Add". See [Creating and managing IAM
 users](https://cloud.google.com/sql/docs/mysql/add-manage-iam-users) in Google
 Cloud documentation for more info.
 
+</TabItem>
+<TabItem label="gcloud CLI">
+
+Create an IAM-based database user linked to your service account:
+
+```code
+$ gcloud sql users create cloudsql-user@<Var name="project-id" />.iam.gserviceaccount.com \
+    --instance=<Var name="instance-name" /> \
+    --type=CLOUD_IAM_SERVICE_ACCOUNT
+```
+
+<Admonition type="tip" title="Discover your Cloud SQL instance name">
+List your Cloud SQL instances:
+
+```code
+$ gcloud sql instances list --format="table(name,databaseVersion,region,state)"
+```
+
+</Admonition>
+
+</TabItem>
+</Tabs>
+
+<Checkpoint
+  title="Verify IAM database user"
+  description="Confirm that the IAM user was created on the Cloud SQL instance."
+>
+
+```code
+$ gcloud sql users list --instance=<Var name="instance-name" /> \
+    --format="table(name,type)"
+```
+
+You should see a user with type `CLOUD_IAM_SERVICE_ACCOUNT` for your service account.
+
+</Checkpoint>
+
 ## Step 4/9. Install Teleport
 
 (!docs/pages/includes/install-linux.mdx!)
 
 ## Step 5/9. Configure the Teleport Database Service
+
+<Admonition type="note" title="Where to run commands">
+Run the commands in this step on the host where you will run the Teleport Database Service (e.g., a Compute Engine instance).
+</Admonition>
 
 ### Create a join token
 
@@ -143,9 +300,42 @@ Cloud documentation for more info.
 
 (!docs/pages/includes/database-access/cloudsql_service_credentials.mdx serviceAccount="teleport-db-service"!)
 
+<Admonition type="tip" title="Recommended: use attached service accounts">
+When running on a GCE instance, attach the `teleport-db-service` service account directly to the instance instead of using service account keys. This avoids managing key files:
+
+```code
+$ gcloud compute instances set-service-account <Var name="gce-instance-name" /> \
+    --service-account=teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com \
+    --scopes=https://www.googleapis.com/auth/cloud-platform \
+    --zone=<Var name="zone" />
+```
+
+</Admonition>
+
 ## Step 7/9. Start the Teleport Database Service
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
+
+<Checkpoint
+  title="Verify the Database Service joined the cluster"
+  description="Confirm that the Teleport Database Service is running and has joined the cluster."
+>
+
+```code
+$ tsh db ls
+```
+
+You should see your Cloud SQL MySQL database in the output:
+
+```
+Name     Description         Labels
+-------- ------------------- --------
+cloudsql GCP Cloud SQL MySQL env=dev
+```
+
+If the database does not appear, verify your Teleport role permissions. See the [RBAC](../../rbac.mdx) guide.
+
+</Checkpoint>
 
 ## Step 8/9. Create a Teleport user
 

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/postgres-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/postgres-cloudsql.mdx
@@ -40,9 +40,25 @@ page_type: how-to
 
 (!docs/pages/includes/database-access/cloudsql-create-service-account-for-db-service.mdx!)
 
+Alternatively, create the service account using the `gcloud` CLI:
+
+```code
+$ gcloud iam service-accounts create teleport-db-service \
+    --display-name="Teleport Database Service" \
+    --project=<Var name="project-id" />
+```
+
 ### (Optional) Grant permissions
 
 (!docs/pages/includes/database-access/cloudsql_grant_db_service_account.mdx!)
+
+To grant these permissions via the CLI instead:
+
+```code
+$ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
+    --member="serviceAccount:teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com" \
+    --role="roles/cloudsql.client"
+```
 
 ## Step 2/9. Create a service account for a database user
 
@@ -50,9 +66,57 @@ Teleport uses service accounts to connect to Cloud SQL databases.
 
 (!docs/pages/includes/database-access/cloudsql_create_db_user_account.mdx!)
 
+Alternatively, create the database user service account using the CLI:
+
+```code
+$ gcloud iam service-accounts create cloudsql-user \
+    --display-name="Cloud SQL Database User" \
+    --project=<Var name="project-id" />
+```
+
 (!docs/pages/includes/database-access/cloudsql_grant_db_user.mdx!)
 
+To grant via the CLI instead:
+
+```code
+$ gcloud projects add-iam-policy-binding <Var name="project-id" /> \
+    --member="serviceAccount:cloudsql-user@<Var name="project-id" />.iam.gserviceaccount.com" \
+    --role="roles/cloudsql.instanceUser"
+```
+
 (!docs/pages/includes/database-access/cloudsql-grant-impersonation.mdx!)
+
+To grant impersonation via the CLI instead:
+
+```code
+$ gcloud iam service-accounts add-iam-policy-binding \
+    cloudsql-user@<Var name="project-id" />.iam.gserviceaccount.com \
+    --member="serviceAccount:teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com" \
+    --role="roles/iam.serviceAccountTokenCreator"
+```
+
+<Checkpoint
+  title="Verify service account impersonation"
+  description="Confirm that the Database Service account can impersonate the database user account."
+>
+
+Run:
+
+```code
+$ gcloud iam service-accounts get-iam-policy \
+    cloudsql-user@<Var name="project-id" />.iam.gserviceaccount.com
+```
+
+The output should include a binding that pairs `teleport-db-service` with `roles/iam.serviceAccountTokenCreator`:
+
+```yaml
+bindings:
+- members:
+  - serviceAccount:teleport-db-service@<project-id>.iam.gserviceaccount.com
+  role: roles/iam.serviceAccountTokenCreator
+```
+
+</Checkpoint>
 
 ## Step 3/9. Configure your Cloud SQL database
 
@@ -61,7 +125,17 @@ with Cloud SQL PostgreSQL instances.
 
 (!docs/pages/includes/database-access/cloudsql_enable_iam_auth.mdx type="PostgreSQL" flag="cloudsql.iam_authentication"!)
 
+To enable IAM authentication via the CLI instead:
+
+```code
+$ gcloud sql instances patch <Var name="instance-name" /> \
+    --database-flags=cloudsql.iam_authentication=on
+```
+
 ### Create a database user
+
+<Tabs>
+<TabItem label="Google Cloud console">
 
 Now go back to the Users page of your Cloud SQL instance and add a new user
 account. In the sidebar, choose "Cloud IAM" authentication type and add the
@@ -77,11 +151,35 @@ Press "Add" and your Users table should look similar to this:
 See [Creating and managing IAM users](https://cloud.google.com/sql/docs/postgres/create-manage-iam-users)
 in Google Cloud documentation for more info.
 
+</TabItem>
+<TabItem label="gcloud CLI">
+
+Create an IAM-based database user linked to your service account:
+
+```code
+$ gcloud sql users create cloudsql-user@<Var name="project-id" />.iam.gserviceaccount.com \
+    --instance=<Var name="instance-name" /> \
+    --type=CLOUD_IAM_SERVICE_ACCOUNT
+```
+
+</TabItem>
+</Tabs>
+
+<Admonition type="note" title="PostgreSQL IAM user naming convention">
+For Cloud SQL PostgreSQL, IAM database users use a `.iam` suffix when connecting.
+The database user name is the service account email with `.gserviceaccount.com`
+replaced by `.iam`. For example, `cloudsql-user@my-project.iam.gserviceaccount.com`
+becomes `cloudsql-user@my-project.iam` as the database user name in `tsh db connect`.
+</Admonition>
+
 ## Step 4/9. Install Teleport
 
 (!docs/pages/includes/install-linux.mdx!)
 
 ## Step 5/9. Configure the Teleport Database Service
+
+Run the commands in this step on the host where you will run the Teleport
+Database Service (e.g., a Compute Engine instance).
 
 ### Create a join token
 
@@ -99,9 +197,40 @@ in Google Cloud documentation for more info.
 
 (!docs/pages/includes/database-access/cloudsql_service_credentials.mdx serviceAccount="teleport-db-service"!)
 
+When running on a GCE instance, you can attach the `teleport-db-service` service
+account directly to the instance instead of using service account keys:
+
+```code
+$ gcloud compute instances set-service-account <Var name="gce-instance-name" /> \
+    --service-account=teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com \
+    --scopes=https://www.googleapis.com/auth/cloud-platform \
+    --zone=<Var name="zone" />
+```
+
 ## Step 7/9. Start the Teleport Database Service
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
+
+<Checkpoint
+  title="Verify the Database Service joined the cluster"
+  description="Confirm that the Teleport Database Service is running and has joined the cluster."
+>
+
+```code
+$ tsh db ls
+```
+
+You should see your Cloud SQL PostgreSQL database in the output:
+
+```
+Name     Description              Labels
+-------- ------------------------ --------
+cloudsql GCP Cloud SQL PostgreSQL env=dev
+```
+
+If the database does not appear, verify your Teleport role permissions. See the [RBAC](../../rbac.mdx) guide.
+
+</Checkpoint>
 
 ## Step 8/9. Create a Teleport user
 

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/spanner.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/spanner.mdx
@@ -38,6 +38,16 @@ page_type: how-to
   with outbound HTTPS access to `spanner.googleapis.com:443`
 - (!docs/pages/includes/tctl.mdx!)
 
+<Admonition type="tip" title="Discover your GCP project and Spanner instance">
+If you are unsure of your GCP project ID or Spanner instance ID, run:
+
+```code
+$ gcloud config get-value project
+$ gcloud spanner instances list --format="table(name,displayName,state)"
+```
+
+</Admonition>
+
 ## Step 1/6. Create service accounts
 
 Teleport requires two types of Google Cloud service accounts:
@@ -81,7 +91,7 @@ This account represents a database user. Teleport users specify this name when c
 1. Click **Create Service Account**.
 1. Set the name to `spanner-user`.
 1. Skip optional steps and click **Done**. You will grant permissions later.
-=
+
 </TabItem>
 
 <TabItem label="gcloud CLI">
@@ -92,6 +102,20 @@ $ gcloud iam service-accounts create spanner-user --display-name="Spanner User"
 
 </TabItem>
 </Tabs>
+
+<Checkpoint
+  title="Verify service accounts were created"
+  description="Confirm that both service accounts exist in your project."
+>
+
+```code
+$ gcloud iam service-accounts list --format="table(email,displayName)" \
+    --filter="email:(teleport-db-service@ OR spanner-user@)"
+```
+
+You should see both `teleport-db-service` and `spanner-user` in the output.
+
+</Checkpoint>
 
 ## Step 2/6. Grant permissions
 
@@ -113,6 +137,14 @@ to impersonate the database user account.
 </TabItem>
 
 <TabItem label="gcloud CLI">
+
+<Admonition type="tip" title="Discover your Spanner instance ID">
+
+```code
+$ gcloud spanner instances list --format="table(name,displayName,state)"
+```
+
+</Admonition>
 
 ```code
 $ gcloud spanner instances add-iam-policy-binding <Var name="instance-id" /> \
@@ -180,6 +212,10 @@ bindings:
 
 ## Step 3/6. Install and configure the Teleport Database Service
 
+<Admonition type="note" title="Where to run commands">
+Run the commands in this step on the host where you will run the Teleport Database Service (e.g., a Compute Engine instance with outbound access to `spanner.googleapis.com:443`).
+</Admonition>
+
 (!docs/pages/includes/install-linux.mdx!)
 
 (!docs/pages/includes/tctl-token.mdx serviceName="Database" tokenType="db" tokenFile="/tmp/token" !)
@@ -192,6 +228,15 @@ or cloud-hosted Teleport Enterprise site.
 - <Var name="project-id"/> The GCP project ID. You can normally see it in the
 organization view at the top of the GCP dashboard.
 - <Var name="instance-id"/> The name of your Cloud Spanner instance.
+
+<Admonition type="tip" title="Discover placeholder values">
+
+```code
+$ gcloud config get-value project
+$ gcloud spanner instances list --format="table(name,displayName,state)"
+```
+
+</Admonition>
 
 ```code
 $ sudo teleport db configure create \
@@ -209,6 +254,23 @@ $ sudo teleport db configure create \
 ## Step 4/6. Configure GCP credentials
 
 (!docs/pages/includes/database-access/cloudsql_service_credentials.mdx serviceAccount="teleport-db-service"!)
+
+<Admonition type="tip" title="Recommended: use attached service accounts or workload identity">
+When running on a GCE instance, attach the `teleport-db-service` service account directly to the instance. This avoids creating and managing service account keys:
+
+```code
+$ gcloud compute instances set-service-account <Var name="gce-instance-name" /> \
+    --service-account=teleport-db-service@<Var name="project-id" />.iam.gserviceaccount.com \
+    --scopes=https://www.googleapis.com/auth/cloud-platform \
+    --zone=<Var name="zone" />
+```
+
+For workloads running outside of GCP (e.g., on-premises or other clouds), use
+[Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+instead of service account keys. Workload Identity Federation lets you exchange
+an external identity token for a short-lived GCP access token without storing
+long-lived credentials.
+</Admonition>
 
 ## Step 5/6. Start the Teleport Database Service
 
@@ -253,6 +315,15 @@ $ tsh login --proxy=<Var name="example.teleport.sh" /> --user=<Var name="example
 
 Connect using the service account name (without the domain suffix):
 (Note: `--db-name` here refers to the specific database ID within your Spanner instance.)
+
+<Admonition type="tip" title="Discover your Spanner database name">
+
+```code
+$ gcloud spanner databases list --instance=<Var name="instance-id" /> \
+    --format="table(name,state)"
+```
+
+</Admonition>
 
 ```code
 $ tsh db connect --db-user=spanner-user --db-name=database-name spanner-example

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/spanner.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/spanner.mdx
@@ -38,15 +38,12 @@ page_type: how-to
   with outbound HTTPS access to `spanner.googleapis.com:443`
 - (!docs/pages/includes/tctl.mdx!)
 
-<Admonition type="tip" title="Discover your GCP project and Spanner instance">
-If you are unsure of your GCP project ID or Spanner instance ID, run:
+To find your GCP project ID or Spanner instance ID, run:
 
 ```code
 $ gcloud config get-value project
 $ gcloud spanner instances list --format="table(name,displayName,state)"
 ```
-
-</Admonition>
 
 ## Step 1/6. Create service accounts
 
@@ -138,13 +135,11 @@ to impersonate the database user account.
 
 <TabItem label="gcloud CLI">
 
-<Admonition type="tip" title="Discover your Spanner instance ID">
+To find your Spanner instance ID, run:
 
 ```code
 $ gcloud spanner instances list --format="table(name,displayName,state)"
 ```
-
-</Admonition>
 
 ```code
 $ gcloud spanner instances add-iam-policy-binding <Var name="instance-id" /> \
@@ -212,9 +207,7 @@ bindings:
 
 ## Step 3/6. Install and configure the Teleport Database Service
 
-<Admonition type="note" title="Where to run commands">
 Run the commands in this step on the host where you will run the Teleport Database Service (e.g., a Compute Engine instance with outbound access to `spanner.googleapis.com:443`).
-</Admonition>
 
 (!docs/pages/includes/install-linux.mdx!)
 
@@ -229,14 +222,12 @@ or cloud-hosted Teleport Enterprise site.
 organization view at the top of the GCP dashboard.
 - <Var name="instance-id"/> The name of your Cloud Spanner instance.
 
-<Admonition type="tip" title="Discover placeholder values">
+To discover these placeholder values, run:
 
 ```code
 $ gcloud config get-value project
 $ gcloud spanner instances list --format="table(name,displayName,state)"
 ```
-
-</Admonition>
 
 ```code
 $ sudo teleport db configure create \
@@ -255,8 +246,7 @@ $ sudo teleport db configure create \
 
 (!docs/pages/includes/database-access/cloudsql_service_credentials.mdx serviceAccount="teleport-db-service"!)
 
-<Admonition type="tip" title="Recommended: use attached service accounts or workload identity">
-When running on a GCE instance, attach the `teleport-db-service` service account directly to the instance. This avoids creating and managing service account keys:
+When running on a GCE instance, we recommend attaching the `teleport-db-service` service account directly to the instance. This avoids creating and managing service account keys:
 
 ```code
 $ gcloud compute instances set-service-account <Var name="gce-instance-name" /> \
@@ -270,7 +260,6 @@ For workloads running outside of GCP (e.g., on-premises or other clouds), use
 instead of service account keys. Workload Identity Federation lets you exchange
 an external identity token for a short-lived GCP access token without storing
 long-lived credentials.
-</Admonition>
 
 ## Step 5/6. Start the Teleport Database Service
 
@@ -316,14 +305,12 @@ $ tsh login --proxy=<Var name="example.teleport.sh" /> --user=<Var name="example
 Connect using the service account name (without the domain suffix):
 (Note: `--db-name` here refers to the specific database ID within your Spanner instance.)
 
-<Admonition type="tip" title="Discover your Spanner database name">
+To find your Spanner database name, run:
 
 ```code
 $ gcloud spanner databases list --instance=<Var name="instance-id" /> \
     --format="table(name,state)"
 ```
-
-</Admonition>
 
 ```code
 $ tsh db connect --db-user=spanner-user --db-name=database-name spanner-example


### PR DESCRIPTION
## Summary

Fixes for guide-following medium and high-level blockers surfaced by Beams agent testing of GCP-related documentation. Changes add CLI alternatives for GUI-only steps, missing critical steps, `<Checkpoint>` verification blocks, and "Run on:" markers for multi-machine orchestration that tripped up autonomous runs.

## Changes

- **google-cloud.mdx**: Added bold "Run on:" markers distinguishing workstation vs.
  Application Service host commands, gcloud compute ssh connection instructions, token
  transfer methods between machines, and decision guidance for choosing between
  authentication approaches.

-  **gke-discovery.mdx**: Added Workload Identity as a non-destructive alternative to VM
  stop/restart for credential attachment, a batch script for applying RBAC across all
  discovered clusters, discovery commands for placeholder values, and <Checkpoint> blocks
  after credential attachment and discovery verification.

- **gcp-discovery.mdx**: Added batch guest-attribute enablement commands (project-wide and
  per-instance), replaced empty placeholder arrays with realistic example values,
  documented the host key bootstrap flow with multiple methods (batch/startup script/SSH),
   and added <Checkpoint> blocks after instance preparation.

- **gcp-tags.mdx**: Added the critical missing Step 2/3 for attaching the service account to
  the VM (gcloud compute instances set-service-account) with both CLI and Console tabs, a
  <Checkpoint> verifying attachment, and a troubleshooting section for when labels don't
  appear.

-  **alloydb.mdx:** Added discovery tips for the 4-component URI format (project, region,
  cluster, instance), <Checkpoint> blocks after impersonation setup and IAM user creation,
   and the .iam suffix naming convention note.

- **mysql-cloudsql.mdx**: Added <Admonition type="tip" title="CLI alternative"> blocks with
  gcloud equivalents after each GUI-only include (service account creation, role
  assignment, IAM auth enablement, database user creation), and wrapped the inline "Create
   a database user" section in Tabs with a CLI option.

- **postgres-cloudsql.mdx**: Added gcloud CLI alternatives for service account creation, role
  assignment, IAM auth enablement, and database user creation alongside the existing
  Console instructions, a <Checkpoint> after impersonation setup and service join, the
  .iam suffix naming convention note for PostgreSQL IAM users, and the recommended
  attached-service-account credential method.

- **spanner.mdx**: Added discovery tips for Spanner instance ID and project ID, a <Checkpoint>
   after service account creation, and a recommendation for Workload Identity Federation
  over service account keys in the credentials step.