### PR TITLE
fix(helm): configure proxy token audience and TTL for Kubernetes joining

### DIFF
--- a/examples/chart/teleport-cluster/templates/proxy.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy.yaml
@@ -35,6 +35,14 @@ value we use in this chart matches the value used by the lib chart. */}}
 {{/* Set the auth server URL to the internal k8s cluster service */}}
 {{- $_ := set $proxy.Values "teleportAuthService" (printf "%s:3025" (include "teleport-cluster.auth.serviceFQDN" .)) -}}
 {{- $_ := set $proxy.Values "forceHAReplicas" (not (empty (get (default (dict) .Values.proxy.highAvailability) "replicaCount"))) -}}
+{{- $teleportConfig := default (dict) $proxy.Values.teleportConfig -}}
+{{- $teleport := default (dict) (get $teleportConfig "teleport") -}}
+{{- $configJoinParams := default (dict) (get $teleport "join_params") -}}
+{{- $valueJoinParams := default (dict) $proxy.Values.joinParams -}}
+{{- if eq (coalesce (get $configJoinParams "method") (get $valueJoinParams "method")) "kubernetes" -}}
+{{- $_ := set $proxy.Values "serviceAccountTokenAudience" $proxy.Values.clusterName -}}
+{{- $_ := set $proxy.Values "serviceAccountTokenExpirationSeconds" 600 -}}
+{{- end -}}
 
 {{/* Render all proxy charts */}}
 {{- include "teleport-proxy-lib.all" $proxy -}}

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -1373,6 +1373,43 @@ tests:
             name: proxy-serviceaccount-token
             readOnly: true
 
+  - it: sets projected token audience and ttl for kubernetes join
+    set:
+      clusterName: teleport.example.com
+      proxy:
+        teleportConfig:
+          teleport:
+            join_params:
+              method: kubernetes
+              token_name: teleport-proxy
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: proxy-serviceaccount-token
+            projected:
+              sources:
+                - serviceAccountToken:
+                    path: token
+                    audience: teleport.example.com
+                    expirationSeconds: 600
+                - configMap:
+                    items:
+                      - key: ca.crt
+                        path: ca.crt
+                    name: kube-root-ca.crt
+                - downwardAPI:
+                    items:
+                      - path: "namespace"
+                        fieldRef:
+                          fieldPath: metadata.namespace
+
   - it: sets extraLabels on Deployment
     template: proxy.yaml
     values:


### PR DESCRIPTION
Changelog: Fixed `teleport-cluster` Kubernetes/OIDC proxy joining by setting projected ServiceAccount token audiences to the Teleport `clusterName` and the TTL to 10 minutes. 

## Manual Test Plan
### Test Environment
- Helm v3.20.1
- Kubernetes capabilities 1.21

```
helm template release-name examples/chart/teleport-cluster \
       --kube-version 1.21.0 \
       --set clusterName=teleport.example.com \
       --set proxy.teleportConfig.teleport.join_params.method=kubernetes \
       --set proxy.teleportConfig.teleport.join_params.token_name=teleport-proxy
...

                path: token
            - configMap:
                items:
                - key: ca.crt
                  path: ca.crt
--
                path: token
                audience: "teleport.example.com"
                expirationSeconds: 600
            - configMap:
                items:
```


### Test Cases
- [ x ] `make -C example/chart lint-teleport-cluster test-teleport-cluster`
- [ x ] Rendered a k8s join config and verified audience matches `clusterName` and token TTL has valid default for 600s
- [ x ] Rendered a non k8s join config and verified no audience or TTL override is applied

This fixes Kubernetes/OIDC proxy joins that fail when the projected ServiceAccount token has the default audience or a TTL of 30 minutes or more.
