### PR TITLE
Fix agent not enforcing MFA device lock after in-band MFA.

### DIFF
--- a/lib/srv/keyboard_auth.go
+++ b/lib/srv/keyboard_auth.go
@@ -55,7 +55,7 @@ func (h *AuthHandlers) KeyboardInteractiveAuth(
 		for _, p := range preconds {
 			switch p.GetKind() {
 			case decisionpb.PreconditionKind_PRECONDITION_KIND_IN_BAND_MFA:
-				verifier, err := srvssh.NewMFAPromptVerifier(h.c.ValidatedMFAChallengeVerifier, sourceCluster, id.Username, metadata.SessionID())
+				verifier, err := srvssh.NewMFAPromptVerifier(h.c.ValidatedMFAChallengeVerifier, sourceCluster, id.Username, metadata.SessionID(), perms)
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}

--- a/lib/srv/keyboard_auth_test.go
+++ b/lib/srv/keyboard_auth_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/sshca"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestKeyboardInteractiveAuth_PreCondInBandMFA_Success(t *testing.T) {
@@ -48,11 +49,7 @@ func TestKeyboardInteractiveAuth_PreCondInBandMFA_Success(t *testing.T) {
 		}.Build(),
 	}
 
-	inPerms := &ssh.Permissions{
-		Extensions: map[string]string{
-			"foo": "bar",
-		},
-	}
+	inPerms := newPerms(t)
 
 	outPerms, err := h.KeyboardInteractiveAuth(t.Context(), preconds, id, inPerms)
 	require.Nil(t, outPerms)
@@ -105,7 +102,7 @@ func TestKeyboardInteractiveAuth_PreCondInBandMFA_UsesRouteToCluster(t *testing.
 		}.Build(),
 	}
 
-	inPerms := &ssh.Permissions{}
+	inPerms := newPerms(t)
 
 	outPerms, err := h.KeyboardInteractiveAuth(t.Context(), preconds, id, inPerms)
 	require.Nil(t, outPerms)
@@ -208,6 +205,20 @@ func setupKeyboardInteractiveAuthTestWithVerifier(t *testing.T, verifier mfav2.M
 	return h, id
 }
 
+func newPerms(t *testing.T) *ssh.Permissions {
+	t.Helper()
+
+	permit := decisionpb.SSHAccessPermit_builder{}.Build()
+	permitJSON, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(permit)
+	require.NoError(t, err)
+
+	return &ssh.Permissions{
+		Extensions: map[string]string{
+			utils.ExtIntSSHAccessPermit: string(permitJSON),
+		},
+	}
+}
+
 type mockAccessPoint struct {
 	srv.AccessPoint
 }
@@ -236,7 +247,9 @@ func (m *mockMFAServiceClient) VerifyValidatedMFAChallenge(_ context.Context, re
 		return nil, m.verifyErr
 	}
 
-	return &mfav2.VerifyValidatedMFAChallengeResponse{}, nil
+	return mfav2.VerifyValidatedMFAChallengeResponse_builder{
+		MfaDevice: mfav2.MFADevice_builder{Id: "test-device-id"}.Build(),
+	}.Build(), nil
 }
 
 type mockConnMetadata struct {

--- a/lib/srv/ssh/mfa.go
+++ b/lib/srv/ssh/mfa.go
@@ -20,19 +20,23 @@ package ssh
 
 import (
 	"context"
+	"slices"
 
 	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
+	mfav2pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
 	sshpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/ssh/v1"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // ValidatedMFAChallengeVerifier verifies that a validated MFA challenge exists in order to determine if the user has
 // completed MFA.
 type ValidatedMFAChallengeVerifier interface {
-	VerifyValidatedMFAChallenge(ctx context.Context, req *mfav2.VerifyValidatedMFAChallengeRequest, opts ...grpc.CallOption) (*mfav2.VerifyValidatedMFAChallengeResponse, error)
+	VerifyValidatedMFAChallenge(ctx context.Context, req *mfav2pb.VerifyValidatedMFAChallengeRequest, opts ...grpc.CallOption) (*mfav2pb.VerifyValidatedMFAChallengeResponse, error)
 }
 
 // MFAPromptVerifier is a PromptVerifier that marshals and verifies MFA prompts and responses.
@@ -41,6 +45,7 @@ type MFAPromptVerifier struct {
 	sourceCluster string
 	username      string
 	sessionID     []byte
+	perms         *ssh.Permissions
 }
 
 var _ PromptVerifier = (*MFAPromptVerifier)(nil)
@@ -51,6 +56,7 @@ func NewMFAPromptVerifier(
 	sourceCluster string,
 	username string,
 	sessionID []byte,
+	perms *ssh.Permissions,
 ) (*MFAPromptVerifier, error) {
 	switch {
 	case verifier == nil:
@@ -64,6 +70,9 @@ func NewMFAPromptVerifier(
 
 	case len(sessionID) == 0:
 		return nil, trace.BadParameter("params SessionID must be set and be non-empty")
+
+	case perms == nil:
+		return nil, trace.BadParameter("params Permissions must be set")
 	}
 
 	return &MFAPromptVerifier{
@@ -71,6 +80,7 @@ func NewMFAPromptVerifier(
 		sourceCluster: sourceCluster,
 		username:      username,
 		sessionID:     sessionID,
+		perms:         perms,
 	}, nil
 }
 
@@ -108,17 +118,26 @@ func (pv *MFAPromptVerifier) VerifyAnswer(ctx context.Context, answer string) er
 			return trace.BadParameter("missing ChallengeName in MFAPromptResponseReference")
 		}
 
-		req := mfav2.VerifyValidatedMFAChallengeRequest_builder{
+		req := mfav2pb.VerifyValidatedMFAChallengeRequest_builder{
 			Name: challengeName,
-			Payload: mfav2.SessionIdentifyingPayload_builder{
+			Payload: mfav2pb.SessionIdentifyingPayload_builder{
 				SshSessionId: pv.sessionID,
 			}.Build(),
 			SourceCluster: pv.sourceCluster,
 			Username:      pv.username,
 		}.Build()
 
-		_, err := pv.verifier.VerifyValidatedMFAChallenge(ctx, req)
-		return trace.Wrap(err)
+		verifyResp, err := pv.verifier.VerifyValidatedMFAChallenge(ctx, req)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// Capture the MFA device in the decisionpb.SSHAccessPermit.LockTargets for downstream lock enforcement.
+		if err := pv.addMFADeviceToPermit(verifyResp.GetMfaDevice()); err != nil {
+			return trace.Wrap(err)
+		}
+
+		return nil
 
 	case 0:
 		return trace.BadParameter("missing Response in MFAPromptResponse")
@@ -126,4 +145,44 @@ func (pv *MFAPromptVerifier) VerifyAnswer(ctx context.Context, answer string) er
 	default:
 		return trace.BadParameter("unsupported MFAPromptResponse Response type: %v", resp)
 	}
+}
+
+func (pv *MFAPromptVerifier) addMFADeviceToPermit(device *mfav2pb.MFADevice) error {
+	if device.GetId() == "" {
+		return trace.BadParameter("missing MFA device with non-empty ID (this is a bug)")
+	}
+
+	rawPermit, ok := pv.perms.Extensions[utils.ExtIntSSHAccessPermit]
+	if !ok {
+		return trace.BadParameter("missing SSH access permit (this is a bug)")
+	}
+
+	permit := &decisionpb.SSHAccessPermit{}
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(rawPermit), permit); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Add the device only if it's not already in the permit.
+	if !slices.ContainsFunc(
+		permit.GetLockTargets(),
+		func(target *decisionpb.LockTarget) bool {
+			return target.GetMfaDevice() == device.GetId()
+		},
+	) {
+		permit.SetLockTargets(append(
+			permit.GetLockTargets(),
+			decisionpb.LockTarget_builder{
+				MfaDevice: device.GetId(),
+			}.Build(),
+		))
+
+		permitJSON, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(permit)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		pv.perms.Extensions[utils.ExtIntSSHAccessPermit] = string(permitJSON)
+	}
+
+	return nil
 }

--- a/lib/srv/ssh/mfa_test.go
+++ b/lib/srv/ssh/mfa_test.go
@@ -24,12 +24,15 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	mfav2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v2"
 	sshpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/ssh/v1"
 	srvssh "github.com/gravitational/teleport/lib/srv/ssh"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -37,66 +40,86 @@ const (
 	challengeName    = "test-challenge-name"
 	sourceCluster    = "test-cluster"
 	teleportUsername = "alice"
+	testDeviceID     = "test-device-id"
 )
 
 func TestNewMFAPromptVerifier_InvalidParams(t *testing.T) {
 	t.Parallel()
 
-	for _, testCase := range []struct {
-		name          string
+	type params struct {
 		verifier      srvssh.ValidatedMFAChallengeVerifier
 		sourceCluster string
 		username      string
 		sessionID     []byte
-		wantErr       error
+		perms         *ssh.Permissions
+	}
+
+	baseParams := params{
+		verifier:      &mockValidatedMFAChallengeVerifier{},
+		sourceCluster: sourceCluster,
+		username:      teleportUsername,
+		sessionID:     []byte(sessionID),
+		perms:         newPerms(t),
+	}
+
+	for _, testCase := range []struct {
+		name    string
+		params  params
+		wantErr error
 	}{
 		{
-			name:          "nil verifier",
-			verifier:      nil,
-			sourceCluster: sourceCluster,
-			username:      teleportUsername,
-			sessionID:     []byte(sessionID),
-			wantErr:       trace.BadParameter("params Verifier must be set"),
+			name: "nil verifier",
+			params: func() params {
+				p := baseParams
+				p.verifier = nil
+				return p
+			}(),
+			wantErr: trace.BadParameter("params Verifier must be set"),
 		},
 		{
-			name:          "empty sourceCluster",
-			verifier:      &mockValidatedMFAChallengeVerifier{},
-			sourceCluster: "",
-			username:      teleportUsername,
-			sessionID:     []byte(sessionID),
-			wantErr:       trace.BadParameter("params SourceCluster must be set"),
+			name: "empty sourceCluster",
+			params: func() params {
+				p := baseParams
+				p.sourceCluster = ""
+				return p
+			}(),
+			wantErr: trace.BadParameter("params SourceCluster must be set"),
 		},
 		{
-			name:          "empty username",
-			verifier:      &mockValidatedMFAChallengeVerifier{},
-			sourceCluster: sourceCluster,
-			username:      "",
-			sessionID:     []byte(sessionID),
-			wantErr:       trace.BadParameter("params Username must be set"),
+			name: "empty username",
+			params: func() params {
+				p := baseParams
+				p.username = ""
+				return p
+			}(),
+			wantErr: trace.BadParameter("params Username must be set"),
 		},
 		{
-			name:          "nil sessionID",
-			verifier:      &mockValidatedMFAChallengeVerifier{},
-			sourceCluster: sourceCluster,
-			username:      teleportUsername,
-			sessionID:     nil,
-			wantErr:       trace.BadParameter("params SessionID must be set and be non-empty"),
+			name: "nil sessionID",
+			params: func() params {
+				p := baseParams
+				p.sessionID = nil
+				return p
+			}(),
+			wantErr: trace.BadParameter("params SessionID must be set and be non-empty"),
 		},
 		{
-			name:          "empty sessionID",
-			verifier:      &mockValidatedMFAChallengeVerifier{},
-			sourceCluster: sourceCluster,
-			username:      teleportUsername,
-			sessionID:     []byte(""),
-			wantErr:       trace.BadParameter("params SessionID must be set and be non-empty"),
+			name: "empty sessionID",
+			params: func() params {
+				p := baseParams
+				p.sessionID = []byte("")
+				return p
+			}(),
+			wantErr: trace.BadParameter("params SessionID must be set and be non-empty"),
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			_, err := srvssh.NewMFAPromptVerifier(
-				testCase.verifier,
-				testCase.sourceCluster,
-				testCase.username,
-				testCase.sessionID,
+				testCase.params.verifier,
+				testCase.params.sourceCluster,
+				testCase.params.username,
+				testCase.params.sessionID,
+				testCase.params.perms,
 			)
 			require.ErrorIs(t, err, testCase.wantErr)
 		})
@@ -111,6 +134,7 @@ func TestMFAPromptVerifier_MarshalPrompt(t *testing.T) {
 		sourceCluster,
 		teleportUsername,
 		[]byte(sessionID),
+		newPerms(t),
 	)
 	require.NoError(t, err)
 
@@ -120,89 +144,141 @@ func TestMFAPromptVerifier_MarshalPrompt(t *testing.T) {
 	require.Contains(t, prompt, srvssh.MFAPromptMessage)
 }
 
-func TestMFAPromptVerifier_VerifyAnswer_Success(t *testing.T) {
+func TestMFAPromptVerifier_VerifyAnswer(t *testing.T) {
 	t.Parallel()
 
-	verifier, err := srvssh.NewMFAPromptVerifier(
-		&mockValidatedMFAChallengeVerifier{expectedChallengeName: challengeName},
-		sourceCluster,
-		teleportUsername,
-		[]byte(sessionID),
-	)
-	require.NoError(t, err)
-
-	resp := sshpb.MFAPromptResponse_builder{
+	validRefResp := sshpb.MFAPromptResponse_builder{
 		Reference: sshpb.MFAPromptResponseReference_builder{
 			ChallengeName: challengeName,
 		}.Build(),
 	}.Build()
-	respJSON, err := protojson.Marshal(resp)
+	validRefJSON, err := protojson.Marshal(validRefResp)
 	require.NoError(t, err)
 
-	err = verifier.VerifyAnswer(t.Context(), string(respJSON))
-	require.NoError(t, err)
-}
-
-func TestMFAPromptVerifier_VerifyAnswer_InvalidJSON(t *testing.T) {
-	t.Parallel()
-
-	verifier, err := srvssh.NewMFAPromptVerifier(
-		&mockValidatedMFAChallengeVerifier{expectedChallengeName: challengeName},
-		sourceCluster,
-		teleportUsername,
-		[]byte(sessionID),
-	)
+	emptyRespJSON, err := protojson.Marshal(sshpb.MFAPromptResponse_builder{}.Build())
 	require.NoError(t, err)
 
-	err = verifier.VerifyAnswer(t.Context(), "not-json")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid value not-json")
-}
-
-func TestMFAPromptVerifier_VerifyAnswer_MissingResponse(t *testing.T) {
-	t.Parallel()
-
-	verifier, err := srvssh.NewMFAPromptVerifier(
-		&mockValidatedMFAChallengeVerifier{expectedChallengeName: challengeName},
-		sourceCluster,
-		teleportUsername,
-		[]byte(sessionID),
-	)
-	require.NoError(t, err)
-
-	resp := sshpb.MFAPromptResponse_builder{}.Build()
-	respJSON, err := protojson.Marshal(resp)
-	require.NoError(t, err)
-
-	err = verifier.VerifyAnswer(t.Context(), string(respJSON))
-	require.ErrorIs(t, err, trace.BadParameter("missing Response in MFAPromptResponse"))
-}
-
-func TestMFAPromptVerifier_VerifyAnswer_EmptyChallengeName(t *testing.T) {
-	t.Parallel()
-
-	verifier, err := srvssh.NewMFAPromptVerifier(
-		&mockValidatedMFAChallengeVerifier{expectedChallengeName: challengeName},
-		sourceCluster,
-		teleportUsername,
-		[]byte(sessionID),
-	)
-	require.NoError(t, err)
-
-	resp := sshpb.MFAPromptResponse_builder{
+	emptyChallengeJSON, err := protojson.Marshal(sshpb.MFAPromptResponse_builder{
 		Reference: sshpb.MFAPromptResponseReference_builder{
 			ChallengeName: "",
 		}.Build(),
-	}.Build()
-	respJSON, err := protojson.Marshal(resp)
+	}.Build())
 	require.NoError(t, err)
 
-	err = verifier.VerifyAnswer(t.Context(), string(respJSON))
-	require.ErrorIs(t, err, trace.BadParameter("missing ChallengeName in MFAPromptResponseReference"))
+	for _, tc := range []struct {
+		name          string
+		perms         *ssh.Permissions
+		mockMFADevice *mfav2.MFADevice
+		answer        string
+		assert        func(t *testing.T, err error, perms *ssh.Permissions)
+	}{
+		{
+			name:   "success",
+			answer: string(validRefJSON),
+			assert: func(t *testing.T, err error, perms *ssh.Permissions) {
+				require.NoError(t, err)
+				permit := &decisionpb.SSHAccessPermit{}
+				require.NoError(t, (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(perms.Extensions[utils.ExtIntSSHAccessPermit]), permit))
+				require.Len(t, permit.GetLockTargets(), 1)
+				require.Equal(t, testDeviceID, permit.GetLockTargets()[0].GetMfaDevice())
+			},
+		},
+		{
+			name:   "invalid JSON",
+			answer: "not-json",
+			assert: func(t *testing.T, err error, perms *ssh.Permissions) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "invalid value not-json")
+			},
+		},
+		{
+			name:   "missing Response",
+			answer: string(emptyRespJSON),
+			assert: func(t *testing.T, err error, perms *ssh.Permissions) {
+				require.ErrorIs(t, err, trace.BadParameter("missing Response in MFAPromptResponse"))
+			},
+		},
+		{
+			name:   "empty ChallengeName",
+			answer: string(emptyChallengeJSON),
+			assert: func(t *testing.T, err error, perms *ssh.Permissions) {
+				require.ErrorIs(t, err, trace.BadParameter("missing ChallengeName in MFAPromptResponseReference"))
+			},
+		},
+		{
+			name:          "empty MFA device",
+			mockMFADevice: mfav2.MFADevice_builder{Id: ""}.Build(),
+			answer:        string(validRefJSON),
+			assert: func(t *testing.T, err error, perms *ssh.Permissions) {
+				require.ErrorIs(t, err, trace.BadParameter("missing MFA device with non-empty ID (this is a bug)"))
+			},
+		},
+		{
+			name:   "missing SSHAccessPermit",
+			perms:  &ssh.Permissions{},
+			answer: string(validRefJSON),
+			assert: func(t *testing.T, err error, perms *ssh.Permissions) {
+				require.ErrorIs(t, err, trace.BadParameter("missing SSH access permit (this is a bug)"))
+			},
+		},
+		{
+			name: "invalid SSHAccessPermit",
+			perms: &ssh.Permissions{
+				Extensions: map[string]string{
+					utils.ExtIntSSHAccessPermit: "not-json",
+				},
+			},
+			answer: string(validRefJSON),
+			assert: func(t *testing.T, err error, perms *ssh.Permissions) {
+				require.Error(t, err)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			perms := tc.perms
+			if perms == nil {
+				perms = newPerms(t)
+			}
+
+			verifier, err := srvssh.NewMFAPromptVerifier(
+				&mockValidatedMFAChallengeVerifier{expectedChallengeName: challengeName, mfaDevice: tc.mockMFADevice},
+				sourceCluster,
+				teleportUsername,
+				[]byte(sessionID),
+				perms,
+			)
+			require.NoError(t, err)
+
+			err = verifier.VerifyAnswer(t.Context(), tc.answer)
+			tc.assert(t, err, perms)
+		})
+	}
+}
+
+func newPerms(t *testing.T, mfaDevices ...string) *ssh.Permissions {
+	t.Helper()
+
+	lockTargets := make([]*decisionpb.LockTarget, 0, len(mfaDevices))
+	for _, device := range mfaDevices {
+		lockTargets = append(lockTargets, decisionpb.LockTarget_builder{MfaDevice: device}.Build())
+	}
+
+	permit := decisionpb.SSHAccessPermit_builder{
+		LockTargets: lockTargets,
+	}.Build()
+	permitJSON, err := protojson.Marshal(permit)
+	require.NoError(t, err)
+
+	return &ssh.Permissions{
+		Extensions: map[string]string{
+			utils.ExtIntSSHAccessPermit: string(permitJSON),
+		},
+	}
 }
 
 type mockValidatedMFAChallengeVerifier struct {
 	expectedChallengeName string
+	mfaDevice             *mfav2.MFADevice
 	err                   error
 }
 
@@ -223,5 +299,14 @@ func (m *mockValidatedMFAChallengeVerifier) VerifyValidatedMFAChallenge(
 		)
 	}
 
-	return &mfav2.VerifyValidatedMFAChallengeResponse{}, nil
+	mfaDevice := mfav2.MFADevice_builder{
+		Id: testDeviceID,
+	}.Build()
+	if m.mfaDevice != nil {
+		mfaDevice = m.mfaDevice
+	}
+
+	return mfav2.VerifyValidatedMFAChallengeResponse_builder{
+		MfaDevice: mfaDevice,
+	}.Build(), nil
 }


### PR DESCRIPTION
Part 2 of bug fix for https://github.com/gravitational/core/issues/146.

After successful in-band MFA during SSH session establishment, the Agent will append the MFA device used to satisfy the MFA challenge as a lock target to [decisionpb.SSHAccessPermit.LockTargets](https://github.com/gravitational/teleport/blob/c82aa74d96607c2fef1975f74bd875c99db33e84/api/gen/proto/go/teleport/decision/v1alpha1/ssh_access_protohybrid.pb.go#L586).

This works because lock enforcement happens further downstream in [AcquireSessionContext](https://github.com/gravitational/teleport/blob/c82aa74d96607c2fef1975f74bd875c99db33e84/lib/srv/session_control.go#L262) and [NewServerContext](https://github.com/gravitational/teleport/blob/c82aa74d96607c2fef1975f74bd875c99db33e84/lib/srv/ctx.go#L482); the former being lock enforcement for new connections and latter for established connections.

## Alternatives considered

1. Pass the MFADevice through [ssh.Permissions.Extensions](https://pkg.go.dev/golang.org/x/crypto/ssh#Permissions) or [ssh.Permissions.ExtraData](https://pkg.go.dev/golang.org/x/crypto/ssh#Permissions). Rejected because the SSH access permit is authoritative on lock targets and side stepping that would be confusing and error prone.
2. Create a new field `MFADevice` on the [IdentityContext](https://github.com/gravitational/teleport/blob/c82aa74d96607c2fef1975f74bd875c99db33e84/lib/srv/ctx.go#L225). Rejected because it was has broader implications and because it conflicts with `IdentityContext.UnmappedIdentity.MFAVerified`.

## Future work

1. Add missing test coverage for locks to `TestSSHOnMultipleNodes`. Current coverage added in this PR should suffice, but adding integration coverage will give us confidence the whole system is working E2E, especially the trusted cluster scenario. It should be a matter of creating a lock, waiting for the lock to propagate, attempting to connect and asserting on the error.

## Manual Test Plan
### Test Environment

Teleport instance built with `make full-ent` running on my Mac. My clients are built from Teleport v18.

### Test Cases
- [x] SSH to node with per-session MFA should succeed
- [x] SSH to node with per-session MFA and device lock should reject the new session
- [x] SSH to node with per-session MFA, no device lock initially, and enable device lock after session established, should terminate the established session