### PR TITLE
[v17] Pin RFD links in public docs

### DIFF
--- a/docs/pages/connect-your-client/vnet.mdx
+++ b/docs/pages/connect-your-client/vnet.mdx
@@ -345,5 +345,5 @@ app, then select Help → Open Logs Directory. This opens
 
 - Read our VNet configuration [guide](../enroll-resources/application-access/guides/vnet.mdx)
   to learn how to configure VNet access to your applications.
-- Read [RFD 163](https://github.com/gravitational/teleport/blob/master/rfd/0163-vnet.md) to learn how VNet works on a technical level.
-- Read [RFD 207](https://github.com/gravitational/teleport/blob/master/rfd/0207-vnet-ssh.md) to learn how VNet SSH access works.
+- Read [RFD 163](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0163-vnet.md) to learn how VNet works on a technical level.
+- Read [RFD 207](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0207-vnet-ssh.md) to learn how VNet SSH access works.

--- a/docs/pages/enroll-resources/application-access/guides/vnet.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/vnet.mdx
@@ -184,4 +184,4 @@ clients.
 
 - Read our VNet usage [guide](../../../connect-your-client/vnet.mdx) for end-users
   accessing your applications with VNet.
-- Read [RFD 163](https://github.com/gravitational/teleport/blob/master/rfd/0163-vnet.md) to learn how VNet works on a technical level.
+- Read [RFD 163](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0163-vnet.md) to learn how VNet works on a technical level.

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/aws-redshift.mdx
@@ -69,4 +69,4 @@ Users created within the database will:
 
 - Connect using your [GUI database client](../../../connect-your-client/gui-clients.mdx).
 - Learn about [role templating](../../../zero-trust-access/access-controls/guides/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
@@ -169,4 +169,4 @@ database queries in the Teleport Audit Logs, when the Teleport username is over
 
 - Connect using your [GUI database client](../../../connect-your-client/gui-clients.mdx).
 - Learn about [role templating](../../../zero-trust-access/access-controls/guides/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mongodb.mdx
@@ -140,4 +140,4 @@ Users created within the database will:
 - Learn more about MongoDB [built-in roles](https://www.mongodb.com/docs/manual/reference/built-in-roles/) and [User-Defined Roles](https://www.mongodb.com/docs/manual/core/security-user-defined-roles/).
 - Connect using your [GUI database client](../../../connect-your-client/gui-clients.mdx).
 - Learn about [role templating](../../../zero-trust-access/access-controls/guides/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
@@ -159,4 +159,4 @@ endpoints. Please use auto-user provisioning on the primary endpoints.
 
 - Connect using your [GUI database client](../../../connect-your-client/gui-clients.mdx).
 - Learn about [role templating](../../../zero-trust-access/access-controls/guides/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
@@ -300,8 +300,8 @@ admin user through Teleport.
   client](../../../connect-your-client/gui-clients.mdx).
 - Learn about [role
   templating](../../../zero-trust-access/access-controls/guides/role-templates.mdx).
-- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0113-automatic-database-users.md).
-- Read database permission management [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0151-database-permission-management.md).
+- Read automatic user provisioning [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0113-automatic-database-users.md).
+- Read database permission management [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0151-database-permission-management.md).
 - The `internal.db_roles` traits we illustrated in this guide
   are replaced with values from the Teleport local user database. For full
   details on how variable expansion works in Teleport roles, see the [Teleport

--- a/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
+++ b/docs/pages/enroll-resources/desktop-access/directory-sharing.mdx
@@ -224,9 +224,9 @@ Web UI. Based on these messages, the Teleport Web UI advertises information
 about—or performs modifications on—the shared directory.
 
 You can read more about TDP in [Teleport RFD
-37](https://github.com/gravitational/teleport/blob/master/rfd/0037-desktop-access-protocol.md)
+37](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0037-desktop-access-protocol.md)
 and how Directory Sharing uses it in [RFD
-67](https://github.com/gravitational/teleport/blob/master/rfd/0067-desktop-access-file-system-sharing.md).
+67](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0067-desktop-access-file-system-sharing.md).
 
 #### In Teleport Connect
 

--- a/docs/pages/reference/architecture/machine-id-architecture.mdx
+++ b/docs/pages/reference/architecture/machine-id-architecture.mdx
@@ -11,7 +11,7 @@ inner workings.
 
 The initial specification and design for Machine & Workload Identity can be
 found in
-[the Request For Discussion.](https://github.com/gravitational/teleport/blob/master/rfd/0064-bot-for-cert-renewals.md)
+[the Request For Discussion.](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0064-bot-for-cert-renewals.md)
 
 ## What is a bot?
 

--- a/docs/pages/reference/architecture/tls-routing.mdx
+++ b/docs/pages/reference/architecture/tls-routing.mdx
@@ -280,4 +280,4 @@ behind layer 7 load balancers.
 
 - See [migration guide](../../zero-trust-access/management/operations/tls-routing.mdx) to learn how to
   upgrade an existing cluster to use TLS routing.
-- Read through TLS routing design document [RFD](https://github.com/gravitational/teleport/blob/master/rfd/0039-sni-alpn-teleport-proxy-routing.md).
+- Read through TLS routing design document [RFD](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0039-sni-alpn-teleport-proxy-routing.md).

--- a/docs/pages/zero-trust-access/access-controls/guides/joining-sessions.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/joining-sessions.mdx
@@ -299,4 +299,4 @@ the file transfer automatically begins.
 
 ## See also
 
-- [Moderated Sessions](https://github.com/gravitational/teleport/blob/master/rfd/0043-kubeaccess-multiparty.md)
+- [Moderated Sessions](https://github.com/gravitational/teleport/blob/8ff3d34581424302182c217e4d8d3be45bf2b0b7/rfd/0043-kubeaccess-multiparty.md)


### PR DESCRIPTION
Pin RFD links in public docs to a recent master commit in preparation for RFDs to move to a dedicated repository in https://github.com/gravitational/teleport/pull/69485.

I've not touched links outside of docs/ like code and proto comments, we can clean those up as we go.