### PR TITLE
[v18] Pin RFD links in public docs

### DIFF
--- a/docs/pages/agentic-identity-framework.mdx
+++ b/docs/pages/agentic-identity-framework.mdx
@@ -119,9 +119,9 @@ The framework is organized into four layers that build on each other: identity, 
     Agents operate on behalf of principals while preserving approval/authorization workflows.
    <hr />
     <ul>
-    <li><a href="https://github.com/gravitational/teleport/blob/master/rfd/0238-delegating-access-to-ai-workloads.md">Delegation Flows</a></li>
-    <li><a href="https://github.com/gravitational/teleport/blob/master/rfd/0238-delegating-access-to-ai-workloads.md#starting-a-session-from-tsh">Session Management</a></li>
-    <li><a href="https://github.com/gravitational/teleport/blob/master/rfd/0238-delegating-access-to-ai-workloads.md#access-controls">Access Control</a></li>
+    <li><a href="https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0238-delegating-access-to-ai-workloads.md">Delegation Flows</a></li>
+    <li><a href="https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0238-delegating-access-to-ai-workloads.md#starting-a-session-from-tsh">Session Management</a></li>
+    <li><a href="https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0238-delegating-access-to-ai-workloads.md#access-controls">Access Control</a></li>
     </ul>
   </Method>
   <Method

--- a/docs/pages/agentic-identity-framework/agentic-identity-framework.mdx
+++ b/docs/pages/agentic-identity-framework/agentic-identity-framework.mdx
@@ -120,9 +120,9 @@ The framework is organized into four layers that build on each other: identity, 
     Agents operate on behalf of principals while preserving approval/authorization workflows.
    <hr />
     <ul>
-    <li><a href="https://github.com/gravitational/teleport/blob/master/rfd/0238-delegating-access-to-ai-workloads.md">Delegation Flows</a></li>
-    <li><a href="https://github.com/gravitational/teleport/blob/master/rfd/0238-delegating-access-to-ai-workloads.md#starting-a-session-from-tsh">Session Management</a></li>
-    <li><a href="https://github.com/gravitational/teleport/blob/master/rfd/0238-delegating-access-to-ai-workloads.md#access-controls">Access Control</a></li>
+    <li><a href="https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0238-delegating-access-to-ai-workloads.md">Delegation Flows</a></li>
+    <li><a href="https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0238-delegating-access-to-ai-workloads.md#starting-a-session-from-tsh">Session Management</a></li>
+    <li><a href="https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0238-delegating-access-to-ai-workloads.md#access-controls">Access Control</a></li>
     </ul>
   </Method>
   <Method

--- a/docs/pages/connect-your-client/teleport-clients/vnet.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/vnet.mdx
@@ -429,5 +429,5 @@ To gather logs from Teleport Connect, attach all files from
 
 - Read our VNet configuration [guide](../../enroll-resources/application-access/vnet.mdx)
   to learn how to configure VNet access to your applications.
-- Read [RFD 163](https://github.com/gravitational/teleport/blob/master/rfd/0163-vnet.md) to learn how VNet works on a technical level.
-- Read [RFD 207](https://github.com/gravitational/teleport/blob/master/rfd/0207-vnet-ssh.md) to learn how VNet SSH access works.
+- Read [RFD 163](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0163-vnet.md) to learn how VNet works on a technical level.
+- Read [RFD 207](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0207-vnet-ssh.md) to learn how VNet SSH access works.

--- a/docs/pages/enroll-resources/application-access/vnet.mdx
+++ b/docs/pages/enroll-resources/application-access/vnet.mdx
@@ -191,4 +191,4 @@ clients.
 
 - Read our VNet usage [guide](../../connect-your-client/teleport-clients/vnet.mdx) for end-users
   accessing your applications with VNet.
-- Read [RFD 163](https://github.com/gravitational/teleport/blob/master/rfd/0163-vnet.md) to learn how VNet works on a technical level.
+- Read [RFD 163](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0163-vnet.md) to learn how VNet works on a technical level.

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
@@ -75,4 +75,4 @@ Users created within the database will:
 
 - Connect using your [GUI database client](../../../connect-your-client/third-party/gui-clients.mdx).
 - Learn about [role templating](../../../zero-trust-access/rbac-get-started/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
@@ -170,4 +170,4 @@ database queries in the Teleport Audit Logs, when the Teleport username is over
 
 - Connect using your [GUI database client](../../../connect-your-client/third-party/gui-clients.mdx).
 - Learn about [role templating](../../../zero-trust-access/rbac-get-started/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
@@ -150,4 +150,4 @@ Users created within the database will:
 - Learn more about MongoDB [built-in roles](https://www.mongodb.com/docs/manual/reference/built-in-roles/) and [User-Defined Roles](https://www.mongodb.com/docs/manual/core/security-user-defined-roles/).
 - Connect using your [GUI database client](../../../connect-your-client/third-party/gui-clients.mdx).
 - Learn about [role templating](../../../zero-trust-access/rbac-get-started/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
@@ -170,4 +170,4 @@ endpoints. Please use auto-user provisioning on the primary endpoints.
 
 - Connect using your [GUI database client](../../../connect-your-client/third-party/gui-clients.mdx).
 - Learn about [role templating](../../../zero-trust-access/rbac-get-started/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
@@ -320,8 +320,8 @@ admin user through Teleport.
   client](../../../connect-your-client/third-party/gui-clients.mdx).
 - Learn about [role
   templating](../../../zero-trust-access/rbac-get-started/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
-- Read database permission management [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0151-database-permission-management.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).
+- Read database permission management [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0151-database-permission-management.md).
 - The `internal.db_roles` traits we illustrated in this guide
   are replaced with values from the Teleport local user database. For full
   details on how variable expansion works in Teleport roles, see the [Teleport

--- a/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
+++ b/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
@@ -230,9 +230,9 @@ Web UI. Based on these messages, the Teleport Web UI advertises information
 about—or performs modifications on—the shared directory.
 
 You can read more about TDP in [Teleport RFD
-37](https://github.com/gravitational/teleport/blob/master/rfd/0037-desktop-access-protocol.md)
+37](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0037-desktop-access-protocol.md)
 and how Directory Sharing uses it in [RFD
-67](https://github.com/gravitational/teleport/blob/master/rfd/0067-desktop-access-file-system-sharing.md).
+67](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0067-desktop-access-file-system-sharing.md).
 
 #### In Teleport Connect
 

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-agentless.mdx
@@ -31,7 +31,7 @@ The OpenSSH server will be set up to trust connections from the Proxy Service ra
 connections from users. This ensures that all connections to OpenSSH servers go through the
 Proxy Service, where session IO and audit events can be recorded and RBAC can be enforced.
 
-For deeper details as to how this works, you may be interested in the [Registered OpenSSH Nodes RFD](https://github.com/gravitational/teleport/blob/master/rfd/0098-registered-openssh-nodes.md)
+For deeper details as to how this works, you may be interested in the [Registered OpenSSH Nodes RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0098-registered-openssh-nodes.md)
 Below are some key details from the RFD:
 - The Proxy Service is uniquely able to request certificates signed by the Auth Service with the Teleport OpenSSH CA on behalf of users, and the OpenSSH server is set up to only trust certificates signed by this CA. Therefore, in order to connect to an OpenSSH server, a user must connect through the Proxy Service to request and use an OpenSSH certificate.
 - Before connecting the user to the OpenSSH server, the Proxy Service performs RBAC checks to see if the user should be allowed to access it.

--- a/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh-manual-install.mdx
@@ -29,7 +29,7 @@ The OpenSSH server will be set up to trust connections from the Proxy Service ra
 connections from users. This ensures that all connections to OpenSSH servers go through the
 Proxy Service, where session IO and audit events can be recorded and RBAC can be enforced.
 
-For deeper details as to how this works, you may be interested in the [Registered OpenSSH Nodes RFD](https://github.com/gravitational/teleport/blob/master/rfd/0098-registered-openssh-nodes.md)
+For deeper details as to how this works, you may be interested in the [Registered OpenSSH Nodes RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0098-registered-openssh-nodes.md)
 Below are some key details from the RFD:
 - The Proxy Service is uniquely able to request certificates signed by the Auth Service with the Teleport OpenSSH CA on behalf of users, and the OpenSSH server is set up to only trust certificates signed by this CA. Therefore, in order to connect to an OpenSSH server, a user must connect through the Proxy to request and use an OpenSSH certificate.
 - Before connecting the user to the OpenSSH server, the Proxy Service performs RBAC checks to see if the user should be allowed to access it.

--- a/docs/pages/reference/architecture/machine-id-architecture.mdx
+++ b/docs/pages/reference/architecture/machine-id-architecture.mdx
@@ -13,7 +13,7 @@ inner workings.
 
 The initial specification and design for Machine & Workload Identity can be
 found in
-[the Request For Discussion.](https://github.com/gravitational/teleport/blob/master/rfd/0064-bot-for-cert-renewals.md)
+[the Request For Discussion.](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0064-bot-for-cert-renewals.md)
 
 ## What is a bot?
 

--- a/docs/pages/reference/architecture/tls-routing.mdx
+++ b/docs/pages/reference/architecture/tls-routing.mdx
@@ -268,4 +268,4 @@ behind layer 7 load balancers.
 
 - See [migration guide](../../zero-trust-access/management/tls-routing.mdx) to learn how to
   upgrade an existing cluster to use TLS routing.
-- Read through TLS routing design document [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0039-sni-alpn-teleport-proxy-routing.md).
+- Read through TLS routing design document [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0039-sni-alpn-teleport-proxy-routing.md).

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -279,7 +279,7 @@ The `identity/key-agent` service provides similar functionality to the
 `identity` output service, but makes it impossible to steal or exfiltrate the
 generated identity by keeping private key material entirely in memory.
 
-It works similarly to the [Hardware Key Agent](https://github.com/gravitational/teleport/blob/master/rfd/0199-hardware-key-agent.md)
+It works similarly to the [Hardware Key Agent](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0199-hardware-key-agent.md)
 in that it runs a gRPC service on a Unix socket, which the Teleport Client calls
 to perform cryptographic signing operations.
 

--- a/docs/pages/zero-trust-access/authentication/joining-sessions.mdx
+++ b/docs/pages/zero-trust-access/authentication/joining-sessions.mdx
@@ -301,4 +301,4 @@ the file transfer automatically begins.
 
 ## See also
 
-- [Moderated Sessions](https://github.com/gravitational/teleport/blob/master/rfd/0043-kubeaccess-multiparty.md)
+- [Moderated Sessions](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0043-kubeaccess-multiparty.md)


### PR DESCRIPTION
Pin RFD links in public docs to a recent master commit in preparation for RFDs to move to a dedicated repository in https://github.com/gravitational/teleport/pull/69485.

I've not touched links outside of docs/ like code and proto comments, we can clean those up as we go.