### PR TITLE
[v18] gha: use kvstore instead of secrets/variables

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -26,6 +26,7 @@ permissions:
     repository-projects: none
     security-events: none
     statuses: none
+    id-token: write
 
 jobs:
   auto-request-review:
@@ -33,17 +34,25 @@ jobs:
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          values: |
+            REVIEWERS,secret
       # Checkout main branch of shared-workflow repository.
       - name: Checkout shared-workflow
         uses: actions/checkout@v4
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Assigning reviewers
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=assign -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=assign -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ env.REVIEWERS }}"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -28,7 +28,7 @@ jobs:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
           values: |
-            BACKPORT_APP_ID,secret
+            BACKPORT_APP_ID,variable
             BACKPORT_PRIVATE_KEY,secret
             REVIEWERS,secret
       - name: Generate GitHub Token

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -23,21 +23,20 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   BACKPORT_APP_ID,secret
-          #   BACKPORT_PRIVATE_KEY,secret
+          values: |
+            BACKPORT_APP_ID,secret
+            BACKPORT_PRIVATE_KEY,secret
+            REVIEWERS,secret
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.BACKPORT_APP_ID }}
-          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
+          app-id: ${{ env.BACKPORT_APP_ID }}
+          private-key: ${{ env.BACKPORT_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -49,11 +48,11 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
         # Run "backport" subcommand on bot.
       - name: Backport PR
-        run: ( cd .github/shared-workflows/bot && go build ) && .github/shared-workflows/bot/bot -workflow=backport -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"
+        run: ( cd .github/shared-workflows/bot && go build ) && .github/shared-workflows/bot/bot -workflow=backport -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}"

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
@@ -60,7 +60,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Setup base cache
         uses: actions/cache/restore@v3
@@ -111,7 +111,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Build Binaries
         id: build_branch

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -43,10 +43,10 @@ jobs:
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
           existing-gh-secrets: "${{ toJSON(secrets) }}"
           existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
+            REVIEWERS,secret
       - name: Checkout base
         uses: actions/checkout@v3 # Cannot upgrade to v4 while this runs in centos:7 due to nodejs GLIBC incompatibility
         with:
@@ -74,8 +74,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1.0.5 # Cannot upgrade past v1.1 while this runs in centos:7 due to nodejs GLIBC incompatibility
         with:
-          app_id: ${{ secrets.REVIEWERS_APP_ID }}
-          private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
       - if: ${{ steps.cache-build-restore.outputs.cache-hit != 'true' }}
         name: Build base
@@ -132,4 +132,4 @@ jobs:
         id: check_branch_bloat
         run: |
           current=$(pwd)/build
-          cd .github/shared-workflows/bot && go run main.go -workflow=bloat --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport,sessionhelper" --base="${base_stats}" --builddir="${current}" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}" > $GITHUB_STEP_SUMMARY
+          cd .github/shared-workflows/bot && go run main.go -workflow=bloat --artifacts="tbot,tctl,teleport,tsh,teleport-update,fdpass-teleport,sessionhelper" --base="${base_stats}" --builddir="${current}" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}" > $GITHUB_STEP_SUMMARY

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -41,8 +41,6 @@ jobs:
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
           values: |
             REVIEWERS_APP_ID,variable
             REVIEWERS_PRIVATE_KEY,secret

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -72,8 +72,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1.0.5 # Cannot upgrade past v1.1 while this runs in centos:7 due to nodejs GLIBC incompatibility
         with:
-          app-id: ${{ env.REVIEWERS_APP_ID }}
-          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
+          app_id: ${{ env.REVIEWERS_APP_ID }}
+          private_key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
       - if: ${{ steps.cache-build-restore.outputs.cache-hit != 'true' }}
         name: Build base

--- a/.github/workflows/build-usage-image.yaml
+++ b/.github/workflows/build-usage-image.yaml
@@ -11,14 +11,12 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   TELEPORT_USAGE_IAM_ROLE_ARN,secret
+          values: |
+            TELEPORT_USAGE_IAM_ROLE_ARN,variable
       # This step is used to extract the version of the usage script.
       - name: Trim leading v in release
         id: version
@@ -28,7 +26,7 @@ jobs:
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       - uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
-          role-to-assume: ${{ secrets.TELEPORT_USAGE_IAM_ROLE_ARN }}
+          role-to-assume: ${{ env.TELEPORT_USAGE_IAM_ROLE_ARN }}
           aws-region: us-east-1
       - uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,10 +29,10 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
       - name: Validate the changelog entry
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=changelog -token="${{ secrets.GITHUB_TOKEN }}" -reviewers='{}'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -38,33 +38,31 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
+            REVIEWERS,secret
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.REVIEWERS_APP_ID }}
-          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
       # Checkout main branch of shared-workflow repository.
       - name: Checkout shared-workflow
         uses: actions/checkout@v4
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Checking reviewers
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=check -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}"

--- a/.github/workflows/cla-assistant.yaml
+++ b/.github/workflows/cla-assistant.yaml
@@ -8,7 +8,7 @@ on:
       - opened
       - synchronize # Run on any diff changes to the PR (e.g. code updates)
   # merge_group will allow this workflow to be triggered when in merge queue.
-  # The job will end up being skipped due to conditionals below. This will be considered a "Success" 
+  # The job will end up being skipped due to conditionals below. This will be considered a "Success"
   # for the required check as the workflow was triggered but the job was skipped due to conditionals
   # See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   merge_group:
@@ -17,6 +17,8 @@ permissions:
   actions: read
   contents: read # this can be 'read' if the signatures are in remote repository
   pull-requests: write
+  id-token: write
+
 jobs:
   cla-assistant:
     # Only do job for pull requests. For issues this is skipped making workflow a no-op
@@ -24,12 +26,21 @@ jobs:
     name: "Check Contributor License Agreement Signed"
     runs-on: ubuntu-latest
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          values: |
+            CLA_ASSISTANT_APP_ID,variable
+            CLA_ASSISTANT_APP_PRIVATE_KEY,secret
       - name: Fetch installation token
         id: fetch-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.CLA_ASSISTANT_APP_ID }}
-          private-key: ${{ secrets.CLA_ASSISTANT_APP_PRIVATE_KEY }}
+          app-id: ${{ env.CLA_ASSISTANT_APP_ID }}
+          private-key: ${{ env.CLA_ASSISTANT_APP_PRIVATE_KEY }}
           repositories: cla-signatures
       - name: "Determine gravitational membership"
         id: get-membership
@@ -47,14 +58,14 @@ jobs:
       # Otherwise for those out of the gravitational org:
       # * CLA Assistant gathers authors from commits made to the PR
       # * Will determine if authors have already signed the CLA
-      # 
+      #
       # To sign the CLA a user can reply to the PR with the comment:
       # * 'I have read the CLA Document and I hereby sign the CLA'
       #
       # The workflow will be rerun again to perform a recheck on:
       # * Any code changes to the PR
       # * PR comment with the body being 'recheck' - In the event of a transient failure
-      # * PR comment with body 'I have read the CLA Document and I hereby sign the CLA' 
+      # * PR comment with body 'I have read the CLA Document and I hereby sign the CLA'
       - name: "CLA Assistant"
         if: steps.get-membership.outcome != 'success' && ((github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target')
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1

--- a/.github/workflows/dismiss.yaml
+++ b/.github/workflows/dismiss.yaml
@@ -43,11 +43,11 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
         # Run "dismiss" subcommand on bot.
       - name: Dismiss
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=dismiss -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=dismiss -token="${{ secrets.GITHUB_TOKEN }}" -reviewers='{}'

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -52,16 +52,13 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
 
       - name: Check out teleport
         uses: actions/checkout@v4
@@ -79,15 +76,19 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.REVIEWERS_APP_ID }}
-          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
+
+      - name: Clear runtime values
+        id: clear_kvstore_env
+        run: echo "REVIEWERS_PRIVATE_KEY=" >> $GITHUB_ENV
 
       - name: Check out shared-workflows
         uses: actions/checkout@v4
         with:
           repository: gravitational/shared-workflows
           path: shared-workflows
-          ref: 6f388765b8ce993721502083c74cb9af1fc5658f
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Install Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -98,8 +99,7 @@ jobs:
       - name: Ensure docs changes include redirects
         env:
           TOKEN: ${{ steps.generate_token.outputs.token }}
-          REVIEWERS: ${{ secrets.reviewers }}
-        run: cd shared-workflows/bot && go run main.go -workflow=docpaths -token="${TOKEN}" -teleport-path="${GITHUB_WORKSPACE}/teleport" -reviewers="${REVIEWERS}"
+        run: cd shared-workflows/bot && go run main.go -workflow=docpaths -token="${TOKEN}" -teleport-path="${GITHUB_WORKSPACE}/teleport" -reviewers='{}'
 
       - name: Install Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -22,8 +22,6 @@ jobs:
       with:
         cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
         cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-        existing-gh-secrets: "${{ toJSON(secrets) }}"
-        existing-gh-variables: "${{ toJSON(vars) }}"
         values: |
           AMPLIFY_APP_IDS,variable
           IAM_ROLE,variable

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Get runtime values from kvstore
       id: kvstore
-      uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+      uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
       with:
         cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
         cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -24,21 +24,21 @@ jobs:
         cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
         existing-gh-secrets: "${{ toJSON(secrets) }}"
         existing-gh-variables: "${{ toJSON(vars) }}"
-        # values: |
-        #   AMPLIFY_APP_IDS,variable
-        #   IAM_ROLE,variable
+        values: |
+          AMPLIFY_APP_IDS,variable
+          IAM_ROLE,variable
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4
       with:
         aws-region: us-west-2
-        role-to-assume: ${{ vars.IAM_ROLE }}
+        role-to-assume: ${{ env.IAM_ROLE }}
 
     - name: Create Amplify preview environment
       uses: gravitational/shared-workflows/tools/amplify-preview@b90d744feb39522329fba9c7764a4fe07d039d29 # tools/amplify-preview/v0.0.3
       id: amplify_preview
       with:
-        app_ids: ${{ vars.AMPLIFY_APP_IDS }}
+        app_ids: ${{ env.AMPLIFY_APP_IDS }}
         create_branches: "true"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         wait: "true"

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -49,19 +49,6 @@ jobs:
           - 3379:3379
 
     steps:
-      - name: Get runtime values from kvstore
-        id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
-        with:
-          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
-          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   REVIEWERS_APP_ID,secret
-          #   REVIEWERS_PRIVATE_KEY,secret
-          #   REVIEWERS,secret
-
       - name: Checkout Teleport
         uses: actions/checkout@v4
         with:
@@ -76,23 +63,40 @@ jobs:
       - name: Prepare unit tests
         run: make test-go-prepare
 
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
+            REVIEWERS,secret
+
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.REVIEWERS_APP_ID }}
-          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
       - name: Checkout shared-workflows
         uses: actions/checkout@v4
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Find excluded tests
         id: find_excluded
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=exclude-flakes -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=exclude-flakes -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ env.REVIEWERS }}"
+
+      - name: Clear runtime values
+        id: clear_kvstore_env
+        run: |
+            echo "REVIEWERS=" >> $GITHUB_ENV
+            echo "REVIEWERS_PRIVATE_KEY=" >> $GITHUB_ENV
 
       - name: Run base difftest
         uses: ./.github/actions/difftest

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -39,11 +39,11 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
       - name: Installing Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
         # Run "check" subcommand on bot.
       - name: Labeling PR
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=label -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=label -token="${{ secrets.GITHUB_TOKEN }}" -reviewers='{}'

--- a/.github/workflows/manual-test-plan.yaml
+++ b/.github/workflows/manual-test-plan.yaml
@@ -43,25 +43,35 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19
 
     steps:
+      - name: Get runtime values from kvstore
+        id: kvstore
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
+        with:
+          cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
+          cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
+          values: |
+            REVIEWERS_APP_ID,variable
+            REVIEWERS_PRIVATE_KEY,secret
       - name: Checkout shared-workflows
         uses: actions/checkout@v6
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 02af65890b521ecdf79856c00f6d2c875bf40ea3 # workflows/v0.0.5
+          ref: 986f92841a4f032e262477e5bb15f214d50b1015 # workflows/v0.0.6
 
       - name: Generate GitHub Token
         id: generate_token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.REVIEWERS_APP_ID }}
-          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+          app-id: ${{ env.REVIEWERS_APP_ID }}
+          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
       - name: Validate Test Plan
         id: validate_test_plan
-        run: cd .github/shared-workflows/bot && go run main.go -workflow=manual-test-plan -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=manual-test-plan -token="${{ steps.generate_token.outputs.token }}" -reviewers='{}'

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -30,11 +30,11 @@ jobs:
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
           existing-gh-secrets: "${{ toJSON(secrets) }}"
           existing-gh-variables: "${{ toJSON(vars) }}"
-          # values: |
-          #   AMPLIFY_DOCS_DEPLOY_HOOK,secret
+          values: |
+            AMPLIFY_DOCS_DEPLOY_HOOK,secret
       - name: Call deployment webhook
         env:
-          WEBHOOK_URL: ${{ secrets.AMPLIFY_DOCS_DEPLOY_HOOK }}
+          WEBHOOK_URL: ${{ env.AMPLIFY_DOCS_DEPLOY_HOOK }}
         run: |
           if curl -X POST --silent --fail --show-error "$WEBHOOK_URL" > /dev/null; then
             echo "Triggered successfully"

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -28,8 +28,6 @@ jobs:
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"
-          existing-gh-secrets: "${{ toJSON(secrets) }}"
-          existing-gh-variables: "${{ toJSON(vars) }}"
           values: |
             AMPLIFY_DOCS_DEPLOY_HOOK,secret
       - name: Call deployment webhook

--- a/.github/workflows/update-docs-webhook.yaml
+++ b/.github/workflows/update-docs-webhook.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Get runtime values from kvstore
         id: kvstore
-        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.0
+        uses: gravitational/shared-workflows/tools/env-kvstore@tools/env-kvstore/v1.0.2
         with:
           cognito-identity-pool-id: "us-west-2:da53389e-a459-4a28-bd54-43eeb8e4b579"
           cognito-role-arn: "arn:aws:iam::247230412011:role/github-actions-cognito-oidc"


### PR DESCRIPTION
Updates the v18 release branch with 5 PRs that switch workflows off of GitHub secrets and variables in favor of SOPS/AWS Secrets Manager kvstore.

- https://github.com/gravitational/teleport/pull/68508
- https://github.com/gravitational/teleport/pull/68450
- https://github.com/gravitational/teleport/pull/68745
- https://github.com/gravitational/teleport/pull/69225
- https://github.com/gravitational/teleport/pull/69331

Contributes to: https://github.com/gravitational/cloud/issues/14685