### PR TITLE
fix: remove 10s initialization timeout in WorkloadAPIService setup

### DIFF
--- a/lib/tbot/services/workloadidentity/workload_api.go
+++ b/lib/tbot/services/workloadidentity/workload_api.go
@@ -123,8 +123,6 @@ func (s *WorkloadAPIService) setup(ctx context.Context) (err error) {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-time.After(10 * time.Second):
-		return trace.BadParameter("timeout waiting for identity to be ready")
 	case <-s.svcIdentity.Ready():
 	}
 	facade, err := s.svcIdentity.Facade()


### PR DESCRIPTION
## Description
The `WorkloadAPIService.setup` waits for the impersonated identity with a hard-coded 10-second timeout. Under adverse but functional network conditions (e.g. slow uplink with contention), the identity can legitimately take longer than 10s to become ready. When the cap fires, the whole `tbot` process crashes:

```
ERROR REPORT:
Original Error: *errors.errorString context canceled
...
User Message: getting trust bundle set
        context canceled] bot/bot.go:105
ERROR: service(workload-identity-api-1)
        timeout waiting for identity to be ready
```

## Fix
Remove the fixed 10s timeout and wait purely on the surrounding context lifecycle, exactly matching the beam vnet service's initialization pattern (see `lib/tbot/services/beams/vnet_service.go`):

```go
select {
case <-ctx.Done():
    return ctx.Err()
case <-s.svcIdentity.Ready():
}
```

The caller already manages the bot context, so cancellation is still honoured; only the artificial 10s cap is removed.

## Test Plan
- The change is a 3-line removal of a timeout branch in a `select`. Existing unit tests in `workload_api_test.go` cover the Workload API service and continue to pass.
- Manual verification: start `tbot` with the Workload Identity API in a slow/contended network environment; the service no longer crashes with "timeout waiting for identity to be ready".
