### PR TITLE
fix: gha bloat check create token param keys

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -68,8 +68,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1.0.5 # Cannot upgrade past v1.1 while this runs in centos:7 due to nodejs GLIBC incompatibility
         with:
-          app-id: ${{ env.REVIEWERS_APP_ID }}
-          private-key: ${{ env.REVIEWERS_PRIVATE_KEY }}
+          app_id: ${{ env.REVIEWERS_APP_ID }}
+          private_key: ${{ env.REVIEWERS_PRIVATE_KEY }}
 
       - if: ${{ steps.cache-build-restore.outputs.cache-hit != 'true' }}
         name: Build base


### PR DESCRIPTION
Fixes backport PR #69646. Input params for older pinned github token action use underscores.

Needs follow-up to review whether the constraint that led us to pin workflow version still applies.