### PR TITLE
Fix cluster-only proxy templates clearing SSH targets

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1625,19 +1625,25 @@ func (tc *TeleportClient) GetTargetNode(ctx context.Context, clt authclient.Clie
 				"search", expanded.Search,
 			),
 		)
-		// Expanded template should override all previous search criteria.
-		host = ""
-		predExpr = ""
-		search = nil
-		if expanded.Host != "" {
+		// A target provided by the template should override all previous search
+		// criteria. Templates that only set routing options, such as proxy or
+		// cluster, should preserve the original target.
+		switch {
+		case expanded.Host != "":
 			host = expanded.Host
+			predExpr = ""
+			search = nil
 			if expandedHost, expandedPort, err := net.SplitHostPort(expanded.Host); err == nil {
 				host = expandedHost
 				port = expandedPort
 			}
-		} else if expanded.Query != "" {
+		case expanded.Query != "":
+			host = ""
 			predExpr = expanded.Query
-		} else if expanded.Search != "" {
+			search = nil
+		case expanded.Search != "":
+			host = ""
+			predExpr = ""
 			search = ParseSearchKeywords(expanded.Search, ',')
 		}
 	}

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -1360,18 +1360,24 @@ func (f fakeGetTargetNodeClient) GetClusterNetworkingConfig(ctx context.Context)
 func TestGetTargetNode(t *testing.T) {
 	now := time.Now()
 	then := now.Add(-5 * time.Hour)
+	clusterOnlyTemplate := &ProxyTemplate{
+		Template: `^test:1234$`,
+		Cluster:  "leaf",
+	}
+	require.NoError(t, clusterOnlyTemplate.Check())
 
 	tests := []struct {
-		name         string
-		options      *SSHOptions
-		labels       map[string]string
-		search       []string
-		predicate    string
-		host         string
-		port         int
-		clt          fakeGetTargetNodeClient
-		errAssertion require.ErrorAssertionFunc
-		expected     TargetNode
+		name           string
+		options        *SSHOptions
+		labels         map[string]string
+		search         []string
+		predicate      string
+		host           string
+		port           int
+		proxyTemplates ProxyTemplates
+		clt            fakeGetTargetNodeClient
+		errAssertion   require.ErrorAssertionFunc
+		expected       TargetNode
 	}{
 		{
 			name: "options override",
@@ -1389,6 +1395,14 @@ func TestGetTargetNode(t *testing.T) {
 			port:         1234,
 			errAssertion: require.NoError,
 			expected:     TargetNode{Hostname: "test", Addr: "test:1234"},
+		},
+		{
+			name:           "cluster-only proxy template preserves explicit target",
+			host:           "test",
+			port:           1234,
+			proxyTemplates: ProxyTemplates{clusterOnlyTemplate},
+			errAssertion:   require.NoError,
+			expected:       TargetNode{Hostname: "test", Addr: "test:1234"},
 		},
 		{
 			name:         "resolved labels",
@@ -1495,6 +1509,7 @@ func TestGetTargetNode(t *testing.T) {
 					PredicateExpression: test.predicate,
 					Host:                test.host,
 					HostPort:            test.port,
+					ProxyTemplates:      test.proxyTemplates,
 				},
 			}
 


### PR DESCRIPTION
Preserve the original target when a matched proxy template only sets routing options such as `cluster` or `proxy`. Add regression coverage for `GetTargetNode`.

Changelog: Fixed `tsh scp` failing with `reissue params have no valid MFA target` when a matching proxy template only sets routing options.

## Manual Test Plan

### Test Environment

  - macOS arm64
  - Go 1.26.5
  - Teleport server v18.x, leaf cluster `dbx-iad`
  - Built patched and unpatched clients from the same commit with:
    `make build/tsh FIDO2=off`
  - Tested with `--mfa-mode=browser`
  - Used a cluster-only proxy template with no `host`, `query`, or `search`:

    ```yaml
    proxy_templates:
      - template: '^iad10a-rj25-10a.*$'
        cluster: "dbx-iad"

  ### Test Cases

  - [x] Ran the focused unit tests:

    go test ./lib/client \
      -run '^(TestGetTargetNode|TestProxyTemplatesApply)$' \
      -count=1

  - [x] Verified the unpatched client reproduces the failure:

    Matched proxy template ... expanded.host:
    Using provided host host:
    reissue params have no valid MFA target
    cannot route to empty target host

  - [x] Verified the patched client preserves and validates the original target:

    Matched proxy template ... expanded.host:
    Using provided host host:iad10a-rj25-10a
    Validated host ... iad10a-rj25-10a
    MFA requirement acquired ... MFA_REQUIRED_YES

  - [x] Verified the patched client reached browser MFA for the correct node and
    leaf cluster. The test was stopped before completing MFA, so no file was
    uploaded.