### PR TITLE
Share one kube cert across clusters without per-session MFA

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3629,10 +3629,14 @@ func (a *Server) submitCertificateIssuedEvent(req *cert.Request, attestedKeyPoli
 	// Unfortunately the only clue we have about Windows certs is the usage
 	// restriction: `RouteToWindowsDesktop` isn't actually passed along to the
 	// certRequest.
+	// The same is true of the kube local proxy's shared certificate,
+	// which carries no KubernetesCluster because the target is chosen per request via path routing.
 	for _, usage := range req.Usage {
 		switch usage {
 		case teleport.UsageWindowsDesktopOnly:
 			desktop = true
+		case teleport.UsageKubeOnly:
+			kubernetes = true
 		}
 	}
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -750,6 +750,9 @@ func validateUserCertsRequest(srv *ScopedServerWithRoles, req *authpb.UserCertsR
 		if req.MFAResponse != nil && req.Purpose != authpb.UserCertsRequest_CERT_PURPOSE_SINGLE_USE_CERTS {
 			return trace.BadParameter("requester %q can only request single use certificates", req.RequesterName)
 		}
+		if req.KubernetesCluster == "" && req.MFAResponse != nil {
+			return trace.BadParameter("requester %s cannot request MFA-verified certificates without a Kubernetes cluster", req.RequesterName)
+		}
 	}
 
 	if req.Purpose != authpb.UserCertsRequest_CERT_PURPOSE_SINGLE_USE_CERTS {
@@ -785,7 +788,7 @@ func validateCertUsage(req *authpb.UserCertsRequest) error {
 			return trace.BadParameter("missing NodeName field in a ssh-only UserCertsRequest")
 		}
 	case authpb.UserCertsRequest_Kubernetes:
-		if req.KubernetesCluster == "" {
+		if req.KubernetesCluster == "" && req.RequesterName != authpb.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_MULTI {
 			return trace.BadParameter("missing KubernetesCluster field in a kubernetes-only UserCertsRequest")
 		}
 	case authpb.UserCertsRequest_Database:

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -7773,3 +7773,83 @@ func TestScopedWatchEvents(t *testing.T) {
 		})
 	}
 }
+
+// TestGenerateUserCerts_unroutedKube covers
+// the shared unrouted Kubernetes certificate used by the multi-cluster kube local proxy.
+func TestGenerateUserCerts_unroutedKube(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	testServer := newTestTLSServer(t)
+
+	const username = "kube-multi-user"
+	_, _, err := authtest.CreateUserAndRole(testServer.Auth(), username, []string{username}, nil)
+	require.NoError(t, err, "CreateUserAndRole failed")
+
+	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err, "GenerateKeyWithAlgorithm failed")
+	publicKeyPEM, err := keys.MarshalPublicKey(key.Public())
+	require.NoError(t, err, "MarshalPublicKey failed")
+
+	for _, tt := range []struct {
+		name        string
+		requester   proto.UserCertsRequest_Requester
+		purpose     proto.UserCertsRequest_CertPurpose
+		mfaResponse *proto.MFAAuthenticateResponse
+		assertErr   require.ErrorAssertionFunc
+	}{
+		{
+			name:      "issued for the multi requester",
+			requester: proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_MULTI,
+			assertErr: require.NoError,
+		},
+		{
+			name:      "rejected for any other requester",
+			requester: proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY,
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter but got %v", err)
+				require.ErrorContains(t, err, "missing KubernetesCluster field")
+			},
+		},
+		{
+			name:        "rejected when carrying MFA state",
+			requester:   proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_MULTI,
+			purpose:     proto.UserCertsRequest_CERT_PURPOSE_SINGLE_USE_CERTS,
+			mfaResponse: &proto.MFAAuthenticateResponse{},
+			assertErr: func(t require.TestingT, err error, _ ...any) {
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter but got %v", err)
+				require.ErrorContains(t, err, "cannot request MFA-verified certificates without a Kubernetes cluster")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			userClient, err := testServer.NewClient(authtest.TestUser(username))
+			require.NoError(t, err, "NewClient failed")
+			t.Cleanup(func() { require.NoError(t, userClient.Close()) })
+
+			resp, err := userClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
+				TLSPublicKey: publicKeyPEM,
+				Username:     username,
+				Expires:      testServer.Clock().Now().Add(time.Hour),
+				Usage:        proto.UserCertsRequest_Kubernetes,
+				// No KubernetesCluster. The target is chosen per request by path routing at the proxy.
+				RequesterName: tt.requester,
+				Purpose:       tt.purpose,
+				MFAResponse:   tt.mfaResponse,
+			})
+			tt.assertErr(t, err)
+			if err != nil {
+				return
+			}
+
+			cert, err := tlsca.ParseCertificatePEM(resp.TLS)
+			require.NoError(t, err, "ParseCertificatePEM failed")
+			identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+			require.NoError(t, err, "FromSubject failed")
+
+			require.Empty(t, identity.KubernetesCluster, "shared cert must carry no Kubernetes cluster route")
+			require.NotEmpty(t, identity.RouteToCluster, "shared cert must still be routed to a Teleport cluster")
+			require.Empty(t, identity.MFAVerified, "shared cert must carry no MFA state")
+			require.Equal(t, []string{teleport.UsageKubeOnly}, identity.Usage)
+		})
+	}
+}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -184,9 +184,11 @@ func (p ReissueParams) usage() proto.UserCertsRequest_CertUsage {
 		// SSH means a request for an SSH certificate for access to a specific
 		// SSH node, as specified by NodeName.
 		return proto.UserCertsRequest_SSH
-	case p.KubernetesCluster != "":
+	case p.KubernetesCluster != "" || p.RequesterName == proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_MULTI:
 		// Kubernetes means a request for a TLS certificate for access to a
-		// specific Kubernetes cluster, as specified by KubernetesCluster.
+		// specific Kubernetes cluster, as specified by KubernetesCluster, or
+		// to any of them via path routing when the kube local proxy asks for
+		// one shared certificate with no cluster route.
 		return proto.UserCertsRequest_Kubernetes
 	case p.RouteToDatabase.ServiceName != "":
 		// Database means a request for a TLS certificate for access to a

--- a/lib/kube/proxy/single_cert_handler_test.go
+++ b/lib/kube/proxy/single_cert_handler_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 )
@@ -97,6 +98,39 @@ func TestSingleCertRouting(t *testing.T) {
 				_, err := clientA.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
 				require.NoError(t, err)
 
+			},
+		},
+		{
+			// The shared unrouted certificate of the tsh kube local proxy: no Kubernetes cluster, no MFA state.
+			// One such cert must serve every Kubernetes cluster in the Teleport cluster via path routing.
+			name:     "unrouted identity path routes to every cluster",
+			roleSpec: defaultRoleSpec,
+			genKubeCertificateOpts: []GenTestKubeClientTLSCertOptions{
+				WithIdentityRoute(clusterName, ""),
+			},
+			assert: func(t *testing.T, restConfig *rest.Config) {
+				for _, kubeCluster := range []string{"a", "b"} {
+					client := pathRoutedKubeClient(t, restConfig, clusterName, kubeCluster)
+					_, err := client.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+					require.NoError(t, err, "unrouted cert must serve kube cluster %q", kubeCluster)
+				}
+			},
+		},
+		{
+			// As above, but carrying the usage restriction auth stamps on a Kubernetes-only certificate.
+			// Without it the identity is unrestricted and the AcceptedUsage check in the auth middleware is skipped.
+			name:     "unrouted kube-only identity path routes to every cluster",
+			roleSpec: defaultRoleSpec,
+			genKubeCertificateOpts: []GenTestKubeClientTLSCertOptions{
+				WithIdentityRoute(clusterName, ""),
+				WithUsage(teleport.UsageKubeOnly),
+			},
+			assert: func(t *testing.T, restConfig *rest.Config) {
+				for _, kubeCluster := range []string{"a", "b"} {
+					client := pathRoutedKubeClient(t, restConfig, clusterName, kubeCluster)
+					_, err := client.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+					require.NoError(t, err, "unrouted kube-only cert must serve kube cluster %q", kubeCluster)
+				}
 			},
 		},
 		{

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -658,6 +658,13 @@ func WithMFAVerified() GenTestKubeClientTLSCertOptions {
 	}
 }
 
+// WithUsage restricts the identity to the given usages.
+func WithUsage(usage ...string) GenTestKubeClientTLSCertOptions {
+	return func(i *tlsca.Identity) {
+		i.Usage = usage
+	}
+}
+
 // GenTestKubeClientTLSCert generates a kube client to access kube service
 func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName, kubeCluster string, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *rest.Config) {
 	client, _, cfg := c.GenTestKubeClientsTLSCert(t, userName, kubeCluster, opts...)

--- a/lib/srv/alpnproxy/kube.go
+++ b/lib/srv/alpnproxy/kube.go
@@ -58,17 +58,19 @@ const certReissueClientWait = time.Second * 3
 // we give them longer time to perform the headless login flow.
 const certReissueClientWaitHeadless = defaults.HeadlessLoginTimeout
 
-type kubeClusterKey struct {
-	teleportCluster string
-	kubeCluster     string
+// KubeClusterKey identifies the Kubernetes cluster a client cert serves. An empty KubeCluster
+// holds the shared unrouted cert, which the proxy path-routes to any cluster in TeleportCluster.
+type KubeClusterKey struct {
+	TeleportCluster string
+	KubeCluster     string
 }
 
 // KubeClientCerts is a map of Kubernetes client certs.
-type KubeClientCerts map[kubeClusterKey]tls.Certificate
+type KubeClientCerts map[KubeClusterKey]tls.Certificate
 
 // Add adds a tls.Certificate for a kube cluster.
 func (c KubeClientCerts) Add(teleportCluster, kubeCluster string, cert tls.Certificate) {
-	c[kubeClusterKey{teleportCluster: teleportCluster, kubeCluster: kubeCluster}] = cert
+	c[KubeClusterKey{TeleportCluster: teleportCluster, KubeCluster: kubeCluster}] = cert
 }
 
 // KubeCertReissuer reissues a client certificate for a Kubernetes cluster.
@@ -255,10 +257,10 @@ func (m *KubeMiddleware) getCert(teleportCluster, kubeCluster string) (cert tls.
 	m.certsMu.RLock()
 	defer m.certsMu.RUnlock()
 
-	if cert, ok := m.certs[kubeClusterKey{teleportCluster: teleportCluster, kubeCluster: kubeCluster}]; ok {
+	if cert, ok := m.certs[KubeClusterKey{TeleportCluster: teleportCluster, KubeCluster: kubeCluster}]; ok {
 		return cert, kubeCluster, nil
 	}
-	if cert, ok := m.certs[kubeClusterKey{teleportCluster: teleportCluster}]; ok {
+	if cert, ok := m.certs[KubeClusterKey{TeleportCluster: teleportCluster}]; ok {
 		return cert, "", nil
 	}
 	return tls.Certificate{}, kubeCluster, trace.NotFound("no client cert found for teleport cluster %q kube cluster %q", teleportCluster, kubeCluster)

--- a/lib/srv/alpnproxy/kube.go
+++ b/lib/srv/alpnproxy/kube.go
@@ -197,7 +197,7 @@ func (m *KubeMiddleware) HandleRequest(rw http.ResponseWriter, req *http.Request
 		return true
 	}
 
-	cert, err := m.getCert(teleportCluster, kubeCluster)
+	cert, certKubeCluster, err := m.getCert(teleportCluster, kubeCluster)
 	// If the cert is cleared using m.ClearCerts(), it won't be found.
 	// This forces the middleware to issue a new cert on a new request.
 	// This is used in access requests in Connect where we want to refresh certs without closing the proxy.
@@ -205,7 +205,7 @@ func (m *KubeMiddleware) HandleRequest(rw http.ResponseWriter, req *http.Request
 		return false
 	}
 
-	err = m.reissueCertIfExpired(req.Context(), cert, teleportCluster, kubeCluster)
+	err = m.reissueCertIfExpired(req.Context(), cert, teleportCluster, certKubeCluster)
 	if err != nil {
 		// If user input is required we return an error that will try to get user attention to the local proxy
 		if errors.Is(err, ErrUserInputRequired) {
@@ -249,19 +249,19 @@ func (m *KubeMiddleware) GetServerName(req *http.Request) (string, bool, error) 
 	return kuberelay.FullSNIForKubeCluster(tc, kc), true, nil
 }
 
-// getCert looks up the per-cluster client cert to use for an outbound kube
-// API request. Clusters are identified by the (teleport, kube) pair parsed
-// from the request URL path.
-func (m *KubeMiddleware) getCert(teleportCluster, kubeCluster string) (tls.Certificate, error) {
-	key := kubeClusterKey{teleportCluster: teleportCluster, kubeCluster: kubeCluster}
-
+// getCert looks up the client cert to use for an outbound kube API request.
+// Clusters are identified by the (teleport, kube) pair parsed from the request URL path.
+func (m *KubeMiddleware) getCert(teleportCluster, kubeCluster string) (cert tls.Certificate, resolvedKubeCluster string, err error) {
 	m.certsMu.RLock()
-	cert, ok := m.certs[key]
-	m.certsMu.RUnlock()
-	if !ok {
-		return tls.Certificate{}, trace.NotFound("no client cert found for teleport cluster %q kube cluster %q", teleportCluster, kubeCluster)
+	defer m.certsMu.RUnlock()
+
+	if cert, ok := m.certs[kubeClusterKey{teleportCluster: teleportCluster, kubeCluster: kubeCluster}]; ok {
+		return cert, kubeCluster, nil
 	}
-	return cert, nil
+	if cert, ok := m.certs[kubeClusterKey{teleportCluster: teleportCluster}]; ok {
+		return cert, "", nil
+	}
+	return tls.Certificate{}, kubeCluster, trace.NotFound("no client cert found for teleport cluster %q kube cluster %q", teleportCluster, kubeCluster)
 }
 
 func (m *KubeMiddleware) getCertForRequest(req *http.Request) (tls.Certificate, error) {
@@ -269,7 +269,8 @@ func (m *KubeMiddleware) getCertForRequest(req *http.Request) (tls.Certificate, 
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}
-	return m.getCert(tc, kc)
+	cert, _, err := m.getCert(tc, kc)
+	return cert, trace.Wrap(err)
 }
 
 // GetClientCerts implements [LocalProxyHTTPMiddleware].

--- a/lib/srv/alpnproxy/kube.go
+++ b/lib/srv/alpnproxy/kube.go
@@ -76,6 +76,10 @@ func (c KubeClientCerts) Add(teleportCluster, kubeCluster string, cert tls.Certi
 // KubeCertReissuer reissues a client certificate for a Kubernetes cluster.
 type KubeCertReissuer = func(ctx context.Context, teleportCluster, kubeCluster string) (tls.Certificate, error)
 
+// KubeSharedCertReissuer reissues the shared unrouted cert on behalf of the cluster whose request needs it,
+// and reports the kube cluster to store the result under.
+type KubeSharedCertReissuer = func(ctx context.Context, teleportCluster, requestedKubeCluster string) (cert tls.Certificate, storeUnderKubeCluster string, err error)
+
 // KubeMiddleware is a LocalProxyHTTPMiddleware for handling Kubernetes
 // requests.
 type KubeMiddleware struct {
@@ -83,6 +87,9 @@ type KubeMiddleware struct {
 
 	// certReissuer is used to reissue a client certificate for a Kubernetes cluster if existing cert expired.
 	certReissuer KubeCertReissuer
+	// sharedCertReissuer reissues the shared unrouted cert.
+	// Only the kube local proxy issues one, so other local proxies leave it unset.
+	sharedCertReissuer KubeSharedCertReissuer
 	// Clock specifies the time provider. Will be used to override the time anchor
 	// for TLS certificate verification. Defaults to real clock if unspecified.
 	clock clockwork.Clock
@@ -111,6 +118,9 @@ type KubeMiddlewareConfig struct {
 	Logger       *slog.Logger
 	CloseContext context.Context
 
+	// SharedCertReissuer reissues the shared unrouted cert, for the local proxies that use one.
+	SharedCertReissuer KubeSharedCertReissuer
+
 	// Relay signals that the middleware should provide the appropriate SNI
 	// override to connect to the Kube forwarder of a Relay rather than the one
 	// of a Proxy.
@@ -127,6 +137,8 @@ func NewKubeMiddleware(cfg KubeMiddlewareConfig) LocalProxyHTTPMiddleware {
 		logger:       cfg.Logger,
 		closeContext: cfg.CloseContext,
 		relay:        cfg.Relay,
+
+		sharedCertReissuer: cfg.SharedCertReissuer,
 	}
 }
 
@@ -199,7 +211,7 @@ func (m *KubeMiddleware) HandleRequest(rw http.ResponseWriter, req *http.Request
 		return true
 	}
 
-	cert, certKubeCluster, err := m.getCert(teleportCluster, kubeCluster)
+	cert, resolvedKubeCluster, err := m.getCert(teleportCluster, kubeCluster)
 	// If the cert is cleared using m.ClearCerts(), it won't be found.
 	// This forces the middleware to issue a new cert on a new request.
 	// This is used in access requests in Connect where we want to refresh certs without closing the proxy.
@@ -207,7 +219,7 @@ func (m *KubeMiddleware) HandleRequest(rw http.ResponseWriter, req *http.Request
 		return false
 	}
 
-	err = m.reissueCertIfExpired(req.Context(), cert, teleportCluster, certKubeCluster)
+	err = m.reissueCertIfExpired(req.Context(), cert, teleportCluster, resolvedKubeCluster, kubeCluster)
 	if err != nil {
 		// If user input is required we return an error that will try to get user attention to the local proxy
 		if errors.Is(err, ErrUserInputRequired) {
@@ -289,7 +301,7 @@ var ErrUserInputRequired = errors.New("user input required")
 
 // reissueCertIfExpired checks if provided certificate has expired and
 // reissues it if needed, replacing the entry in the middleware cert map.
-func (m *KubeMiddleware) reissueCertIfExpired(ctx context.Context, cert tls.Certificate, teleportCluster, kubeCluster string) error {
+func (m *KubeMiddleware) reissueCertIfExpired(ctx context.Context, cert tls.Certificate, teleportCluster, kubeCluster, requestedKubeCluster string) error {
 	needsReissue := false
 	if len(cert.Certificate) == 0 {
 		m.logger.InfoContext(ctx, "missing TLS certificate, attempting to reissue a new one")
@@ -307,7 +319,7 @@ func (m *KubeMiddleware) reissueCertIfExpired(ctx context.Context, cert tls.Cert
 		return nil
 	}
 
-	if m.certReissuer == nil {
+	if m.certReissuer == nil && m.sharedCertReissuer == nil {
 		return trace.BadParameter("can't reissue proxy certificate - reissuer is not available")
 	}
 
@@ -319,10 +331,10 @@ func (m *KubeMiddleware) reissueCertIfExpired(ctx context.Context, cert tls.Cert
 		go func() {
 			defer m.isCertReissuingRunning.Store(false)
 
-			newCert, err := m.certReissuer(m.closeContext, teleportCluster, kubeCluster)
+			newCert, storeUnder, err := m.reissue(teleportCluster, kubeCluster, requestedKubeCluster)
 			if err == nil {
 				m.certsMu.Lock()
-				m.certs.Add(teleportCluster, kubeCluster, newCert)
+				m.certs.Add(teleportCluster, storeUnder, newCert)
 				m.certsMu.Unlock()
 			}
 			errCh <- err
@@ -344,6 +356,18 @@ func (m *KubeMiddleware) reissueCertIfExpired(ctx context.Context, cert tls.Cert
 	case <-ctx.Done():
 		return trace.Wrap(ctx.Err())
 	}
+}
+
+// reissue the cert serving requestedKubeCluster, which is currently held under kubeCluster.
+func (m *KubeMiddleware) reissue(teleportCluster, kubeCluster, requestedKubeCluster string) (cert tls.Certificate, storeUnder string, err error) {
+	if kubeCluster == "" && m.sharedCertReissuer != nil {
+		return m.sharedCertReissuer(m.closeContext, teleportCluster, requestedKubeCluster)
+	}
+	if m.certReissuer == nil {
+		return tls.Certificate{}, "", trace.BadParameter("can't reissue proxy certificate - reissuer is not available")
+	}
+	cert, err = m.certReissuer(m.closeContext, teleportCluster, kubeCluster)
+	return cert, kubeCluster, trace.Wrap(err)
 }
 
 // NewKubeListener creates a listener for kube local proxy.

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -798,4 +799,125 @@ func (m addUserAgentSignedHeaderMiddleware) HandleFinalize(
 	authHeader = strings.Replace(authHeader, "SignedHeaders=", "SignedHeaders=user-agent;", 1)
 	req.Header.Set("Authorization", authHeader)
 	return next.HandleFinalize(ctx, in)
+}
+
+// TestKubeMiddlewareSharedCert covers cert resolution when a single unrouted certificate,
+// stored under the empty kube cluster key, serves every Kubernetes cluster whose per-session MFA is off,
+// while MFA-gated clusters keep their own.
+func TestKubeMiddlewareSharedCert(t *testing.T) {
+	t.Parallel()
+
+	const teleportCluster = "localhost"
+	const sharedKey = ""
+
+	now := time.Now()
+	ca := mustGenSelfSignedCert(t)
+	genCert := func(kubeCluster string, clock clockwork.Clock) tls.Certificate {
+		return mustGenCertSignedWithCA(t, ca,
+			withIdentity(tlsca.Identity{
+				Username:          "test-user",
+				Groups:            []string{"test-group"},
+				KubernetesCluster: kubeCluster,
+			}),
+			withClock(clock),
+		)
+	}
+	fresh := clockwork.NewFakeClockAt(now)
+	stale := clockwork.NewFakeClockAt(now.Add(-24 * time.Hour)) // Issued in the past, so considered as expired.
+	var (
+		sharedCert   = genCert(sharedKey, fresh)
+		mfaCert      = genCert("kube-mfa", fresh)
+		reissuedCert = genCert("reissued", fresh)
+	)
+
+	requestFor := func(t *testing.T, kubeCluster string) *http.Request {
+		u, err := url.Parse("https://example.test" + common.KubeLocalProxyPathPrefix(teleportCluster, kubeCluster) + "/api/v1/namespaces")
+		require.NoError(t, err)
+		return &http.Request{URL: u}
+	}
+
+	for _, tt := range []struct {
+		name            string
+		seed            map[string]tls.Certificate
+		requests        []string
+		wantReissuedFor []string
+		wantCerts       map[string]tls.Certificate
+	}{
+		{
+			name:      "shared cert serves clusters with no entry of their own",
+			seed:      map[string]tls.Certificate{sharedKey: sharedCert},
+			requests:  []string{"kube-a", "kube-b"},
+			wantCerts: map[string]tls.Certificate{"kube-a": sharedCert, "kube-b": sharedCert},
+		},
+		{
+			name:      "per-cluster cert wins over the shared cert",
+			seed:      map[string]tls.Certificate{sharedKey: sharedCert, "kube-mfa": mfaCert},
+			requests:  []string{"kube-mfa"},
+			wantCerts: map[string]tls.Certificate{"kube-mfa": mfaCert},
+		},
+		{
+			name:            "expired shared cert is reissued against the shared key",
+			seed:            map[string]tls.Certificate{sharedKey: genCert(sharedKey, stale)},
+			requests:        []string{"kube-a"},
+			wantReissuedFor: []string{sharedKey},
+			wantCerts:       map[string]tls.Certificate{"kube-a": reissuedCert, "kube-b": reissuedCert},
+		},
+		{
+			name:            "expired per-cluster cert is reissued against its own key",
+			seed:            map[string]tls.Certificate{sharedKey: sharedCert, "kube-mfa": genCert("kube-mfa", stale)},
+			requests:        []string{"kube-mfa"},
+			wantReissuedFor: []string{"kube-mfa"},
+			wantCerts:       map[string]tls.Certificate{"kube-mfa": reissuedCert, "kube-a": sharedCert},
+		},
+		{
+			name:            "reissue stays per-cluster when no shared cert exists",
+			seed:            map[string]tls.Certificate{},
+			requests:        []string{"kube-a"},
+			wantReissuedFor: []string{"kube-a"},
+			wantCerts:       map[string]tls.Certificate{"kube-a": reissuedCert},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				certs := KubeClientCerts{}
+				for kubeCluster, cert := range tt.seed {
+					certs.Add(teleportCluster, kubeCluster, cert)
+				}
+
+				var mu sync.Mutex
+				var reissuedFor []string
+				km := NewKubeMiddleware(KubeMiddlewareConfig{
+					Certs: certs,
+					CertReissuer: func(_ context.Context, _, kubeCluster string) (tls.Certificate, error) {
+						mu.Lock()
+						defer mu.Unlock()
+						reissuedFor = append(reissuedFor, kubeCluster)
+						return reissuedCert, nil
+					},
+					Logger:       logtest.NewLogger(),
+					Clock:        clockwork.NewFakeClockAt(now),
+					CloseContext: context.Background(),
+				})
+				require.NoError(t, km.CheckAndSetDefaults())
+
+				for _, kubeCluster := range tt.requests {
+					require.False(t, km.HandleRequest(responsewriters.NewMemoryResponseWriter(), requestFor(t, kubeCluster)),
+						"request for %q should not have been handled with an error", kubeCluster)
+				}
+
+				mu.Lock()
+				defer mu.Unlock()
+				require.Equal(t, tt.wantReissuedFor, reissuedFor)
+
+				for kubeCluster, want := range tt.wantCerts {
+					got, ok, err := km.GetClientCerts(requestFor(t, kubeCluster))
+					require.NoError(t, err)
+					require.True(t, ok)
+					require.Len(t, got, 1)
+					require.Equal(t, want, got[0], "unexpected cert served for kube cluster %q", kubeCluster)
+				}
+			})
+		})
+	}
 }

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -825,9 +825,10 @@ func TestKubeMiddlewareSharedCert(t *testing.T) {
 	fresh := clockwork.NewFakeClockAt(now)
 	stale := clockwork.NewFakeClockAt(now.Add(-24 * time.Hour)) // Issued in the past, so considered as expired.
 	var (
-		sharedCert   = genCert(sharedKey, fresh)
-		mfaCert      = genCert("kube-mfa", fresh)
-		reissuedCert = genCert("reissued", fresh)
+		sharedCert      = genCert(sharedKey, fresh)
+		staleSharedCert = genCert(sharedKey, stale)
+		mfaCert         = genCert("kube-mfa", fresh)
+		reissuedCert    = genCert("reissued", fresh)
 	)
 
 	requestFor := func(t *testing.T, kubeCluster string) *http.Request {
@@ -840,6 +841,7 @@ func TestKubeMiddlewareSharedCert(t *testing.T) {
 		name            string
 		seed            map[string]tls.Certificate
 		requests        []string
+		sharedReissue   bool
 		wantReissuedFor []string
 		wantCerts       map[string]tls.Certificate
 	}{
@@ -857,24 +859,40 @@ func TestKubeMiddlewareSharedCert(t *testing.T) {
 		},
 		{
 			name:            "expired shared cert is reissued against the shared key",
-			seed:            map[string]tls.Certificate{sharedKey: genCert(sharedKey, stale)},
+			seed:            map[string]tls.Certificate{sharedKey: staleSharedCert},
 			requests:        []string{"kube-a"},
-			wantReissuedFor: []string{sharedKey},
+			wantReissuedFor: []string{"routed:" + sharedKey},
 			wantCerts:       map[string]tls.Certificate{"kube-a": reissuedCert, "kube-b": reissuedCert},
 		},
 		{
 			name:            "expired per-cluster cert is reissued against its own key",
 			seed:            map[string]tls.Certificate{sharedKey: sharedCert, "kube-mfa": genCert("kube-mfa", stale)},
 			requests:        []string{"kube-mfa"},
-			wantReissuedFor: []string{"kube-mfa"},
+			wantReissuedFor: []string{"routed:kube-mfa"},
 			wantCerts:       map[string]tls.Certificate{"kube-mfa": reissuedCert, "kube-a": sharedCert},
 		},
 		{
 			name:            "reissue stays per-cluster when no shared cert exists",
 			seed:            map[string]tls.Certificate{},
 			requests:        []string{"kube-a"},
-			wantReissuedFor: []string{"kube-a"},
+			wantReissuedFor: []string{"routed:kube-a"},
 			wantCerts:       map[string]tls.Certificate{"kube-a": reissuedCert},
+		},
+		{
+			name:            "shared reissue can move one cluster onto its own key",
+			seed:            map[string]tls.Certificate{sharedKey: staleSharedCert},
+			requests:        []string{"kube-a"},
+			sharedReissue:   true,
+			wantReissuedFor: []string{"shared:kube-a"},
+			wantCerts:       map[string]tls.Certificate{"kube-a": reissuedCert, "kube-b": staleSharedCert},
+		},
+		{
+			name:            "cluster with its own cert reissues through the routed reissuer",
+			seed:            map[string]tls.Certificate{sharedKey: sharedCert, "kube-mfa": genCert("kube-mfa", stale)},
+			requests:        []string{"kube-mfa"},
+			sharedReissue:   true,
+			wantReissuedFor: []string{"routed:kube-mfa"},
+			wantCerts:       map[string]tls.Certificate{"kube-mfa": reissuedCert, "kube-a": sharedCert},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -887,18 +905,27 @@ func TestKubeMiddlewareSharedCert(t *testing.T) {
 
 				var mu sync.Mutex
 				var reissuedFor []string
-				km := NewKubeMiddleware(KubeMiddlewareConfig{
+				cfg := KubeMiddlewareConfig{
 					Certs: certs,
 					CertReissuer: func(_ context.Context, _, kubeCluster string) (tls.Certificate, error) {
 						mu.Lock()
 						defer mu.Unlock()
-						reissuedFor = append(reissuedFor, kubeCluster)
+						reissuedFor = append(reissuedFor, "routed:"+kubeCluster)
 						return reissuedCert, nil
 					},
 					Logger:       logtest.NewLogger(),
 					Clock:        clockwork.NewFakeClockAt(now),
 					CloseContext: context.Background(),
-				})
+				}
+				if tt.sharedReissue {
+					cfg.SharedCertReissuer = func(_ context.Context, _, requestedKubeCluster string) (tls.Certificate, string, error) {
+						mu.Lock()
+						defer mu.Unlock()
+						reissuedFor = append(reissuedFor, "shared:"+requestedKubeCluster)
+						return reissuedCert, requestedKubeCluster, nil
+					}
+				}
+				km := NewKubeMiddleware(cfg)
 				require.NoError(t, km.CheckAndSetDefaults())
 
 				for _, kubeCluster := range tt.requests {

--- a/tool/tsh/common/kube_cert_issuer.go
+++ b/tool/tsh/common/kube_cert_issuer.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -54,7 +55,8 @@ type kubeCertIssuer struct {
 	// mfa is the reusable MFA state shared across issuances.
 	mfa *reusableMFA
 	// sharedCertUnsupported latches once an auth server has rejected an unrouted request.
-	sharedCertUnsupported bool
+	// The middleware reissues concurrently with the burst that starts the proxy, so it is atomic.
+	sharedCertUnsupported atomic.Bool
 }
 
 // kubeKeyStore is the subset of [client.LocalKeyAgent] the issuer loads and saves certs through.
@@ -197,6 +199,12 @@ func (issuer *kubeCertIssuer) ReissueSharedCert(ctx context.Context, teleportClu
 
 // reissueSharedCertOverConn reissues the shared unrouted cert over the given connection.
 func (issuer *kubeCertIssuer) reissueSharedCertOverConn(ctx context.Context, cc kubeCertClient, teleportCluster, requestedKubeCluster string) (*tls.Certificate, string, error) {
+	// An auth server has already refused an unrouted request, so do not ask again.
+	if issuer.sharedCertUnsupported.Load() {
+		cert, err := issuer.issueCertOverConn(ctx, cc, teleportCluster, requestedKubeCluster, nil /*mfaCheck*/)
+		return cert, requestedKubeCluster, trace.Wrap(err)
+	}
+
 	authClient, err := cc.ConnectToCluster(ctx, teleportCluster)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -220,7 +228,22 @@ func (issuer *kubeCertIssuer) reissueSharedCertOverConn(ctx context.Context, cc 
 
 	// The cluster can still use the shared cert, so reissue it.
 	cert, err := issuer.issueCertOverConn(ctx, cc, teleportCluster, "" /*kubeCluster*/, nil /*mfaCheck*/)
-	return cert, "", trace.Wrap(err)
+	if err == nil {
+		return cert, "", nil
+	}
+	if !isUnroutedKubeCertRejected(err) {
+		return nil, "", trace.Wrap(err)
+	}
+	// This auth server will not issue the shared cert, so give the cluster its own and latch.
+	// Every other cluster it served converts the same way as its own reissue comes due.
+	logger.DebugContext(ctx, "Auth server rejected the shared unrouted cert, giving the cluster a routed cert",
+		"teleport_cluster", teleportCluster,
+		"kube_cluster", requestedKubeCluster,
+		"error", err,
+	)
+	issuer.sharedCertUnsupported.Store(true)
+	cert, err = issuer.issueCertOverConn(ctx, cc, teleportCluster, requestedKubeCluster, check)
+	return cert, requestedKubeCluster, trace.Wrap(err)
 }
 
 // AcquireConn holds the shared cluster connection until the returned release is called.
@@ -280,7 +303,7 @@ func (issuer *kubeCertIssuer) issueCerts(ctx context.Context, clusters kubeconfi
 		return nil, trace.Wrap(err)
 	}
 
-	if issuer.sharedCertUnsupported {
+	if issuer.sharedCertUnsupported.Load() {
 		return run.certs, trace.Wrap(run.IssuePerCluster(ctx, mfaOff))
 	}
 
@@ -291,7 +314,7 @@ func (issuer *kubeCertIssuer) issueCerts(ctx context.Context, clusters kubeconfi
 		}
 		// The auth server rejected the shared unrouted cert, so issue per cluster instead.
 		logger.DebugContext(ctx, "Auth server rejected the shared unrouted cert, issuing per cluster", "error", err)
-		issuer.sharedCertUnsupported = true
+		issuer.sharedCertUnsupported.Store(true)
 		return run.certs, trace.Wrap(run.IssuePerCluster(ctx, mfaOff))
 	}
 	return run.certs, nil

--- a/tool/tsh/common/kube_cert_issuer.go
+++ b/tool/tsh/common/kube_cert_issuer.go
@@ -486,11 +486,17 @@ func localProxyClusterKey(cluster kubeconfig.LocalProxyCluster) string {
 	return cluster.TeleportCluster + "/" + cluster.KubeCluster
 }
 
-// isUnroutedKubeCertRejected reports whether an auth server refused an unrouted request,
-// as every server predating the shared cert does.
+// isUnroutedKubeCertRejected reports whether an auth server refused the request for naming no Kubernetes cluster,
+// which a routed request would have satisfied. Both causes are recoverable by issuing per cluster instead.
 func isUnroutedKubeCertRejected(err error) bool {
-	// validateCertUsage rejects the request before it reaches any typed error.
-	return trace.IsBadParameter(err) && strings.Contains(err.Error(), "missing KubernetesCluster field")
+	// Every server predating the shared cert refuses an unrouted request.
+	// validateCertUsage rejects it before it reaches any typed error.
+	if trace.IsBadParameter(err) && strings.Contains(err.Error(), "missing KubernetesCluster field") {
+		return true
+	}
+	// Scoped identities are only allowed a Kubernetes cert that names a cluster,
+	// so an unrouted request reads to auth as an unsupported usage.
+	return trace.IsAccessDenied(err) && strings.Contains(err.Error(), "generating scoped user cert for unsupported usage")
 }
 
 // isMFAReuseRejected reports whether an auth server unambiguously rejected the reusable MFA flow.

--- a/tool/tsh/common/kube_cert_issuer.go
+++ b/tool/tsh/common/kube_cert_issuer.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"maps"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -115,6 +116,8 @@ func (issuer *kubeCertIssuer) LoadOrIssueCerts(ctx context.Context, clusters kub
 // If no reusable response is held, it takes the single-flight ceremony path, which may prompt the user.
 // A nil mfaCheck means the MFA requirement is unknown: the issuance takes the MFA-gated path,
 // which degrades to a plain issuance when the server reports MFA as not required.
+// An empty kubeCluster issues the shared unrouted cert for teleportCluster,
+// which the proxy path-routes to any of its Kubernetes clusters. It never prompts and is never persisted.
 func (issuer *kubeCertIssuer) IssueCert(ctx context.Context, teleportCluster, kubeCluster string, mfaCheck *proto.IsMFARequiredResponse) (*tls.Certificate, error) {
 	// Hold one connection across the issuance. Every attempt below shares it.
 	cc, release, err := issuer.conn.Acquire(ctx)
@@ -148,6 +151,16 @@ func (issuer *kubeCertIssuer) issueCertOverConn(ctx context.Context, cc kubeCert
 			return nil, trace.Wrap(err)
 		}
 		defer release()
+		return issuer.requestCert(ctx, cc, params)
+	}
+
+	// Unrouted certs are issued for the proxy to route to any of its clusters.
+	if kubeCluster == "" {
+		params.RequesterName = proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_MULTI
+		params.MFACheck = &proto.IsMFARequiredResponse{
+			Required:    false,
+			MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+		}
 		return issuer.requestCert(ctx, cc, params)
 	}
 
@@ -188,7 +201,7 @@ func (issuer *kubeCertIssuer) loadKubeKeyRings(teleportClusters []string) (map[s
 
 // issueCerts issues certs for the given clusters with at most one MFA ceremony.
 // One issuance runs the ceremony and the rest replay its reusable response.
-// Clusters without per-session MFA are issued serially, as their certs are saved to the key store.
+// Clusters without per-session MFA share one unrouted cert per Teleport cluster.
 func (issuer *kubeCertIssuer) issueCerts(ctx context.Context, clusters kubeconfig.LocalProxyClusters) (alpnproxy.KubeClientCerts, error) {
 	// Hold one connection across the whole burst: the MFA prefetch and the issuances share it.
 	cc, release, err := issuer.conn.Acquire(ctx)
@@ -197,9 +210,33 @@ func (issuer *kubeCertIssuer) issueCerts(ctx context.Context, clusters kubeconfi
 	}
 	defer release()
 
+	certs := make(alpnproxy.KubeClientCerts)
+	var certsMu sync.Mutex
+	issueAndAdd := func(ctx context.Context, cluster kubeconfig.LocalProxyCluster, mfaCheck *proto.IsMFARequiredResponse) error {
+		cert, err := issuer.IssueCert(ctx, cluster.TeleportCluster, cluster.KubeCluster, mfaCheck)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		logger.DebugContext(ctx, "Client cert issued for cluster", "cluster", cluster)
+		certsMu.Lock()
+		defer certsMu.Unlock()
+		certs.Add(cluster.TeleportCluster, cluster.KubeCluster, *cert)
+		return nil
+	}
+
 	mfaChecks, err := issuer.fetchMFAChecks(ctx, cc, clusters)
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	// Headless serializes every issuance on the ceremony lock, so the partition below cannot help it.
+	if issuer.tc.AllowHeadless {
+		for _, cluster := range clusters {
+			if err := issueAndAdd(ctx, cluster, mfaChecks[localProxyClusterKey(cluster)]); err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
+		return certs, nil
 	}
 
 	// Partition clusters into MFA-gated and prompt-free.
@@ -212,33 +249,20 @@ func (issuer *kubeCertIssuer) issueCerts(ctx context.Context, clusters kubeconfi
 		}
 	}
 
-	certs := make(alpnproxy.KubeClientCerts)
-	var certsMu sync.Mutex
-	issueAndAdd := func(ctx context.Context, cluster kubeconfig.LocalProxyCluster) error {
-		mfaCheck := mfaChecks[localProxyClusterKey(cluster)]
-		cert, err := issuer.IssueCert(ctx, cluster.TeleportCluster, cluster.KubeCluster, mfaCheck)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		logger.DebugContext(ctx, "Client cert issued for cluster", "cluster", cluster)
-		certsMu.Lock()
-		defer certsMu.Unlock()
-		certs.Add(cluster.TeleportCluster, cluster.KubeCluster, *cert)
-		return nil
-	}
-
 	// MFA-gated issuances fan out concurrently.
 	group := newKubeClusterGroup(cc, mfaOn, kubeCertIssueConcurrency())
 	defer group.Close(ctx)
-	if err := group.ForEach(ctx, issueAndAdd); err != nil {
+	err = group.ForEach(ctx, func(ctx context.Context, cluster kubeconfig.LocalProxyCluster) error {
+		return issueAndAdd(ctx, cluster, mfaChecks[localProxyClusterKey(cluster)])
+	})
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Clusters without per-session MFA issue serially.
-	for _, cluster := range mfaOff {
-		if err := issueAndAdd(ctx, cluster); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	// Prompt-free issuances share one unrouted cert per Teleport cluster.
+	err = issuer.issueSharedCerts(ctx, mfaOff, certs)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	return certs, nil
 }
@@ -334,6 +358,12 @@ func (issuer *kubeCertIssuer) issueWithCeremony(ctx context.Context, cc kubeCert
 
 // requestCert requests one cert from the cluster, with no single-flight lock.
 func (issuer *kubeCertIssuer) requestCert(ctx context.Context, cc kubeCertClient, params client.ReissueParams) (*tls.Certificate, error) {
+	unrouted := params.KubernetesCluster == ""
+	if unrouted && params.RequesterName != proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_MULTI {
+		return nil, trace.BadParameter("unrouted Kubernetes certificates can only be requested by %v, got %v",
+			proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_MULTI, params.RequesterName)
+	}
+
 	result, err := cc.IssueUserCertsWithMFA(ctx, params)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -345,7 +375,8 @@ func (issuer *kubeCertIssuer) requestCert(ctx context.Context, cc kubeCertClient
 	}
 
 	// Save to the keystore if MFA was not required.
-	if result.MFARequired == proto.MFARequired_MFA_REQUIRED_NO {
+	// The unrouted cert stays in memory.
+	if result.MFARequired == proto.MFARequired_MFA_REQUIRED_NO && !unrouted {
 		if err := issuer.keyStore.AddKubeKeyRing(result.KeyRing); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -362,6 +393,19 @@ func (issuer *kubeCertIssuer) requestCert(ctx context.Context, cc kubeCertClient
 	}
 
 	return &cert, nil
+}
+
+// issueSharedCerts issues one unrouted cert per Teleport cluster covering the given clusters.
+func (issuer *kubeCertIssuer) issueSharedCerts(ctx context.Context, clusters kubeconfig.LocalProxyClusters, certs alpnproxy.KubeClientCerts) error {
+	for _, teleportCluster := range slices.Sorted(slices.Values(clusters.TeleportClusters())) {
+		cert, err := issuer.IssueCert(ctx, teleportCluster, "" /*kubeCluster*/, nil /*mfaCheck*/)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		logger.DebugContext(ctx, "Shared client cert issued for Teleport cluster", "teleport_cluster", teleportCluster)
+		certs.Add(teleportCluster, "", *cert)
+	}
+	return nil
 }
 
 // kubeCertClient is the subset of [client.ClusterClient] the issuer issues through.

--- a/tool/tsh/common/kube_cert_issuer.go
+++ b/tool/tsh/common/kube_cert_issuer.go
@@ -183,6 +183,10 @@ func (issuer *kubeCertIssuer) issueCertOverConn(ctx context.Context, cc kubeCert
 // So the reissue rechecks the requesting cluster: if MFA is now required, that cluster gets a cert routed to itself,
 // since a shared cert can carry no MFA state. The rest of the fleet keeps using the shared one.
 func (issuer *kubeCertIssuer) ReissueSharedCert(ctx context.Context, teleportCluster, requestedKubeCluster string) (*tls.Certificate, string, error) {
+	if requestedKubeCluster == "" {
+		return nil, "", trace.BadParameter("reissuing the shared Kubernetes certificate requires a Kubernetes cluster name")
+	}
+
 	// Hold one connection across the recheck and the issuance below.
 	cc, release, err := issuer.conn.Acquire(ctx)
 	if err != nil {

--- a/tool/tsh/common/kube_cert_issuer.go
+++ b/tool/tsh/common/kube_cert_issuer.go
@@ -319,6 +319,7 @@ func (issuer *kubeCertIssuer) issueCerts(ctx context.Context, clusters kubeconfi
 		// The auth server rejected the shared unrouted cert, so issue per cluster instead.
 		logger.DebugContext(ctx, "Auth server rejected the shared unrouted cert, issuing per cluster", "error", err)
 		issuer.sharedCertUnsupported.Store(true)
+		run.DropShared()
 		return run.certs, trace.Wrap(run.IssuePerCluster(ctx, mfaOff))
 	}
 	return run.certs, nil

--- a/tool/tsh/common/kube_cert_issuer.go
+++ b/tool/tsh/common/kube_cert_issuer.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"maps"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -210,61 +209,31 @@ func (issuer *kubeCertIssuer) issueCerts(ctx context.Context, clusters kubeconfi
 	}
 	defer release()
 
-	certs := make(alpnproxy.KubeClientCerts)
-	var certsMu sync.Mutex
-	issueAndAdd := func(ctx context.Context, cluster kubeconfig.LocalProxyCluster, mfaCheck *proto.IsMFARequiredResponse) error {
-		cert, err := issuer.IssueCert(ctx, cluster.TeleportCluster, cluster.KubeCluster, mfaCheck)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		logger.DebugContext(ctx, "Client cert issued for cluster", "cluster", cluster)
-		certsMu.Lock()
-		defer certsMu.Unlock()
-		certs.Add(cluster.TeleportCluster, cluster.KubeCluster, *cert)
-		return nil
-	}
-
 	mfaChecks, err := issuer.fetchMFAChecks(ctx, cc, clusters)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	run := issuer.newCertRun(mfaChecks)
 
 	// Headless serializes every issuance on the ceremony lock, so the partition below cannot help it.
 	if issuer.tc.AllowHeadless {
-		for _, cluster := range clusters {
-			if err := issueAndAdd(ctx, cluster, mfaChecks[localProxyClusterKey(cluster)]); err != nil {
-				return nil, trace.Wrap(err)
-			}
-		}
-		return certs, nil
+		return run.certs, trace.Wrap(run.IssuePerCluster(ctx, clusters))
 	}
 
-	// Partition clusters into MFA-gated and prompt-free.
-	var mfaOn, mfaOff kubeconfig.LocalProxyClusters
-	for _, cluster := range clusters {
-		if mfaChecks[localProxyClusterKey(cluster)].GetRequired() {
-			mfaOn = append(mfaOn, cluster)
-		} else {
-			mfaOff = append(mfaOff, cluster)
-		}
-	}
+	mfaOn, mfaOff := run.PartitionByMFA(clusters)
 
 	// MFA-gated issuances fan out concurrently.
 	group := newKubeClusterGroup(cc, mfaOn, kubeCertIssueConcurrency())
 	defer group.Close(ctx)
-	err = group.ForEach(ctx, func(ctx context.Context, cluster kubeconfig.LocalProxyCluster) error {
-		return issueAndAdd(ctx, cluster, mfaChecks[localProxyClusterKey(cluster)])
-	})
-	if err != nil {
+	if err := group.ForEach(ctx, run.IssueOne); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Prompt-free issuances share one unrouted cert per Teleport cluster.
-	err = issuer.issueSharedCerts(ctx, mfaOff, certs)
-	if err != nil {
+	if err := run.IssueShared(ctx, mfaOff); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return certs, nil
+	return run.certs, nil
 }
 
 // issueMFAGatedCert issues one cert that may require MFA.
@@ -393,19 +362,6 @@ func (issuer *kubeCertIssuer) requestCert(ctx context.Context, cc kubeCertClient
 	}
 
 	return &cert, nil
-}
-
-// issueSharedCerts issues one unrouted cert per Teleport cluster covering the given clusters.
-func (issuer *kubeCertIssuer) issueSharedCerts(ctx context.Context, clusters kubeconfig.LocalProxyClusters, certs alpnproxy.KubeClientCerts) error {
-	for _, teleportCluster := range slices.Sorted(slices.Values(clusters.TeleportClusters())) {
-		cert, err := issuer.IssueCert(ctx, teleportCluster, "" /*kubeCluster*/, nil /*mfaCheck*/)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		logger.DebugContext(ctx, "Shared client cert issued for Teleport cluster", "teleport_cluster", teleportCluster)
-		certs.Add(teleportCluster, "", *cert)
-	}
-	return nil
 }
 
 // kubeCertClient is the subset of [client.ClusterClient] the issuer issues through.

--- a/tool/tsh/common/kube_cert_issuer.go
+++ b/tool/tsh/common/kube_cert_issuer.go
@@ -181,12 +181,22 @@ func (issuer *kubeCertIssuer) issueCertOverConn(ctx context.Context, cc kubeCert
 // So the reissue rechecks the requesting cluster: if MFA is now required, that cluster gets a cert routed to itself,
 // since a shared cert can carry no MFA state. The rest of the fleet keeps using the shared one.
 func (issuer *kubeCertIssuer) ReissueSharedCert(ctx context.Context, teleportCluster, requestedKubeCluster string) (*tls.Certificate, string, error) {
+	// Hold one connection across the recheck and the issuance below.
 	cc, release, err := issuer.conn.Acquire(ctx)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 	defer release()
 
+	cert, storeUnder, err := issuer.reissueSharedCertOverConn(ctx, cc, teleportCluster, requestedKubeCluster)
+	if err != nil && client.IsErrorResolvableWithRelogin(err) {
+		issuer.conn.invalidate(ctx)
+	}
+	return cert, storeUnder, trace.Wrap(err)
+}
+
+// reissueSharedCertOverConn reissues the shared unrouted cert over the given connection.
+func (issuer *kubeCertIssuer) reissueSharedCertOverConn(ctx context.Context, cc kubeCertClient, teleportCluster, requestedKubeCluster string) (*tls.Certificate, string, error) {
 	authClient, err := cc.ConnectToCluster(ctx, teleportCluster)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -204,12 +214,12 @@ func (issuer *kubeCertIssuer) ReissueSharedCert(ctx context.Context, teleportClu
 			"teleport_cluster", teleportCluster,
 			"kube_cluster", requestedKubeCluster,
 		)
-		cert, err := issuer.IssueCert(ctx, teleportCluster, requestedKubeCluster, check)
+		cert, err := issuer.issueCertOverConn(ctx, cc, teleportCluster, requestedKubeCluster, check)
 		return cert, requestedKubeCluster, trace.Wrap(err)
 	}
 
 	// The cluster can still use the shared cert, so reissue it.
-	cert, err := issuer.IssueCert(ctx, teleportCluster, "" /*kubeCluster*/, nil /*mfaCheck*/)
+	cert, err := issuer.issueCertOverConn(ctx, cc, teleportCluster, "" /*kubeCluster*/, nil /*mfaCheck*/)
 	return cert, "", trace.Wrap(err)
 }
 

--- a/tool/tsh/common/kube_cert_issuer.go
+++ b/tool/tsh/common/kube_cert_issuer.go
@@ -174,6 +174,45 @@ func (issuer *kubeCertIssuer) issueCertOverConn(ctx context.Context, cc kubeCert
 	return issuer.issueMFAGatedCert(ctx, cc, params)
 }
 
+// ReissueSharedCert reissues the shared unrouted cert on behalf of the cluster whose request needs it,
+// and reports the kube cluster to store the result under.
+//
+// A shared cert only serves clusters whose per-session MFA is off, and that can change while the proxy runs.
+// So the reissue rechecks the requesting cluster: if MFA is now required, that cluster gets a cert routed to itself,
+// since a shared cert can carry no MFA state. The rest of the fleet keeps using the shared one.
+func (issuer *kubeCertIssuer) ReissueSharedCert(ctx context.Context, teleportCluster, requestedKubeCluster string) (*tls.Certificate, string, error) {
+	cc, release, err := issuer.conn.Acquire(ctx)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	defer release()
+
+	authClient, err := cc.ConnectToCluster(ctx, teleportCluster)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	defer authClient.Close()
+
+	check, err := authClient.IsMFARequired(ctx, &proto.IsMFARequiredRequest{
+		Target: &proto.IsMFARequiredRequest_KubernetesCluster{KubernetesCluster: requestedKubeCluster},
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	if check.GetRequired() {
+		logger.DebugContext(ctx, "Cluster now requires per-session MFA, giving it a routed cert",
+			"teleport_cluster", teleportCluster,
+			"kube_cluster", requestedKubeCluster,
+		)
+		cert, err := issuer.IssueCert(ctx, teleportCluster, requestedKubeCluster, check)
+		return cert, requestedKubeCluster, trace.Wrap(err)
+	}
+
+	// The cluster can still use the shared cert, so reissue it.
+	cert, err := issuer.IssueCert(ctx, teleportCluster, "" /*kubeCluster*/, nil /*mfaCheck*/)
+	return cert, "", trace.Wrap(err)
+}
+
 // AcquireConn holds the shared cluster connection until the returned release is called.
 // Dialing it performs a relogin if the base session is expired.
 func (issuer *kubeCertIssuer) AcquireConn(ctx context.Context) (func(), error) {

--- a/tool/tsh/common/kube_cert_issuer.go
+++ b/tool/tsh/common/kube_cert_issuer.go
@@ -53,6 +53,8 @@ type kubeCertIssuer struct {
 	conn *clusterConn
 	// mfa is the reusable MFA state shared across issuances.
 	mfa *reusableMFA
+	// sharedCertUnsupported latches once an auth server has rejected an unrouted request.
+	sharedCertUnsupported bool
 }
 
 // kubeKeyStore is the subset of [client.LocalKeyAgent] the issuer loads and saves certs through.
@@ -229,9 +231,19 @@ func (issuer *kubeCertIssuer) issueCerts(ctx context.Context, clusters kubeconfi
 		return nil, trace.Wrap(err)
 	}
 
+	if issuer.sharedCertUnsupported {
+		return run.certs, trace.Wrap(run.IssuePerCluster(ctx, mfaOff))
+	}
+
 	// Prompt-free issuances share one unrouted cert per Teleport cluster.
 	if err := run.IssueShared(ctx, mfaOff); err != nil {
-		return nil, trace.Wrap(err)
+		if !isUnroutedKubeCertRejected(err) {
+			return nil, trace.Wrap(err)
+		}
+		// The auth server rejected the shared unrouted cert, so issue per cluster instead.
+		logger.DebugContext(ctx, "Auth server rejected the shared unrouted cert, issuing per cluster", "error", err)
+		issuer.sharedCertUnsupported = true
+		return run.certs, trace.Wrap(run.IssuePerCluster(ctx, mfaOff))
 	}
 	return run.certs, nil
 }
@@ -433,6 +445,13 @@ func kubeCertFromKeyRing(keyRing *client.KeyRing, kubeCluster string) (tls.Certi
 
 func localProxyClusterKey(cluster kubeconfig.LocalProxyCluster) string {
 	return cluster.TeleportCluster + "/" + cluster.KubeCluster
+}
+
+// isUnroutedKubeCertRejected reports whether an auth server refused an unrouted request,
+// as every server predating the shared cert does.
+func isUnroutedKubeCertRejected(err error) bool {
+	// validateCertUsage rejects the request before it reaches any typed error.
+	return trace.IsBadParameter(err) && strings.Contains(err.Error(), "missing KubernetesCluster field")
 }
 
 // isMFAReuseRejected reports whether an auth server unambiguously rejected the reusable MFA flow.

--- a/tool/tsh/common/kube_cert_issuer_test.go
+++ b/tool/tsh/common/kube_cert_issuer_test.go
@@ -455,7 +455,7 @@ func TestKubeCertIssuer_MFAOffNoCeremony(t *testing.T) {
 
 		require.Equal(t, 1, issuances)
 		require.Len(t, certs, 1)
-		require.Contains(t, certs, alpnproxy.KubeClusterKey{TeleportCluster: "root"})
+		require.Contains(t, certs, alpnproxy.KubeClusterKey{TeleportCluster: "root", KubeCluster: ""})
 		require.Zero(t, cc.saves)
 	})
 }
@@ -817,6 +817,82 @@ func TestKubeCertIssuer_HeadlessUnroutedRejected(t *testing.T) {
 	})
 }
 
+// TestKubeCertIssuer_UnroutedRejectedFallback verifies that
+// an auth server predating the shared cert does not break the proxy.
+// The issuer falls back to per-cluster certs and latches,
+// so a later burst does not retry a request that server refuses.
+func TestKubeCertIssuer_UnroutedRejectedFallback(t *testing.T) {
+	t.Parallel()
+
+	const numClusters = 3
+	clusters := newTestKubeClusters(numClusters)
+	keyRing := newTestKubeKeyRing(t, clusters)
+
+	synctest.Test(t, func(t *testing.T) {
+		var unroutedAttempts, routedIssuances atomic.Int32
+		cc := &fakeKubeCertClient{mfaRequired: false}
+		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+			if params.KubernetesCluster == "" {
+				unroutedAttempts.Add(1)
+				return nil, trace.BadParameter("missing KubernetesCluster field in a kubernetes-only UserCertsRequest")
+			}
+			routedIssuances.Add(1)
+			return &client.IssueUserCertsWithMFAResult{
+				KeyRing:     keyRing,
+				MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+			}, nil
+		}
+
+		issuer := newTestKubeCertIssuer(cc)
+		certs, err := issuer.issueCerts(t.Context(), clusters)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), unroutedAttempts.Load())
+		require.Equal(t, int32(numClusters), routedIssuances.Load())
+
+		// Every cluster is served by its own cert, and no shared entry lingers from the attempt.
+		require.Len(t, certs, numClusters)
+		require.NotContains(t, certs, alpnproxy.KubeClusterKey{TeleportCluster: "root", KubeCluster: ""})
+		require.Equal(t, numClusters, cc.saves)
+
+		// A later burst must not retry the shape this server already refused.
+		certs, err = issuer.issueCerts(t.Context(), clusters)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), unroutedAttempts.Load(), "the rejection must latch")
+		require.Equal(t, int32(2*numClusters), routedIssuances.Load())
+		require.Len(t, certs, numClusters)
+	})
+}
+
+// TestKubeCertIssuer_UnroutedErrorNotSwallowed verifies that
+// only the old-server rejection triggers the per-cluster fallback.
+// Any other failure has to surface, or a real problem would show up as a silent loss of the shared cert.
+func TestKubeCertIssuer_UnroutedErrorNotSwallowed(t *testing.T) {
+	t.Parallel()
+
+	clusters := newTestKubeClusters(3)
+	keyRing := newTestKubeKeyRing(t, clusters)
+
+	synctest.Test(t, func(t *testing.T) {
+		var routedIssuances atomic.Int32
+		cc := &fakeKubeCertClient{mfaRequired: false}
+		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+			if params.KubernetesCluster == "" {
+				return nil, trace.AccessDenied("user has no access to Kubernetes clusters")
+			}
+			routedIssuances.Add(1)
+			return &client.IssueUserCertsWithMFAResult{
+				KeyRing:     keyRing,
+				MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+			}, nil
+		}
+
+		issuer := newTestKubeCertIssuer(cc)
+		_, err := issuer.issueCerts(t.Context(), clusters)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied but got %v", err)
+		require.Zero(t, routedIssuances.Load(), "an unrelated failure must not fall back to per-cluster issuance")
+		require.False(t, issuer.sharedCertUnsupported, "an unrelated failure must not latch")
+	})
+}
 func newTestKubeClusters(n int) kubeconfig.LocalProxyClusters {
 	clusters := make(kubeconfig.LocalProxyClusters, 0, n)
 	for i := range n {

--- a/tool/tsh/common/kube_cert_issuer_test.go
+++ b/tool/tsh/common/kube_cert_issuer_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/utils/cert"
 )
 
@@ -416,7 +417,8 @@ func TestKubeCertIssuer_ExpiredResponseSingleRefresh(t *testing.T) {
 }
 
 // TestKubeCertIssuer_MFAOffNoCeremony verifies that
-// clusters without per-session MFA issue with no ceremony, serially, saving their certs to the key store.
+// clusters without per-session MFA share one unrouted cert issued with no ceremony,
+// held in memory rather than saved to the key store.
 func TestKubeCertIssuer_MFAOffNoCeremony(t *testing.T) {
 	t.Parallel()
 
@@ -425,10 +427,21 @@ func TestKubeCertIssuer_MFAOffNoCeremony(t *testing.T) {
 	keyRing := newTestKubeKeyRing(t, clusters)
 
 	synctest.Test(t, func(t *testing.T) {
+		var issuances int
 		cc := &fakeKubeCertClient{mfaRequired: false}
 		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+			issuances++
 			if params.ReusableMFAResponse != nil {
 				return nil, trace.BadParameter("no MFA ceremony expected for MFA-off clusters")
+			}
+			if params.KubernetesCluster != "" {
+				return nil, trace.BadParameter("expected an unrouted request, got cluster %q", params.KubernetesCluster)
+			}
+			if params.RequesterName != proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_MULTI {
+				return nil, trace.BadParameter("unexpected requester %v", params.RequesterName)
+			}
+			if params.MFACheck.GetRequired() {
+				return nil, trace.BadParameter("unrouted issuance must assert MFA is not required")
 			}
 			return &client.IssueUserCertsWithMFAResult{
 				KeyRing:     keyRing,
@@ -437,14 +450,13 @@ func TestKubeCertIssuer_MFAOffNoCeremony(t *testing.T) {
 		}
 
 		issuer := newTestKubeCertIssuer(cc)
-
-		start := time.Now()
 		certs, err := issuer.issueCerts(t.Context(), clusters)
 		require.NoError(t, err)
-		require.Len(t, certs, numClusters)
-		require.Equal(t, numClusters, cc.saves)
-		// Key-store-writing issuances must not run concurrently.
-		require.Equal(t, 3*time.Second, time.Since(start))
+
+		require.Equal(t, 1, issuances)
+		require.Len(t, certs, 1)
+		require.Contains(t, certs, alpnproxy.KubeClusterKey{TeleportCluster: "root"})
+		require.Zero(t, cc.saves)
 	})
 }
 
@@ -636,6 +648,175 @@ func TestKubeCertIssuer_CanceledContextFailsIssuance(t *testing.T) {
 	})
 }
 
+// TestKubeCertIssuer_MixedFleet verifies that
+// only the clusters without per-session MFA collapse onto the shared cert,
+// while MFA-gated ones keep their own routed certs.
+func TestKubeCertIssuer_MixedFleet(t *testing.T) {
+	t.Parallel()
+
+	clusters := newTestKubeClusters(4)
+	keyRing := newTestKubeKeyRing(t, clusters)
+	// kube-0 and kube-1 are MFA-gated; kube-2 and kube-3 are not.
+	mfaOn := func(kubeCluster string) bool {
+		return kubeCluster == "kube-0" || kubeCluster == "kube-1"
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		var routed, unrouted atomic.Int32
+		var ceremonyResp proto.MFAAuthenticateResponse
+		cc := &fakeKubeCertClient{mfaRequiredFor: mfaOn}
+		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+			if params.KubernetesCluster == "" {
+				unrouted.Add(1)
+				return &client.IssueUserCertsWithMFAResult{
+					KeyRing:     keyRing,
+					MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+				}, nil
+			}
+			if !mfaOn(params.KubernetesCluster) {
+				return nil, trace.BadParameter("cluster %q has no MFA and must use the shared cert", params.KubernetesCluster)
+			}
+			routed.Add(1)
+			return &client.IssueUserCertsWithMFAResult{
+				KeyRing:             keyRing,
+				MFARequired:         proto.MFARequired_MFA_REQUIRED_YES,
+				ReusableMFAResponse: &ceremonyResp,
+			}, nil
+		}
+
+		certs, err := newTestKubeCertIssuer(cc).issueCerts(t.Context(), clusters)
+		require.NoError(t, err)
+
+		require.Equal(t, int32(2), routed.Load())
+		require.Equal(t, int32(1), unrouted.Load())
+		require.Len(t, certs, 3)
+		require.Zero(t, cc.saves)
+	})
+}
+
+// TestKubeCertIssuer_SharedCertPerTeleportCluster verifies that
+// the shared cert is scoped to a Teleport cluster.
+// A fleet spanning root and leaf gets one unrouted cert each, never one for both.
+func TestKubeCertIssuer_SharedCertPerTeleportCluster(t *testing.T) {
+	t.Parallel()
+
+	clusters := kubeconfig.LocalProxyClusters{
+		{TeleportCluster: "root", KubeCluster: "kube-root-0"},
+		{TeleportCluster: "root", KubeCluster: "kube-root-1"},
+		{TeleportCluster: "leaf", KubeCluster: "kube-leaf-0"},
+	}
+	keyRing := newTestKubeKeyRing(t, clusters)
+
+	synctest.Test(t, func(t *testing.T) {
+		var mu sync.Mutex
+		var routes []string
+		cc := &fakeKubeCertClient{mfaRequired: false}
+		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+			if params.KubernetesCluster != "" {
+				return nil, trace.BadParameter("expected an unrouted request, got cluster %q", params.KubernetesCluster)
+			}
+			mu.Lock()
+			routes = append(routes, params.RouteToCluster)
+			mu.Unlock()
+			return &client.IssueUserCertsWithMFAResult{
+				KeyRing:     keyRing,
+				MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+			}, nil
+		}
+
+		certs, err := newTestKubeCertIssuer(cc).issueCerts(t.Context(), clusters)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Equal(t, []string{"leaf", "root"}, routes)
+		require.Len(t, certs, 2)
+	})
+}
+
+// TestKubeCertIssuer_HeadlessSkipsSharedCert verifies that
+// headless keeps issuing per-cluster certs.
+// Its requester carries distinct server-side handling and cannot request an unrouted cert.
+func TestKubeCertIssuer_HeadlessSkipsSharedCert(t *testing.T) {
+	t.Parallel()
+
+	const numClusters = 3
+	clusters := newTestKubeClusters(numClusters)
+	keyRing := newTestKubeKeyRing(t, clusters)
+
+	synctest.Test(t, func(t *testing.T) {
+		var issuances int
+		cc := &fakeKubeCertClient{mfaRequired: false}
+		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+			issuances++
+			if params.KubernetesCluster == "" {
+				return nil, trace.BadParameter("headless must not request an unrouted cert")
+			}
+			if params.RequesterName != proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY_HEADLESS {
+				return nil, trace.BadParameter("unexpected requester %v", params.RequesterName)
+			}
+			if params.MFACheck == nil {
+				return nil, trace.BadParameter("headless issuance must carry a prefetched MFA check")
+			}
+			return &client.IssueUserCertsWithMFAResult{
+				KeyRing:     keyRing,
+				MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+			}, nil
+		}
+
+		issuer := newTestKubeCertIssuer(cc)
+		issuer.tc.AllowHeadless = true
+
+		certs, err := issuer.issueCerts(t.Context(), clusters)
+		require.NoError(t, err)
+		require.Equal(t, numClusters, issuances)
+		require.Len(t, certs, numClusters)
+		require.Equal(t, numClusters, cc.saves)
+	})
+}
+
+// TestKubeCertIssuer_UnroutedRequesterGuard verifies that
+// the issuer refuses to send an unrouted request under any other requester.
+// Without a cluster route the requester is the only thing marking it as Kubernetes usage,
+// so the wrong one yields an unrestricted certificate rather than an error from the server.
+func TestKubeCertIssuer_UnroutedRequesterGuard(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		cc := &fakeKubeCertClient{}
+		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+			return nil, trace.BadParameter("issuance must not be attempted")
+		}
+
+		_, err := newTestKubeCertIssuer(cc).requestCert(t.Context(), cc, client.ReissueParams{
+			RouteToCluster: "root",
+			RequesterName:  proto.UserCertsRequest_TSH_KUBE_LOCAL_PROXY,
+		})
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter but got %v", err)
+		require.ErrorContains(t, err, "unrouted Kubernetes certificates can only be requested by")
+	})
+}
+
+// TestKubeCertIssuer_HeadlessUnroutedRejected verifies that
+// a headless session cannot issue a shared cert even if asked directly.
+// Headless carries its own requester, which auth does not accept for an unrouted request.
+func TestKubeCertIssuer_HeadlessUnroutedRejected(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		cc := &fakeKubeCertClient{}
+		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+			return nil, trace.BadParameter("issuance must not be attempted")
+		}
+		issuer := newTestKubeCertIssuer(cc)
+		issuer.tc.AllowHeadless = true
+
+		_, err := issuer.IssueCert(t.Context(), "root", "" /*kubeCluster*/, nil /*mfaCheck*/)
+		require.True(t, trace.IsBadParameter(err), "expected bad parameter but got %v", err)
+		require.ErrorContains(t, err, "unrouted Kubernetes certificates can only be requested by")
+	})
+}
+
 func newTestKubeClusters(n int) kubeconfig.LocalProxyClusters {
 	clusters := make(kubeconfig.LocalProxyClusters, 0, n)
 	for i := range n {
@@ -657,6 +838,9 @@ func newTestKubeKeyRing(t *testing.T, clusters kubeconfig.LocalProxyClusters) *c
 	for _, cluster := range clusters {
 		keyRing.KubeTLSCredentials[cluster.KubeCluster] = client.TLSCredential{PrivateKey: priv, Cert: creds.Cert}
 	}
+	// An unrouted request is keyed by its empty Kubernetes cluster,
+	// as the real client does when storing the credential it gets back.
+	keyRing.KubeTLSCredentials[""] = client.TLSCredential{PrivateKey: priv, Cert: creds.Cert}
 	return keyRing
 }
 
@@ -678,10 +862,16 @@ func newTestKubeCertIssuer(cc *fakeKubeCertClient) *kubeCertIssuer {
 type fakeMFAAuthClient struct {
 	authclient.ClientI
 	required bool
+	// requiredFor overrides required per Kubernetes cluster when set.
+	requiredFor func(kubeCluster string) bool
 }
 
 func (f *fakeMFAAuthClient) IsMFARequired(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
-	if f.required {
+	required := f.required
+	if f.requiredFor != nil {
+		required = f.requiredFor(req.GetKubernetesCluster())
+	}
+	if required {
 		return &proto.IsMFARequiredResponse{
 			Required:    true,
 			MFARequired: proto.MFARequired_MFA_REQUIRED_YES,
@@ -700,6 +890,9 @@ type fakeKubeCertClient struct {
 	mfaRequired bool
 	issueFn     func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error)
 	keyRings    map[string]*client.KeyRing
+	// mfaRequiredFor overrides mfaRequired per Kubernetes cluster, for fleets
+	// where only some clusters are MFA-gated.
+	mfaRequiredFor func(kubeCluster string) bool
 
 	mu       sync.Mutex
 	connects []string
@@ -754,5 +947,5 @@ func (f *fakeKubeCertClient) ConnectToCluster(ctx context.Context, clusterName s
 	f.mu.Lock()
 	f.connects = append(f.connects, clusterName)
 	f.mu.Unlock()
-	return &fakeMFAAuthClient{required: f.mfaRequired}, nil
+	return &fakeMFAAuthClient{required: f.mfaRequired, requiredFor: f.mfaRequiredFor}, nil
 }

--- a/tool/tsh/common/kube_cert_issuer_test.go
+++ b/tool/tsh/common/kube_cert_issuer_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/utils/cert"
 )
@@ -818,7 +819,7 @@ func TestKubeCertIssuer_HeadlessUnroutedRejected(t *testing.T) {
 }
 
 // TestKubeCertIssuer_UnroutedRejectedFallback verifies that
-// an auth server predating the shared cert does not break the proxy.
+// an auth server that refuses the unrouted request does not break the proxy.
 // The issuer falls back to per-cluster certs and latches,
 // so a later burst does not retry a request that server refuses.
 func TestKubeCertIssuer_UnroutedRejectedFallback(t *testing.T) {
@@ -828,39 +829,59 @@ func TestKubeCertIssuer_UnroutedRejectedFallback(t *testing.T) {
 	clusters := newTestKubeClusters(numClusters)
 	keyRing := newTestKubeKeyRing(t, clusters)
 
-	synctest.Test(t, func(t *testing.T) {
-		var unroutedAttempts, routedIssuances atomic.Int32
-		cc := &fakeKubeCertClient{mfaRequired: false}
-		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
-			if params.KubernetesCluster == "" {
-				unroutedAttempts.Add(1)
-				return nil, trace.BadParameter("missing KubernetesCluster field in a kubernetes-only UserCertsRequest")
-			}
-			routedIssuances.Add(1)
-			return &client.IssueUserCertsWithMFAResult{
-				KeyRing:     keyRing,
-				MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
-			}, nil
-		}
+	for _, tt := range []struct {
+		name      string
+		rejection error
+	}{
+		{
+			// Every auth server predating the shared cert.
+			name:      "old auth server",
+			rejection: trace.BadParameter("missing KubernetesCluster field in a kubernetes-only UserCertsRequest"),
+		},
+		{
+			// A scoped identity is only allowed a Kubernetes cert that names a cluster.
+			name:      "scoped identity",
+			rejection: trace.Wrap(services.ErrScopedIdentity, "generating scoped user cert for unsupported usage %q", proto.UserCertsRequest_Kubernetes),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		issuer := newTestKubeCertIssuer(cc)
-		certs, err := issuer.issueCerts(t.Context(), clusters)
-		require.NoError(t, err)
-		require.Equal(t, int32(1), unroutedAttempts.Load())
-		require.Equal(t, int32(numClusters), routedIssuances.Load())
+			synctest.Test(t, func(t *testing.T) {
+				var unroutedAttempts, routedIssuances atomic.Int32
+				cc := &fakeKubeCertClient{mfaRequired: false}
+				cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+					if params.KubernetesCluster == "" {
+						unroutedAttempts.Add(1)
+						return nil, tt.rejection
+					}
+					routedIssuances.Add(1)
+					return &client.IssueUserCertsWithMFAResult{
+						KeyRing:     keyRing,
+						MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+					}, nil
+				}
 
-		// Every cluster is served by its own cert, and no shared entry lingers from the attempt.
-		require.Len(t, certs, numClusters)
-		require.NotContains(t, certs, alpnproxy.KubeClusterKey{TeleportCluster: "root", KubeCluster: ""})
-		require.Equal(t, numClusters, cc.saves)
+				issuer := newTestKubeCertIssuer(cc)
+				certs, err := issuer.issueCerts(t.Context(), clusters)
+				require.NoError(t, err)
+				require.Equal(t, int32(1), unroutedAttempts.Load())
+				require.Equal(t, int32(numClusters), routedIssuances.Load())
 
-		// A later burst must not retry the shape this server already refused.
-		certs, err = issuer.issueCerts(t.Context(), clusters)
-		require.NoError(t, err)
-		require.Equal(t, int32(1), unroutedAttempts.Load(), "the rejection must latch")
-		require.Equal(t, int32(2*numClusters), routedIssuances.Load())
-		require.Len(t, certs, numClusters)
-	})
+				// Every cluster is served by its own cert, and no shared entry lingers from the attempt.
+				require.Len(t, certs, numClusters)
+				require.NotContains(t, certs, alpnproxy.KubeClusterKey{TeleportCluster: "root", KubeCluster: ""})
+				require.Equal(t, numClusters, cc.saves)
+
+				// A later burst must not retry the shape this server already refused.
+				certs, err = issuer.issueCerts(t.Context(), clusters)
+				require.NoError(t, err)
+				require.Equal(t, int32(1), unroutedAttempts.Load(), "the rejection must latch")
+				require.Equal(t, int32(2*numClusters), routedIssuances.Load())
+				require.Len(t, certs, numClusters)
+			})
+		})
+	}
 }
 
 // TestKubeCertIssuer_UnroutedErrorNotSwallowed verifies that

--- a/tool/tsh/common/kube_cert_issuer_test.go
+++ b/tool/tsh/common/kube_cert_issuer_test.go
@@ -884,6 +884,51 @@ func TestKubeCertIssuer_UnroutedRejectedFallback(t *testing.T) {
 	}
 }
 
+// TestKubeCertIssuer_ReissueUnroutedRejectedFallback verifies that
+// an auth server that refuses the unrouted request cannot strand a running proxy,
+// as one reached mid-session during a rolling upgrade would.
+// The reissue gives the requesting cluster its own cert and latches,
+// so the clusters the shared cert served convert as their own reissues come due.
+func TestKubeCertIssuer_ReissueUnroutedRejectedFallback(t *testing.T) {
+	t.Parallel()
+
+	const kubeCluster = "kube-0"
+	clusters := newTestKubeClusters(1)
+	keyRing := newTestKubeKeyRing(t, clusters)
+
+	synctest.Test(t, func(t *testing.T) {
+		var unroutedAttempts, routedIssuances atomic.Int32
+		cc := &fakeKubeCertClient{mfaRequired: false}
+		cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+			if params.KubernetesCluster == "" {
+				unroutedAttempts.Add(1)
+				return nil, trace.BadParameter("missing KubernetesCluster field in a kubernetes-only UserCertsRequest")
+			}
+			routedIssuances.Add(1)
+			return &client.IssueUserCertsWithMFAResult{
+				KeyRing:     keyRing,
+				MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+			}, nil
+		}
+
+		issuer := newTestKubeCertIssuer(cc)
+		cert, storeUnder, err := issuer.ReissueSharedCert(t.Context(), "root", kubeCluster)
+		require.NoError(t, err, "the reissue must recover instead of leaving the cluster unreachable")
+		require.NotNil(t, cert)
+		require.Equal(t, kubeCluster, storeUnder, "the cluster must be moved onto its own cert")
+		require.Equal(t, int32(1), unroutedAttempts.Load())
+		require.Equal(t, int32(1), routedIssuances.Load())
+		require.True(t, issuer.sharedCertUnsupported.Load(), "the rejection must latch")
+
+		// A later reissue must not retry the shape this server already refused.
+		_, storeUnder, err = issuer.ReissueSharedCert(t.Context(), "root", kubeCluster)
+		require.NoError(t, err)
+		require.Equal(t, kubeCluster, storeUnder)
+		require.Equal(t, int32(1), unroutedAttempts.Load(), "the rejection must latch")
+		require.Equal(t, int32(2), routedIssuances.Load())
+	})
+}
+
 // TestKubeCertIssuer_UnroutedErrorNotSwallowed verifies that
 // only the old-server rejection triggers the per-cluster fallback.
 // Any other failure has to surface, or a real problem would show up as a silent loss of the shared cert.
@@ -911,7 +956,7 @@ func TestKubeCertIssuer_UnroutedErrorNotSwallowed(t *testing.T) {
 		_, err := issuer.issueCerts(t.Context(), clusters)
 		require.True(t, trace.IsAccessDenied(err), "expected access denied but got %v", err)
 		require.Zero(t, routedIssuances.Load(), "an unrelated failure must not fall back to per-cluster issuance")
-		require.False(t, issuer.sharedCertUnsupported, "an unrelated failure must not latch")
+		require.False(t, issuer.sharedCertUnsupported.Load(), "an unrelated failure must not latch")
 	})
 }
 func newTestKubeClusters(n int) kubeconfig.LocalProxyClusters {

--- a/tool/tsh/common/kube_cert_issuer_test.go
+++ b/tool/tsh/common/kube_cert_issuer_test.go
@@ -863,6 +863,7 @@ func TestKubeCertIssuer_UnroutedRejectedFallback(t *testing.T) {
 				}
 
 				issuer := newTestKubeCertIssuer(cc)
+				start := time.Now()
 				certs, err := issuer.issueCerts(t.Context(), clusters)
 				require.NoError(t, err)
 				require.Equal(t, int32(1), unroutedAttempts.Load())
@@ -872,6 +873,9 @@ func TestKubeCertIssuer_UnroutedRejectedFallback(t *testing.T) {
 				require.Len(t, certs, numClusters)
 				require.NotContains(t, certs, alpnproxy.KubeClusterKey{TeleportCluster: "root", KubeCluster: ""})
 				require.Equal(t, numClusters, cc.saves)
+				// One rejected unrouted attempt, then the per-cluster issuances.
+				// Those write to the key store, so they must not run concurrently.
+				require.Equal(t, (1+numClusters)*time.Second, time.Since(start))
 
 				// A later burst must not retry the shape this server already refused.
 				certs, err = issuer.issueCerts(t.Context(), clusters)

--- a/tool/tsh/common/kube_cert_issuer_test.go
+++ b/tool/tsh/common/kube_cert_issuer_test.go
@@ -961,9 +961,14 @@ type fakeMFAAuthClient struct {
 	required bool
 	// requiredFor overrides required per Kubernetes cluster when set.
 	requiredFor func(kubeCluster string) bool
+	// err fails the check instead of answering it, when set.
+	err error
 }
 
 func (f *fakeMFAAuthClient) IsMFARequired(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
 	required := f.required
 	if f.requiredFor != nil {
 		required = f.requiredFor(req.GetKubernetesCluster())
@@ -990,6 +995,8 @@ type fakeKubeCertClient struct {
 	// mfaRequiredFor overrides mfaRequired per Kubernetes cluster, for fleets
 	// where only some clusters are MFA-gated.
 	mfaRequiredFor func(kubeCluster string) bool
+	// mfaCheckErr fails the MFA requirement check instead of answering it, when set.
+	mfaCheckErr error
 
 	mu       sync.Mutex
 	connects []string
@@ -1044,5 +1051,5 @@ func (f *fakeKubeCertClient) ConnectToCluster(ctx context.Context, clusterName s
 	f.mu.Lock()
 	f.connects = append(f.connects, clusterName)
 	f.mu.Unlock()
-	return &fakeMFAAuthClient{required: f.mfaRequired, requiredFor: f.mfaRequiredFor}, nil
+	return &fakeMFAAuthClient{required: f.mfaRequired, requiredFor: f.mfaRequiredFor, err: f.mfaCheckErr}, nil
 }

--- a/tool/tsh/common/kube_cert_run.go
+++ b/tool/tsh/common/kube_cert_run.go
@@ -96,6 +96,18 @@ func (r *kubeCertRun) IssueShared(ctx context.Context, clusters kubeconfig.Local
 	return nil
 }
 
+// DropShared removes the shared certs issued so far,
+// so a fallback to per-cluster certs cannot leave one behind for the proxy to serve.
+func (r *kubeCertRun) DropShared() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for key := range r.certs {
+		if key.KubeCluster == "" {
+			delete(r.certs, key)
+		}
+	}
+}
+
 func (r *kubeCertRun) add(teleportCluster, kubeCluster string, cert tls.Certificate) {
 	r.mu.Lock()
 	r.certs.Add(teleportCluster, kubeCluster, cert)

--- a/tool/tsh/common/kube_cert_run.go
+++ b/tool/tsh/common/kube_cert_run.go
@@ -1,0 +1,103 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"crypto/tls"
+	"slices"
+	"sync"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
+)
+
+// kubeCertRun is the state of one issuance burst.
+// The per-session MFA requirement of every cluster it covers, and the certs issued so far.
+// Its own lock makes it safe for the concurrent fan-out,
+// so callers never have to work out whether a given path needs one.
+type kubeCertRun struct {
+	issuer    *kubeCertIssuer
+	mfaChecks map[string]*proto.IsMFARequiredResponse
+	certs     alpnproxy.KubeClientCerts
+	mu        sync.Mutex
+}
+
+func (issuer *kubeCertIssuer) newCertRun(mfaChecks map[string]*proto.IsMFARequiredResponse) *kubeCertRun {
+	return &kubeCertRun{
+		issuer:    issuer,
+		mfaChecks: mfaChecks,
+		certs:     make(alpnproxy.KubeClientCerts),
+	}
+}
+
+// PartitionByMFA splits clusters by whether they need per-session MFA.
+func (r *kubeCertRun) PartitionByMFA(clusters kubeconfig.LocalProxyClusters) (mfaOn, mfaOff kubeconfig.LocalProxyClusters) {
+	for _, cluster := range clusters {
+		if r.mfaChecks[localProxyClusterKey(cluster)].GetRequired() {
+			mfaOn = append(mfaOn, cluster)
+		} else {
+			mfaOff = append(mfaOff, cluster)
+		}
+	}
+	return mfaOn, mfaOff
+}
+
+// IssueOne issues the cert for a single cluster and collects it.
+func (r *kubeCertRun) IssueOne(ctx context.Context, cluster kubeconfig.LocalProxyCluster) error {
+	cert, err := r.issuer.IssueCert(ctx, cluster.TeleportCluster, cluster.KubeCluster, r.mfaChecks[localProxyClusterKey(cluster)])
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	logger.DebugContext(ctx, "Client cert issued for cluster", "cluster", cluster)
+	r.add(cluster.TeleportCluster, cluster.KubeCluster, *cert)
+	return nil
+}
+
+// IssuePerCluster issues one routed cert per cluster, serially.
+func (r *kubeCertRun) IssuePerCluster(ctx context.Context, clusters kubeconfig.LocalProxyClusters) error {
+	for _, cluster := range clusters {
+		if err := r.IssueOne(ctx, cluster); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// IssueShared issues one unrouted cert per Teleport cluster covering the given clusters.
+func (r *kubeCertRun) IssueShared(ctx context.Context, clusters kubeconfig.LocalProxyClusters) error {
+	for _, teleportCluster := range slices.Sorted(slices.Values(clusters.TeleportClusters())) {
+		cert, err := r.issuer.IssueCert(ctx, teleportCluster, "" /*kubeCluster*/, nil /*mfaCheck*/)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		logger.DebugContext(ctx, "Shared client cert issued for Teleport cluster", "teleport_cluster", teleportCluster)
+		r.add(teleportCluster, "", *cert)
+	}
+	return nil
+}
+
+func (r *kubeCertRun) add(teleportCluster, kubeCluster string, cert tls.Certificate) {
+	r.mu.Lock()
+	r.certs.Add(teleportCluster, kubeCluster, cert)
+	r.mu.Unlock()
+}

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -387,6 +387,8 @@ func makeKubeLocalProxy(cf *CLIConf, tc *client.TeleportClient, clusters kubecon
 		Logger:       logger,
 		CloseContext: cf.Context,
 		Relay:        tc.RelayAddr != "",
+
+		SharedCertReissuer: kubeProxy.getSharedCertReissuer(),
 	})
 
 	if tc.RelayAddr != "" {
@@ -527,39 +529,64 @@ func (k *kubeLocalProxy) WriteKubeConfig() error {
 // getCertReissuer returns a function that reissues the user certificate for a Kubernetes cluster,
 // used by the local proxy middleware when a cert it serves expires.
 // The issuer performs a relogin if required.
-func (k *kubeLocalProxy) getCertReissuer() func(ctx context.Context, teleportCluster, kubeCluster string) (tls.Certificate, error) {
+func (k *kubeLocalProxy) getCertReissuer() alpnproxy.KubeCertReissuer {
 	return func(ctx context.Context, teleportCluster, kubeCluster string) (tls.Certificate, error) {
-		k.reissueMu.Lock()
-		defer k.reissueMu.Unlock()
-
-		// We save user's current context in case there is a relogin, which
-		// will delete our ephemeral kubeconfig and we'll need to recreate it.
-		cfg, err := kubeconfig.Load(k.KubeConfigPath())
-		if err != nil {
-			return tls.Certificate{}, trace.Wrap(err, "could not load ephemeral kubeconfig at %q", k.KubeConfigPath())
-		}
-		currentContext := cfg.CurrentContext
-
-		// Hold the cluster connection across the reissue so the relogin can only happen here,
-		// before the kubeconfig is recreated below.
-		release, err := k.certIssuer.AcquireConn(ctx)
-		if err != nil {
-			return tls.Certificate{}, trace.Wrap(err)
-		}
-		defer release()
-
-		// We recreate ephemeral kubeconfig to make sure it's there even after relogin.
-		k.kubeconfig.CurrentContext = currentContext
-		if err := k.WriteKubeConfig(); err != nil {
-			return tls.Certificate{}, trace.Wrap(err)
-		}
-
-		cert, err := k.certIssuer.IssueCert(ctx, teleportCluster, kubeCluster, nil /*mfaCheck*/)
-		if err != nil {
-			return tls.Certificate{}, trace.Wrap(err)
-		}
-		return *cert, nil
+		cert, _, err := k.reissue(ctx, teleportCluster, kubeCluster, kubeCluster)
+		return cert, trace.Wrap(err)
 	}
+}
+
+// getSharedCertReissuer returns a function that reissues the shared unrouted cert,
+// which serves every cluster whose per-session MFA is off.
+func (k *kubeLocalProxy) getSharedCertReissuer() alpnproxy.KubeSharedCertReissuer {
+	return func(ctx context.Context, teleportCluster, requestedKubeCluster string) (tls.Certificate, string, error) {
+		return k.reissue(ctx, teleportCluster, "" /*kubeCluster*/, requestedKubeCluster)
+	}
+}
+
+// reissue issues one cert with the ephemeral kubeconfig preserved across a possible relogin,
+// and reports the kube cluster to store it under.
+// An empty kubeCluster reissues the shared unrouted cert on behalf of requestedKubeCluster.
+func (k *kubeLocalProxy) reissue(ctx context.Context, teleportCluster, kubeCluster, requestedKubeCluster string) (tls.Certificate, string, error) {
+	// reissueMu serializes the reissues, which are not safe for concurrent use, and the ephemeral kubeconfig load and rewrite.
+	k.reissueMu.Lock()
+	defer k.reissueMu.Unlock()
+
+	// We save user's current context in case there is a relogin,
+	// which will delete our ephemeral kubeconfig and we'll need to recreate it.
+	cfg, err := kubeconfig.Load(k.KubeConfigPath())
+	if err != nil {
+		return tls.Certificate{}, "", trace.Wrap(err, "could not load ephemeral kubeconfig at %q", k.KubeConfigPath())
+	}
+	currentContext := cfg.CurrentContext
+
+	// Hold the cluster connection across the reissue so the relogin can only happen here,
+	// before the kubeconfig is recreated below.
+	release, err := k.certIssuer.AcquireConn(ctx)
+	if err != nil {
+		return tls.Certificate{}, "", trace.Wrap(err)
+	}
+	defer release()
+
+	// We recreate ephemeral kubeconfig to make sure it's there even after relogin.
+	k.kubeconfig.CurrentContext = currentContext
+	if err := k.WriteKubeConfig(); err != nil {
+		return tls.Certificate{}, "", trace.Wrap(err)
+	}
+
+	if kubeCluster == "" {
+		cert, storeUnder, err := k.certIssuer.ReissueSharedCert(ctx, teleportCluster, requestedKubeCluster)
+		if err != nil {
+			return tls.Certificate{}, "", trace.Wrap(err)
+		}
+		return *cert, storeUnder, nil
+	}
+
+	cert, err := k.certIssuer.IssueCert(ctx, teleportCluster, kubeCluster, nil /*mfaCheck*/)
+	if err != nil {
+		return tls.Certificate{}, "", trace.Wrap(err)
+	}
+	return *cert, kubeCluster, nil
 }
 
 // checkMultipleClusterSelections takes a map of name selectors to matched

--- a/tool/tsh/common/kube_proxy_test.go
+++ b/tool/tsh/common/kube_proxy_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/scheme"
 
+	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
@@ -52,7 +53,10 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func (p *kubeTestPack) testProxyKube(t *testing.T) {
@@ -418,4 +422,61 @@ func TestKubeProxyCertReissuerReloginOverCachedConn(t *testing.T) {
 	restored, err := kubeconfig.Load(path)
 	require.NoError(t, err)
 	require.Equal(t, "test-context", restored.CurrentContext)
+}
+
+// testSharedKubeCert covers the shared unrouted cert end to end against live clusters.
+// The clusters without per-session MFA are served by one cert per Teleport cluster,
+// and the proxy path-routes it to each of them, including across the trust boundary into a leaf.
+func (p *kubeTestPack) testSharedKubeCert(t *testing.T) {
+	// A fresh profile, so no kube certs are cached from earlier subtests.
+	// The shared cert covers only the clusters missing from the key store.
+	mustLoginSetEnvLegacy(t, p.suite)
+	t.Setenv(proxyKubeConfigEnvVar, filepath.Join(t.TempDir(), "config"))
+
+	cf := &CLIConf{
+		Context:            t.Context(),
+		HomePath:           os.Getenv(types.HomeEnvVar),
+		InsecureSkipVerify: true,
+	}
+	tc, err := makeClient(cf)
+	require.NoError(t, err)
+
+	clusters := kubeconfig.LocalProxyClusters{
+		{TeleportCluster: p.rootClusterName, KubeCluster: p.rootKubeCluster1},
+		{TeleportCluster: p.rootClusterName, KubeCluster: p.rootKubeCluster2},
+		{TeleportCluster: p.leafClusterName, KubeCluster: p.leafKubeCluster},
+	}
+
+	certs, err := newKubeCertIssuer(tc).LoadOrIssueCerts(t.Context(), clusters)
+	require.NoError(t, err)
+
+	// Three kube clusters over two Teleport clusters yield two certs, each keyed by its Teleport cluster alone.
+	require.Len(t, certs, 2)
+	for _, teleportCluster := range []string{p.rootClusterName, p.leafClusterName} {
+		key := alpnproxy.KubeClusterKey{TeleportCluster: teleportCluster, KubeCluster: ""}
+		require.Contains(t, certs, key)
+
+		cert := certs[key]
+		leaf, err := utils.TLSCertLeaf(cert)
+		require.NoError(t, err)
+		identity, err := tlsca.FromSubject(leaf.Subject, leaf.NotAfter)
+		require.NoError(t, err)
+
+		require.Empty(t, identity.KubernetesCluster, "the shared cert must carry no Kubernetes cluster route")
+		require.Equal(t, teleportCluster, identity.RouteToCluster)
+		require.Empty(t, identity.MFAVerified, "the shared cert must carry no MFA state")
+		require.Equal(t, []string{teleport.UsageKubeOnly}, identity.Usage)
+	}
+
+	kubeProxy, err := makeKubeLocalProxy(cf, tc, clusters, clientcmdapi.NewConfig(), "0",
+		kubeconfig.ContextName("{{.ClusterName}}", "{{.KubeName}}"))
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeProxy.Close() })
+	require.NoError(t, kubeProxy.WriteKubeConfig())
+	go kubeProxy.Start(t.Context())
+
+	// The leaf request is the one that crosses the trust boundary with an unrouted cert.
+	for _, cluster := range clusters {
+		sendRequestToKubeLocalProxy(t, kubeProxy.kubeconfig, cluster.TeleportCluster, cluster.KubeCluster)
+	}
 }

--- a/tool/tsh/common/kube_proxy_test.go
+++ b/tool/tsh/common/kube_proxy_test.go
@@ -424,6 +424,63 @@ func TestKubeProxyCertReissuerReloginOverCachedConn(t *testing.T) {
 	require.Equal(t, "test-context", restored.CurrentContext)
 }
 
+// TestKubeProxySharedCertReissuerReloginOverCachedConn verifies that
+// the shared cert reissuer recovers when the cached cluster connection is dead.
+// Its MFA recheck runs before any issuance, so it has to drop the connection itself.
+// Steady kubectl traffic keeps the connection from ever expiring on its own.
+func TestKubeProxySharedCertReissuerReloginOverCachedConn(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	cfg := clientcmdapi.NewConfig()
+	cfg.CurrentContext = "test-context"
+	require.NoError(t, kubeconfig.Save(path, *cfg))
+
+	clusters := newTestKubeClusters(1)
+	keyRing := newTestKubeKeyRing(t, clusters)
+
+	// The dead connection fails the MFA recheck, which the shared reissue runs first.
+	deadCC := &fakeKubeCertClient{
+		mfaCheckErr: trace.Wrap(&interceptors.RemoteError{Err: apiclient.ErrClientCredentialsHaveExpired}),
+	}
+
+	freshCC := &fakeKubeCertClient{mfaRequired: false}
+	freshCC.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+		return &client.IssueUserCertsWithMFAResult{
+			KeyRing:     keyRing,
+			MFARequired: proto.MFARequired_MFA_REQUIRED_NO,
+		}, nil
+	}
+
+	issuer := newTestKubeCertIssuer(freshCC)
+	issuer.conn = &clusterConn{dialer: reloginClusterDialer{path: path, cc: freshCC}, conn: deadCC}
+
+	kubeProxy := &kubeLocalProxy{
+		kubeConfigPath: path,
+		kubeconfig:     cfg,
+		certIssuer:     issuer,
+	}
+	reissue := kubeProxy.getSharedCertReissuer()
+
+	// The recheck over the dead connection fails and kubectl gets an error for this request,
+	// but the issuer detects that a relogin can resolve the error and drops the connection
+	// instead of leaving it lingering for the next request.
+	_, _, err := reissue(t.Context(), clusters[0].TeleportCluster, clusters[0].KubeCluster)
+	require.ErrorIs(t, err, apiclient.ErrClientCredentialsHaveExpired)
+	require.Equal(t, 1, deadCC.closes, "the dead connection must be dropped so the next reissue dials afresh")
+
+	// Steady traffic delivers the next request.
+	cert, storeUnder, err := reissue(t.Context(), clusters[0].TeleportCluster, clusters[0].KubeCluster)
+	require.NoError(t, err, "the reissue must recover once the relogin ran on the fresh dial")
+	require.NotNil(t, cert.PrivateKey)
+	require.Empty(t, storeUnder, "the cluster still has no per-session MFA, so it keeps the shared cert")
+
+	// The ephemeral kubeconfig deleted by the relogin was recreated before the issuance.
+	restored, err := kubeconfig.Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "test-context", restored.CurrentContext)
+}
+
 // testSharedKubeCert covers the shared unrouted cert end to end against live clusters.
 // The clusters without per-session MFA are served by one cert per Teleport cluster,
 // and the proxy path-routes it to each of them, including across the trust boundary into a leaf.

--- a/tool/tsh/common/kube_proxy_test.go
+++ b/tool/tsh/common/kube_proxy_test.go
@@ -480,3 +480,71 @@ func (p *kubeTestPack) testSharedKubeCert(t *testing.T) {
 		sendRequestToKubeLocalProxy(t, kubeProxy.kubeconfig, cluster.TeleportCluster, cluster.KubeCluster)
 	}
 }
+
+// TestKubeLocalProxyReissueDispatch covers which issuance a reissue runs.
+// An empty kubeCluster means the expired cert was the shared one,
+// which has to go through the shared path so a cluster that has since turned on per-session MFA is moved off it.
+// A named kubeCluster reissues that cluster's own cert and stays where it is.
+func TestKubeLocalProxyReissueDispatch(t *testing.T) {
+	t.Parallel()
+
+	clusters := kubeconfig.LocalProxyClusters{{TeleportCluster: "root", KubeCluster: "kube-0"}}
+
+	for _, tt := range []struct {
+		name string
+		// kubeCluster is the cluster the expired cert was held under.
+		kubeCluster string
+		// mfaNowRequired is whether the requesting cluster has since turned on per-session MFA.
+		mfaNowRequired bool
+		wantIssuedFor  string
+		wantStoreUnder string
+	}{
+		{
+			name:           "shared cert stays shared while MFA is off",
+			kubeCluster:    "",
+			wantIssuedFor:  "",
+			wantStoreUnder: "",
+		},
+		{
+			name:           "shared cert moves off when MFA is now required",
+			kubeCluster:    "",
+			mfaNowRequired: true,
+			wantIssuedFor:  "kube-0",
+			wantStoreUnder: "kube-0",
+		},
+		{
+			name:           "routed cert reissues in place",
+			kubeCluster:    "kube-0",
+			wantIssuedFor:  "kube-0",
+			wantStoreUnder: "kube-0",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			keyRing := newTestKubeKeyRing(t, clusters)
+			var issuedFor string
+			cc := &fakeKubeCertClient{mfaRequired: tt.mfaNowRequired}
+			cc.issueFn = func(ctx context.Context, params client.ReissueParams) (*client.IssueUserCertsWithMFAResult, error) {
+				issuedFor = params.KubernetesCluster
+				mfaState := proto.MFARequired_MFA_REQUIRED_NO
+				if params.KubernetesCluster != "" && tt.mfaNowRequired {
+					mfaState = proto.MFARequired_MFA_REQUIRED_YES
+				}
+				return &client.IssueUserCertsWithMFAResult{KeyRing: keyRing, MFARequired: mfaState}, nil
+			}
+
+			kubeProxy := &kubeLocalProxy{
+				certIssuer:     newTestKubeCertIssuer(cc),
+				kubeconfig:     clientcmdapi.NewConfig(),
+				kubeConfigPath: filepath.Join(t.TempDir(), "config"),
+			}
+			require.NoError(t, kubeProxy.WriteKubeConfig())
+
+			_, storeUnder, err := kubeProxy.reissue(t.Context(), "root", tt.kubeCluster, "kube-0")
+			require.NoError(t, err)
+			require.Equal(t, tt.wantIssuedFor, issuedFor, "unexpected cluster issued for")
+			require.Equal(t, tt.wantStoreUnder, storeUnder, "unexpected key to store under")
+		})
+	}
+}

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -63,6 +63,7 @@ func TestKube(t *testing.T) {
 	t.Run("list kube", pack.testListKube)
 	t.Run("proxy kube", pack.testProxyKube)
 	t.Run("proxy kube with exec-cmd", pack.testProxyKubeWithExecCmd)
+	t.Run("proxy kube shared cert", pack.testSharedKubeCert)
 }
 
 func TestKubeLogin(t *testing.T) {


### PR DESCRIPTION
Part of #68111.

<!-- Provide a descriptive entry for the changelog of the next release. -->

Changelog: `tsh proxy kube` now issues a single shared certificate for Kubernetes clusters that do not require per-session MFA, reducing certificate issuances across large fan-outs.

`tsh proxy kube` is slow across many Kubernetes clusters because it requests one certificate per cluster. For clusters without per-session MFA each certificate is also written to the key store, so they are issued one at a time. This change gives those clusters one shared certificate per Teleport cluster. It names no Kubernetes cluster, so the proxy path routes it to any of them. Clusters that require per-session MFA are unchanged.

The change reaches into `lib/auth` because auth rejected any Kubernetes certificate request that named no cluster. It now allows one from the kube local proxy requester.

A shared certificate carries no MFA state, so it cannot serve a cluster that turns on per-session MFA while the proxy is running. Requests to that cluster are denied without a prompt. Recovery happens when one of its own requests finds the shared certificate expired, which rechecks it and gives it its own certificate while the rest of the fleet keeps the shared one. So the cluster stays unreachable for the remaining lifetime of the certificate, and longer if another cluster drives the reissue first, because that only refreshes the shared certificate. Before this change the cluster recovered when its own certificate expired. Recovering on the denial itself needs the proxy to inspect responses rather than only certificate expiry, which is left for follow-up work.

For 50 clusters without per-session MFA, startup drops from 50 certificate issuances to 1 and 50 key store writes to 0.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment

<TBD: cluster, version, config>

### Test Cases
- [ ] `tsh proxy kube` over several clusters without per-session MFA, then `kubectl` against each one
- [ ] Only one certificate issuance appears in the audit log for that fan-out
- [ ] A fleet mixing MFA and non-MFA clusters, confirming the MFA ones still prompt once and still work
- [ ] Turning on per-session MFA for a cluster while the proxy runs, confirming the others are unaffected, and that the cluster prompts and works again once one of its own requests drives the reissue
- [ ] A fleet spanning a root and a leaf cluster, confirming both are reachable
- [ ] `tsh proxy kube --headless`, confirming it behaves as before
- [ ] A cluster fronted by a relay, confirming requests still reach the right cluster
- [ ] This `tsh` against an auth server that predates the change, confirming the proxy still starts and works
- [ ] An auth server that predates the change reached mid-session, confirming the proxy moves to per-cluster certificates instead of failing until restart
- [ ] A user logged in with a scoped identity, confirming the proxy starts and every cluster is reachable
- [ ] A `tsh` session that expires while the proxy runs, confirming a later `kubectl` triggers relogin rather than failing repeatedly