### PR TITLE
Fix request.reason.mode calcuation for glob and claims_to_roles expressions

### DIFF
--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1142,9 +1142,9 @@ type RequestValidator struct {
 	// requireReasonForAllRoles indicates that non-empty reason is required for all access
 	// requests. This happens if any of the user roles has options.request_access "reason".
 	requireReasonForAllRoles bool
-	// reasonRequiredMatchers holds groups of role matchers that require a non-empty reason to
-	// be specified when a matching role is requested. The same applies to all requested
-	// resources allowed by those roles. Each group is compiled from spec.allow.request.roles
+	// reasonRequiredMatchers holds role matchers that require a non-empty reason to be
+	// specified when a matching role is requested. The same applies to all requested
+	// resources allowed by those roles. The matchers are compiled from spec.allow.request.roles
 	// (including claims_to_roles) and spec.allow.request.search_as_roles of a role assigned to
 	// the user that has spec.allow.request.reason.mode="required" set. Using matchers rather
 	// than literal role names ensures wildcard, regexp and claims_to_roles entries are honored.
@@ -1153,7 +1153,7 @@ type RequestValidator struct {
 	// necessarily require reason when they are requested themselves. Instead they mark roles
 	// in spec.allow.request.roles and spec.allow.request.search_as_roles as roles requiring
 	// reason.
-	reasonRequiredMatchers [][]parse.Matcher
+	reasonRequiredMatchers []parse.Matcher
 	// customPromptRoles is a set of role names, which specifies a custom prompt when requested.
 	// Such roles are all requestable roles and search_as_roles allowed by a user's role
 	// which has spec.allow.request.reason.prompt set.
@@ -1553,10 +1553,8 @@ func (v *RequestValidator) isReasonRequired(ctx context.Context, requestedRoles 
 	}
 
 	for _, r := range allApplicableRoles {
-		for _, matchers := range v.reasonRequiredMatchers {
-			if matchesAnyRole(matchers, r) {
-				return true, fmt.Sprintf("request reason must be specified (required for role %q)", r), nil
-			}
+		if matchesAnyRole(v.reasonRequiredMatchers, r) {
+			return true, fmt.Sprintf("request reason must be specified (required for role %q)", r), nil
 		}
 	}
 
@@ -1913,7 +1911,7 @@ func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
 
 	if allow.Reason != nil {
 		if allow.Reason.Mode.Required() {
-			m.reasonRequiredMatchers = append(m.reasonRequiredMatchers, allNewAllowMatchers)
+			m.reasonRequiredMatchers = append(m.reasonRequiredMatchers, allNewAllowMatchers...)
 		}
 
 		customPrompt := strings.TrimSpace(allow.Reason.Prompt)

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1904,17 +1904,16 @@ func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
 	m.roles.allowSearch = apiutils.Deduplicate(append(m.roles.allowSearch, allow.SearchAsRoles...))
 	m.roles.denySearch = apiutils.Deduplicate(append(m.roles.denySearch, deny.SearchAsRoles...))
 
+	newAllowRequestMatchers := m.roles.allowRequest[astart:]
+	newAllowSearchMatchers := literalMatchers(allow.SearchAsRoles)
+
+	allNewAllowMatchers := make([]parse.Matcher, 0, len(newAllowRequestMatchers)+len(newAllowSearchMatchers))
+	allNewAllowMatchers = append(allNewAllowMatchers, newAllowRequestMatchers...)
+	allNewAllowMatchers = append(allNewAllowMatchers, newAllowSearchMatchers...)
+
 	if allow.Reason != nil {
 		if allow.Reason.Mode.Required() {
-			// Roles requiring a reason are matched against the requested/applicable roles
-			// using the same matchers that decide whether a role is requestable at all.
-			// Building the matchers from the just-appended allow.Roles matchers (which fold
-			// in claims_to_roles, wildcards and regexps) plus the search_as_roles ensures
-			// those forms are honored, not only literal role names.
-			reasonMatchers := make([]parse.Matcher, 0, len(m.roles.allowRequest[astart:])+len(allow.SearchAsRoles))
-			reasonMatchers = append(reasonMatchers, m.roles.allowRequest[astart:]...)
-			reasonMatchers = append(reasonMatchers, literalMatchers(allow.SearchAsRoles)...)
-			m.reasonRequiredMatchers = append(m.reasonRequiredMatchers, reasonMatchers)
+			m.reasonRequiredMatchers = append(m.reasonRequiredMatchers, allNewAllowMatchers)
 		}
 
 		customPrompt := strings.TrimSpace(allow.Reason.Prompt)
@@ -1932,13 +1931,6 @@ func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
 		// if this role added additional allow matchers, then we need to record the relationship
 		// between its matchers and its thresholds. This information is used later to calculate
 		// the rtm and threshold list.
-		newAllowRequestMatchers := m.roles.allowRequest[astart:]
-		newAllowSearchMatchers := literalMatchers(allow.SearchAsRoles)
-
-		allNewAllowMatchers := make([]parse.Matcher, 0, len(newAllowRequestMatchers)+len(newAllowSearchMatchers))
-		allNewAllowMatchers = append(allNewAllowMatchers, newAllowRequestMatchers...)
-		allNewAllowMatchers = append(allNewAllowMatchers, newAllowSearchMatchers...)
-
 		if len(allNewAllowMatchers) > 0 {
 			m.thresholdMatchers = append(m.thresholdMatchers, struct {
 				matchers   []parse.Matcher

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1142,16 +1142,18 @@ type RequestValidator struct {
 	// requireReasonForAllRoles indicates that non-empty reason is required for all access
 	// requests. This happens if any of the user roles has options.request_access "reason".
 	requireReasonForAllRoles bool
-	// requiringReasonRoles is a set of role names, which require non-empty reason to be
-	// specified when requested. The same applies to all requested resources allowed by those
-	// roles. Such roles are all requestable roles and search_as_roles allowed by a role
-	// assigned to a user and having spec.allow.request.reason.mode="required" set.
+	// reasonRequiredMatchers holds groups of role matchers that require a non-empty reason to
+	// be specified when a matching role is requested. The same applies to all requested
+	// resources allowed by those roles. Each group is compiled from spec.allow.request.roles
+	// (including claims_to_roles) and spec.allow.request.search_as_roles of a role assigned to
+	// the user that has spec.allow.request.reason.mode="required" set. Using matchers rather
+	// than literal role names ensures wildcard, regexp and claims_to_roles entries are honored.
 	//
 	// Please note this means, roles having spec.allow.request.reason.mode="required" don't
 	// necessarily require reason when they are requested themselves. Instead they mark roles
 	// in spec.allow.request.roles and spec.allow.request.search_as_roles as roles requiring
 	// reason.
-	requiringReasonRoles map[string]struct{}
+	reasonRequiredMatchers [][]parse.Matcher
 	// customPromptRoles is a set of role names, which specifies a custom prompt when requested.
 	// Such roles are all requestable roles and search_as_roles allowed by a user's role
 	// which has spec.allow.request.reason.prompt set.
@@ -1209,12 +1211,11 @@ func NewRequestValidator(ctx context.Context, clock clockwork.Clock, getter Requ
 
 func NewRequestValidatorForUser(ctx context.Context, clock clockwork.Clock, getter RequestValidatorGetter, user UserState, opts ...ValidateRequestOption) (RequestValidator, error) {
 	m := RequestValidator{
-		logger:               slog.With(teleport.ComponentKey, "request.validator"),
-		clock:                clock,
-		getter:               getter,
-		userState:            user,
-		requiringReasonRoles: make(map[string]struct{}),
-		customPromptRoles:    make(map[string]string),
+		logger:            slog.With(teleport.ComponentKey, "request.validator"),
+		clock:             clock,
+		getter:            getter,
+		userState:         user,
+		customPromptRoles: make(map[string]string),
 	}
 	for _, opt := range opts {
 		opt(&m.opts)
@@ -1552,12 +1553,24 @@ func (v *RequestValidator) isReasonRequired(ctx context.Context, requestedRoles 
 	}
 
 	for _, r := range allApplicableRoles {
-		if _, ok := v.requiringReasonRoles[r]; ok {
-			return true, fmt.Sprintf("request reason must be specified (required for role %q)", r), nil
+		for _, matchers := range v.reasonRequiredMatchers {
+			if matchesAnyRole(matchers, r) {
+				return true, fmt.Sprintf("request reason must be specified (required for role %q)", r), nil
+			}
 		}
 	}
 
 	return false, "", nil
+}
+
+// matchesAnyRole reports whether the role name matches any of the given matchers.
+func matchesAnyRole(matchers []parse.Matcher, role string) bool {
+	for _, matcher := range matchers {
+		if matcher.Match(role) {
+			return true
+		}
+	}
+	return false
 }
 
 func (v *RequestValidator) populateCustomReasonPrompts(ctx context.Context, requestedRoles []string, requestedResourceAccessIDs []types.ResourceAccessID) error {
@@ -1868,27 +1881,6 @@ func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
 
 	allow, deny := role.GetAccessRequestConditions(types.Allow), role.GetAccessRequestConditions(types.Deny)
 
-	if allow.Reason != nil {
-		if allow.Reason.Mode.Required() {
-			for _, r := range allow.Roles {
-				m.requiringReasonRoles[r] = struct{}{}
-			}
-			for _, r := range allow.SearchAsRoles {
-				m.requiringReasonRoles[r] = struct{}{}
-			}
-		}
-
-		customPrompt := strings.TrimSpace(allow.Reason.Prompt)
-		if len(customPrompt) > 0 {
-			for _, r := range allow.Roles {
-				m.customPromptRoles[r] = customPrompt
-			}
-			for _, r := range allow.SearchAsRoles {
-				m.customPromptRoles[r] = customPrompt
-			}
-		}
-	}
-
 	// NOTE: Not using allow.KubernetesResources as we need to map older roles to new values.
 	setAllowRequestKubeResourceLookup(role.GetRequestKubernetesResources(types.Allow), allow.SearchAsRoles, m.kubernetesResource.allow)
 
@@ -1911,6 +1903,30 @@ func (m *RequestValidator) push(ctx context.Context, role types.Role) error {
 
 	m.roles.allowSearch = apiutils.Deduplicate(append(m.roles.allowSearch, allow.SearchAsRoles...))
 	m.roles.denySearch = apiutils.Deduplicate(append(m.roles.denySearch, deny.SearchAsRoles...))
+
+	if allow.Reason != nil {
+		if allow.Reason.Mode.Required() {
+			// Roles requiring a reason are matched against the requested/applicable roles
+			// using the same matchers that decide whether a role is requestable at all.
+			// Building the matchers from the just-appended allow.Roles matchers (which fold
+			// in claims_to_roles, wildcards and regexps) plus the search_as_roles ensures
+			// those forms are honored, not only literal role names.
+			reasonMatchers := make([]parse.Matcher, 0, len(m.roles.allowRequest[astart:])+len(allow.SearchAsRoles))
+			reasonMatchers = append(reasonMatchers, m.roles.allowRequest[astart:]...)
+			reasonMatchers = append(reasonMatchers, literalMatchers(allow.SearchAsRoles)...)
+			m.reasonRequiredMatchers = append(m.reasonRequiredMatchers, reasonMatchers)
+		}
+
+		customPrompt := strings.TrimSpace(allow.Reason.Prompt)
+		if len(customPrompt) > 0 {
+			for _, r := range allow.Roles {
+				m.customPromptRoles[r] = customPrompt
+			}
+			for _, r := range allow.SearchAsRoles {
+				m.customPromptRoles[r] = customPrompt
+			}
+		}
+	}
 
 	if m.opts.expandVars {
 		// if this role added additional allow matchers, then we need to record the relationship

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -2927,6 +2927,41 @@ func TestReasonRequired(t *testing.T) {
 				},
 			},
 		},
+		// The following roles exercise reason.mode="required" when the requestable
+		// roles are expressed as a wildcard, a regexp, or via claims_to_roles rather
+		// than as a literal role name (see issue #54397).
+		"fork-access-requester-with-reason-wildcard": {
+			Allow: types.RoleConditions{
+				Request: &types.AccessRequestConditions{
+					Roles: []string{"fork-*"},
+					Reason: &types.AccessRequestConditionsReason{
+						Mode: "required",
+					},
+				},
+			},
+		},
+		"fork-access-requester-with-reason-regexp": {
+			Allow: types.RoleConditions{
+				Request: &types.AccessRequestConditions{
+					Roles: []string{"^fork-.*$"},
+					Reason: &types.AccessRequestConditionsReason{
+						Mode: "required",
+					},
+				},
+			},
+		},
+		"fork-access-requester-with-reason-claims": {
+			Allow: types.RoleConditions{
+				Request: &types.AccessRequestConditions{
+					ClaimsToRoles: []types.ClaimMapping{
+						{Claim: "logins", Value: "*", Roles: []string{"fork-access"}},
+					},
+					Reason: &types.AccessRequestConditionsReason{
+						Mode: "required",
+					},
+				},
+			},
+		},
 	}
 	for name, spec := range roleDesc {
 		role, err := types.NewRole(name, spec)
@@ -3030,6 +3065,24 @@ func TestReasonRequired(t *testing.T) {
 			name:         "role request: handle wildcard",
 			currentRoles: []string{"fork-access-requester-with-reason"},
 			requestRoles: []string{"*"},
+			expectError:  trace.BadParameter(`request reason must be specified (required for role "fork-access")`),
+		},
+		{
+			name:         "role request: require reason when reason.required role uses a wildcard matcher",
+			currentRoles: []string{"fork-access-requester-with-reason-wildcard"},
+			requestRoles: []string{"fork-access"},
+			expectError:  trace.BadParameter(`request reason must be specified (required for role "fork-access")`),
+		},
+		{
+			name:         "role request: require reason when reason.required role uses a regexp matcher",
+			currentRoles: []string{"fork-access-requester-with-reason-regexp"},
+			requestRoles: []string{"fork-access"},
+			expectError:  trace.BadParameter(`request reason must be specified (required for role "fork-access")`),
+		},
+		{
+			name:         "role request: require reason when reason.required role derives roles from claims_to_roles",
+			currentRoles: []string{"fork-access-requester-with-reason-claims"},
+			requestRoles: []string{"fork-access"},
 			expectError:  trace.BadParameter(`request reason must be specified (required for role "fork-access")`),
 		},
 		{


### PR DESCRIPTION
Closes #54397
Closes gravitational/customer-sensitive-requests#700



### What

The `request.reason.mode: required` force a user to provide a Access Request Description. The option is configurable and make forces a JIT issuer to provided desc why he is requesting access. 

The current functionality was  only checking literal value equlity instead of `regexp` and `claims_to_roles` matching rules. 


### Why  we match the `mode: required` agains` regexp` or `claims_to_roles`  ? 

This is needed because the the by default support regexp and claims_to_roles that and this cases where missing from intimal requested reason functionality: 



https://goteleport.com/docs/identity-governance/access-requests/access-request-configuration/#requiring-request-reasons





<!-- Provide a descriptive entry for the changelog of the next release. -->

changelog: Fixed access request reason requirement (request.reason.mode: required) being ignored when requestable roles were specified with a wildcard, regexp, or claims_to_roles instead of literal role names.


<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
local env 
### Test Cases
- [x] regexp match works: 
```
  kind: role
  version: v7
  metadata:
    name: regexp-requester
  spec:
    allow:
      request:
        roles: ['^critical-.*$']
        reason:
          mode: required
  ```
- [x] Glob match works: 
 ```
  kind: role
  version: v7
  metadata:
    name: wildcard-requester
  spec:
    allow:
      request:
        roles: ['critical-*']
        reason:
          mode: required
```
- [x] Claims to roles evaluation works:
```
  kind: role
  version: v7
  metadata:
    name: claims-requester
  spec:
    allow:
      request:
        claims_to_roles:
          - claim: 'logins'
            value: '*'
            roles: ['critical-access']
        reason:
          mode: required
  ```


TODO: 
- [ ] Update docs. 