### PR TITLE
Add a missing license header

### DIFF
--- a/mobile/TeleportKit/Package.swift
+++ b/mobile/TeleportKit/Package.swift
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // swift-tools-version: 6.3
 
 import PackageDescription


### PR DESCRIPTION
We haven't yet set up the license check to run on Swift changes, which resulted in `mobile/TeleportKit/Package.swift` being able to land without the license header.