### PR TITLE
[v18] Fix Instances UI error when the user only has access to one kind

### DIFF
--- a/lib/auth/inventory/inventoryv1/service.go
+++ b/lib/auth/inventory/inventoryv1/service.go
@@ -81,28 +81,39 @@ func (s *Service) ListUnifiedInstances(
 		return nil, trace.Wrap(err)
 	}
 
-	// If no instance types are specified, default to all instance types
-	instanceTypes := req.GetFilter().GetInstanceTypes()
-	if len(instanceTypes) == 0 {
-		instanceTypes = []inventorypb.InstanceType{
-			inventorypb.InstanceType_INSTANCE_TYPE_INSTANCE,
-			inventorypb.InstanceType_INSTANCE_TYPE_BOT_INSTANCE,
-		}
+	filter := req.GetFilter()
+	if filter == nil {
+		filter = inventorypb.ListUnifiedInstancesFilter_builder{}.Build()
+		req.SetFilter(filter)
 	}
 
-	// Ensure that the instance types requested align with the user's permissions
-	for _, instanceType := range instanceTypes {
-		switch instanceType {
-		case inventorypb.InstanceType_INSTANCE_TYPE_INSTANCE:
-			if err := authCtx.CheckAccessToKind(types.KindInstance, types.VerbList, types.VerbRead); err != nil {
-				return nil, trace.Wrap(err)
+	instanceErr := authCtx.CheckAccessToKind(types.KindInstance, types.VerbList, types.VerbRead)
+	botInstanceErr := authCtx.CheckAccessToKind(types.KindBotInstance, types.VerbList, types.VerbRead)
+
+	if len(filter.GetInstanceTypes()) > 0 {
+		for _, instanceType := range filter.GetInstanceTypes() {
+			switch instanceType {
+			case inventorypb.InstanceType_INSTANCE_TYPE_INSTANCE:
+				if instanceErr != nil {
+					return nil, trace.Wrap(instanceErr)
+				}
+			case inventorypb.InstanceType_INSTANCE_TYPE_BOT_INSTANCE:
+				if botInstanceErr != nil {
+					return nil, trace.Wrap(botInstanceErr)
+				}
+			default:
+				return nil, trace.NotImplemented("instance type %v is not supported", instanceType)
 			}
-		case inventorypb.InstanceType_INSTANCE_TYPE_BOT_INSTANCE:
-			if err := authCtx.CheckAccessToKind(types.KindBotInstance, types.VerbList, types.VerbRead); err != nil {
-				return nil, trace.Wrap(err)
-			}
-		default:
-			return nil, trace.NotImplemented("instance type %v is not supported", instanceType)
+		}
+	} else {
+		// If the user didn't apply any filters but only has permissions for one of the two instance kinds, only return that kind
+		switch {
+		case instanceErr != nil && botInstanceErr != nil:
+			return nil, trace.NewAggregate(instanceErr, botInstanceErr)
+		case botInstanceErr != nil:
+			filter.SetInstanceTypes([]inventorypb.InstanceType{inventorypb.InstanceType_INSTANCE_TYPE_INSTANCE})
+		case instanceErr != nil:
+			filter.SetInstanceTypes([]inventorypb.InstanceType{inventorypb.InstanceType_INSTANCE_TYPE_BOT_INSTANCE})
 		}
 	}
 

--- a/lib/web/inventory_test.go
+++ b/lib/web/inventory_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -241,4 +242,79 @@ func TestListUnifiedInstances(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
 	require.Empty(t, listResp.Instances, "should find no items matching the search")
+}
+
+// TestListUnifiedInstancesPartialPermissions verifies how the list treats a user who can only read one of the two
+// instance kinds: with no type filter applied they still get a list of the kind they can read, while explicitly
+// filtering for a kind they can't read is an access denied error.
+func TestListUnifiedInstancesPartialPermissions(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	env := newWebPack(t, 1, func(cfg *WebPackOptions) {
+		cfg.enableAuthCache = true
+	})
+
+	require.NoError(t, env.server.Auth().UpsertInstance(ctx, &types.InstanceV1{
+		ResourceHeader: types.ResourceHeader{Metadata: types.Metadata{Name: "instance-1"}},
+		Spec:           types.InstanceSpecV1{Hostname: "host-1", Version: "18.1.0"},
+	}))
+	_, err := env.server.Auth().BotInstance.CreateBotInstance(ctx, machineidv1.BotInstance_builder{
+		Metadata: headerv1.Metadata_builder{Name: "bot-1"}.Build(),
+		Spec:     machineidv1.BotInstanceSpec_builder{BotName: "bot-1", InstanceId: "bot-1"}.Build(),
+		Status:   machineidv1.BotInstanceStatus_builder{}.Build(),
+	}.Build())
+	require.NoError(t, err)
+
+	packWithAccessTo := func(username string, kinds ...string) *authPack {
+		rules := make([]types.Rule, 0, len(kinds))
+		for _, kind := range kinds {
+			rules = append(rules, types.NewRule(kind, []string{types.VerbRead, types.VerbList}))
+		}
+		role, err := types.NewRole(services.RoleNameForUser(username), types.RoleSpecV6{
+			Allow: types.RoleConditions{Rules: rules},
+		})
+		require.NoError(t, err)
+		return env.proxies[0].authPack(t, username, []types.Role{role})
+	}
+
+	instanceOnly := packWithAccessTo("instance-only", types.KindInstance)
+	botOnly := packWithAccessTo("bot-only", types.KindBotInstance)
+	noAccess := packWithAccessTo("no-access")
+
+	endpoint := instanceOnly.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "instances")
+
+	var listResp listUnifiedInstancesResponse
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		resp, err := instanceOnly.clt.Get(ctx, endpoint, url.Values{})
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
+		assert.Len(t, listResp.Instances, 1)
+	}, 10*time.Second, 100*time.Millisecond, "inventory cache failed to become healthy and populated")
+	require.Equal(t, "instance-1", listResp.Instances[0].ID)
+
+	// A user who can only read bot instances gets the bot instance
+	resp, err := botOnly.clt.Get(ctx, endpoint, url.Values{})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
+	require.Len(t, listResp.Instances, 1)
+	require.Equal(t, "bot-1", listResp.Instances[0].ID)
+
+	// If the user explicitly applies a filter, they should get access denied error if they don't have the necessary permissions
+	_, err = instanceOnly.clt.Get(ctx, endpoint, url.Values{"types": []string{"bot_instance"}})
+	require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+	_, err = instanceOnly.clt.Get(ctx, endpoint, url.Values{"types": []string{"instance,bot_instance"}})
+	require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
+
+	resp, err = instanceOnly.clt.Get(ctx, endpoint, url.Values{"types": []string{"instance"}})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
+	require.Len(t, listResp.Instances, 1)
+	require.Equal(t, "instance-1", listResp.Instances[0].ID)
+
+	// A user who can read neither is denied
+	_, err = noAccess.clt.Get(ctx, endpoint, url.Values{})
+	require.True(t, trace.IsAccessDenied(err), "expected access denied, got %v", err)
 }

--- a/web/packages/shared/components/Controls/MultiselectMenu.tsx
+++ b/web/packages/shared/components/Controls/MultiselectMenu.tsx
@@ -193,6 +193,7 @@ export const MultiselectMenu = <T extends readonly Option<any>[]>({
                   handleSelect(opt.value);
                 }}
                 id={opt.value}
+                data-testid={`option-${opt.value}`}
                 checked={(buffered ? intSelected : selected)?.includes(
                   opt.value
                 )}

--- a/web/packages/teleport/src/Instances/Instances.test.tsx
+++ b/web/packages/teleport/src/Instances/Instances.test.tsx
@@ -143,6 +143,52 @@ it('having only instances permissions should show warning banner', async () => {
   });
 });
 
+it('type filter option should be disabled for bot instances when the user can only read instances', async () => {
+  server.use(listOnlyRegularInstances);
+  const { user } = renderComponent({
+    customAcl: makeAcl({
+      instances: {
+        ...defaultAccess,
+        list: true,
+        read: true,
+      },
+      botInstances: {
+        ...defaultAccess,
+        list: false,
+        read: false,
+      },
+    }),
+  });
+
+  await user.click(screen.getByRole('button', { name: /Type/i }));
+
+  expect(screen.getByTestId('option-instance')).toBeEnabled();
+  expect(screen.getByTestId('option-bot_instance')).toBeDisabled();
+});
+
+it('type filter option should be disabled for instances when the user can only read bot instances', async () => {
+  server.use(listOnlyBotInstances);
+  const { user } = renderComponent({
+    customAcl: makeAcl({
+      instances: {
+        ...defaultAccess,
+        list: false,
+        read: false,
+      },
+      botInstances: {
+        ...defaultAccess,
+        list: true,
+        read: true,
+      },
+    }),
+  });
+
+  await user.click(screen.getByRole('button', { name: /Type/i }));
+
+  expect(screen.getByTestId('option-instance')).toBeDisabled();
+  expect(screen.getByTestId('option-bot_instance')).toBeEnabled();
+});
+
 it('cache still initializing error should show correct error', async () => {
   server.use(
     listInstancesError(

--- a/web/packages/teleport/src/Instances/Instances.tsx
+++ b/web/packages/teleport/src/Instances/Instances.tsx
@@ -149,6 +149,23 @@ export function Instances() {
   const onlyBotInstancesSelected =
     selectedTypes.length === 1 && selectedTypes[0] === 'bot_instance';
 
+  const typeOptions = [
+    {
+      value: 'instance' as const,
+      label: 'Instances',
+      disabled: !hasInstancePermissions,
+      disabledTooltip:
+        'Listing instances requires permissions instance.list and instance.read.',
+    },
+    {
+      value: 'bot_instance' as const,
+      label: 'Bot Instances',
+      disabled: !hasBotInstancePermissions,
+      disabledTooltip:
+        'Listing bot instances requires permissions bot_instance.list and bot_instance.read.',
+    },
+  ];
+
   const {
     isSuccess,
     data,
@@ -403,7 +420,6 @@ export function Instances() {
               label="Type"
               tooltip="Filter by instance type"
               buffered={true}
-              disabled={!hasInstancePermissions}
             />
             <MultiselectMenu
               options={serviceOptions}
@@ -482,11 +498,6 @@ type UpgraderType =
   | 'kube-updater'
   | 'unit-updater'
   | 'systemd-unit-updater';
-
-const typeOptions: { value: InstanceType; label: string }[] = [
-  { value: 'instance', label: 'Instances' },
-  { value: 'bot_instance', label: 'Bot Instances' },
-];
 
 const serviceOptions: { value: ServiceType; label: string }[] = [
   { value: 'App', label: 'Applications' },


### PR DESCRIPTION
Backport #69551 to branch/v18

changelog: Fix Instances UI error when the user only has access to one instance kind

## Manual Test Plan
### Test Environment

Local teleport running `v18.10.0`

### Test Cases
- [x] Verify that if a user only has access to `instance`s but not `bot_instance`s, there is no failed request and instances are listed and the kind filter option for `bot_instance`s is disabled.
- [x] Verify that if a user only has access to `bot_instance`s but not `instance`s, there is no failed request and bot instances are listed and the kind filter option for `instance`s is disabled.
- [x] Verify that if the user has access to both, there is no blue permissions warning and both types are listed and both filter options work.
