### PR TITLE
Add MFA device lock test coverage to TestSSHOnMultipleNodes.

### DIFF
--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1944,10 +1944,6 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 		cluster         string
 		withoutDevice   bool
 		logSuccess      []string
-		// lockMFADevice locks the user's enrolled MFA device before `tsh login` and the SSH command.
-		lockMFADevice bool
-		// lockAuth is the auth server where the lock is created. Defaults to tt.auth if nil.
-		lockAuth *auth.Server
 	}
 
 	parallelCases := []sshCase{
@@ -2194,53 +2190,6 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			errAssertion: require.NoError,
 			headless:     true,
 		},
-		{
-			name:          "mfa device lock rejects new connection (root cluster)",
-			target:        sshHostID,
-			proxyAddr:     rootProxyAddr.String(),
-			auth:          rootAuth.GetAuthServer(),
-			roles:         []string{perSessionMFARole.GetName()},
-			webauthnLogin: successfulChallenge("localhost"),
-			lockMFADevice: true,
-			errAssertion: func(t require.TestingT, err error, _ ...any) {
-				require.Regexp(t, `ssh: rejected: administratively prohibited \(lock targeting MFADevice:"[^"]+" is in force\)`, err)
-			},
-			stdoutAssertion: require.Empty,
-			stderrAssertion: require.Empty,
-			mfaPromptCount:  1,
-		},
-		{
-			name:          "mfa device lock rejects new connection (leaf cluster)",
-			target:        sshLeafHostID,
-			proxyAddr:     leafProxyAddr,
-			auth:          leafAuth.GetAuthServer(),
-			roles:         []string{perSessionMFARole.GetName()},
-			webauthnLogin: successfulChallenge("leafcluster"),
-			lockMFADevice: true,
-			errAssertion: func(t require.TestingT, err error, _ ...any) {
-				require.Regexp(t, `ssh: rejected: administratively prohibited \(lock targeting MFADevice:"[^"]+" is in force\)`, err)
-			},
-			stdoutAssertion: require.Empty,
-			stderrAssertion: require.Empty,
-			mfaPromptCount:  1,
-		},
-		{
-			name:          "mfa device lock rejects new connection (root user and leaf cluster)",
-			target:        sshLeafHostID,
-			proxyAddr:     rootProxyAddr.String(),
-			cluster:       "leafcluster",
-			auth:          rootAuth.GetAuthServer(),
-			lockAuth:      leafAuth.GetAuthServer(),
-			roles:         []string{perSessionMFARole.GetName()},
-			webauthnLogin: successfulChallenge("localhost"),
-			lockMFADevice: true,
-			errAssertion: func(t require.TestingT, err error, _ ...any) {
-				require.Regexp(t, `ssh: rejected: administratively prohibited \(lock targeting MFADevice:"[^"]+" is in force\)`, err)
-			},
-			stdoutAssertion: require.Empty,
-			stderrAssertion: require.Empty,
-			mfaPromptCount:  1,
-		},
 	}
 
 	sequentialCases := []sshCase{
@@ -2353,50 +2302,6 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			}
 			user, device := newUserDevice(t, tt.auth, roles, !tt.withoutDevice)
 
-			// Lock the user's MFA device if the test case calls for it.
-			if tt.lockMFADevice {
-				devices, err := tt.auth.Services.GetMFADevices(ctx, user.GetName(), false)
-				require.NoError(t, err)
-				require.NotEmpty(t, devices)
-				lockDeviceID := devices[0].Id
-
-				lockAuth := tt.lockAuth
-				if lockAuth == nil {
-					lockAuth = tt.auth
-				}
-
-				lock, err := types.NewLock(
-					"test-lock-"+uuid.NewString(),
-					types.LockSpecV2{
-						Target: types.LockTarget{MFADevice: lockDeviceID},
-					},
-				)
-				require.NoError(t, err)
-
-				err = lockAuth.UpsertLock(ctx, lock)
-				require.NoError(t, err)
-				t.Cleanup(func() {
-					require.NoError(t, lockAuth.DeleteLock(ctx, lock.GetName()))
-				})
-
-				// UpsertLock only writes the lock to the backend; enforcement begins once the lock replicates to the
-				// cluster's lock watchers. Wait until the lock is in force to avoid racing the SSH attempt against the
-				// propagation.
-				require.EventuallyWithT(
-					t,
-					func(t *assert.CollectT) {
-						assert.Error(
-							t,
-							lockAuth.CheckLockInForce(
-								constants.LockingModeBestEffort,
-								[]types.LockTarget{lock.Target()},
-							),
-						)
-					},
-					10*time.Second, 100*time.Millisecond, "lock was not propagated",
-				)
-			}
-
 			if tt.authPreference != nil {
 				_, err = tt.auth.UpsertAuthPreference(ctx, tt.authPreference)
 				require.NoError(t, err)
@@ -2508,6 +2413,211 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 	for _, tt := range sequentialCases {
 		t.Run(tt.name, func(t *testing.T) {
 			sshTestRun(t, tt)
+		})
+	}
+}
+
+func TestSSHMFADeviceLock(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	osUser, err := user.Current()
+	require.NoError(t, err)
+
+	perSessionMFARole, err := types.NewRole(
+		"mfa-login",
+		types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Logins:     []string{osUser.Username},
+				NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			},
+			Options: types.RoleOptions{RequireMFAType: types.RequireMFAType_SESSION},
+		})
+	require.NoError(t, err)
+
+	connector := mockConnector(t)
+
+	const (
+		rootClusterName = "root"
+		rootHostName    = "node01"
+
+		leafClusterName = "leaf"
+		leafHostName    = "node02"
+	)
+
+	rootServer, err := testserver.NewTeleportProcess(
+		t.TempDir(),
+		testserver.WithClusterName(rootClusterName),
+		testserver.WithHostname(rootHostName),
+		testserver.WithBootstrap(connector, perSessionMFARole),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.InsecureMode = true
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = rootServer.Close()
+		_ = rootServer.Wait()
+	})
+
+	leafServer, err := testserver.NewTeleportProcess(
+		t.TempDir(),
+		testserver.WithClusterName(leafClusterName),
+		testserver.WithHostname(leafHostName),
+		testserver.WithBootstrap(connector, perSessionMFARole),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.InsecureMode = true
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = leafServer.Close()
+		_ = leafServer.Wait()
+	})
+
+	SetupTrustedCluster(ctx, t, rootServer, leafServer, types.RoleMapping{
+		Remote: perSessionMFARole.GetName(),
+		Local:  []string{perSessionMFARole.GetName()},
+	})
+
+	rootAuth := rootServer.GetAuthServer()
+	leafAuth := leafServer.GetAuthServer()
+
+	for _, auth := range []*auth.Server{rootAuth, leafAuth} {
+		_, err := auth.UpsertAuthPreference(ctx,
+			&types.AuthPreferenceV2{
+				Spec: types.AuthPreferenceSpecV2{
+					Type:         constants.Local,
+					SecondFactor: constants.SecondFactorOptional,
+					Webauthn:     &types.Webauthn{RPID: "127.0.0.1"},
+				},
+			})
+		require.NoError(t, err)
+	}
+
+	rootProxyAddr, err := rootServer.ProxyWebAddr()
+	require.NoError(t, err)
+	leafProxyAddr, err := leafServer.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// Wait for the in-process SSH nodes to register with their auth servers.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		rootNodes, err := rootAuth.GetNodes(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Len(t, rootNodes, 1)
+
+		leafNodes, err := leafAuth.GetNodes(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Len(t, leafNodes, 1)
+	}, 10*time.Second, 100*time.Millisecond, "SSH nodes never registered")
+
+	const origin = "https://127.0.0.1"
+
+	// newUserWithDevice creates a fresh user with the per-session MFA role and enrolls a webauthn device for them on
+	// the given auth server. A unique user and device per subtest keeps the parallel subtests isolated.
+	newUserWithDevice := func(t *testing.T, asrv *auth.Server) (types.User, *mocku2f.Key, string) {
+		u, err := types.NewUser("alice-" + uuid.NewString())
+		require.NoError(t, err)
+		u.SetRoles([]string{perSessionMFARole.GetName()})
+		u, err = asrv.UpsertUser(ctx, u)
+		require.NoError(t, err)
+
+		device, err := mocku2f.Create()
+		require.NoError(t, err)
+		device.SetPasswordless()
+		registerDeviceForUser(t, asrv, device, u.GetName(), origin)
+
+		devices, err := asrv.Services.GetMFADevices(ctx, u.GetName(), false)
+		require.NoError(t, err)
+		require.Len(t, devices, 1)
+		return u, device, devices[0].Id
+	}
+
+	for _, tc := range []struct {
+		name         string
+		proxyAddr    string
+		loginCluster string
+		userAuth     *auth.Server // cluster that owns the user and the MFA device
+		lockAuth     *auth.Server // cluster where the lock is created
+		target       string
+	}{
+		{
+			name:      "root cluster",
+			proxyAddr: rootProxyAddr.String(),
+			userAuth:  rootAuth,
+			lockAuth:  rootAuth,
+			target:    rootHostName,
+		},
+		{
+			name:      "leaf cluster direct",
+			proxyAddr: leafProxyAddr.String(),
+			userAuth:  leafAuth,
+			lockAuth:  leafAuth,
+			target:    leafHostName,
+		},
+		{
+			name:         "root user to leaf cluster",
+			proxyAddr:    rootProxyAddr.String(),
+			loginCluster: "leaf",
+			userAuth:     rootAuth,
+			lockAuth:     leafAuth,
+			target:       leafHostName,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			user, device, deviceID := newUserWithDevice(t, tc.userAuth)
+
+			tshHome := t.TempDir()
+			loginArgs := []string{"login", "--insecure", "--proxy", tc.proxyAddr, "--user", user.GetName()}
+			if tc.loginCluster != "" {
+				loginArgs = append(loginArgs, tc.loginCluster)
+			}
+			err := Run(
+				ctx,
+				loginArgs,
+				setHomePath(tshHome),
+				setMockSSOLogin(tc.userAuth, user, connector.GetName()),
+				func(cf *CLIConf) error {
+					cf.AddKeysToAgent = client.AddKeysToAgentNo
+					return nil
+				},
+			)
+			require.NoError(t, err)
+
+			lock, err := types.NewLock("test-lock-"+uuid.NewString(), types.LockSpecV2{
+				Target: types.LockTarget{MFADevice: deviceID},
+			})
+			require.NoError(t, err)
+
+			err = tc.lockAuth.UpsertLock(ctx, lock)
+			require.NoError(t, err)
+
+			lockInForceMsg := services.LockInForceAccessDenied(lock).Error()
+
+			// The lock is enforced by the target node's own lock watcher, which replicates backend events
+			// asynchronously and is not observable from the outside. Rejection is the only signal that the watcher
+			// caught up, so the assertion is a poll: an attempt that succeeds (lock not yet propagated) or fails with
+			// any other error (node or tunnel transiently unavailable) keeps polling.
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				discard := &output{}
+				err := Run(ctx, []string{"ssh", "--insecure", tc.target, "echo", "hello"},
+					setHomePath(tshHome),
+					setMockSSOLogin(tc.userAuth, user, connector.GetName()),
+					setupWebAuthnChallengeSolver(device, true /* success */),
+					func(cf *CLIConf) error {
+						cf.OverrideStdout = discard
+						cf.overrideStderr = discard
+						cf.UseLocalSSHAgent = false
+						return nil
+					},
+				)
+				assert.ErrorContains(t, err, lockInForceMsg)
+			}, 30*time.Second, time.Second, "node never rejected the SSH connection with the MFA device lock error")
+
+			require.GreaterOrEqual(t, int(device.Counter()), 1, "expected at least one completed in-band MFA ceremony")
 		})
 	}
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1944,6 +1944,10 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 		cluster         string
 		withoutDevice   bool
 		logSuccess      []string
+		// lockMFADevice locks the user's enrolled MFA device before `tsh login` and the SSH command.
+		lockMFADevice bool
+		// lockAuth is the auth server where the lock is created. Defaults to tt.auth if nil.
+		lockAuth *auth.Server
 	}
 
 	parallelCases := []sshCase{
@@ -2190,6 +2194,53 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 			errAssertion: require.NoError,
 			headless:     true,
 		},
+		{
+			name:          "mfa device lock rejects new connection (root cluster)",
+			target:        sshHostID,
+			proxyAddr:     rootProxyAddr.String(),
+			auth:          rootAuth.GetAuthServer(),
+			roles:         []string{perSessionMFARole.GetName()},
+			webauthnLogin: successfulChallenge("localhost"),
+			lockMFADevice: true,
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.Regexp(t, `ssh: rejected: administratively prohibited \(lock targeting MFADevice:"[^"]+" is in force\)`, err)
+			},
+			stdoutAssertion: require.Empty,
+			stderrAssertion: require.Empty,
+			mfaPromptCount:  1,
+		},
+		{
+			name:          "mfa device lock rejects new connection (leaf cluster)",
+			target:        sshLeafHostID,
+			proxyAddr:     leafProxyAddr,
+			auth:          leafAuth.GetAuthServer(),
+			roles:         []string{perSessionMFARole.GetName()},
+			webauthnLogin: successfulChallenge("leafcluster"),
+			lockMFADevice: true,
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.Regexp(t, `ssh: rejected: administratively prohibited \(lock targeting MFADevice:"[^"]+" is in force\)`, err)
+			},
+			stdoutAssertion: require.Empty,
+			stderrAssertion: require.Empty,
+			mfaPromptCount:  1,
+		},
+		{
+			name:          "mfa device lock rejects new connection (root user and leaf cluster)",
+			target:        sshLeafHostID,
+			proxyAddr:     rootProxyAddr.String(),
+			cluster:       "leafcluster",
+			auth:          rootAuth.GetAuthServer(),
+			lockAuth:      leafAuth.GetAuthServer(),
+			roles:         []string{perSessionMFARole.GetName()},
+			webauthnLogin: successfulChallenge("localhost"),
+			lockMFADevice: true,
+			errAssertion: func(t require.TestingT, err error, _ ...any) {
+				require.Regexp(t, `ssh: rejected: administratively prohibited \(lock targeting MFADevice:"[^"]+" is in force\)`, err)
+			},
+			stdoutAssertion: require.Empty,
+			stderrAssertion: require.Empty,
+			mfaPromptCount:  1,
+		},
 	}
 
 	sequentialCases := []sshCase{
@@ -2301,6 +2352,50 @@ func TestSSHOnMultipleNodes(t *testing.T) {
 				roles = []string{"access", sshLoginRole.GetName()}
 			}
 			user, device := newUserDevice(t, tt.auth, roles, !tt.withoutDevice)
+
+			// Lock the user's MFA device if the test case calls for it.
+			if tt.lockMFADevice {
+				devices, err := tt.auth.Services.GetMFADevices(ctx, user.GetName(), false)
+				require.NoError(t, err)
+				require.NotEmpty(t, devices)
+				lockDeviceID := devices[0].Id
+
+				lockAuth := tt.lockAuth
+				if lockAuth == nil {
+					lockAuth = tt.auth
+				}
+
+				lock, err := types.NewLock(
+					"test-lock-"+uuid.NewString(),
+					types.LockSpecV2{
+						Target: types.LockTarget{MFADevice: lockDeviceID},
+					},
+				)
+				require.NoError(t, err)
+
+				err = lockAuth.UpsertLock(ctx, lock)
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					require.NoError(t, lockAuth.DeleteLock(ctx, lock.GetName()))
+				})
+
+				// UpsertLock only writes the lock to the backend; enforcement begins once the lock replicates to the
+				// cluster's lock watchers. Wait until the lock is in force to avoid racing the SSH attempt against the
+				// propagation.
+				require.EventuallyWithT(
+					t,
+					func(t *assert.CollectT) {
+						assert.Error(
+							t,
+							lockAuth.CheckLockInForce(
+								constants.LockingModeBestEffort,
+								[]types.LockTarget{lock.Target()},
+							),
+						)
+					},
+					10*time.Second, 100*time.Millisecond, "lock was not propagated",
+				)
+			}
 
 			if tt.authPreference != nil {
 				_, err = tt.auth.UpsertAuthPreference(ctx, tt.authPreference)


### PR DESCRIPTION
Part 3 of bug fix for https://github.com/gravitational/core/issues/146.

This adds missing test coverage to `TestSSHOnMultipleNodes` so we properly exercise locks at the E2E integration-level. Yay, automation! 🤖 

Why? Teleport uses [locks to revoke access](https://goteleport.com/docs/zero-trust-access/management/security/revoking-access/#locks). While yes, we do have test coverage at lower levels, having high-level test coverage gives us confidence that all the components in the system work as expected in cohort for this critical path and will hopefully help us catch regressions at this level before they become a CVE 🙊 

Important: this only exercises locks for **new** connections, not established. We can probably add this in a future effort if prioritized.

```
❯ stress -count 100 -p 10 /tmp/tsh-common.test -test.run '^TestSSHMFADeviceLock$' -test.shuffle on -test.timeout 5m
5s: 0 runs so far, 0 failures, 10 active
10s: 0 runs so far, 0 failures, 10 active
15s: 0 runs so far, 0 failures, 10 active
20s: 0 runs so far, 0 failures, 10 active
25s: 0 runs so far, 0 failures, 10 active
30s: 10 runs so far, 0 failures, 10 active
35s: 10 runs so far, 0 failures, 10 active
40s: 10 runs so far, 0 failures, 10 active
45s: 10 runs so far, 0 failures, 10 active
50s: 10 runs so far, 0 failures, 10 active
55s: 10 runs so far, 0 failures, 10 active
1m0s: 16 runs so far, 0 failures, 10 active
1m5s: 20 runs so far, 0 failures, 10 active
1m10s: 20 runs so far, 0 failures, 10 active
1m15s: 20 runs so far, 0 failures, 10 active
1m20s: 20 runs so far, 0 failures, 10 active
1m25s: 21 runs so far, 0 failures, 10 active
1m30s: 23 runs so far, 0 failures, 10 active
1m35s: 30 runs so far, 0 failures, 10 active
1m40s: 30 runs so far, 0 failures, 10 active
1m45s: 30 runs so far, 0 failures, 10 active
1m50s: 32 runs so far, 0 failures, 10 active
1m55s: 33 runs so far, 0 failures, 10 active
2m0s: 40 runs so far, 0 failures, 10 active
2m5s: 40 runs so far, 0 failures, 10 active
2m10s: 42 runs so far, 0 failures, 10 active
2m15s: 43 runs so far, 0 failures, 10 active
2m20s: 50 runs so far, 0 failures, 10 active
2m25s: 51 runs so far, 0 failures, 10 active
2m30s: 53 runs so far, 0 failures, 10 active
2m35s: 53 runs so far, 0 failures, 10 active
2m40s: 56 runs so far, 0 failures, 10 active
2m45s: 60 runs so far, 0 failures, 10 active
2m50s: 63 runs so far, 0 failures, 10 active
2m55s: 63 runs so far, 0 failures, 10 active
3m0s: 66 runs so far, 0 failures, 10 active
3m5s: 69 runs so far, 0 failures, 10 active
3m10s: 72 runs so far, 0 failures, 10 active
3m15s: 73 runs so far, 0 failures, 10 active
3m20s: 76 runs so far, 0 failures, 10 active
3m25s: 77 runs so far, 0 failures, 10 active
3m30s: 80 runs so far, 0 failures, 10 active
3m35s: 83 runs so far, 0 failures, 10 active
3m40s: 86 runs so far, 0 failures, 10 active
3m45s: 88 runs so far, 0 failures, 10 active
3m50s: 90 runs so far, 0 failures, 10 active
3m55s: 93 runs so far, 0 failures, 7 active
4m0s: 96 runs so far, 0 failures, 4 active
4m4s: 100 runs total, 0 failures
```

## TODOs
- [ ] Migrate this PR to new repo once it is ready.